### PR TITLE
feat: Archon

### DIFF
--- a/Ix/Binius/ArithExpr.lean
+++ b/Ix/Binius/ArithExpr.lean
@@ -6,7 +6,7 @@ namespace Binius
 /-- Arithmetic expression type for BinaryField128b -/
 inductive ArithExpr
   | const : UInt128 → ArithExpr
-  | var : OracleId → ArithExpr
+  | var : USize → ArithExpr
   | add : ArithExpr → ArithExpr → ArithExpr
   | mul : ArithExpr → ArithExpr → ArithExpr
   | pow : ArithExpr → UInt64 → ArithExpr
@@ -16,14 +16,14 @@ namespace ArithExpr
 
 def toString : ArithExpr → String
   | const _ => "Const"
-  | var v => s!"Var({v.toUSize})"
+  | var v => s!"Var({v})"
   | add x y => s!"Add({x.toString}, {y.toString})"
   | mul x y => s!"Mul({x.toString}, {y.toString})"
   | pow x e => s!"Pow({x.toString}, {e})"
 
 def toBytes : @& ArithExpr → ByteArray
   | const u128 => ⟨#[0]⟩ ++ u128.toLEBytes
-  | var oracleId => ⟨#[1]⟩ ++ oracleId.toUSize.toLEBytes
+  | var oracleId => ⟨#[1]⟩ ++ oracleId.toLEBytes
   | add x y =>
     let xBytes := x.toBytes
     ⟨#[2, xBytes.size.toUInt8]⟩ ++ xBytes ++ y.toBytes

--- a/Tests/ArithExpr.lean
+++ b/Tests/ArithExpr.lean
@@ -7,9 +7,6 @@ open LSpec SlimCheck Gen
 
 open Binius
 
-def genOracleId : Gen OracleId :=
-  OracleId.mk <$> genUSize
-
 def genArithExpr : Gen ArithExpr := getSize >>= go
   where
     go : Nat → Gen ArithExpr
