### PR TITLE
feat: serde for Archon proofs

### DIFF
--- a/Ix/Archon/Protocol.lean
+++ b/Ix/Archon/Protocol.lean
@@ -24,4 +24,30 @@ opaque prove : @& Array CircuitModule → @& Array Boundary →
 opaque verify : @& Array CircuitModule → @& Array Boundary →
   (logInvRate securitiByts : USize) → Proof → Except String Unit
 
+/--
+Serialize an Archon proof as a `ByteArray`.
+* The 2 first bytes form an `UInt16` that tells how many modules there are
+* Then, chunks of 8 bytes form `UInt64`s that tell the heights for each module
+* Finally, the rest of the bytes compose the Binius proof transcript
+-/
+@[extern "c_rs_proof_to_bytes"]
+opaque Proof.toBytes : @& Proof → ByteArray
+
+@[extern "c_rs_proof_of_bytes"]
+private opaque Proof.ofBytes' : @& ByteArray → Proof
+
+def Proof.ofBytes (bytes : ByteArray) : Except String Proof :=
+  let size := bytes.size
+  if _ : 1 < size then -- 2 bytes are needed for the first `u16`
+    let b₀ := bytes[0]
+    let b₁ := bytes[1]
+    let numModules := b₀.toNat + 256 * b₁.toNat
+    let numHeightsBytes := numModules * 8 -- 8 bytes (an `u64`) for each module height
+    if size < 2 + numHeightsBytes then
+      .error "Not enough data to read modules heights"
+    else
+      .ok $ Proof.ofBytes' bytes
+  else
+    .error "Not enough data to read the number of modules"
+
 end Archon

--- a/Tests/Archon.lean
+++ b/Tests/Archon.lean
@@ -96,8 +96,10 @@ def proveAndVerify : TestSeq :=
   let witnessModule := witnessModule.populate height
   let witness := compileWitnessModules #[witnessModule] #[height]
   let proof := prove #[circuitModule] #[] 1 100 witness
-  withExceptOk "Archon prove and verify work"
-    (verify #[circuitModule] #[] 1 100 proof) fun _ => .done
+  let proofBytes := proof.toBytes
+  withExceptOk "Archon proof serde works" (Proof.ofBytes proofBytes) fun proof =>
+    withExceptOk "Archon prove and verify work"
+      (verify #[circuitModule] #[] 1 100 proof) fun _ => .done
 
 def versionCircuitModules : TestSeq :=
   let c₁ := CircuitModule.new 0

--- a/c/archon.c
+++ b/c/archon.c
@@ -388,10 +388,7 @@ extern lean_obj_res c_rs_prove(
     );
     ditch_linear(witness_linear);
 
-    linear_object *proof_linear = linear_object_init(
-        proof,
-        &rs_proof_free
-    );
+    linear_object *proof_linear = linear_object_init(proof, &rs_proof_free);
     return alloc_lean_linear_object(proof_linear);
 }
 
@@ -434,4 +431,19 @@ extern lean_obj_res c_rs_verify(
     rs__c_result_unit_string_free(result);
 
     return except;
+}
+
+extern lean_obj_res c_rs_proof_to_bytes(b_lean_obj_arg l_proof) {
+    linear_object *proof_linear = validated_linear(l_proof);
+    void *proof = get_object_ref(proof_linear);
+    size_t proof_size = rs_proof_size(proof);
+    lean_object *byte_array = lean_alloc_sarray(1, proof_size, proof_size);
+    rs_proof_to_bytes(proof, proof_size, lean_sarray_cptr(byte_array));
+    return byte_array;
+}
+
+extern lean_obj_res c_rs_proof_of_bytes(b_lean_obj_arg byte_array) {
+    void *proof = rs_proof_of_bytes(byte_array);
+    linear_object *proof_linear = linear_object_init(proof, &rs_proof_free);
+    return alloc_lean_linear_object(proof_linear);
 }

--- a/c/rust.h
+++ b/c/rust.h
@@ -50,6 +50,9 @@ c_result *rs_validate_witness(size_t, void**, b_lean_obj_arg, void*);
 void rs_proof_free(void*);
 void *rs_prove(size_t, void**, b_lean_obj_arg, size_t, size_t, void*);
 c_result *rs_verify(size_t, void**, b_lean_obj_arg, size_t, size_t, void*);
+size_t rs_proof_size(void*);
+void rs_proof_to_bytes(void*, size_t, uint8_t*);
+void *rs_proof_of_bytes(b_lean_obj_arg);
 
 /* --- Iroh --- */
 

--- a/src/archon/protocol.rs
+++ b/src/archon/protocol.rs
@@ -19,15 +19,15 @@ use super::{
 };
 
 pub struct Proof {
-    proof_core: ProofCore,
-    modules_heights: Vec<u64>,
+    pub(crate) modules_heights: Vec<u64>,
+    pub(crate) proof_core: ProofCore,
 }
 
 impl Default for Proof {
     fn default() -> Self {
         Proof {
-            proof_core: ProofCore { transcript: vec![] },
             modules_heights: vec![],
+            proof_core: ProofCore { transcript: vec![] },
         }
     }
 }
@@ -88,8 +88,8 @@ pub fn prove_core<Backend: ComputationBackend>(
         backend,
     )?;
     Ok(Proof {
-        proof_core,
         modules_heights,
+        proof_core,
     })
 }
 
@@ -120,8 +120,8 @@ pub fn verify_core(
     security_bits: usize,
 ) -> Result<()> {
     let Proof {
-        proof_core,
         modules_heights,
+        proof_core,
     } = proof;
     let constraint_system = compile_circuit_modules(circuit_modules, &modules_heights)?;
     verify_binius::<

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -23,7 +23,7 @@ impl<T> CArray<T> {
     }
 
     #[inline]
-    pub fn copy_from_slice(&self, src: &[T]) {
+    pub fn copy_from_slice(&mut self, src: &[T]) {
         unsafe {
             std::ptr::copy_nonoverlapping(src.as_ptr(), self.0.as_ptr() as *mut _, src.len());
         }


### PR DESCRIPTION
Since we're interfacing Lean and Rust, we need complete control the serde process. Hence we can't use traits for automatic serde derivations.