### PR TITLE
chore: Configure `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,10 +13,16 @@ updates:
         update-types:
           - "minor"
           - "patch"
-
+    allow:
+      # Update both direct and indirect dependencies
+      - dependency-type: "all"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
- Allow updates to `Cargo.lock` packages included indirectly
- Bundle GH Actions updates into a single PR when possible