### PR TITLE
chore: make Archon witness population more flexible

### DIFF
--- a/Ix/Archon/Witness.lean
+++ b/Ix/Archon/Witness.lean
@@ -33,8 +33,24 @@ opaque addEntryWithCapacity : WitnessModule → (logBits : UInt8) → EntryId ×
 opaque bindOracleTo : WitnessModule → OracleIdx → EntryId → TowerField → WitnessModule
 
 /-- **Invalidates** the input `WitnessModule` -/
-@[never_extract, extern "c_rs_witness_module_push_u128_to"]
-opaque pushUInt128To : WitnessModule → @& UInt128 → EntryId → WitnessModule
+@[never_extract, extern "c_rs_witness_module_push_u8s_to"]
+opaque pushUInt8sTo : WitnessModule → @& Array UInt8 → EntryId → WitnessModule
+
+/-- **Invalidates** the input `WitnessModule` -/
+@[never_extract, extern "c_rs_witness_module_push_u16s_to"]
+opaque pushUInt16sTo : WitnessModule → @& Array UInt16 → EntryId → WitnessModule
+
+/-- **Invalidates** the input `WitnessModule` -/
+@[never_extract, extern "c_rs_witness_module_push_u32s_to"]
+opaque pushUInt32sTo : WitnessModule → @& Array UInt32 → EntryId → WitnessModule
+
+/-- **Invalidates** the input `WitnessModule` -/
+@[never_extract, extern "c_rs_witness_module_push_u64s_to"]
+opaque pushUInt64sTo : WitnessModule → @& Array UInt64 → EntryId → WitnessModule
+
+/-- **Invalidates** the input `WitnessModule` -/
+@[never_extract, extern "c_rs_witness_module_push_u128s_to"]
+opaque pushUInt128sTo : WitnessModule → @& Array UInt128 → EntryId → WitnessModule
 
 /-- **Invalidates** the input `WitnessModule` -/
 @[never_extract, extern "c_rs_witness_module_populate"]

--- a/c/archon.c
+++ b/c/archon.c
@@ -47,19 +47,81 @@ extern lean_obj_res c_rs_witness_module_bind_oracle_to(
     return alloc_lean_linear_object(new_linear);
 }
 
