### PR TITLE
chore: bump binius

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 [[package]]
 name = "binius_circuits"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -453,7 +453,7 @@ dependencies = [
 [[package]]
 name = "binius_core"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "assert_matches",
  "auto_impl",
@@ -473,6 +473,9 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_json_any_key",
  "stackalloc",
  "thiserror 2.0.12",
  "tracing",
@@ -482,7 +485,7 @@ dependencies = [
 [[package]]
 name = "binius_field"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "binius_maybe_rayon",
  "binius_utils",
@@ -501,7 +504,7 @@ dependencies = [
 [[package]]
 name = "binius_hal"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "auto_impl",
  "binius_field",
@@ -519,7 +522,7 @@ dependencies = [
 [[package]]
 name = "binius_hash"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "binius_field",
  "binius_maybe_rayon",
@@ -539,7 +542,7 @@ dependencies = [
 [[package]]
 name = "binius_macros"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -549,7 +552,7 @@ dependencies = [
 [[package]]
 name = "binius_math"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "auto_impl",
  "binius_field",
@@ -571,7 +574,7 @@ dependencies = [
 [[package]]
 name = "binius_maybe_rayon"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "cfg-if",
  "either",
@@ -582,7 +585,7 @@ dependencies = [
 [[package]]
 name = "binius_ntt"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "binius_field",
  "binius_math",
@@ -595,7 +598,7 @@ dependencies = [
 [[package]]
 name = "binius_utils"
 version = "0.2.0"
-source = "git+https://github.com/IrreducibleOSS/binius.git?rev=60ec55578c6c1bb4a624e129a7074ec807d8b8cd#60ec55578c6c1bb4a624e129a7074ec807d8b8cd"
+source = "git+https://github.com/IrreducibleOSS/binius.git?rev=2326ae9b78a9679eeed86d30188a9bcc5eea55e0#2326ae9b78a9679eeed86d30188a9bcc5eea55e0"
 dependencies = [
  "auto_impl",
  "binius_maybe_rayon",
@@ -4448,6 +4451,16 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_json_any_key"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c409ca1209f6c4741028b9e1e56d973c868ffaef25ffbaf2471e486c2a74b3"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ crate-type = ["staticlib"]
 [dependencies]
 anyhow = "1"
 array-util = "1.0.2"
-binius_core = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_circuits = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_field = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_macros = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_maybe_rayon = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_math = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_hal = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_hash = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
-binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "60ec55578c6c1bb4a624e129a7074ec807d8b8cd" }
+binius_core = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_circuits = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_field = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_macros = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_maybe_rayon = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_math = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_hal = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_hash = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
+binius_utils = { git = "https://github.com/IrreducibleOSS/binius.git", rev = "2326ae9b78a9679eeed86d30188a9bcc5eea55e0" }
 bumpalo = "3"
 groestl_crypto = { package = "groestl", version = "0.10.1" }
 proptest = "1"

--- a/Ix/Archon/ArithExpr.lean
+++ b/Ix/Archon/ArithExpr.lean
@@ -1,15 +1,13 @@
+import Ix.Archon.OracleIdx
 import Ix.Unsigned
-import Ix.Binius.Common
 
 namespace Archon
-
-open Binius
 
 /-- Arithmetic expression type for BinaryField128b -/
 inductive ArithExpr
   | const : UInt128 → ArithExpr
   | var : USize → ArithExpr
-  | oracle : OracleId → ArithExpr
+  | oracle : OracleIdx → ArithExpr
   | add : ArithExpr → ArithExpr → ArithExpr
   | mul : ArithExpr → ArithExpr → ArithExpr
   | pow : ArithExpr → UInt64 → ArithExpr

--- a/Ix/Archon/Circuit.lean
+++ b/Ix/Archon/Circuit.lean
@@ -1,11 +1,11 @@
 import Blake3
 import Ix.Archon.ArithExpr
+import Ix.Archon.OracleIdx
 import Ix.Archon.Transparent
 import Ix.Archon.Witness
+import Ix.Binius.Common
 
 namespace Archon
-
-open Binius
 
 private opaque GenericNonempty : NonemptyType
 def CircuitModule : Type := GenericNonempty.type
@@ -19,7 +19,7 @@ namespace CircuitModule
 @[never_extract, extern "c_rs_circuit_module_new"]
 opaque new : USize → CircuitModule
 
-abbrev selector : CircuitModule → OracleId := fun _ => ⟨0⟩
+abbrev selector : CircuitModule → OracleIdx := fun _ => ⟨0⟩
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_freeze_oracles"]
@@ -30,45 +30,45 @@ opaque initWitnessModule : @& CircuitModule → WitnessModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_flush"]
-opaque flush : CircuitModule → FlushDirection → ChannelId → @& Array OracleId →
+opaque flush : CircuitModule → Binius.FlushDirection → Binius.ChannelId → @& Array OracleIdx →
   (multiplicity : UInt64) → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_assert_zero"]
-opaque assertZero : CircuitModule → @& String → @& Array OracleId →
+opaque assertZero : CircuitModule → @& String → @& Array OracleIdx →
   @& ArithExpr → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_assert_not_zero"]
-opaque assertNotZero : CircuitModule → OracleId → CircuitModule
+opaque assertNotZero : CircuitModule → OracleIdx → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_committed"]
-opaque addCommitted : CircuitModule → @& String → TowerField → OracleId × CircuitModule
+opaque addCommitted : CircuitModule → @& String → TowerField → OracleIdx × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_transparent"]
-opaque addTransparent : CircuitModule → @& String → @& Transparent → OracleId × CircuitModule
+opaque addTransparent : CircuitModule → @& String → @& Transparent → OracleIdx × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_linear_combination"]
 opaque addLinearCombination : CircuitModule → @& String → (offset : @& UInt128) →
-  (inner : @& Array (OracleId × UInt128)) → OracleId × CircuitModule
+  (inner : @& Array (OracleIdx × UInt128)) → OracleIdx × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_packed"]
-opaque addPacked : CircuitModule → @& String → OracleId →
-  (logDegree : USize) → OracleId × CircuitModule
+opaque addPacked : CircuitModule → @& String → OracleIdx →
+  (logDegree : USize) → OracleIdx × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_shifted"]
-opaque addShifted : CircuitModule → @& String → OracleId → (shiftOffset : UInt32) →
-  (blockBits : USize) → @& ShiftVariant → OracleId × CircuitModule
+opaque addShifted : CircuitModule → @& String → OracleIdx → (shiftOffset : UInt32) →
+  (blockBits : USize) → @& ShiftVariant → OracleIdx × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_projected"]
-opaque addProjected : CircuitModule → @& String → OracleId → (mask : UInt64) →
-  (unprojectedSize startIndex : USize) → OracleId × CircuitModule
+opaque addProjected : CircuitModule → @& String → OracleIdx → (mask : UInt64) →
+  (unprojectedSize startIndex : USize) → OracleIdx × CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_push_namespace"]

--- a/Ix/Archon/OracleIdx.lean
+++ b/Ix/Archon/OracleIdx.lean
@@ -1,0 +1,7 @@
+namespace Archon
+
+structure OracleIdx where
+  toUSize : USize
+  deriving Inhabited
+
+end Archon

--- a/Ix/Archon/Witness.lean
+++ b/Ix/Archon/Witness.lean
@@ -1,9 +1,7 @@
-import Ix.Binius.Common
+import Ix.Archon.OracleIdx
 import Ix.Unsigned
 
 namespace Archon
-
-open Binius
 
 inductive TowerField
   | b1 | b2 | b4 | b8 | b16 | b32 | b64 | b128
@@ -32,7 +30,7 @@ opaque addEntryWithCapacity : WitnessModule → (logBits : UInt8) → EntryId ×
 
 /-- **Invalidates** the input `WitnessModule` -/
 @[never_extract, extern "c_rs_witness_module_bind_oracle_to"]
-opaque bindOracleTo : WitnessModule → OracleId → EntryId → TowerField → WitnessModule
+opaque bindOracleTo : WitnessModule → OracleIdx → EntryId → TowerField → WitnessModule
 
 /-- **Invalidates** the input `WitnessModule` -/
 @[never_extract, extern "c_rs_witness_module_push_u128_to"]

--- a/Ix/Binius/Common.lean
+++ b/Ix/Binius/Common.lean
@@ -1,9 +1,5 @@
 namespace Binius
 
-structure OracleId where
-  toUSize : USize
-  deriving Inhabited
-
 structure ChannelId where
   toUSize : USize
   deriving Inhabited

--- a/Tests/FFIConsistency.lean
+++ b/Tests/FFIConsistency.lean
@@ -36,7 +36,7 @@ def genArithExpr : Gen ArithExpr := getSize >>= go
       frequency [
         (30, .const <$> genUInt128),
         (30, .var <$> genUSize),
-        (30, .oracle <$> OracleId.mk <$> genUSize),
+        (30, .oracle <$> OracleIdx.mk <$> genUSize),
         (25, .add <$> go n <*> go n),
         (25, .mul <$> go n <*> go n),
         (40, .pow <$> go n <*> genUInt64)

--- a/deny.toml
+++ b/deny.toml
@@ -100,7 +100,8 @@ allow = [
     "Zlib",
     "MPL-2.0",
     "ISC",
-    "CDLA-Permissive-2.0"
+    "CDLA-Permissive-2.0",
+    "Unlicense"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/src/archon/arith_expr.rs
+++ b/src/archon/arith_expr.rs
@@ -1,13 +1,13 @@
 use binius_core::oracle::OracleId;
 use binius_math::ArithExpr as ArithExprCore;
 
-use super::F;
+use super::{F, OracleIdx};
 
 #[derive(Clone, PartialEq)]
 pub enum ArithExpr {
     Const(F),
     Var(usize),
-    Oracle(OracleId),
+    Oracle(OracleIdx),
     Add(Box<ArithExpr>, Box<ArithExpr>),
     Mul(Box<ArithExpr>, Box<ArithExpr>),
     Pow(Box<ArithExpr>, u64),
@@ -35,7 +35,7 @@ impl ArithExpr {
 
     pub(crate) fn offset_oracles(&mut self, by: usize) {
         match self {
-            Self::Oracle(o) => *o += by,
+            Self::Oracle(o) => o.offset(by),
             Self::Add(a, b) | Self::Mul(a, b) => {
                 a.offset_oracles(by);
                 b.offset_oracles(by);
@@ -50,10 +50,13 @@ impl ArithExpr {
             Self::Const(c) => ArithExprCore::Const(c),
             Self::Var(i) => ArithExprCore::Var(i),
             Self::Oracle(o) => {
-                let i = binds.iter().position(|&id| o == id).unwrap_or_else(|| {
-                    binds.push(o);
-                    binds.len() - 1
-                });
+                let i = binds
+                    .iter()
+                    .position(|id| o.val() == id.index())
+                    .unwrap_or_else(|| {
+                        binds.push(o.oracle_id(0));
+                        binds.len() - 1
+                    });
                 ArithExprCore::Var(i)
             }
             Self::Add(a, b) => {

--- a/src/archon/circuit.rs
+++ b/src/archon/circuit.rs
@@ -5,9 +5,8 @@ use binius_core::oracle::ShiftVariant;
 use binius_core::{
     constraint_system::{
         ConstraintSystem,
-        channel::{ChannelId, Flush, FlushDirection},
+        channel::{ChannelId, FlushDirection},
     },
-    oracle::OracleId,
     transparent::step_down::StepDown,
 };
 use binius_field::{TowerField, arch::OptimalUnderlier, underlier::UnderlierType};
@@ -17,6 +16,7 @@ use std::sync::Arc;
 
 use crate::archon::transparent::{Incremental, constant_from_b128};
 
+use super::OracleIdx;
 use super::{
     F, ModuleId, OracleInfo, OracleKind, arith_expr::ArithExpr, transparent::Transparent,
     witness::WitnessModule,
@@ -37,12 +37,20 @@ pub fn init_witness_modules(circuit_modules: &[CircuitModule]) -> Result<Vec<Wit
         .collect()
 }
 
+pub(super) struct ArchonFlush {
+    pub(super) oracles: Vec<OracleIdx>,
+    pub(super) channel_id: ChannelId,
+    pub(super) direction: FlushDirection,
+    pub(super) selector: OracleIdx,
+    pub(super) multiplicity: u64,
+}
+
 pub struct CircuitModule {
     pub(super) module_id: ModuleId,
     pub(super) oracles: Freezable<Vec<OracleInfo>>,
-    pub(super) flushes: Vec<Flush<F>>,
+    pub(super) flushes: Vec<ArchonFlush>,
     pub(super) constraints: Vec<Constraint>,
-    pub(super) non_zero_oracle_ids: Vec<OracleId>,
+    pub(super) non_zero_oracle_idxs: Vec<OracleIdx>,
     pub(super) namespacer: Namespacer,
 }
 
@@ -60,14 +68,14 @@ impl CircuitModule {
             oracles,
             flushes: vec![],
             constraints: vec![],
-            non_zero_oracle_ids: vec![],
+            non_zero_oracle_idxs: vec![],
             namespacer: Namespacer::default(),
         }
     }
 
     #[inline]
-    pub const fn selector(&self) -> OracleId {
-        0
+    pub const fn selector(&self) -> OracleIdx {
+        OracleIdx(0)
     }
 
     #[inline]
@@ -88,15 +96,15 @@ impl CircuitModule {
         &mut self,
         direction: FlushDirection,
         channel_id: ChannelId,
-        selector: OracleId,
-        oracle_ids: impl IntoIterator<Item = OracleId>,
+        selector: OracleIdx,
+        oracle_idxs: impl IntoIterator<Item = OracleIdx>,
         multiplicity: u64,
     ) {
-        self.flushes.push(Flush {
-            oracles: oracle_ids.into_iter().map(OracleOrConst::Oracle).collect(),
+        self.flushes.push(ArchonFlush {
+            oracles: oracle_idxs.into_iter().collect(),
             channel_id,
             direction,
-            selectors: vec![selector],
+            selector,
             multiplicity,
         });
     }
@@ -105,26 +113,26 @@ impl CircuitModule {
     pub fn assert_zero(
         &mut self,
         name: &(impl ToString + ?Sized),
-        oracle_ids: impl IntoIterator<Item = OracleId>,
+        oracle_idxs: impl IntoIterator<Item = OracleIdx>,
         composition: ArithExpr,
     ) {
         self.constraints.push(Constraint {
             name: name.to_string(),
-            oracle_ids: oracle_ids.into_iter().collect(),
+            oracle_idxs: oracle_idxs.into_iter().collect(),
             composition,
         });
     }
 
     #[inline]
-    pub fn assert_not_zero(&mut self, oracle_id: OracleId) {
-        self.non_zero_oracle_ids.push(oracle_id);
+    pub fn assert_not_zero(&mut self, oracle_idx: OracleIdx) {
+        self.non_zero_oracle_idxs.push(oracle_idx);
     }
 
     #[inline]
     pub fn add_committed<FS: TowerField>(
         &mut self,
         name: &(impl ToString + ?Sized),
-    ) -> Result<OracleId> {
+    ) -> Result<OracleIdx> {
         let oracle_info = OracleInfo {
             name: self.namespacer.scoped_name(name),
             tower_level: FS::TOWER_LEVEL,
@@ -138,7 +146,7 @@ impl CircuitModule {
         &mut self,
         name: &(impl ToString + ?Sized),
         transparent: Transparent,
-    ) -> Result<OracleId> {
+    ) -> Result<OracleIdx> {
         let oracle_info = OracleInfo {
             name: self.namespacer.scoped_name(name),
             tower_level: transparent.tower_level(),
@@ -151,13 +159,13 @@ impl CircuitModule {
         &mut self,
         name: &(impl ToString + ?Sized),
         offset: F,
-        inner: impl IntoIterator<Item = (OracleId, F)>,
-    ) -> Result<OracleId> {
+        inner: impl IntoIterator<Item = (OracleIdx, F)>,
+    ) -> Result<OracleIdx> {
         let inner = inner.into_iter().collect::<Vec<_>>();
         let tower_level = inner
             .iter()
-            .map(|(oracle_id, coeff)| {
-                self.oracles.get_ref()[*oracle_id]
+            .map(|(oracle_idx, coeff)| {
+                self.oracles.get_ref()[oracle_idx.val()]
                     .tower_level
                     .max(coeff.min_tower_level())
             })
@@ -176,10 +184,10 @@ impl CircuitModule {
     pub fn add_packed(
         &mut self,
         name: &(impl ToString + ?Sized),
-        inner: OracleId,
+        inner: OracleIdx,
         log_degree: usize,
-    ) -> Result<OracleId> {
-        let inner_tower_level = self.oracles.get_ref()[inner].tower_level;
+    ) -> Result<OracleIdx> {
+        let inner_tower_level = self.oracles.get_ref()[inner.val()].tower_level;
         let oracle_info = OracleInfo {
             name: self.namespacer.scoped_name(name),
             tower_level: inner_tower_level + log_degree,
@@ -191,12 +199,12 @@ impl CircuitModule {
     pub fn add_shifted(
         &mut self,
         name: &(impl ToString + ?Sized),
-        inner: OracleId,
+        inner: OracleIdx,
         shift_offset: u32,
         block_bits: usize,
         variant: ShiftVariant,
-    ) -> Result<OracleId> {
-        let inner_tower_level = self.oracles.get_ref()[inner].tower_level;
+    ) -> Result<OracleIdx> {
+        let inner_tower_level = self.oracles.get_ref()[inner.val()].tower_level;
         let oracle_info = OracleInfo {
             name: self.namespacer.scoped_name(name),
             tower_level: inner_tower_level,
@@ -213,12 +221,12 @@ impl CircuitModule {
     pub fn add_projected(
         &mut self,
         name: &(impl ToString + ?Sized),
-        inner: OracleId,
+        inner: OracleIdx,
         mask: u64,
         unprojected_size: usize,
         start_index: usize,
-    ) -> Result<OracleId> {
-        let inner_tower_level = self.oracles.get_ref()[inner].tower_level;
+    ) -> Result<OracleIdx> {
+        let inner_tower_level = self.oracles.get_ref()[inner.val()].tower_level;
 
         let mut selector_binary: Vec<F> = (0..64)
             .map(|n| F::from(((mask >> n) & 1) as u128))
@@ -252,9 +260,9 @@ impl CircuitModule {
     }
 
     #[inline]
-    fn add_oracle_info(&mut self, oracle_info: OracleInfo) -> Result<OracleId> {
+    fn add_oracle_info(&mut self, oracle_info: OracleInfo) -> Result<OracleIdx> {
         self.oracles.get_mut()?.push(oracle_info);
-        Ok(self.oracles.get_ref().len() - 1)
+        Ok(OracleIdx(self.oracles.get_ref().len() - 1))
     }
 }
 
@@ -302,11 +310,11 @@ pub fn compile_circuit_modules(
                     let n_vars = n_vars_fn(*tower_level);
                     let inner = inner
                         .iter()
-                        .map(|(oracle_id, f)| (oracle_id + oracle_offset, *f));
+                        .map(|(oracle_idx, f)| (oracle_idx.oracle_id(oracle_offset), *f));
                     builder.add_linear_combination_with_offset(name, n_vars, *offset, inner)?
                 }
                 OracleKind::Packed { inner, log_degree } => {
-                    builder.add_packed(name, inner + oracle_offset, *log_degree)?
+                    builder.add_packed(name, inner.oracle_id(oracle_offset), *log_degree)?
                 }
                 OracleKind::Transparent(Transparent::Constant(b128)) => {
                     let n_vars = n_vars_fn(*tower_level);
@@ -332,7 +340,7 @@ pub fn compile_circuit_modules(
                     variant,
                 } => builder.add_shifted(
                     name,
-                    inner + oracle_offset,
+                    inner.oracle_id(oracle_offset),
                     *shift_offset as usize,
                     *block_bits,
                     *variant,
@@ -346,7 +354,7 @@ pub fn compile_circuit_modules(
                     start_index,
                 } => builder.add_projected(
                     name,
-                    inner + oracle_offset,
+                    inner.oracle_id(oracle_offset),
                     selector_binary.clone(),
                     *start_index,
                 )?,
@@ -355,38 +363,43 @@ pub fn compile_circuit_modules(
 
         for Constraint {
             name,
-            oracle_ids,
+            oracle_idxs,
             composition,
         } in &module.constraints
         {
-            let mut oracle_ids = oracle_ids.iter().map(|o| o + oracle_offset).collect();
+            let mut oracle_ids = oracle_idxs
+                .iter()
+                .map(|o| o.oracle_id(oracle_offset))
+                .collect();
             let mut composition = composition.clone();
             composition.offset_oracles(oracle_offset);
             let composition = composition.into_arith_expr_core(&mut oracle_ids);
             builder.assert_zero(name, oracle_ids, composition.into());
         }
 
-        for non_zero_oracle_id in &module.non_zero_oracle_ids {
-            builder.assert_not_zero(non_zero_oracle_id + oracle_offset);
+        for non_zero_oracle_idx in &module.non_zero_oracle_idxs {
+            builder.assert_not_zero(non_zero_oracle_idx.oracle_id(oracle_offset));
         }
 
-        for Flush {
+        for ArchonFlush {
             oracles,
             channel_id,
             direction,
-            selectors,
+            selector,
             multiplicity,
         } in &module.flushes
         {
-            let oracles = oracles.iter().map(|o| match o {
-                OracleOrConst::Const { .. } => *o,
-                OracleOrConst::Oracle(o) => OracleOrConst::Oracle(o + oracle_offset),
-            });
+            // let oracles = oracles.iter().map(|o| match o {
+            //     OracleOrConst::Const { .. } => *o,
+            //     OracleOrConst::Oracle(o) => OracleOrConst::Oracle(o + oracle_offset),
+            // });
             builder.flush_custom(
                 *direction,
                 *channel_id,
-                selectors.iter().map(|s| s + oracle_offset).collect(),
-                oracles,
+                vec![selector.oracle_id(oracle_offset)],
+                oracles
+                    .iter()
+                    .map(|o| OracleOrConst::Oracle(o.oracle_id(oracle_offset))),
                 *multiplicity,
             )?;
         }
@@ -398,7 +411,7 @@ pub fn compile_circuit_modules(
 
 pub(super) struct Constraint {
     pub(super) name: String,
-    pub(super) oracle_ids: Vec<OracleId>,
+    pub(super) oracle_idxs: Vec<OracleIdx>,
     pub(super) composition: ArithExpr,
 }
 

--- a/src/archon/mod.rs
+++ b/src/archon/mod.rs
@@ -13,26 +13,53 @@ use transparent::Transparent;
 
 pub(crate) type F = BinaryField128b;
 
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OracleIdx(pub(crate) usize);
+
+impl OracleIdx {
+    #[inline]
+    pub(crate) fn oracle_id(&self, offset: usize) -> OracleId {
+        OracleId::from_index(self.0 + offset)
+    }
+
+    #[inline]
+    pub(crate) fn val(&self) -> usize {
+        self.0
+    }
+
+    #[inline]
+    pub(crate) fn offset(&mut self, by: usize) {
+        self.0 += by
+    }
+}
+
+impl std::fmt::Display for OracleIdx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.val(), f)
+    }
+}
+
 pub enum OracleKind {
     Committed,
     LinearCombination {
         offset: F,
-        inner: Vec<(OracleId, F)>,
+        inner: Vec<(OracleIdx, F)>,
     },
     Packed {
-        inner: OracleId,
+        inner: OracleIdx,
         log_degree: usize,
     },
     Transparent(Transparent),
     StepDown,
     Shifted {
-        inner: OracleId,
+        inner: OracleIdx,
         shift_offset: u32,
         block_bits: usize,
         variant: ShiftVariant,
     },
     Projected {
-        inner: OracleId,
+        inner: OracleIdx,
         mask: u64,
         mask_bits: Vec<F>,
         unprojected_size: usize,

--- a/src/archon/precompiles/blake3.rs
+++ b/src/archon/precompiles/blake3.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
-use crate::archon::ModuleId;
 use crate::archon::arith_expr::ArithExpr;
 use crate::archon::circuit::CircuitModule;
 use crate::archon::witness::WitnessModule;
+use crate::archon::{ModuleId, OracleIdx};
 use binius_circuits::arithmetic::u32::LOG_U32_BITS;
-use binius_core::oracle::{OracleId, ShiftVariant};
+use binius_core::oracle::ShiftVariant;
 use binius_field::{BinaryField1b, BinaryField32b, BinaryField128b, Field};
 use binius_utils::checked_arithmetics::log2_ceil_usize;
 
@@ -63,8 +63,8 @@ pub struct Trace {
 }
 
 pub struct Blake3CompressionOracles {
-    pub input: [OracleId; STATE_SIZE],
-    pub output: [OracleId; STATE_SIZE],
+    pub input: [OracleIdx; STATE_SIZE],
+    pub output: [OracleIdx; STATE_SIZE],
 }
 
 #[allow(clippy::type_complexity)]
@@ -108,11 +108,11 @@ fn state_transition_module(
     let height = 2u64.pow(u32::try_from(state_n_vars)?);
 
     let mut circuit_module = CircuitModule::new(id);
-    let state_transitions: [OracleId; STATE_SIZE] = array_util::try_from_fn(|xy| {
+    let state_transitions: [OracleIdx; STATE_SIZE] = array_util::try_from_fn(|xy| {
         circuit_module.add_committed::<B32>(&format!("state-transition-{:?}", xy))
     })?;
 
-    let input: [OracleId; STATE_SIZE] = array_util::try_from_fn(|xy| {
+    let input: [OracleIdx; STATE_SIZE] = array_util::try_from_fn(|xy| {
         circuit_module.add_projected(
             &format!("input-{:?}", xy),
             state_transitions[xy],
@@ -122,7 +122,7 @@ fn state_transition_module(
         )
     })?;
 
-    let output: [OracleId; STATE_SIZE] = array_util::try_from_fn(|xy| {
+    let output: [OracleIdx; STATE_SIZE] = array_util::try_from_fn(|xy| {
         circuit_module.add_projected(
             &format!("output-{:?}", xy),
             state_transitions[xy],
@@ -228,10 +228,10 @@ fn additions_xor_rotates_module(
         ShiftVariant::CircularLeft,
     )?;
 
-    let couts: [OracleId; ADDITION_OPERATIONS_NUMBER] = array_util::try_from_fn(|xy| {
+    let couts: [OracleIdx; ADDITION_OPERATIONS_NUMBER] = array_util::try_from_fn(|xy| {
         circuit_module.add_committed::<B1>(&format!("cout-{:?}", xy))
     })?;
-    let cins: [OracleId; ADDITION_OPERATIONS_NUMBER] = array_util::try_from_fn(|xy| {
+    let cins: [OracleIdx; ADDITION_OPERATIONS_NUMBER] = array_util::try_from_fn(|xy| {
         circuit_module.add_shifted(
             &format!("cin-{:?}", xy),
             couts[xy],

--- a/src/archon/protocol.rs
+++ b/src/archon/protocol.rs
@@ -159,6 +159,7 @@ pub fn verify(
 
 #[cfg(test)]
 mod tests {
+    use crate::archon::OracleIdx;
     use crate::archon::precompiles::blake3::blake3_compress;
     use crate::archon::precompiles::blake3::tests::generate_trace;
     use crate::archon::protocol::{prove, verify};
@@ -170,14 +171,13 @@ mod tests {
         witness::{WitnessModule, compile_witness_modules},
     };
     use anyhow::Result;
-    use binius_core::oracle::OracleId;
     use binius_field::BinaryField1b as B1;
     use binius_hal::make_portable_backend;
 
     struct Oracles {
-        s: OracleId,
-        a: OracleId,
-        b: OracleId,
+        s: OracleIdx,
+        a: OracleIdx,
+        b: OracleIdx,
     }
 
     fn a_xor_b_circuit_module(module_id: ModuleId) -> Result<(CircuitModule, Oracles)> {

--- a/src/lean/ffi/archon/arith_expr.rs
+++ b/src/lean/ffi/archon/arith_expr.rs
@@ -1,16 +1,11 @@
-use binius_core::oracle::OracleId;
 use binius_field::BinaryField128b;
 
 use crate::{
-    archon::arith_expr::ArithExpr,
-    lean::{
-        ctor::LeanCtorObject,
-        ffi::{as_ref_unsafe, boxed_usize_ptr_to_usize},
-        sarray::LeanSArrayObject,
-    },
+    archon::{OracleIdx, arith_expr::ArithExpr},
+    lean::{ctor::LeanCtorObject, ffi::as_ref_unsafe, sarray::LeanSArrayObject},
 };
 
-use super::external_ptr_to_u128;
+use super::{boxed_usize_ptr_to_oracle_idx, external_ptr_to_u128};
 
 pub(super) fn lean_ctor_to_arith_expr(ctor: &LeanCtorObject) -> ArithExpr {
     match ctor.tag() {
@@ -28,7 +23,7 @@ pub(super) fn lean_ctor_to_arith_expr(ctor: &LeanCtorObject) -> ArithExpr {
         2 => {
             // Oracle
             let [ptr] = ctor.objs();
-            ArithExpr::Oracle(boxed_usize_ptr_to_usize(ptr))
+            ArithExpr::Oracle(boxed_usize_ptr_to_oracle_idx(ptr))
         }
         3 => {
             // Add
@@ -71,8 +66,8 @@ fn arith_expr_from_bytes(bytes: &[u8]) -> ArithExpr {
         2 => {
             let mut slice = [0; size_of::<usize>()];
             slice.copy_from_slice(&bytes[1..size_of::<usize>() + 1]);
-            let u = OracleId::from_le_bytes(slice);
-            ArithExpr::Oracle(u)
+            let idx = usize::from_le_bytes(slice);
+            ArithExpr::Oracle(OracleIdx(idx))
         }
         3 => {
             let x_size = bytes[1] as usize;

--- a/src/lean/ffi/archon/mod.rs
+++ b/src/lean/ffi/archon/mod.rs
@@ -4,20 +4,27 @@ pub mod protocol;
 pub mod transparent;
 pub mod witness;
 
-use binius_core::oracle::OracleId;
 use binius_field::BinaryField128b;
 use std::ffi::c_void;
 
-use crate::lean::{
-    ctor::LeanCtorObject,
-    ffi::{as_ref_unsafe, boxed_usize_ptr_to_usize, external_ptr_to_u128},
+use crate::{
+    archon::OracleIdx,
+    lean::{
+        ctor::LeanCtorObject,
+        ffi::{as_ref_unsafe, boxed_usize_ptr_to_usize, external_ptr_to_u128},
+    },
 };
 
-pub(super) fn ctor_ptr_to_lc_factor(ptr: *const c_void) -> (OracleId, BinaryField128b) {
+#[inline]
+pub(super) fn boxed_usize_ptr_to_oracle_idx(ptr: *const c_void) -> OracleIdx {
+    OracleIdx(boxed_usize_ptr_to_usize(ptr))
+}
+
+pub(super) fn ctor_ptr_to_lc_factor(ptr: *const c_void) -> (OracleIdx, BinaryField128b) {
     let ctor_ptr = ptr.cast::<LeanCtorObject>();
     let ctor = as_ref_unsafe(ctor_ptr);
-    let [oracle_id_ptr, u128_external_ptr] = ctor.objs();
-    let oracle_id = boxed_usize_ptr_to_usize(oracle_id_ptr);
+    let [oracle_idx_ptr, u128_external_ptr] = ctor.objs();
+    let oracle_idx = boxed_usize_ptr_to_oracle_idx(oracle_idx_ptr);
     let u128 = external_ptr_to_u128(u128_external_ptr);
-    (oracle_id, BinaryField128b::new(u128))
+    (oracle_idx, BinaryField128b::new(u128))
 }

--- a/src/lean/ffi/archon/witness.rs
+++ b/src/lean/ffi/archon/witness.rs
@@ -1,11 +1,13 @@
-use binius_core::oracle::OracleId;
 use binius_field::{
     BinaryField1b as B1, BinaryField2b as B2, BinaryField4b as B4, BinaryField8b as B8,
     BinaryField16b as B16, BinaryField32b as B32, BinaryField64b as B64, BinaryField128b as B128,
 };
 
 use crate::{
-    archon::witness::{EntryId, Witness, WitnessModule, compile_witness_modules},
+    archon::{
+        OracleIdx,
+        witness::{EntryId, Witness, WitnessModule, compile_witness_modules},
+    },
     lean::{
         CArray,
         array::LeanArrayObject,
@@ -50,19 +52,19 @@ extern "C" fn rs_witness_module_add_entry_with_capacity(
 #[unsafe(no_mangle)]
 extern "C" fn rs_witness_module_bind_oracle_to(
     witness_module: &mut WitnessModule,
-    oracle_id: OracleId,
+    oracle_idx: OracleIdx,
     entry_id: EntryId,
     tower_level: u8,
 ) {
     match tower_level {
-        0 => witness_module.bind_oracle_to::<B1>(oracle_id, entry_id),
-        1 => witness_module.bind_oracle_to::<B2>(oracle_id, entry_id),
-        2 => witness_module.bind_oracle_to::<B4>(oracle_id, entry_id),
-        3 => witness_module.bind_oracle_to::<B8>(oracle_id, entry_id),
-        4 => witness_module.bind_oracle_to::<B16>(oracle_id, entry_id),
-        5 => witness_module.bind_oracle_to::<B32>(oracle_id, entry_id),
-        6 => witness_module.bind_oracle_to::<B64>(oracle_id, entry_id),
-        7 => witness_module.bind_oracle_to::<B128>(oracle_id, entry_id),
+        0 => witness_module.bind_oracle_to::<B1>(oracle_idx, entry_id),
+        1 => witness_module.bind_oracle_to::<B2>(oracle_idx, entry_id),
+        2 => witness_module.bind_oracle_to::<B4>(oracle_idx, entry_id),
+        3 => witness_module.bind_oracle_to::<B8>(oracle_idx, entry_id),
+        4 => witness_module.bind_oracle_to::<B16>(oracle_idx, entry_id),
+        5 => witness_module.bind_oracle_to::<B32>(oracle_idx, entry_id),
+        6 => witness_module.bind_oracle_to::<B64>(oracle_idx, entry_id),
+        7 => witness_module.bind_oracle_to::<B128>(oracle_idx, entry_id),
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
This patch creates our own oracle ID type, `OracleIdx`, which is marked as `#[repr(C)]` (unlike binius' `OracleId`).

It also prepares the ground for when `ChannelId` becomes a wrapper around `usize`, probably not `#[repr(C)]`.