### PR TITLE
feat: `add_shifted` and `add_projected`

### DIFF
--- a/Ix/Archon/Circuit.lean
+++ b/Ix/Archon/Circuit.lean
@@ -10,6 +10,9 @@ private opaque GenericNonempty : NonemptyType
 def CircuitModule : Type := GenericNonempty.type
 instance : Nonempty CircuitModule := GenericNonempty.property
 
+inductive ShiftVariant
+  | circularLeft | logicalLeft | logicalRight
+
 namespace CircuitModule
 
 @[never_extract, extern "c_rs_circuit_module_new"]
@@ -55,6 +58,16 @@ opaque addLinearCombination : CircuitModule → @& String → (offset : @& UInt1
 @[never_extract, extern "c_rs_circuit_module_add_packed"]
 opaque addPacked : CircuitModule → @& String → OracleId →
   (logDegree : USize) → OracleId × CircuitModule
+
+/-- **Invalidates** the input `CircuitModule` -/
+@[never_extract, extern "c_rs_circuit_module_add_shifted"]
+opaque addShifted : CircuitModule → @& String → OracleId → (shiftOffset : UInt32) →
+  (blockBits : USize) → @& ShiftVariant → OracleId × CircuitModule
+
+/-- **Invalidates** the input `CircuitModule` -/
+@[never_extract, extern "c_rs_circuit_module_add_projected"]
+opaque addProjected : CircuitModule → @& String → OracleId → (mask : UInt64) →
+  OracleId × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_push_namespace"]

--- a/Ix/Archon/Witness.lean
+++ b/Ix/Archon/Witness.lean
@@ -44,7 +44,7 @@ opaque populate : WitnessModule → (height : UInt64) → WitnessModule
 
 end WitnessModule
 
-/-- **Invalidates** the input `Array WitnessModule` -/
+/-- **Invalidates** the elements of the input `Array WitnessModule` -/
 @[never_extract, extern "c_rs_compile_witness_modules"]
 opaque compileWitnessModules : Array WitnessModule → (heights : @& Array UInt64) → Witness
 

--- a/c/archon.c
+++ b/c/archon.c
@@ -225,20 +225,66 @@ extern lean_obj_res c_rs_circuit_module_add_linear_combination(
 extern lean_obj_res c_rs_circuit_module_add_packed(
     lean_obj_arg l_circuit,
     b_lean_obj_arg name,
-    size_t oracle_id,
+    size_t inner,
     size_t log_degree
 ) {
     linear_object *linear = validated_linear(l_circuit);
     char const *chars = lean_string_cstr(name);
-    size_t oracle_id2 = rs_circuit_module_add_packed(
+    size_t oracle_id = rs_circuit_module_add_packed(
         get_object_ref(linear),
         chars,
-        oracle_id,
+        inner,
         log_degree
     );
     linear_object *new_linear = linear_bump(linear);
     lean_obj_res tuple = lean_alloc_ctor(0, 2, 0);
-    lean_ctor_set(tuple, 0, lean_box_usize(oracle_id2));
+    lean_ctor_set(tuple, 0, lean_box_usize(oracle_id));
+    lean_ctor_set(tuple, 1, alloc_lean_linear_object(new_linear));
+    return tuple;
+}
+
+extern lean_obj_res c_rs_circuit_module_add_shifted(
+    lean_obj_arg l_circuit,
+    b_lean_obj_arg name,
+    size_t inner,
+    uint32_t shift_offset,
+    size_t block_bits,
+    uint8_t shift_variant
+) {
+    linear_object *linear = validated_linear(l_circuit);
+    char const *chars = lean_string_cstr(name);
+    size_t oracle_id = rs_circuit_module_add_shifted(
+        get_object_ref(linear),
+        chars,
+        inner,
+        shift_offset,
+        block_bits,
+        shift_variant
+    );
+    linear_object *new_linear = linear_bump(linear);
+    lean_obj_res tuple = lean_alloc_ctor(0, 2, 0);
+    lean_ctor_set(tuple, 0, lean_box_usize(oracle_id));
+    lean_ctor_set(tuple, 1, alloc_lean_linear_object(new_linear));
+    return tuple;
+}
+
+extern lean_obj_res c_rs_circuit_module_add_projected(
+    lean_obj_arg l_circuit,
+    b_lean_obj_arg name,
+    size_t inner,
+    uint64_t mask
+) {
+    linear_object *linear = validated_linear(l_circuit);
+    char const *chars = lean_string_cstr(name);
+    size_t oracle_id = rs_circuit_module_add_projected(
+        get_object_ref(linear),
+        chars,
+        inner,
+        mask
+    );
+    linear_object *new_linear = linear_bump(linear);
+    lean_obj_res tuple = lean_alloc_ctor(0, 2, 0);
+    lean_ctor_set(tuple, 0, lean_box_usize(oracle_id));
     lean_ctor_set(tuple, 1, alloc_lean_linear_object(new_linear));
     return tuple;
 }

--- a/c/rust.h
+++ b/c/rust.h
@@ -26,16 +26,20 @@ void rs_circuit_module_free(void*);
 void rs_circuit_module_freeze_oracles(void*);
 void *rs_circuit_module_init_witness_module(void*);
 void rs_circuit_module_flush(void*, bool, size_t, b_lean_obj_arg, uint64_t);
-void rs_circuit_module_assert_zero(void*, char const*, b_lean_obj_arg, b_lean_obj_arg);
+void rs_circuit_module_assert_zero(
+    void*, char const*, b_lean_obj_arg, b_lean_obj_arg
+);
 void rs_circuit_module_assert_not_zero(void*, size_t);
 size_t rs_circuit_module_add_committed(void*, char const *, uint8_t);
 size_t rs_circuit_module_add_transparent(void*, char const *, b_lean_obj_arg);
 size_t rs_circuit_module_add_linear_combination(
     void*, char const *, b_lean_obj_arg, b_lean_obj_arg
 );
-size_t rs_circuit_module_add_packed(
-    void*, char const *, size_t, size_t
+size_t rs_circuit_module_add_packed(void*, char const *, size_t, size_t);
+size_t rs_circuit_module_add_shifted(
+    void*, char const *, size_t, uint32_t, size_t, uint8_t
 );
+size_t rs_circuit_module_add_projected(void*, char const *, size_t, uint64_t);
 void rs_circuit_module_push_namespace(void*, char const *);
 void rs_circuit_module_pop_namespace(void*);
 

--- a/src/archon/mod.rs
+++ b/src/archon/mod.rs
@@ -25,14 +25,14 @@ pub enum OracleKind {
     StepDown,
     Shifted {
         inner: OracleId,
-        shift_offset: usize,
+        shift_offset: u32,
         block_bits: usize,
         variant: ShiftVariant,
     },
     Projected {
         inner: OracleId,
-        selector: u64,
-        selector_binary: Vec<F>,
+        mask: u64,
+        mask_bits: Vec<F>,
     },
 }
 


### PR DESCRIPTION
Implement `CircuitModule.add_shifted` and `CircuitModule.add_projected` for Archon.

Since there's an issue with witness generation for projected columns, a test will be added later.