-extern lean_obj_res c_rs_witness_module_push_u128_to(
+static inline lean_obj_res c_rs_witness_module_push_data_to(
     lean_obj_arg l_witness,
-    b_lean_obj_arg u128,
-    size_t entry_id
+    b_lean_obj_arg data,
+    size_t entry_id,
+    void (*rs_fn)(void*, b_lean_obj_arg, size_t)
 ) {
     linear_object *linear = validated_linear(l_witness);
-    rs_witness_module_push_u128_to(
-        get_object_ref(linear),
-        lean_get_external_data(u128),
-        entry_id
-    );
+    rs_fn(get_object_ref(linear), data, entry_id);
     linear_object *new_linear = linear_bump(linear);
     return alloc_lean_linear_object(new_linear);
+}
+
+extern lean_obj_res c_rs_witness_module_push_u8s_to(
+    lean_obj_arg l_witness,
+    b_lean_obj_arg u8s,
+    size_t entry_id
+) {
+    return c_rs_witness_module_push_data_to(
+        l_witness,
+        u8s,
+        entry_id,
+        rs_witness_module_push_u8s_to
+    );
+}
+
+extern lean_obj_res c_rs_witness_module_push_u16s_to(
+    lean_obj_arg l_witness,
+    b_lean_obj_arg u16s,
+    size_t entry_id
+) {
+    return c_rs_witness_module_push_data_to(
+        l_witness,
+        u16s,
+        entry_id,
+        rs_witness_module_push_u16s_to
+    );
+}
+
+extern lean_obj_res c_rs_witness_module_push_u32s_to(
+    lean_obj_arg l_witness,
+    b_lean_obj_arg u32s,
+    size_t entry_id
+) {
+    return c_rs_witness_module_push_data_to(
+        l_witness,
+        u32s,
+        entry_id,
+        rs_witness_module_push_u32s_to
+    );
+}
+
+extern lean_obj_res c_rs_witness_module_push_u64s_to(
+    lean_obj_arg l_witness,
+    b_lean_obj_arg u64s,
+    size_t entry_id
+) {
+    return c_rs_witness_module_push_data_to(
+        l_witness,
+        u64s,
+        entry_id,
+        rs_witness_module_push_u64s_to
+    );
+}
+
+extern lean_obj_res c_rs_witness_module_push_u128s_to(
+    lean_obj_arg l_witness,
+    b_lean_obj_arg u128s,
+    size_t entry_id
+) {
+    return c_rs_witness_module_push_data_to(
+        l_witness,
+        u128s,
+        entry_id,
+        rs_witness_module_push_u128s_to
+    );
 }
 
 extern lean_obj_res c_rs_witness_module_populate(lean_obj_arg l_witness, uint64_t height) {

--- a/c/rust.h
+++ b/c/rust.h
@@ -13,7 +13,11 @@ void rs_witness_module_free(void*);
 size_t rs_witness_module_add_entry(void*);
 size_t rs_witness_module_add_entry_with_capacity(void*, uint8_t);
 void rs_witness_module_bind_oracle_to(void*, size_t, size_t, uint8_t);
-void rs_witness_module_push_u128_to(void*, void*, size_t);
+void rs_witness_module_push_u8s_to(void*, b_lean_obj_arg, size_t);
+void rs_witness_module_push_u16s_to(void*, b_lean_obj_arg, size_t);
+void rs_witness_module_push_u32s_to(void*, b_lean_obj_arg, size_t);
+void rs_witness_module_push_u64s_to(void*, b_lean_obj_arg, size_t);
+void rs_witness_module_push_u128s_to(void*, b_lean_obj_arg, size_t);
 void rs_witness_module_populate(void*, uint64_t);
 void *rs_compile_witness_modules(void**, b_lean_obj_arg);
 

--- a/src/archon/precompiles/blake3.rs
+++ b/src/archon/precompiles/blake3.rs
@@ -137,10 +137,7 @@ fn state_transition_module(
 
     for (xy, trace) in traces.clone().state_trace.into_iter().enumerate() {
         let entry_id_xy = witness_module.new_entry();
-
-        for chunk in trace.chunks(4) {
-            witness_module.push_u32s_to(chunk.try_into()?, entry_id_xy);
-        }
+        witness_module.push_u32s_to(trace, entry_id_xy);
         witness_module.bind_oracle_to::<B32>(state_transitions[xy], entry_id_xy);
     }
 
@@ -299,18 +296,10 @@ fn additions_xor_rotates_module(
         let yin_entry = witness_module.new_entry();
         let zout_entry = witness_module.new_entry();
 
-        for chunk in xin_traces[xy].chunks(4) {
-            witness_module.push_u32s_to(chunk.try_into()?, xin_entry)
-        }
-        for chunk in yin_traces[xy].chunks(4) {
-            witness_module.push_u32s_to(chunk.try_into()?, yin_entry)
-        }
-        for chunk in traces.cout_trace[xy].chunks(4) {
-            witness_module.push_u32s_to(chunk.try_into()?, cout_entry)
-        }
-        for chunk in zout_traces[xy].chunks(4) {
-            witness_module.push_u32s_to(chunk.try_into()?, zout_entry)
-        }
+        witness_module.push_u32s_to(xin_traces[xy].clone(), xin_entry);
+        witness_module.push_u32s_to(yin_traces[xy].clone(), yin_entry);
+        witness_module.push_u32s_to(traces.cout_trace[xy].clone(), cout_entry);
+        witness_module.push_u32s_to(zout_traces[xy].clone(), zout_entry);
 
         witness_module.bind_oracle_to::<B1>(xins[xy], xin_entry);
         witness_module.bind_oracle_to::<B1>(yins[xy], yin_entry);
@@ -320,9 +309,7 @@ fn additions_xor_rotates_module(
 
     // not to forget about d_in
     let d_in_entry = witness_module.new_entry();
-    for chunk in traces.d_in_trace.chunks(4) {
-        witness_module.push_u32s_to(chunk.try_into()?, d_in_entry)
-    }
+    witness_module.push_u32s_to(traces.d_in_trace.clone(), d_in_entry);
     witness_module.bind_oracle_to::<B1>(d_in, d_in_entry);
 
     witness_module.populate(height)?;
@@ -364,17 +351,9 @@ fn cv_output_module(
     let state_i_entry = witness_module.new_entry();
     let state_i_8_entry = witness_module.new_entry();
 
-    for cv_vals in traces.cv_trace.chunks(4) {
-        witness_module.push_u32s_to(cv_vals.try_into().unwrap(), cv_entry);
-    }
-
-    for state_i_vals in traces.state_i_trace.chunks(4) {
-        witness_module.push_u32s_to(state_i_vals.try_into().unwrap(), state_i_entry);
-    }
-
-    for state_i_8_vals in traces.state_i_8_trace.chunks(4) {
-        witness_module.push_u32s_to(state_i_8_vals.try_into().unwrap(), state_i_8_entry);
-    }
+    witness_module.push_u32s_to(traces.cv_trace.clone(), cv_entry);
+    witness_module.push_u32s_to(traces.state_i_trace.clone(), state_i_entry);
+    witness_module.push_u32s_to(traces.state_i_8_trace.clone(), state_i_8_entry);
 
     witness_module.bind_oracle_to::<B32>(cv, cv_entry);
     witness_module.bind_oracle_to::<B32>(state_i, state_i_entry);
@@ -951,13 +930,13 @@ pub mod tests {
         let a_0_entry = witness_modules[witness_module_id].new_entry();
         let d_in_entry = witness_modules[witness_module_id].new_entry();
 
-        for chunk in traces.a_0_trace.chunks(4) {
-            witness_modules[witness_module_id].push_u32s_to(chunk.try_into().unwrap(), a_0_entry)
-        }
-
-        for chunk in traces.d_in_trace.chunks(4) {
-            witness_modules[witness_module_id].push_u32s_to(chunk.try_into().unwrap(), d_in_entry)
-        }
+        let Trace {
+            a_0_trace,
+            d_in_trace,
+            ..
+        } = traces;
+        witness_modules[witness_module_id].push_u32s_to(a_0_trace, a_0_entry);
+        witness_modules[witness_module_id].push_u32s_to(d_in_trace, d_in_entry);
 
         witness_modules[witness_module_id].bind_oracle_to::<B1>(a_0, a_0_entry);
         witness_modules[witness_module_id].bind_oracle_to::<B1>(d_in, d_in_entry);

--- a/src/archon/protocol.rs
+++ b/src/archon/protocol.rs
@@ -192,7 +192,7 @@ mod tests {
 
     fn populate_a_xor_b_witness_with_ones(witness_module: &mut WitnessModule, oracles: &Oracles) {
         let ones = witness_module.new_entry_with_capacity(7);
-        witness_module.push_u128_to(u128::MAX, ones);
+        witness_module.push_u128s_to([u128::MAX], ones);
         witness_module.bind_oracle_to::<B1>(oracles.s, ones);
         witness_module.bind_oracle_to::<B1>(oracles.a, ones);
         witness_module.bind_oracle_to::<B1>(oracles.b, ones);
@@ -204,8 +204,8 @@ mod tests {
         let mut witness_module = circuit_module.init_witness_module().unwrap();
         let zeros = witness_module.new_entry_with_capacity(7);
         let ones = witness_module.new_entry_with_capacity(7);
-        witness_module.push_u128_to(0, zeros);
-        witness_module.push_u128_to(u128::MAX, ones);
+        witness_module.push_u128s_to([0], zeros);
+        witness_module.push_u128s_to([u128::MAX], ones);
         witness_module.bind_oracle_to::<B1>(oracles.s, ones);
         witness_module.bind_oracle_to::<B1>(oracles.a, ones);
         witness_module.bind_oracle_to::<B1>(oracles.b, zeros);

--- a/src/lean/ffi/archon/witness.rs
+++ b/src/lean/ffi/archon/witness.rs
@@ -11,8 +11,9 @@ use crate::{
     lean::{
         CArray,
         array::LeanArrayObject,
-        ffi::{drop_raw, lean_unbox_u64, to_raw},
+        ffi::{drop_raw, external_ptr_to_u128, lean_unbox_u32, lean_unbox_u64, to_raw},
     },
+    lean_unbox,
 };
 
 /// Also holds a reference to the witness modules vector, which lives in the heap
@@ -70,12 +71,53 @@ extern "C" fn rs_witness_module_bind_oracle_to(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn rs_witness_module_push_u128_to(
+extern "C" fn rs_witness_module_push_u8s_to(
     witness_module: &mut WitnessModule,
-    u128: &u128,
+    u8s: &LeanArrayObject,
     entry_id: EntryId,
 ) {
-    witness_module.push_u128_to(*u128, entry_id);
+    let u8s = u8s.to_vec(|ptr| lean_unbox!(u8, ptr));
+    witness_module.push_u8s_to(u8s, entry_id);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rs_witness_module_push_u16s_to(
+    witness_module: &mut WitnessModule,
+    u16s: &LeanArrayObject,
+    entry_id: EntryId,
+) {
+    let u16s = u16s.to_vec(|ptr| lean_unbox!(u16, ptr));
+    witness_module.push_u16s_to(u16s, entry_id);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rs_witness_module_push_u32s_to(
+    witness_module: &mut WitnessModule,
+    u32s: &LeanArrayObject,
+    entry_id: EntryId,
+) {
+    let u32s = u32s.to_vec(lean_unbox_u32);
+    witness_module.push_u32s_to(u32s, entry_id);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rs_witness_module_push_u64s_to(
+    witness_module: &mut WitnessModule,
+    u64s: &LeanArrayObject,
+    entry_id: EntryId,
+) {
+    let u64s = u64s.to_vec(lean_unbox_u64);
+    witness_module.push_u64s_to(u64s, entry_id);
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rs_witness_module_push_u128s_to(
+    witness_module: &mut WitnessModule,
+    u128s: &LeanArrayObject,
+    entry_id: EntryId,
+) {
+    let u128s = u128s.to_vec(external_ptr_to_u128);
+    witness_module.push_u128s_to(u128s, entry_id);
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Accept pushes of arbitrary numbers of uints to entries of witness modules instead of always requiring 128 bits of data. The data is accumulated on buffers and gets concretized into underliers in chunks of 128 bits (the size of an `OptimalUnderlier`).

This API is propagated to Lean via unsafe bindings.