@@ -17,7 +14,7 @@ def genArithExpr : Gen ArithExpr := getSize >>= go
     | Nat.succ n =>
       frequency [
         (40, .const <$> genUInt128),
-        (40, .var <$> genOracleId),
+        (40, .var <$> genUSize),
         (25, .add <$> go n <*> go n),
         (25, .mul <$> go n <*> go n),
         (50, .pow <$> go n <*> genUInt64)

--- a/Tests/Binius.lean
+++ b/Tests/Binius.lean
@@ -18,7 +18,7 @@ def Tests.Binius.bindingsSuite :=
   let builder := builder.pushNamespace "x"
   let builder := builder.popNamespace
   let builder := builder.assertZero "y" #[oracleId0, oracleId1] $
-    .add (.pow (.var oracleId1) 2) (.mul (.var oracleId2) (.const 10))
+    .add (.pow (.var 0) 2) (.mul (.var 1) (.const 10))
   let builder := builder.assertNotZero oracleId0
   let logRows := builder.logRows #[oracleId0, oracleId1]
   let (channelId0, builder) := builder.addChannel
@@ -41,7 +41,7 @@ def Tests.Binius.witnessSuite :=
   let builder := ConstraintSystemBuilder.new ()
   let (a, builder) := builder.addCommitted "a" 4 BinaryField1b.towerLevel
   let (b, builder) := builder.addCommitted "b" 4 BinaryField1b.towerLevel
-  let builder := builder.assertZero "a + b" #[a, b] (.add (.var a) (.var b))
+  let builder := builder.assertZero "a + b" #[a, b] (.add (.var 0) (.var 1))
   let cs := builder.build
 
   let mkWitness := fun aData bData =>

--- a/src/archon/arith_expr.rs
+++ b/src/archon/arith_expr.rs
@@ -1,0 +1,72 @@
+use binius_core::oracle::OracleId;
+use binius_math::ArithExpr as ArithExprCore;
+
+use super::F;
+
+#[derive(Clone)]
+pub enum ArithExpr {
+    Const(F),
+    Var(usize),
+    Oracle(OracleId),
+    Add(Box<ArithExpr>, Box<ArithExpr>),
+    Mul(Box<ArithExpr>, Box<ArithExpr>),
+    Pow(Box<ArithExpr>, u64),
+}
+
+impl std::ops::Add for ArithExpr {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::Add(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl std::ops::Mul for ArithExpr {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::Mul(Box::new(self), Box::new(rhs))
+    }
+}
+
+impl ArithExpr {
+    #[inline]
+    pub fn pow(self, e: u64) -> Self {
+        Self::Pow(Box::new(self), e)
+    }
+
+    pub(crate) fn offset_oracles(&mut self, by: usize) {
+        match self {
+            Self::Oracle(o) => *o += by,
+            Self::Add(a, b) | Self::Mul(a, b) => {
+                a.offset_oracles(by);
+                b.offset_oracles(by);
+            }
+            Self::Pow(a, _) => a.offset_oracles(by),
+            _ => (),
+        }
+    }
+
+    pub(crate) fn into_arith_expr_core(self, binds: &mut Vec<OracleId>) -> ArithExprCore<F> {
+        match self {
+            Self::Const(c) => ArithExprCore::Const(c),
+            Self::Var(i) => ArithExprCore::Var(i),
+            Self::Oracle(o) => {
+                let i = binds.iter().position(|&id| o == id).unwrap_or_else(|| {
+                    binds.push(o);
+                    binds.len() - 1
+                });
+                ArithExprCore::Var(i)
+            }
+            Self::Add(a, b) => {
+                let a = a.into_arith_expr_core(binds);
+                let b = b.into_arith_expr_core(binds);
+                a + b
+            }
+            Self::Mul(a, b) => {
+                let a = a.into_arith_expr_core(binds);
+                let b = b.into_arith_expr_core(binds);
+                a * b
+            }
+            Self::Pow(a, e) => a.into_arith_expr_core(binds).pow(e),
+        }
+    }
+}

--- a/src/archon/circuit.rs
+++ b/src/archon/circuit.rs
@@ -1,0 +1,401 @@
+use anyhow::{Result, bail, ensure};
+use binius_circuits::builder::ConstraintSystemBuilder;
+use binius_core::{
+    constraint_system::{
+        ConstraintSystem,
+        channel::{ChannelId, Flush, FlushDirection},
+    },
+    oracle::OracleId,
+    transparent::constant::Constant,
+};
+use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
+use std::sync::Arc;
+
+use super::{
+    F, ModuleId, OracleInfo, OracleKind,
+    arith_expr::ArithExpr,
+    transparent::{ConstVal, Transparent},
+    witness::WitnessModule,
+};
+
+#[inline]
+pub fn freeze_circuit_modules_oracles(circuit_modules: &mut [CircuitModule]) {
+    circuit_modules
+        .par_iter_mut()
+        .for_each(|module| module.freeze_oracles())
+}
+
+#[inline]
+pub fn init_witness_modules(circuit_modules: &[CircuitModule]) -> Result<Vec<WitnessModule>> {
+    circuit_modules
+        .par_iter()
+        .map(CircuitModule::init_witness_module)
+        .collect()
+}
+
+pub struct CircuitModule {
+    module_id: ModuleId,
+    oracles: Freezable<Vec<OracleInfo>>,
+    flushes: Vec<Flush>,
+    constraints: Vec<Constraint>,
+    non_zero_oracle_ids: Vec<OracleId>,
+    namespacer: Namespacer,
+}
+
+impl CircuitModule {
+    #[inline]
+    pub fn new(module_id: ModuleId) -> Self {
+        Self {
+            module_id,
+            oracles: Freezable::default(),
+            flushes: vec![],
+            constraints: vec![],
+            non_zero_oracle_ids: vec![],
+            namespacer: Namespacer::default(),
+        }
+    }
+
+    #[inline]
+    pub fn freeze_oracles(&mut self) {
+        self.oracles.freeze()
+    }
+
+    #[inline]
+    pub fn init_witness_module(&self) -> Result<WitnessModule> {
+        Ok(WitnessModule::new(
+            self.module_id,
+            self.oracles.get_frozen()?,
+        ))
+    }
+
+    #[inline]
+    pub fn flush(
+        &mut self,
+        direction: FlushDirection,
+        channel_id: ChannelId,
+        selector: OracleId,
+        oracle_ids: impl IntoIterator<Item = OracleId>,
+        multiplicity: u64,
+    ) {
+        self.flushes.push(Flush {
+            oracles: oracle_ids.into_iter().collect(),
+            channel_id,
+            direction,
+            selector,
+            multiplicity,
+        });
+    }
+
+    #[inline]
+    pub fn assert_zero<S: ToString + ?Sized>(
+        &mut self,
+        name: &S,
+        oracle_ids: impl IntoIterator<Item = OracleId>,
+        composition: ArithExpr,
+    ) {
+        self.constraints.push(Constraint {
+            name: name.to_string(),
+            oracle_ids: oracle_ids.into_iter().collect(),
+            composition,
+        });
+    }
+
+    #[inline]
+    pub fn assert_not_zero(&mut self, oracle_id: OracleId) {
+        self.non_zero_oracle_ids.push(oracle_id);
+    }
+
+    #[inline]
+    pub fn add_committed<S: ToString + ?Sized>(
+        &mut self,
+        name: &S,
+        tower_level: usize,
+    ) -> Result<OracleId> {
+        let oracle_info = OracleInfo {
+            name: self.namespacer.scoped_name(name),
+            tower_level,
+            kind: OracleKind::Committed,
+        };
+        self.add_oracle_info(oracle_info)
+    }
+
+    #[inline]
+    pub fn add_transparent<S: ToString + ?Sized>(
+        &mut self,
+        name: &S,
+        transparent: Transparent,
+    ) -> Result<OracleId> {
+        let oracle_info = OracleInfo {
+            name: self.namespacer.scoped_name(name),
+            tower_level: transparent.tower_level(),
+            kind: OracleKind::Transparent(transparent),
+        };
+        self.add_oracle_info(oracle_info)
+    }
+
+    pub fn add_linear_combination<S: ToString + ?Sized>(
+        &mut self,
+        name: &S,
+        offset: F,
+        inner: impl Iterator<Item = (OracleId, F)>,
+    ) -> Result<OracleId> {
+        let inner = inner.into_iter().collect::<Vec<_>>();
+        let tower_level = inner
+            .iter()
+            .map(|(oracle_id, _)| self.oracles.get_ref()[*oracle_id].tower_level)
+            .max()
+            .unwrap_or(0);
+        let oracle_info = OracleInfo {
+            name: self.namespacer.scoped_name(name),
+            tower_level,
+            kind: OracleKind::LinearCombination { offset, inner },
+        };
+        self.add_oracle_info(oracle_info)
+    }
+
+    #[inline]
+    pub fn push_namespace<S: ToString + ?Sized>(&mut self, name: &S) {
+        self.namespacer.push(name);
+    }
+
+    #[inline]
+    pub fn pop_namespace(&mut self) {
+        self.namespacer.pop();
+    }
+
+    #[inline]
+    fn add_oracle_info(&mut self, oracle_info: OracleInfo) -> Result<OracleId> {
+        self.oracles.get_mut()?.push(oracle_info);
+        Ok(self.oracles.get_ref().len() - 1)
+    }
+}
+
+pub fn compile_circuit_modules(
+    modules: &[CircuitModule],
+    modules_n_vars: &[Option<Vec<usize>>],
+) -> Result<ConstraintSystem<F>> {
+    ensure!(
+        modules.len() == modules_n_vars.len(),
+        "Number of oracles is incompatible with the number of n_vars data"
+    );
+    let mut oracle_offset = 0;
+    let mut builder = ConstraintSystemBuilder::new();
+    for (module_idx, (module, module_n_vars)) in modules.iter().zip(modules_n_vars).enumerate() {
+        let Some(module_n_vars) = module_n_vars else {
+            // Deactivated module. Skip.
+            continue;
+        };
+        ensure!(
+            module_idx == module.module_id,
+            "Wrong compilation order. Expected module {module_idx}, but got {}.",
+            module.module_id
+        );
+        ensure!(
+            module.oracles.get_ref().len() == module_n_vars.len(),
+            "n_vars data length is incompatible with the number of oracles for module {module_idx}."
+        );
+
+        for (
+            oracle_id,
+            OracleInfo {
+                name,
+                tower_level,
+                kind,
+            },
+        ) in module.oracles.get_ref().iter().enumerate()
+        {
+            macro_rules! add_transparent {
+                ($t:expr) => {
+                    builder.add_transparent(name, $t)?
+                };
+            }
+            let n_vars = module_n_vars[oracle_id];
+            match kind {
+                OracleKind::Committed => builder.add_committed(name, n_vars, *tower_level),
+                OracleKind::LinearCombination { offset, inner } => {
+                    let inner = inner
+                        .iter()
+                        .map(|(oracle_id, f)| (oracle_id + oracle_offset, *f));
+                    builder.add_linear_combination_with_offset(name, n_vars, *offset, inner)?
+                }
+                OracleKind::Transparent(Transparent::Constant(c)) => match c {
+                    ConstVal::B1(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B2(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B4(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B8(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B16(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B32(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B64(b) => add_transparent!(Constant::new(n_vars, *b)),
+                    ConstVal::B128(b) => add_transparent!(Constant::new(n_vars, *b)),
+                },
+            };
+        }
+
+        for Constraint {
+            name,
+            oracle_ids,
+            composition,
+        } in &module.constraints
+        {
+            let mut oracle_ids = oracle_ids.iter().map(|o| o + oracle_offset).collect();
+            let mut composition = composition.clone();
+            composition.offset_oracles(oracle_offset);
+            let composition = composition.into_arith_expr_core(&mut oracle_ids);
+            builder.assert_zero(name, oracle_ids, composition);
+        }
+
+        for non_zero_oracle_id in &module.non_zero_oracle_ids {
+            builder.assert_not_zero(non_zero_oracle_id + oracle_offset);
+        }
+
+        for Flush {
+            oracles,
+            channel_id,
+            direction,
+            selector,
+            multiplicity,
+        } in &module.flushes
+        {
+            builder.flush_custom(
+                *direction,
+                *channel_id,
+                selector + oracle_offset,
+                oracles.iter().map(|o| o + oracle_offset),
+                *multiplicity,
+            )?;
+        }
+
+        oracle_offset += module.oracles.get_ref().len();
+    }
+    builder.build()
+}
+
+struct Constraint {
+    name: String,
+    oracle_ids: Vec<OracleId>,
+    composition: ArithExpr,
+}
+
+#[derive(Clone)]
+enum Freezable<T> {
+    Raw(T),
+    Frozen(Arc<T>),
+}
+
+impl<T: Default> Default for Freezable<T> {
+    fn default() -> Self {
+        Self::Raw(T::default())
+    }
+}
+
+impl<T> Freezable<T> {
+    fn freeze(&mut self)
+    where
+        T: Default,
+    {
+        if let Self::Raw(data) = self {
+            *self = Self::Frozen(Arc::new(std::mem::take(data)))
+        }
+    }
+
+    fn get_ref(&self) -> &T {
+        match self {
+            Self::Raw(data) => data,
+            Self::Frozen(data) => data,
+        }
+    }
+
+    fn get_mut(&mut self) -> Result<&mut T> {
+        match self {
+            Self::Raw(data) => Ok(data),
+            Self::Frozen(_) => bail!("Data is frozen"),
+        }
+    }
+
+    fn get_frozen(&self) -> Result<Arc<T>> {
+        match self {
+            Self::Raw(_) => bail!("Data is not frozen"),
+            Self::Frozen(data) => Ok(data.clone()),
+        }
+    }
+}
+
+/// A namespacing struct that caches joined paths.
+#[derive(Default)]
+struct Namespacer {
+    path: Vec<String>,
+    joined_path: Option<String>,
+}
+
+impl Namespacer {
+    fn push<S: ToString + ?Sized>(&mut self, limb: &S) {
+        self.path.push(limb.to_string());
+        self.joined_path = None;
+    }
+
+    fn pop(&mut self) {
+        self.path.pop();
+        self.joined_path = None;
+    }
+
+    fn scoped_name<S: ToString + ?Sized>(&mut self, name: &S) -> String {
+        let concat = |joined: &str, name| {
+            if joined.is_empty() {
+                name
+            } else {
+                format!("{joined}::{name}")
+            }
+        };
+        if let Some(joined) = &self.joined_path {
+            concat(joined, name.to_string())
+        } else {
+            let joined = self.path.join("::");
+            let concatenated = concat(&joined, name.to_string());
+            self.joined_path = Some(joined);
+            concatenated
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Namespacer;
+
+    #[test]
+    fn test_namespace() {
+        let test_when_empty = |namespacer: &mut Namespacer| {
+            assert_eq!(namespacer.scoped_name("a"), "a");
+            assert_eq!(namespacer.scoped_name("b"), "b");
+        };
+        let test_with_foo = |namespacer: &mut Namespacer| {
+            assert_eq!(namespacer.scoped_name("a"), "foo::a");
+        };
+        let test_with_foo_bar = |namespacer: &mut Namespacer| {
+            assert_eq!(namespacer.scoped_name("a"), "foo::bar::a");
+        };
+
+        let namespacer = &mut Namespacer::default();
+        test_when_empty(namespacer);
+
+        namespacer.pop();
+        test_when_empty(namespacer);
+
+        namespacer.push("foo");
+        test_with_foo(namespacer);
+
+        namespacer.push("bar");
+        test_with_foo_bar(namespacer);
+
+        namespacer.pop();
+        test_with_foo(namespacer);
+
+        namespacer.push("bar");
+        test_with_foo_bar(namespacer);
+
+        namespacer.pop();
+        test_with_foo(namespacer);
+
+        namespacer.pop();
+        test_when_empty(namespacer);
+    }
+}

--- a/src/archon/mod.rs
+++ b/src/archon/mod.rs
@@ -1,0 +1,29 @@
+pub mod arith_expr;
+pub mod circuit;
+pub mod protocol;
+pub mod transparent;
+pub mod witness;
+
+use binius_core::oracle::OracleId;
+use binius_field::BinaryField128b;
+
+use transparent::Transparent;
+
+pub(crate) type F = BinaryField128b;
+
+pub enum OracleKind {
+    Committed,
+    LinearCombination {
+        offset: F,
+        inner: Vec<(OracleId, F)>,
+    },
+    Transparent(Transparent),
+}
+
+pub type ModuleId = usize;
+
+pub struct OracleInfo {
+    pub name: String,
+    pub tower_level: usize,
+    pub kind: OracleKind,
+}

--- a/src/archon/protocol.rs
+++ b/src/archon/protocol.rs
@@ -1,0 +1,194 @@
+use anyhow::Result;
+use binius_circuits::builder::types::U;
+use binius_core::{
+    constraint_system::{
+        Proof as ProofCore, channel::Boundary, prove as prove_core,
+        validate::validate_witness as validate_witness_core, verify as verify_core,
+    },
+    fiat_shamir::HasherChallenger,
+    tower::CanonicalTowerFamily,
+};
+use binius_field::BinaryField8b as B8;
+use binius_hal::ComputationBackend;
+use binius_hash::compress::Groestl256ByteCompression;
+use binius_math::EvaluationDomainFactory;
+use groestl_crypto::Groestl256;
+
+use super::{
+    F,
+    circuit::{CircuitModule, compile_circuit_modules},
+    witness::Witness,
+};
+
+pub struct Proof {
+    proof_core: ProofCore,
+    modules_n_vars: Vec<Option<Vec<usize>>>,
+}
+
+pub fn validate_witness(
+    circuit_modules: &[CircuitModule],
+    witness: &Witness<'_>,
+    boundaries: &[Boundary<F>],
+) -> Result<()> {
+    let Witness {
+        mlei,
+        modules_n_vars,
+    } = witness;
+    let constraint_system = compile_circuit_modules(circuit_modules, modules_n_vars)?;
+    validate_witness_core(&constraint_system, boundaries, mlei)?;
+    Ok(())
+}
+
+pub fn prove<DomainFactory, Backend>(
+    circuit_modules: &[CircuitModule],
+    witness: Witness<'_>,
+    boundaries: &[Boundary<F>],
+    log_inv_rate: usize,
+    security_bits: usize,
+    domain_factory: &DomainFactory,
+    backend: &Backend,
+) -> Result<Proof>
+where
+    Backend: ComputationBackend,
+    DomainFactory: EvaluationDomainFactory<B8>,
+{
+    let Witness {
+        mlei,
+        modules_n_vars,
+    } = witness;
+    let constraint_system = compile_circuit_modules(circuit_modules, &modules_n_vars)?;
+    let proof_core = prove_core::<
+        U,
+        CanonicalTowerFamily,
+        _,
+        Groestl256,
+        Groestl256ByteCompression,
+        HasherChallenger<Groestl256>,
+        _,
+    >(
+        &constraint_system,
+        log_inv_rate,
+        security_bits,
+        boundaries,
+        mlei,
+        domain_factory,
+        backend,
+    )?;
+    Ok(Proof {
+        proof_core,
+        modules_n_vars,
+    })
+}
+
+pub fn verify(
+    circuit_modules: &[CircuitModule],
+    boundaries: &[Boundary<F>],
+    proof: Proof,
+    log_inv_rate: usize,
+    security_bits: usize,
+) -> Result<()> {
+    let Proof {
+        proof_core,
+        modules_n_vars,
+    } = proof;
+    let constraint_system = compile_circuit_modules(circuit_modules, &modules_n_vars)?;
+    verify_core::<
+        U,
+        CanonicalTowerFamily,
+        Groestl256,
+        Groestl256ByteCompression,
+        HasherChallenger<Groestl256>,
+    >(
+        &constraint_system,
+        log_inv_rate,
+        security_bits,
+        boundaries,
+        proof_core,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use binius_core::oracle::OracleId;
+    use binius_field::{BinaryField1b, TowerField};
+
+    use crate::archon::{
+        ModuleId,
+        arith_expr::ArithExpr,
+        circuit::{CircuitModule, init_witness_modules},
+        protocol::validate_witness,
+        witness::{WitnessModule, compile_witness_modules},
+    };
+
+    struct Oracles {
+        a: OracleId,
+        b: OracleId,
+    }
+
+    fn a_xor_b_circuit_module(module_id: ModuleId) -> Result<(CircuitModule, Oracles)> {
+        let mut circuit_module = CircuitModule::new(module_id);
+        let a = circuit_module.add_committed("a", BinaryField1b::TOWER_LEVEL)?;
+        let b = circuit_module.add_committed("b", BinaryField1b::TOWER_LEVEL)?;
+        circuit_module.assert_zero("a xor b", [], ArithExpr::Oracle(a) + ArithExpr::Oracle(b));
+        circuit_module.freeze_oracles();
+        Ok((circuit_module, Oracles { a, b }))
+    }
+
+    fn populate_a_xor_b_witness_with_zeros(witness_module: &mut WitnessModule, oracles: &Oracles) {
+        let zeros = witness_module.new_entry_with_capacity(7);
+        witness_module.push_u128_to(0, zeros);
+        witness_module.bind_oracle_to(oracles.a, zeros);
+        witness_module.bind_oracle_to(oracles.b, zeros);
+    }
+
+    #[test]
+    fn test_invalid_witness() {
+        let (circuit_module, oracles) = a_xor_b_circuit_module(0).unwrap();
+        let mut witness_module = circuit_module.init_witness_module().unwrap();
+        let a = witness_module.new_entry_with_capacity(7);
+        let b = witness_module.new_entry_with_capacity(7);
+        witness_module.push_u128_to(0, a);
+        witness_module.push_u128_to(1, b);
+        witness_module.bind_oracle_to(oracles.a, a);
+        witness_module.bind_oracle_to(oracles.b, b);
+        let witness_modules = [witness_module];
+        let witness = compile_witness_modules(&witness_modules).unwrap();
+        assert!(validate_witness(&[circuit_module], &witness, &[]).is_err());
+    }
+
+    #[test]
+    fn test_single_module() {
+        let (circuit_module, oracles) = a_xor_b_circuit_module(0).unwrap();
+        let mut witness_module = circuit_module.init_witness_module().unwrap();
+        populate_a_xor_b_witness_with_zeros(&mut witness_module, &oracles);
+        let witness_modules = [witness_module];
+        let witness = compile_witness_modules(&witness_modules).unwrap();
+        assert!(validate_witness(&[circuit_module], &witness, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_multiple_modules() {
+        let (circuit_module0, oracles0) = a_xor_b_circuit_module(0).unwrap();
+        let (circuit_module1, oracles1) = a_xor_b_circuit_module(1).unwrap();
+        let circuit_modules = [circuit_module0, circuit_module1];
+        let mut witness_modules = init_witness_modules(&circuit_modules).unwrap();
+        populate_a_xor_b_witness_with_zeros(&mut witness_modules[0], &oracles0);
+        populate_a_xor_b_witness_with_zeros(&mut witness_modules[1], &oracles1);
+        let witness = compile_witness_modules(&witness_modules).unwrap();
+        assert!(validate_witness(&circuit_modules, &witness, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_deactivated_module() {
+        let (circuit_module0, oracles0) = a_xor_b_circuit_module(0).unwrap();
+        let (circuit_module1, _) = a_xor_b_circuit_module(1).unwrap();
+        let circuit_modules = [circuit_module0, circuit_module1];
+        let mut witness_modules = init_witness_modules(&circuit_modules).unwrap();
+        populate_a_xor_b_witness_with_zeros(&mut witness_modules[0], &oracles0);
+        // Witness module 1 isn't populated
+        let witness = compile_witness_modules(&witness_modules).unwrap();
+        assert!(validate_witness(&circuit_modules, &witness, &[]).is_ok());
+    }
+}

--- a/src/archon/transparent.rs
+++ b/src/archon/transparent.rs
@@ -1,0 +1,45 @@
+use binius_field::{
+    BinaryField1b as B1, BinaryField2b as B2, BinaryField4b as B4, BinaryField8b as B8,
+    BinaryField16b as B16, BinaryField32b as B32, BinaryField64b as B64, BinaryField128b as B128,
+    TowerField,
+};
+
+pub enum Transparent {
+    Constant(ConstVal),
+}
+
+impl Transparent {
+    #[inline]
+    pub(crate) fn tower_level(&self) -> usize {
+        match self {
+            Self::Constant(c) => c.tower_level(),
+        }
+    }
+}
+
+pub enum ConstVal {
+    B1(B1),
+    B2(B2),
+    B4(B4),
+    B8(B8),
+    B16(B16),
+    B32(B32),
+    B64(B64),
+    B128(B128),
+}
+
+impl ConstVal {
+    #[inline]
+    fn tower_level(&self) -> usize {
+        match self {
+            Self::B1(_) => B1::TOWER_LEVEL,
+            Self::B2(_) => B2::TOWER_LEVEL,
+            Self::B4(_) => B4::TOWER_LEVEL,
+            Self::B8(_) => B8::TOWER_LEVEL,
+            Self::B16(_) => B16::TOWER_LEVEL,
+            Self::B32(_) => B32::TOWER_LEVEL,
+            Self::B64(_) => B64::TOWER_LEVEL,
+            Self::B128(_) => B128::TOWER_LEVEL,
+        }
+    }
+}

--- a/src/archon/witness.rs
+++ b/src/archon/witness.rs
@@ -1,0 +1,170 @@
+use anyhow::{Context, Result, bail, ensure};
+use binius_core::{oracle::OracleId, witness::MultilinearExtensionIndex};
+use binius_field::{
+    BinaryField1b as B1, BinaryField2b as B2, BinaryField4b as B4, BinaryField8b as B8,
+    BinaryField16b as B16, BinaryField32b as B32, BinaryField64b as B64, BinaryField128b as B128,
+    arch::OptimalUnderlier,
+    as_packed_field::PackedType,
+    underlier::{UnderlierType, WithUnderlier},
+};
+use binius_math::MultilinearExtension;
+use binius_utils::checked_arithmetics::log2_strict_usize;
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use std::{collections::HashMap, sync::Arc};
+
+use super::{ModuleId, OracleInfo};
+
+pub type EntryId = usize;
+
+pub struct WitnessModule {
+    module_id: ModuleId,
+    oracles: Arc<Vec<OracleInfo>>,
+    entries: Vec<Vec<OptimalUnderlier>>,
+    entry_map: FxHashMap<OracleId, EntryId>,
+}
+
+pub struct Witness<'a> {
+    pub(crate) mlei: MultilinearExtensionIndex<'a, OptimalUnderlier, B128>,
+    /// The sets of `n_vars` for each module. `None` means that the circuit
+    /// module needs to be deactivated/skipped at compilation time.
+    pub(crate) modules_n_vars: Vec<Option<Vec<usize>>>,
+}
+
+impl Witness<'_> {
+    #[inline]
+    fn with_capacity(num_modules: usize) -> Self {
+        Self {
+            mlei: MultilinearExtensionIndex::new(),
+            modules_n_vars: Vec::with_capacity(num_modules),
+        }
+    }
+}
+
+pub fn compile_witness_modules(modules: &[WitnessModule]) -> Result<Witness<'_>> {
+    let mut witness = Witness::with_capacity(modules.len());
+    let mut oracle_offset = 0;
+    for (module_idx, module) in modules.iter().enumerate() {
+        ensure!(
+            module_idx == module.module_id,
+            "Wrong compilation order. Expected module {module_idx}, but got {}.",
+            module.module_id
+        );
+        if module.entry_map.is_empty() {
+            witness.modules_n_vars.push(None);
+            continue;
+        }
+        let oracles_data = module
+            .oracles
+            .par_iter()
+            .enumerate()
+            .map(|(oracle_id, oracle_info)| {
+                let OracleInfo { tower_level, .. } = oracle_info;
+                let Some(entry_id) = module.entry_map.get(&oracle_id) else {
+                    bail!("Entry not found for oracle {oracle_id}, module {module_idx}.");
+                };
+                let entry = &module.entries[*entry_id];
+                ensure!(
+                    entry.len().is_power_of_two(),
+                    "Length of entry {entry_id}, bound to oracle {oracle_id}, module {module_idx}, is not a power of two."
+                );
+                let n_vars = log2_strict_usize(entry.len()) + OptimalUnderlier::LOG_BITS - tower_level;
+                macro_rules! oracle_poly {
+                    ($bf:ident) => {{
+                        let values =
+                            PackedType::<OptimalUnderlier, $bf>::from_underliers_ref(entry);
+                        let mle = MultilinearExtension::from_values_generic(values)
+                            .context(format!(
+                                "MLE instantiation for entry {entry_id}, oracle {oracle_id}, module {module_idx}"
+                            ))?
+                            .specialize_arc_dyn();
+                        Ok(((oracle_offset + oracle_id, mle), n_vars))
+                    }};
+                }
+                match tower_level {
+                    0 => oracle_poly!(B1),
+                    1 => oracle_poly!(B2),
+                    2 => oracle_poly!(B4),
+                    3 => oracle_poly!(B8),
+                    4 => oracle_poly!(B16),
+                    5 => oracle_poly!(B32),
+                    6 => oracle_poly!(B64),
+                    7 => oracle_poly!(B128),
+                    _ => bail!(
+                        "Unsupported tower level {tower_level} for oracle {oracle_id}, module {module_idx}"
+                    ),
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut oracle_poly_vec = Vec::with_capacity(oracles_data.len());
+        let mut n_vars_vec = Vec::with_capacity(oracles_data.len());
+        for oracle_data_result in oracles_data {
+            let (oracle_poly, n_vars) = oracle_data_result?;
+            oracle_poly_vec.push(oracle_poly);
+            n_vars_vec.push(n_vars);
+        }
+        witness.mlei.update_multilin_poly(oracle_poly_vec)?;
+        witness.modules_n_vars.push(Some(n_vars_vec));
+        oracle_offset += module.oracles.len();
+    }
+    Ok(witness)
+}
+
+impl WitnessModule {
+    #[inline]
+    pub fn new_entry(&mut self) -> EntryId {
+        self.entries.push(vec![]);
+        self.entries.len() - 1
+    }
+
+    #[inline]
+    pub fn new_entry_with_capacity(&mut self, log_bits: usize) -> EntryId {
+        let num_underliers = (1 << log_bits) / OptimalUnderlier::BITS;
+        self.entries.push(Vec::with_capacity(num_underliers));
+        self.entries.len() - 1
+    }
+
+    #[inline]
+    pub fn bind_oracle_to(&mut self, oracle_id: OracleId, entry_id: EntryId) {
+        self.entry_map.insert(oracle_id, entry_id);
+    }
+
+    #[inline]
+    pub fn push_u8s_to(&mut self, u8s: [u8; 16], entry_id: EntryId) {
+        self.entries[entry_id].push(OptimalUnderlier::from_u128(u128::from_le_bytes(u8s)))
+    }
+
+    #[inline]
+    pub fn push_u16s_to(&mut self, u16s: [u16; 8], entry_id: EntryId) {
+        let u128 = unsafe { std::mem::transmute::<[u16; 8], u128>(u16s) };
+        self.entries[entry_id].push(OptimalUnderlier::from_u128(u128))
+    }
+
+    #[inline]
+    pub fn push_u32s_to(&mut self, u32s: [u32; 4], entry_id: EntryId) {
+        let u128 = unsafe { std::mem::transmute::<[u32; 4], u128>(u32s) };
+        self.entries[entry_id].push(OptimalUnderlier::from_u128(u128))
+    }
+
+    #[inline]
+    pub fn push_u64s_to(&mut self, u64s: [u64; 2], entry_id: EntryId) {
+        let u128 = unsafe { std::mem::transmute::<[u64; 2], u128>(u64s) };
+        self.entries[entry_id].push(OptimalUnderlier::from_u128(u128))
+    }
+
+    #[inline]
+    pub fn push_u128_to(&mut self, u128: u128, entry_id: EntryId) {
+        self.entries[entry_id].push(OptimalUnderlier::from_u128(u128))
+    }
+
+    #[inline]
+    pub(crate) fn new(module_id: ModuleId, oracles: Arc<Vec<OracleInfo>>) -> Self {
+        let num_oracles = oracles.len();
+        Self {
+            module_id,
+            oracles,
+            entries: vec![],
+            entry_map: HashMap::with_capacity_and_hasher(num_oracles, FxBuildHasher),
+        }
+    }
+}

--- a/src/lean/ffi/binius_arith_expr.rs
+++ b/src/lean/ffi/binius_arith_expr.rs
@@ -1,9 +1,7 @@
 use binius_field::BinaryField128b;
 use binius_math::ArithExpr;
 
-use crate::lean::{
-    boxed::BoxedUSize, ctor::LeanCtorObject, ffi::as_ref_unsafe, sarray::LeanSArrayObject,
-};
+use crate::lean::{ctor::LeanCtorObject, ffi::as_ref_unsafe, sarray::LeanSArrayObject};
 
 use super::binius::external_ptr_to_u128;
 
@@ -17,9 +15,8 @@ pub(super) fn lean_ctor_to_arith_expr(ctor: &LeanCtorObject) -> ArithExpr<Binary
         }
         1 => {
             // Var
-            let [boxed_usize_ptr] = ctor.objs();
-            let boxed_usize = as_ref_unsafe(boxed_usize_ptr.cast::<BoxedUSize>());
-            ArithExpr::Var(boxed_usize.value)
+            let [ptr_as_usize] = ctor.objs();
+            ArithExpr::Var(ptr_as_usize as usize)
         }
         2 => {
             // Add

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod aiur;
+pub mod archon;
 pub mod lean;


### PR DESCRIPTION
The `archon` crate is an abstraction layer on top of Binius that enables the construction of self-contained circuit modules, whose respective witnesses can be populated independently.

Building a circuit module doesn't require knowledge about witness size, which qualifies a set of circuit modules as a stable protocol contract between provers and verifiers.

When compiling witness modules, empty ones are skipped, meaning the corresponding circuit module will be considered deactivated.

Compilation is the process of aggregating multiple modules into a single entity. Witness modules are compiled into a `Witness` and circuit modules are compiled into a `ConstraintSystem` (from the `binius` crate). But since `ConstraintSystem` needs the sizes of the populated oracles, compiling circuit modules requires this information, which is present on the compiled `Witness`.

The `protocol.rs` file puts all this together, providing the functions `validate_witness`, `prove` and `verify`.

This patch doesn't include the following planned features:
* Automatic versioning of canonicalized circuit modules
* Automatic populating logic for oracles that can be computed