### PR TITLE
feat: Add CLI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
           build-args: "--wfail -v"
           test: true
       - name: Test Ix CLI
-        run: lake test -v -- cli
+        run: |
+          mkdir -p ~/.local/bin
+          lake test -- cli
       - name: Check lean.h.hash
         run: lake run check-lean-h-hash
 

--- a/Ix/Cli/ProveCmd.lean
+++ b/Ix/Cli/ProveCmd.lean
@@ -13,7 +13,7 @@ open Ix.Compile
 --typechecking:
 --id' (A : Type) (x : A) : A
 --claim: #bbd740022aa44acd553c52e156807a5571428220a926377fe3c57d63b06a99f4 : #ba33b735b743386477f7a0e6802c67d388c165cab0e34b04880b50270205f265 @ #0000000000000000000000000000000000000000000000000000000000000000
-def runProveCheck 
+def runProveCheck
   (env: Lean.Environment)
   (constInfo: Lean.ConstantInfo)
   (commit: Bool)
@@ -23,7 +23,7 @@ def runProveCheck
   let signature <- runMeta (Lean.PrettyPrinter.ppSignature constInfo.name) env
   IO.println "typechecking:"
   IO.println signature.fmt.pretty
-  let ((claim, _, _), _stt) <- 
+  let ((claim, _, _), _stt) <-
     (checkClaim constInfo.name constInfo.type constSort constInfo.levelParams commit).runIO env
   IO.println $ s!"claim: {claim}"
   -- TODO: prove
@@ -52,7 +52,7 @@ def runProveEval
     let argInfo <- match env.constants.find? a.toName with
       | some c => runMeta (mkConst' c.name) env
       | none => throw $ IO.userError s!"unknown constant {a.toName}"
-  let (lvls, input, output, type, sort) <- 
+  let (lvls, input, output, type, sort) <-
     runMeta (metaMakeEvalClaim constInfo.name (args.toList)) env
   IO.println "evaluating:"
   IO.println signature.fmt.pretty
@@ -73,6 +73,7 @@ def runProveEval
 def runProve (p: Cli.Parsed): IO UInt32 := do
   let input : String       := p.positionalArg! "input" |>.as! String
   let const : String       := p.positionalArg! "const" |>.as! String
+  StoreIO.toIO Store.ensureStoreDir
   let path := ⟨input⟩
   Lean.setLibsPaths input
   let env ← Lean.runFrontend (← IO.FS.readFile path) path

--- a/Ix/Cli/StoreCmd.lean
+++ b/Ix/Cli/StoreCmd.lean
@@ -14,7 +14,7 @@ def runStore (p : Cli.Parsed) : IO UInt32 := do
   let source : String       := p.positionalArg! "source" |>.as! String
   let mut cronos ← Cronos.new.clock "Lean-frontend"
   Lean.setLibsPaths source
-  --StoreIO.toIO ensureStoreDir
+  StoreIO.toIO Store.ensureStoreDir
   let path := ⟨source⟩
   let leanEnv ← Lean.runFrontend (← IO.FS.readFile path) path
   cronos ← cronos.clock "Lean-frontend"
@@ -93,4 +93,3 @@ def storeCmd : Cli.Cmd := `[Cli|
     storeGetCmd;
     storeRematCmd
 ]
-

--- a/Tests/Cli.lean
+++ b/Tests/Cli.lean
@@ -1,8 +1,20 @@
 /-! Integration tests for the Ix CLI -/
 
-def Tests.ixCli : IO UInt32 := do
-  let out ← IO.Process.output { cmd := "lake", args := #["build", "ix"]}
+def Tests.Cli.run (buildCmd: String) (buildArgs : Array String) (buildDir : Option System.FilePath) : IO UInt32 := do
+  let proc : IO.Process.SpawnArgs :=
+    match buildDir with
+    | some bd => { cmd := buildCmd, args := buildArgs, cwd := bd }
+    | none => { cmd := buildCmd, args := buildArgs }
+  let out ← IO.Process.output proc
   if out.exitCode ≠ 0 then
-    IO.eprintln s!"Build failure exit code: {out.exitCode}\n{out.stderr}"
-    return out.exitCode
+    IO.eprintln out.stderr
+  else
+    IO.println out.stdout
+  return out.exitCode
+
+def Tests.Cli.suite : IO UInt32 := do
+  let _install ← Tests.Cli.run "lake" (#["run", "install"]) none
+  let ixTestDir := (← IO.currentDir) / "ix_test"
+  let _store ← Tests.Cli.run "ix" (#["store", "IxTest.lean"]) (some ixTestDir)
+  let _prove ← Tests.Cli.run "ix" (#["prove", "IxTest.lean", "one"]) (some ixTestDir)
   return 0

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -12,6 +12,8 @@ import Tests.Blake3
 def main (args: List String) : IO UInt32 := do
   if args.contains "compile"
   then LSpec.lspecEachIO Tests.Ix.Compile.suiteIO id
+  else if args.contains "cli" then
+    Tests.Cli.suite
   else
     LSpec.lspecIO (.ofList [
       ("aiur", Tests.Aiur.suite),

--- a/ix_test/IxTest.lean
+++ b/ix_test/IxTest.lean
@@ -5,6 +5,6 @@ import Init
 import Std
 
 def id' (A: Type) (x: A) := x
---def ref (A: Type) (x y: A) := hello
+def ref (A: Type) (_x : A) := hello
 
 def one : Nat := 1

--- a/ix_test/IxTest/Basic.lean
+++ b/ix_test/IxTest/Basic.lean
@@ -1,1 +1,1 @@
-def hello (A: Type) (x y : A) : A := x
+def hello (A: Type) (x : A) : A := x

--- a/ix_test/lean-toolchain
+++ b/ix_test/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:4.17.0
+leanprover/lean4:4.18.0


### PR DESCRIPTION
- Adds tests to install the `ix` binary and run the `ix store` and `ix prove` commands with the `ix_test` project
- Fixes a bug where the `~/.ix/store` directory wasn't being created by making sure to call `Store.ensureStoreDir` when storing and proving