### PR TITLE
feat: versioning Archon circuit modules

### DIFF
--- a/Ix/Archon/Circuit.lean
+++ b/Ix/Archon/Circuit.lean
@@ -1,3 +1,4 @@
+import Blake3
 import Ix.Archon.ArithExpr
 import Ix.Archon.Transparent
 import Ix.Archon.Witness
@@ -78,5 +79,8 @@ opaque pushNamespace : CircuitModule → @& String → CircuitModule
 opaque popNamespace : CircuitModule → CircuitModule
 
 end CircuitModule
+
+@[extern "c_rs_circuit_module_version"]
+opaque version : @& Array CircuitModule → Blake3.Blake3Hash
 
 end Archon

--- a/Tests/Archon.lean
+++ b/Tests/Archon.lean
@@ -1,6 +1,7 @@
 import LSpec
 import Ix.Archon.Circuit
 import Ix.Archon.Protocol
+import Ix.ByteArray
 
 open LSpec Archon
 
@@ -98,10 +99,20 @@ def proveAndVerify : TestSeq :=
   withExceptOk "Archon prove and verify work"
     (verify #[circuitModule] #[] 1 100 proof) fun _ => .done
 
+def versionCircuitModules : TestSeq :=
+  let c₁ := CircuitModule.new 0
+  let (_, c₁) := c₁.addCommitted "a" .b1
+  let c₂ := CircuitModule.new 0
+  let (_, c₂) := c₂.addCommitted "b" .b1
+  let v₁ := version #[c₁]
+  let v₂ := version #[c₂]
+  test "Circuit module versioning is name-irrelevant" (v₁.val == v₂.val)
+
 def Tests.Archon.suite := [
     transparent,
     linearCombination,
     packed,
     shifted,
     proveAndVerify,
+    versionCircuitModules,
   ]

--- a/c/archon.c
+++ b/c/archon.c
@@ -311,6 +311,19 @@ extern lean_obj_res c_rs_circuit_module_pop_namespace(lean_obj_arg l_circuit) {
     return alloc_lean_linear_object(new_linear);
 }
 
+extern lean_obj_res c_rs_circuit_module_version(b_lean_obj_arg l_circuit_modules) {
+    size_t num_modules = lean_array_size(l_circuit_modules);
+    lean_object **modules_cptrs = lean_array_cptr(l_circuit_modules);
+    void *modules_ptrs[num_modules];
+    for (size_t i = 0; i < num_modules; i++) {
+        linear_object *linear = validated_linear(modules_cptrs[i]);
+        modules_ptrs[i] = get_object_ref(linear);
+    }
+    lean_object *byte_array = lean_alloc_sarray(1, 32, 32);
+    rs_circuit_module_version(num_modules, modules_ptrs, lean_sarray_cptr(byte_array));
+    return byte_array;
+}
+
 /* --- Protocol --- */
 
 extern lean_obj_res c_rs_validate_witness(

--- a/c/rust.h
+++ b/c/rust.h
@@ -42,6 +42,7 @@ size_t rs_circuit_module_add_shifted(
 size_t rs_circuit_module_add_projected(void*, char const *, size_t, uint64_t, size_t, size_t);
 void rs_circuit_module_push_namespace(void*, char const *);
 void rs_circuit_module_pop_namespace(void*);
+void rs_circuit_module_version(size_t, void**, uint8_t*);
 
 /* --- Archon protocol --- */
 

--- a/src/archon/circuit.rs
+++ b/src/archon/circuit.rs
@@ -38,12 +38,12 @@ pub fn init_witness_modules(circuit_modules: &[CircuitModule]) -> Result<Vec<Wit
 }
 
 pub struct CircuitModule {
-    module_id: ModuleId,
-    oracles: Freezable<Vec<OracleInfo>>,
-    flushes: Vec<Flush<F>>,
-    constraints: Vec<Constraint>,
-    non_zero_oracle_ids: Vec<OracleId>,
-    namespacer: Namespacer,
+    pub(super) module_id: ModuleId,
+    pub(super) oracles: Freezable<Vec<OracleInfo>>,
+    pub(super) flushes: Vec<Flush<F>>,
+    pub(super) constraints: Vec<Constraint>,
+    pub(super) non_zero_oracle_ids: Vec<OracleId>,
+    pub(super) namespacer: Namespacer,
 }
 
 impl CircuitModule {
@@ -396,14 +396,14 @@ pub fn compile_circuit_modules(
     builder.build()
 }
 
-struct Constraint {
-    name: String,
-    oracle_ids: Vec<OracleId>,
-    composition: ArithExpr,
+pub(super) struct Constraint {
+    pub(super) name: String,
+    pub(super) oracle_ids: Vec<OracleId>,
+    pub(super) composition: ArithExpr,
 }
 
 #[derive(Clone)]
-enum Freezable<T> {
+pub(super) enum Freezable<T> {
     Raw(T),
     Frozen(Arc<T>),
 }
@@ -418,7 +418,7 @@ impl<T> Freezable<T> {
         }
     }
 
-    fn get_ref(&self) -> &T {
+    pub(super) fn get_ref(&self) -> &T {
         match self {
             Self::Raw(data) => data,
             Self::Frozen(data) => data,
@@ -442,7 +442,7 @@ impl<T> Freezable<T> {
 
 /// A namespacing struct that caches joined paths.
 #[derive(Default)]
-struct Namespacer {
+pub(super) struct Namespacer {
     path: Vec<String>,
     joined_path: Option<String>,
 }

--- a/src/archon/mod.rs
+++ b/src/archon/mod.rs
@@ -1,4 +1,5 @@
 pub mod arith_expr;
+pub mod canonical;
 pub mod circuit;
 pub mod precompiles;
 pub mod protocol;

--- a/src/lean/ffi/archon/circuit.rs
+++ b/src/lean/ffi/archon/circuit.rs
@@ -9,8 +9,9 @@ use binius_field::{
 use std::ffi::c_char;
 
 use crate::{
-    archon::{ModuleId, circuit::CircuitModule, witness::WitnessModule},
+    archon::{ModuleId, canonical::version, circuit::CircuitModule, witness::WitnessModule},
     lean::{
+        CArray,
         array::LeanArrayObject,
         ctor::LeanCtorObject,
         ffi::{
@@ -195,4 +196,14 @@ extern "C" fn rs_circuit_module_push_namespace(
 #[unsafe(no_mangle)]
 extern "C" fn rs_circuit_module_pop_namespace(circuit_module: &mut CircuitModule) {
     circuit_module.pop_namespace();
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rs_circuit_module_version(
+    num_modules: usize,
+    circuit_modules: &CArray<&CircuitModule>,
+    buffer: &mut [u8; 32],
+) {
+    let circuit_modules = circuit_modules.slice(num_modules);
+    buffer.copy_from_slice(version(circuit_modules).as_bytes());
 }


### PR DESCRIPTION
Implement name-irrelevant versioning for `CircuitModule` and provide a Lean binding for it. The version of a sequence of circuit modules (a slice in Rust and an array in Lean) is a Blake3 hash.