### PR TITLE
ci: Add MacOS aarch64-darwin runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,34 @@ concurrency:
 
 jobs:
   lean-jobs:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install GCC on MacOS
+        if: contains(matrix.os, 'macos')
+        run: |
+          /opt/homebrew/bin/gcc-14 --version
+          mkdir -p ~/local/bin
+          ln -sf /opt/homebrew/bin/gcc-14 ~/local/bin/gcc
+          export PATH=~/local/bin:$PATH
+          which gcc
       - uses: leanprover/lean-action@v1 # https://github.com/leanprover/lean-action
         with:
-          build-args: "--wfail"
+          build-args: "--wfail -v"
           test: true
+      - name: Test Ix CLI
+        run: lake test -v -- cli
       - name: Check lean.h.hash
         run: lake run check-lean-h-hash
 
   rust-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +53,10 @@ jobs:
         run: cargo nextest run --release --profile ci --workspace --run-ignored all
 
   rust-lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,9 +71,11 @@ jobs:
       - name: Check clippy warnings
         run: cargo xclippy -D warnings
       - name: Get Rust version
+        if: contains(matrix.os, 'ubuntu')
         run: |
           echo "RUST_VERSION=$(awk -F '"' '/^channel/ {print $2}' rust-toolchain.toml)" | tee -a $GITHUB_ENV
       - name: Cargo-deny
