### PR TITLE
chore: fix order of match branches

### DIFF
--- a/Ix/Aiur/Bytecode.lean
+++ b/Ix/Aiur/Bytecode.lean
@@ -420,7 +420,7 @@ partial def toIndex
   | .load ptr => do
     let size := match ptr.typ.unwrap with
     | .pointer typ => typSize layoutMap typ
-    | _ => panic! "unreachable"
+    | _ => unreachable!
     let ptr ← toIndex layoutMap bindings ptr
     assert! (ptr.size == 1)
     pushOp (Bytecode.Op.load size (ptr.get' 0)) size
@@ -491,15 +491,17 @@ partial def TypedTerm.compile
     pure { ops, ctrl := .if (b.get' 0) t f, returnIdents := (initIdent, lastIdent) }
   | .ret term => do
     let idxs ← toIndex layoutMap bindings term
-    modify (fun state => { state with returnIdent := state.returnIdent + 1 })
     let state ← get
+    let state := { state with returnIdent := state.returnIdent + 1 }
+    set state
     let ops := state.ops
     let id := state.returnIdent
     pure { ops, ctrl := .ret (id - 1) idxs, returnIdents := (id - 1, id) }
   | _ => do
     let idxs ← toIndex layoutMap bindings term
-    modify (fun state => { state with returnIdent := state.returnIdent + 1 })
     let state ← get
+    let state := { state with returnIdent := state.returnIdent + 1 }
+    set state
     let ops := state.ops
     let id := state.returnIdent
     pure { ops, ctrl := .ret (id - 1) idxs, returnIdents := (id - 1, id) }

--- a/Ix/Aiur/Execute.lean
+++ b/Ix/Aiur/Execute.lean
@@ -8,9 +8,6 @@ structure QueryResult where
   multiplicity : UInt64
   deriving Inhabited
 
-instance : ToString QueryResult where
-  toString x := s!"{x.multiplicity}×{x.values}"
-
 @[inline] def QueryResult.bumpMultiplicity (res : QueryResult) : QueryResult :=
   { res with multiplicity := res.multiplicity + 1 }
 

--- a/Ix/Aiur/Term.lean
+++ b/Ix/Aiur/Term.lean
@@ -1,6 +1,5 @@
-import Std.Data.HashMap
+import Std.Data.HashSet.Basic
 import Ix.IndexMap
-open Std
 
 namespace Aiur
 
@@ -206,7 +205,9 @@ abbrev TypedDecls := IndexMap Global TypedDeclaration
 
 mutual
 
-partial def Typ.size (decls : TypedDecls) (visited : HashMap Global Unit := {}) : Typ → Nat
+open Std (HashSet)
+
+partial def Typ.size (decls : TypedDecls) (visited : HashSet Global := {}) : Typ → Nat
   | Typ.primitive .. => 1
   | Typ.pointer .. => 1
   | Typ.function .. => 1
@@ -215,14 +216,14 @@ partial def Typ.size (decls : TypedDecls) (visited : HashMap Global Unit := {}) 
     | some (.dataType data) => data.size decls visited
     | _ => panic! "impossible case"
 
-partial def Constructor.size (decls : TypedDecls) (visited : HashMap Global Unit := {}) (c : Constructor) : Nat :=
+partial def Constructor.size (decls : TypedDecls) (visited : HashSet Global := {}) (c : Constructor) : Nat :=
   c.argTypes.foldl (λ acc t => acc + t.size decls visited) 0
 
-partial def DataType.size (dt : DataType) (decls : TypedDecls) (visited : HashMap Global Unit := {}) : Nat :=
+partial def DataType.size (dt : DataType) (decls : TypedDecls) (visited : HashSet Global := {}) : Nat :=
   if visited.contains dt.name then
     panic! s!"cycle detected at datatype `{dt.name}`"
   else
-    let visited := visited.insert dt.name ()
+    let visited := visited.insert dt.name
     let ctorSizes := dt.constructors.map (Constructor.size decls visited)
     let maxFields := ctorSizes.foldl max 0
     maxFields + 1

--- a/Ix/IndexMap.lean
+++ b/Ix/IndexMap.lean
@@ -16,7 +16,7 @@ instance : Inhabited (IndexMap α β) where
     let pairs := #[]
     have {i} : ∀ (a : α), indices[a]? = some i → i < pairs.size := by
       intro a ha
-      have : indices[a]? = none := Std.HashMap.getElem?_emptyc
+      have : indices[a]? = none := Std.HashMap.getElem?_empty
       simp [this] at ha
     ⟨pairs, indices, this⟩
 

--- a/Ix/SmallMap.lean
+++ b/Ix/SmallMap.lean
@@ -1,0 +1,32 @@
+/-- A map meant for very few entries, preserving insertion order. -/
+structure SmallMap (α : Type u) (β : Type v) where
+  pairs : Array (α × β)
+  deriving Inhabited
+
+namespace SmallMap
+
+variable (m : SmallMap α β) [BEq α] (a : α) (b : β)
+
+def insert : SmallMap α β :=
+  match m.pairs.findFinIdx? (·.fst == a) with
+  | some idx => ⟨m.pairs.set idx.val (a, b) idx.is_lt⟩
+  | none => ⟨m.pairs.push (a, b)⟩
+
+def update (f : β → β) : SmallMap α β :=
+  match m.pairs.findFinIdx? (·.fst == a) with
+  | some idx => ⟨m.pairs.set idx.val (a, f m.pairs[idx.val].snd) idx.is_lt⟩
+  | none => m
+
+@[inline] def get : Option β :=
+  Prod.snd <$> m.pairs.find? (·.fst == a)
+
+@[inline] def size : Nat :=
+  m.pairs.size
+
+@[inline] def map (f : β → β) : SmallMap α β :=
+  ⟨m.pairs.map fun (a, b) => (a, f b)⟩
+
+@[inline] def toList : List (α × β) :=
+  m.pairs.toList
+
+end SmallMap


### PR DESCRIPTION
Implement and use a `SmallMap` to make sure the order of simplified match branches are kept stable.