### PR TITLE
chore: fixed n_vars for every oracle in a module

### DIFF
--- a/src/archon/protocol.rs
+++ b/src/archon/protocol.rs
@@ -22,7 +22,7 @@ use super::{
 
 pub struct Proof {
     proof_core: ProofCore,
-    modules_n_vars: Vec<Option<Vec<usize>>>,
+    modules_n_vars: Vec<u8>,
 }
 
 pub fn validate_witness(


### PR DESCRIPTION
Force every oracle in a circuit/witness module to have the same size. Also, represent this size as an `u8` because it's in the logarithmic scale.