+        if: contains(matrix.os, 'ubuntu')
         uses: EmbarkStudios/cargo-deny-action@v2
         with:
           rust-version: ${{ env.RUST_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lean-jobs:
     strategy:
       matrix:
-        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+        os: [warp-ubuntu-latest-x64-8x, warp-macos-latest-arm64-6x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,7 +14,10 @@ jobs:
   # Runs Lean tests via Nix
   nix-test:
     name: Nix Tests
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, warp-macos-latest-arm64-6x]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -26,13 +29,13 @@ jobs:
           name: argumentcomputer
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       # Ix CLI
-      - run: nix build
+      - run: nix build --print-build-logs
       - run: nix run .#default -- --help
       # Ix tests
-      - run: nix build .#test
+      - run: nix build .#test --print-build-logs
       - run: nix run .#test
 
-  # Test Nix devShell support on Ubuntu
+  # Tests Nix devShell support on Ubuntu
   nix-devshell:
     name: Nix devShell Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -38,7 +38,7 @@ jobs:
   # Tests Nix devShell support on Ubuntu
   nix-devshell:
     name: Nix devShell Tests
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,14 +388,14 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.15.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff16d65e48353db458be63ee395c03028f24564fd48668389bd65fd945f5ac36"
+checksum = "f1f7a89a8ee5889d2593ae422ce6e1bb03e48a0e8a16e4fa0882dfcbe7e182ef"
 dependencies = [
- "blake3",
  "bytes",
  "futures-lite",
  "genawaiter",
+ "iroh-blake3",
  "iroh-io",
  "positioned-io",
  "range-collections",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -2302,15 +2302,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-blobs"
-version = "0.34.1"
+name = "iroh-blake3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa596a999c2df0269942918ec51abc64766433872f3c64ba9e9be8d9d2c7200"
+checksum = "efbba31f40a650f58fa28dd585a8ca76d8ae3ba63aacab4c8269004a0c803930"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "iroh-blobs"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d7a6872c7ec4a2613d0386b4dc19b5f3cf4822d81361c5136a63fd56ba2372"
 dependencies = [
  "anyhow",
  "async-channel",
  "bao-tree",
- "blake3",
  "bytes",
  "chrono",
  "data-encoding",
@@ -2323,6 +2335,7 @@ dependencies = [
  "hex",
  "iroh",
  "iroh-base",
+ "iroh-blake3",
  "iroh-io",
  "iroh-metrics",
  "nested_enum_utils",
@@ -2517,6 +2530,7 @@ dependencies = [
  "binius_math",
  "binius_maybe_rayon",
  "binius_utils",
+ "blake3",
  "bumpalo",
  "bytemuck",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ binius_math = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "232
 binius_hal = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
 binius_hash = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
 binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+blake3 ="=1.6.1"
 bumpalo = "3"
 groestl_crypto = { package = "groestl", version = "0.10.1" }
 proptest = "1"
@@ -25,15 +26,15 @@ rayon = "1"
 rand = "0.9.1"
 rustc-hash = "2"
 indexmap = "2"
-iroh = { version = "0.34.0", optional = true }
-tokio = { version = "1.44.1", optional = true }
-iroh-base = { version = "0.34.0", optional = true }
-iroh-blobs = { version = "0.34.0", features = ["rpc"], optional = true }
 bytes = "1.10.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 bytemuck = "1.23.0"
 
+[target.'cfg(not(all(target_os = "macos", target_arch = "aarch64")))'.dependencies]
+iroh = "0.34.0"
+tokio = "1.44.1"
+iroh-base = "0.34.0"
+iroh-blobs = { version = "0.34.0", features = ["rpc"] }
 
 [features]
-default = ["net"]
-net = ["dep:iroh", "dep:tokio", "dep:iroh-base", "dep:iroh-blobs"]
+default = []

--- a/Tests/Cli.lean
+++ b/Tests/Cli.lean
@@ -1,0 +1,8 @@
+/-! Integration tests for the Ix CLI -/
+
+def Tests.ixCli : IO UInt32 := do
+  let out ← IO.Process.output { cmd := "lake", args := #["build", "ix"]}
+  if out.exitCode ≠ 0 then
+    IO.eprintln s!"Build failure exit code: {out.exitCode}\n{out.stderr}"
+    return out.exitCode
+  return 0

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -6,10 +6,13 @@ import Tests.Unsigned
 import Tests.Ix
 import Tests.Ix.Compile
 import Tests.Keccak
+import Tests.Cli
 
 def main (args: List String) : IO UInt32 := do
-  if args.contains "compile"
-  then LSpec.lspecEachIO Tests.Ix.Compile.suiteIO id
+  if args.contains "compile" then
+    LSpec.lspecEachIO Tests.Ix.Compile.suiteIO id
+   else if args.contains "cli" then
+     Tests.ixCli
   else
     LSpec.lspecIO (.ofList [
       ("aiur", Tests.Aiur.suite),

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
         "x86_64-darwin"
         "x86_64-linux"
       ];
-      
+
       perSystem = { system, pkgs, ... }:
       let
         lib = (import ./ix.nix { inherit system pkgs fenix crane lean4-nix blake3-lean; }).lib;

--- a/ix.nix
+++ b/ix.nix
@@ -34,11 +34,11 @@ let
     # Gets all C files in `./c`, without the extension
     cFiles = let ext = ".c"; in builtins.map (file: builtins.replaceStrings [ext] [""] file) (getFiles ext);
     # Creates `gcc -c` command for each C file
-    buildCmd = builtins.map (file: "gcc -Wall -Werror -Wextra -c ${file}.c -o ${file}.o") cFiles;
+    buildCmd = builtins.map (file: "${pkgs.gcc}/bin/gcc -Wall -Werror -Wextra -c ${file}.c -o ${file}.o") cFiles;
     # Final `buildPhase` instructions
     buildSteps = buildCmd ++
     [
-      "ar rcs libix_c.a ${builtins.concatStringsSep " " (builtins.map (file: "-o ${file}.o") cFiles)}"
+      "ar rcs libix_c.a ${builtins.concatStringsSep " " (builtins.map (file: "${file}.o") cFiles)}"
     ];
     # Gets all header files in `./c`
     hFiles = getFiles ".h";

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -54,7 +54,7 @@ extern_lib ix_rs pkg := do
 
 /-- Build the static lib for the C files -/
 extern_lib ix_c pkg := do
-  let compiler := "cc"
+  let compiler := "gcc"
   let cDir := pkg.dir / "c"
   let buildCDir := pkg.buildDir / "c"
   let weakArgs := #["-fPIC", "-I", (← getLeanIncludeDir).toString, "-I", cDir.toString]

--- a/src/lean/ffi/iroh.rs
+++ b/src/lean/ffi/iroh.rs
@@ -1,14 +1,23 @@
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 use anyhow::Result;
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 use bytes::Bytes;
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 use iroh::{Endpoint, protocol::Router};
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 use iroh_blobs::{net_protocol::Blobs, ticket::BlobTicket};
-use std::{error::Error, ffi::CString};
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+use std::error::Error;
+use std::ffi::CString;
 
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+use crate::lean::ffi::raw_to_str;
 use crate::lean::{
-    ffi::{CResult, c_char, raw_to_str, to_raw},
+    ffi::{CResult, c_char, to_raw},
     sarray::LeanSArrayObject,
 };
 
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 #[unsafe(no_mangle)]
 extern "C" fn rs_iroh_send(bytes: &LeanSArrayObject) -> *const CResult {
     // Create a Tokio runtime to block on the async function
@@ -32,6 +41,19 @@ extern "C" fn rs_iroh_send(bytes: &LeanSArrayObject) -> *const CResult {
     to_raw(c_result)
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[unsafe(no_mangle)]
+extern "C" fn rs_iroh_send(_bytes: &LeanSArrayObject) -> *const CResult {
+    let msg = CString::new("Iroh functions not supported on MacOS aarch64-darwin")
+        .expect("CString::new failure");
+    let c_result = CResult {
+        is_ok: false,
+        data: msg.into_raw().cast(),
+    };
+    to_raw(c_result)
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 async fn iroh_send(bytes: &[u8]) -> Result<(), Box<dyn Error>> {
     // Create an endpoint, it allows creating and accepting
     // connections in the iroh p2p world
@@ -69,6 +91,7 @@ async fn iroh_send(bytes: &[u8]) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 #[unsafe(no_mangle)]
 extern "C" fn rs_iroh_recv(
     ticket: *const c_char,
@@ -102,6 +125,23 @@ extern "C" fn rs_iroh_recv(
     to_raw(c_result)
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[unsafe(no_mangle)]
+extern "C" fn rs_iroh_recv(
+    _ticket: *const c_char,
+    _buffer: &mut LeanSArrayObject,
+    _buffer_capacity: usize,
+) -> *const CResult {
+    let msg = CString::new("Iroh functions not supported on MacOS aarch64-darwin")
+        .expect("CString::new failure");
+    let c_result = CResult {
+        is_ok: false,
+        data: msg.into_raw().cast(),
+    };
+    to_raw(c_result)
+}
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 async fn iroh_recv(ticket: &str, buffer_capacity: usize) -> Result<Bytes, Box<dyn Error>> {
     // Create an endpoint, it allows creating and accepting
     // connections in the iroh p2p world

--- a/src/lean/ffi/mod.rs
+++ b/src/lean/ffi/mod.rs
@@ -1,7 +1,6 @@
 pub mod archon;
 pub mod binius;
 pub mod byte_array;
-#[cfg(feature = "net")]
 pub mod iroh;
 pub mod keccak;
 


### PR DESCRIPTION
- Adds Mac CI for the Lean, Rust, and Nix builds
- Temporary fix for #121
- Adds an integration test for the Ix CLI
- Fixes a Mac compilation error from the Iroh FFI where the `CoreFoundation` and `SystemConfiguration` frameworks aren't linked. I wasn't able to figure out how to do that, so on Mac the Iroh functions in the Ix CLI error for now
- Tries to enforce consistent behavior on Mac and Ubuntu by forcing the same GCC for C compilation. On Mac the default `gcc` actually links to Apple `clang`