### PR TITLE
feat: synthesis for Aiur toplevels

### DIFF
--- a/Ix/Aiur/Synthesis.lean
+++ b/Ix/Aiur/Synthesis.lean
@@ -1,0 +1,218 @@
+import Batteries.Data.RBMap.Basic
+import Ix.Aiur.Constraints
+import Ix.SmallMap
+
+namespace Aiur.Circuit
+
+abbrev B64_MULT_GEN : UInt128 := 508773776270040456
+
+open Archon Binius
+
+structure AiurChannels where
+  func : ChannelId
+  add : ChannelId
+  mul : ChannelId
+  mem : SmallMap Nat ChannelId
+
+inductive CachedOracleKey
+  | const : UInt128 → CachedOracleKey
+  | lc : ArithExpr → TowerField → CachedOracleKey
+  deriving Ord
+
+structure SynthState where
+  circuitModule : CircuitModule
+  cachedOracles : Batteries.RBMap CachedOracleKey OracleIdx compare
+
+@[inline] def SynthState.init (circuitModule : CircuitModule) : SynthState :=
+  ⟨circuitModule, default⟩
+
+abbrev SynthM := StateM SynthState
+
+@[inline] def synthesizeM (circuitModuleId : USize) (f : SynthM α) : CircuitModule :=
+  let (_, stt) := f.run $ .init (CircuitModule.new circuitModuleId)
+  stt.circuitModule
+
+@[inline] def flush (direction : FlushDirection) (channelId : ChannelId)
+    (selector : OracleIdx) (args : @& Array OracleIdx) (multiplicity : UInt64) : SynthM Unit :=
+  modify fun stt =>
+    let circuitModule := stt.circuitModule.flush direction channelId selector
+      args multiplicity
+    { stt with circuitModule }
+
+@[inline] def send (channelId : ChannelId) (args : @& Array OracleIdx) : SynthM Unit :=
+  flush .push channelId CircuitModule.selector args 1
+
+@[inline] def recv (channelId : ChannelId) (args : @& Array OracleIdx) : SynthM Unit :=
+  flush .pull channelId CircuitModule.selector args 1
+
+@[inline] def assertZero (name : @& String) (expr : @& ArithExpr) : SynthM Unit :=
+  modify fun stt =>
+    { stt with circuitModule := stt.circuitModule.assertZero name #[] expr }
+
+def addCommitted (name : @& String) (tf : TowerField) : SynthM OracleIdx :=
+  modifyGet fun stt =>
+    let (o, circuitModule) := stt.circuitModule.addCommitted name tf
+    (o, { stt with circuitModule })
+
+def addTransparent (name : @& String) (transparent : Transparent) : SynthM OracleIdx :=
+  modifyGet fun stt =>
+    let (o, circuitModule) := stt.circuitModule.addTransparent name transparent
+    (o, { stt with circuitModule })
+
+def addLinearCombination (name : @& String) (offset : @& UInt128)
+    (inner : @& Array (OracleIdx × UInt128)) : SynthM OracleIdx :=
+  modifyGet fun stt =>
+    let (o, circuitModule) := stt.circuitModule.addLinearCombination name offset inner
+    (o, { stt with circuitModule })
+
+def addPacked (name : @& String) (inner : OracleIdx) (logDegree : USize) : SynthM OracleIdx :=
+  modifyGet fun stt =>
+    let (o, circuitModule) := stt.circuitModule.addPacked name inner logDegree
+    (o, { stt with circuitModule })
+
+def addShifted (name : @& String) (inner : OracleIdx) (shiftOffset : UInt32)
+    (blockBits : USize) (shiftVariant : ShiftVariant) : SynthM OracleIdx :=
+  modifyGet fun stt =>
+    let (o, circuitModule) := stt.circuitModule.addShifted name inner shiftOffset
+      blockBits shiftVariant
+    (o, { stt with circuitModule })
+
+def addProjected (name : @& String) (inner : OracleIdx) (mask : UInt64)
+    (unprojectedSize startIndex : USize) : SynthM OracleIdx :=
+  modifyGet fun stt =>
+    let (o, circuitModule) := stt.circuitModule.addProjected name inner mask
+      unprojectedSize startIndex
+    (o, { stt with circuitModule })
+
+@[inline] def cacheConstAux (value : UInt128) (stt : SynthState) : OracleIdx × SynthState :=
+  let (o, circuitModule) := stt.circuitModule.addTransparent
+    s!"cached-const-{value}" (.const value)
+  let cachedOracles := stt.cachedOracles.insert (.const value) o
+  (o, ⟨circuitModule, cachedOracles⟩)
+
+def cacheConst (value : UInt128) : SynthM OracleIdx :=
+  modifyGet fun stt => match stt.cachedOracles.find? (.const value) with
+  | some o => (o, stt)
+  | none => cacheConstAux value stt
+
+def cacheLc (expr : ArithExpr) (tf : TowerField) : SynthM OracleIdx :=
+  let key := .lc expr tf
+  modifyGet fun stt => match stt.cachedOracles.find? key with
+  | some o => (o, stt)
+  | none => if let .const value := expr then cacheConstAux value stt else
+    let (summands, offset) := accSummandsAndOffset expr #[] 0
+    let inner := summands.map (·, 1)
+    let (o, circuitModule) := stt.circuitModule.addLinearCombination
+      s!"cached-lc-{expr}-{tf}" offset inner
+    let cachedOracles := stt.cachedOracles.insert key o
+    (o, ⟨circuitModule, cachedOracles⟩)
+where
+  accSummandsAndOffset expr summands (offset : UInt128) := match expr with
+    | .const c => (summands, addUInt128InBinaryField offset c tf)
+    | .oracle o => (summands.push o, offset)
+    | .add a b =>
+      let (summands', offset') := accSummandsAndOffset a summands offset
+      accSummandsAndOffset b summands' offset'
+    | _ => unreachable!
+
+def provide (channelId : ChannelId) (multiplicity : OracleIdx)
+    (args : Array OracleIdx) : SynthM Unit := do
+  let ones ← cacheConst 1
+  send channelId (args.push ones)
+  recv channelId (args.push multiplicity)
+
+def require (channelId : ChannelId) (prevIdx : OracleIdx) (args : Array OracleIdx)
+    (sel : OracleIdx) : SynthM Unit := do
+  let idx ← addLinearCombination s!"index-{channelId.toUSize}" 0 #[(prevIdx, B64_MULT_GEN)]
+  flush .pull channelId sel (args.push prevIdx) 1
+  flush .push channelId sel (args.push idx) 1
+
+def synthesizeFunction (funcIdx : Nat) (function : Bytecode.Function)
+    (layout : Layout) (aiurChannels : AiurChannels) : SynthM Unit := do
+  let columns ← modifyGet fun stt =>
+    let (cs, circuitModule) := Columns.ofLayout stt.circuitModule layout
+    (cs, { stt with circuitModule })
+  let constraints := buildFuncionConstraints function layout columns
+  assertZero "topmost" (constraints.topmostSelector - CircuitModule.selector)
+  let funcIdxOracle ← cacheConst (.ofNatWrap funcIdx)
+  provide aiurChannels.func constraints.multiplicity (constraints.io.push funcIdxOracle)
+  constraints.uniqueConstraints.zipIdx.forM fun (expr, i) =>
+    assertZero s!"unique constraint {i}" expr
+  constraints.sharedConstraints.zipIdx.forM fun (expr, i) =>
+    assertZero s!"shared constraint {i}" expr
+  constraints.sends.forM fun (channel, sel, args) => do
+    let sel ← cacheLc sel .b1
+    let args ← args.mapM (cacheLc · .b64)
+    match channel with
+    | .add => flush .push aiurChannels.add sel args 1
+    | .mul => flush .push aiurChannels.mul sel args 1
+    | _ => unreachable!
+  constraints.requires.forM fun (channel, sel, prevIdx, args) => do
+    let sel ← cacheLc sel .b1
+    let args ← args.mapM (cacheLc · .b64)
+    match channel with
+    | .func funcIdx =>
+      let idx ← cacheConst (.ofNatWrap funcIdx.toNat)
+      require aiurChannels.func prevIdx (args.push idx) sel
+    | .mem width =>
+      let channelId := aiurChannels.mem.get width |>.get!
+      require channelId prevIdx args sel
+    | _ => unreachable!
+
+def synthesizeAdd (channelId : ChannelId) : SynthM Unit := do
+  let xin ← addCommitted "add-xin" .b1
+  let yin ← addCommitted "add-yin" .b1
+  let zout ← addCommitted "add-zout" .b1
+  let cout ← addCommitted "add-cout" .b1
+  let cin ← addShifted "add-cin" cout 1 TowerField.b64.logDegree .logicalLeft
+  let xinPacked ← addPacked "add-xin-packed" xin TowerField.b64.logDegree
+  let yinPacked ← addPacked "add-yin-packed" yin TowerField.b64.logDegree
+  let zoutPacked ← addPacked "add-zout-packed" zout TowerField.b64.logDegree
+  let mask := 0b111111
+  let coutProjected ← addProjected "add-cout-projected" cout mask 64 0
+  assertZero "add-sum" $ xin + yin + cin - zout
+  assertZero "add-carry" $ (xin + cin) * (yin + cin) + cin - cout
+  recv channelId #[xinPacked, yinPacked, zoutPacked, coutProjected]
+
+def synthesizeMul (channelId : ChannelId) : SynthM Unit :=
+  sorry
+
+def synthesizeMemory (channelId : ChannelId) (width : Nat) : SynthM Unit := do
+  let address ← addTransparent s!"mem-{width}-address" .incremental
+  let values ← Array.range width |>.mapM (addCommitted s!"mem-{width}-value-{·}" .b64)
+  let multiplicipy ← addCommitted s!"mem-{width}-multiplicity" .b64
+  let args := values.push address
+  provide channelId multiplicipy args
+
+structure AiurCircuitModules where
+  funcs : Array CircuitModule
+  add : CircuitModule
+  mul : CircuitModule
+  -- If we don't need these widths, we can change to `Array CircuitModule` later
+  mem : SmallMap Nat CircuitModule
+
+def synthesize (toplevel : Bytecode.Toplevel) : AiurCircuitModules :=
+  let channelAllocator := ChannelAllocator.init
+  let (funcChannel, channelAllocator) := channelAllocator.next
+  let (addChannel, channelAllocator) := channelAllocator.next
+  let (mulChannel, channelAllocator) := channelAllocator.next
+  let (memChannels, _) := toplevel.memWidths.foldl (init := (default, channelAllocator))
+    fun (map, channelAllocator) width =>
+      let (channelId, channelAllocator) := channelAllocator.next
+      (map.insert width channelId, channelAllocator)
+  let aiurChannels := AiurChannels.mk funcChannel addChannel mulChannel memChannels
+  let funcsModules := toplevel.functions.zip toplevel.layouts |>.zipIdx.map
+    fun ((function, layout), functionIdx) => synthesizeM functionIdx.toUSize
+      (synthesizeFunction functionIdx function layout aiurChannels)
+  let numFunctions := toplevel.functions.size.toUSize
+  let addModule := synthesizeM (numFunctions + 1) (synthesizeAdd addChannel)
+  let mulModule := synthesizeM (numFunctions + 2) (synthesizeMul mulChannel)
+  let memIdStart := numFunctions + 3
+  let memModules := memChannels.pairs.zipIdx.map
+    fun ((width, channelId), memIdx) =>
+      let circuitModule := synthesizeM (memIdStart + memIdx.toUSize)
+        (synthesizeMemory channelId width)
+      (width, circuitModule)
+  ⟨funcsModules, addModule, mulModule, ⟨memModules⟩⟩
+
+end Aiur.Circuit

--- a/Ix/Archon/ArithExpr.lean
+++ b/Ix/Archon/ArithExpr.lean
@@ -11,7 +11,7 @@ inductive ArithExpr
   | add : ArithExpr → ArithExpr → ArithExpr
   | mul : ArithExpr → ArithExpr → ArithExpr
   | pow : ArithExpr → UInt64 → ArithExpr
-  deriving Inhabited
+  deriving Inhabited, Ord
 
 instance : Add ArithExpr := ⟨.add⟩
 instance : Sub ArithExpr := ⟨.add⟩
@@ -35,6 +35,8 @@ def toString : ArithExpr → String
   | add x y => s!"Add({x.toString}, {y.toString})"
   | mul x y => s!"Mul({x.toString}, {y.toString})"
   | pow x e => s!"Pow({x.toString}, {e})"
+
+instance : ToString ArithExpr := ⟨toString⟩
 
 def toBytes : @& ArithExpr → ByteArray
   | const u128 => ⟨#[0]⟩ ++ u128.toLEBytes

--- a/Ix/Archon/Circuit.lean
+++ b/Ix/Archon/Circuit.lean
@@ -19,7 +19,7 @@ namespace CircuitModule
 @[never_extract, extern "c_rs_circuit_module_new"]
 opaque new : USize → CircuitModule
 
-abbrev selector : CircuitModule → OracleIdx := fun _ => ⟨0⟩
+abbrev selector : OracleIdx := ⟨0⟩
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_freeze_oracles"]
@@ -30,8 +30,8 @@ opaque initWitnessModule : @& CircuitModule → WitnessModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_flush"]
-opaque flush : CircuitModule → Binius.FlushDirection → Binius.ChannelId → @& Array OracleIdx →
-  (multiplicity : UInt64) → CircuitModule
+opaque flush : CircuitModule → Binius.FlushDirection → Binius.ChannelId →
+  (selector : OracleIdx) → @& Array OracleIdx → (multiplicity : UInt64) → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_assert_zero"]

--- a/Ix/Archon/OracleIdx.lean
+++ b/Ix/Archon/OracleIdx.lean
@@ -2,6 +2,6 @@ namespace Archon
 
 structure OracleIdx where
   toUSize : USize
-  deriving Inhabited
+  deriving Inhabited, Ord
 
 end Archon

--- a/Ix/Archon/TowerField.lean
+++ b/Ix/Archon/TowerField.lean
@@ -1,0 +1,33 @@
+import Ix.Unsigned
+
+namespace Archon
+
+inductive TowerField
+  | b1 | b2 | b4 | b8 | b16 | b32 | b64 | b128
+  deriving Ord
+
+def TowerField.logDegree : TowerField → USize
+  | .b1 => 0
+  | .b2 => 1
+  | .b4 => 2
+  | .b8 => 3
+  | .b16 => 4
+  | .b32 => 5
+  | .b64 => 6
+  | .b128 => 7
+
+instance : ToString TowerField where
+  toString
+    | .b1 => "b1"
+    | .b2 => "b2"
+    | .b4 => "b4"
+    | .b8 => "b8"
+    | .b16 => "b16"
+    | .b32 => "b32"
+    | .b64 => "b64"
+    | .b128 => "b128"
+
+@[extern "c_rs_add_u128_in_binary_field"]
+opaque addUInt128InBinaryField : @& UInt128 → @& UInt128 → TowerField → UInt128
+
+end Archon

--- a/Ix/Archon/Transparent.lean
+++ b/Ix/Archon/Transparent.lean
@@ -3,18 +3,18 @@ import Ix.Unsigned
 namespace Archon
 
 inductive Transparent
-  | constant : UInt128 → Transparent
+  | const : UInt128 → Transparent
   | incremental
   deriving Inhabited
 
 namespace Transparent
 
 def toString : Transparent → String
-  | constant u128 => s!"Constant{u128}"
+  | const u128 => s!"Constant{u128}"
   | incremental => "Incremental"
 
 def toBytes : @& Transparent → ByteArray
-  | constant u128 => ⟨#[0]⟩ ++ u128.toLEBytes
+  | const u128 => ⟨#[0]⟩ ++ u128.toLEBytes
   | incremental => ⟨#[1]⟩
 
 /--

--- a/Ix/Archon/Witness.lean
+++ b/Ix/Archon/Witness.lean
@@ -1,10 +1,8 @@
 import Ix.Archon.OracleIdx
+import Ix.Archon.TowerField
 import Ix.Unsigned
 
 namespace Archon
-
-inductive TowerField
-  | b1 | b2 | b4 | b8 | b16 | b32 | b64 | b128
 
 private opaque GenericNonempty : NonemptyType
 def WitnessModule : Type := GenericNonempty.type

--- a/Ix/Unsigned.lean
+++ b/Ix/Unsigned.lean
@@ -23,6 +23,9 @@ abbrev size := 2^128
 @[extern "c_u128_of_lo_hi"]
 opaque ofLoHi : (lo : UInt64) → (hi : UInt64) → UInt128
 
+instance : Inhabited UInt128 where
+  default := ofLoHi 0 0
+
 def ofNatCore (n : Nat) (_ : n < size := by decide) : UInt128 :=
   let lo := n % UInt64.size |>.toUInt64
   let hi := n / UInt64.size |>.toUInt64

--- a/Tests/Archon.lean
+++ b/Tests/Archon.lean
@@ -13,7 +13,7 @@ def populateAndValidate (circuitModule : CircuitModule)
 
 def transparent : TestSeq :=
   let circuitModule := CircuitModule.new 0
-  let (_, circuitModule) := circuitModule.addTransparent "constant" (.constant 300)
+  let (_, circuitModule) := circuitModule.addTransparent "constant" (.const 300)
   let (_, circuitModule) := circuitModule.addTransparent "incremental" .incremental
   let circuitModule := circuitModule.freezeOracles
   let witnessModule := circuitModule.initWitnessModule

--- a/Tests/FFIConsistency.lean
+++ b/Tests/FFIConsistency.lean
@@ -54,7 +54,7 @@ instance : SampleableExt ArithExpr := SampleableExt.mkSelfContained genArithExpr
 
 def genTransparent : Gen Transparent :=
   frequency [
-      (10, .constant <$> genUInt128),
+      (10, .const <$> genUInt128),
       (10, pure .incremental),
     ]
 

--- a/c/archon.c
+++ b/c/archon.c
@@ -182,6 +182,7 @@ extern lean_obj_res c_rs_circuit_module_flush(
     lean_obj_arg l_circuit,
     bool direction_pull,
     size_t channel_id,
+    size_t selector,
     b_lean_obj_arg oracle_ids,
     uint64_t multiplicity
 ) {
@@ -190,6 +191,7 @@ extern lean_obj_res c_rs_circuit_module_flush(
         get_object_ref(linear),
         direction_pull,
         channel_id,
+        selector,
         oracle_ids,
         multiplicity
     );

--- a/c/rust.h
+++ b/c/rust.h
@@ -29,7 +29,7 @@ void *rs_circuit_module_new(size_t);
 void rs_circuit_module_free(void*);
 void rs_circuit_module_freeze_oracles(void*);
 void *rs_circuit_module_init_witness_module(void*);
-void rs_circuit_module_flush(void*, bool, size_t, b_lean_obj_arg, uint64_t);
+void rs_circuit_module_flush(void*, bool, size_t, size_t, b_lean_obj_arg, uint64_t);
 void rs_circuit_module_assert_zero(
     void*, char const*, b_lean_obj_arg, b_lean_obj_arg
 );
@@ -72,3 +72,7 @@ void *rs_keccak256_hasher_init(void);
 void rs_keccak256_hasher_free(void*);
 void *rs_keccak256_hasher_update(void*, void*);
 void *rs_keccak256_hasher_finalize(void*, void*);
+
+/* --- u128 --- */
+
+uint8_t *rs_add_u128_in_binary_field(uint8_t*, uint8_t*, uint8_t);

--- a/c/unsigned.c
+++ b/c/unsigned.c
@@ -86,3 +86,16 @@ extern uint8_t c_u128_cmp(b_lean_obj_arg a, b_lean_obj_arg b) {
 extern lean_obj_res c_u128_to_le_bytes(b_lean_obj_arg u128) {
     return mk_byte_array(2 * sizeof(uint64_t), lean_get_external_data(u128));
 }
+
+extern lean_obj_res c_rs_add_u128_in_binary_field(
+    b_lean_obj_arg a,
+    b_lean_obj_arg b,
+    uint8_t tower_level
+) {
+    uint8_t *bytes = rs_add_u128_in_binary_field(
+        lean_get_external_data(a),
+        lean_get_external_data(b),
+        tower_level
+    );
+    return lean_alloc_external(get_u128_class(), bytes);
+}

--- a/src/lean/ffi/archon/circuit.rs
+++ b/src/lean/ffi/archon/circuit.rs
@@ -54,7 +54,7 @@ extern "C" fn rs_circuit_module_flush(
     circuit_module: &mut CircuitModule,
     direction_pull: bool,
     channel_idx: usize,
-    oracle_id: OracleIdx,
+    selector: OracleIdx,
     oracle_idxs: &LeanArrayObject,
     multiplicity: u64,
 ) {
@@ -62,7 +62,7 @@ extern "C" fn rs_circuit_module_flush(
     use FlushDirection::{Pull, Push};
     let direction = if direction_pull { Pull } else { Push };
     let channel_id = channel_idx;
-    circuit_module.flush(direction, channel_id, oracle_id, oracle_idxs, multiplicity);
+    circuit_module.flush(direction, channel_id, selector, oracle_idxs, multiplicity);
 }
 
 #[unsafe(no_mangle)]

--- a/src/lean/ffi/mod.rs
+++ b/src/lean/ffi/mod.rs
@@ -3,6 +3,7 @@ pub mod binius;
 pub mod byte_array;
 pub mod iroh;
 pub mod keccak;
+pub mod u128;
 
 use std::ffi::{CStr, CString, c_char, c_void};
 

--- a/src/lean/ffi/u128.rs
+++ b/src/lean/ffi/u128.rs
@@ -1,0 +1,37 @@
+use binius_field::{
+    BinaryField1b as B1, BinaryField2b as B2, BinaryField4b as B4, BinaryField8b as B8,
+    BinaryField16b as B16, BinaryField32b as B32, BinaryField64b as B64, BinaryField128b as B128,
+    underlier::SmallU,
+};
+
+use super::to_raw;
+
+#[allow(trivial_numeric_casts)]
+#[unsafe(no_mangle)]
+extern "C" fn rs_add_u128_in_binary_field(a: &u128, b: &u128, tower_level: u8) -> *const u128 {
+    macro_rules! add_for_binary_field {
+        (lo, $t:ident) => {{
+            let a = $t::new(SmallU::new((*a).try_into().unwrap()));
+            let b = $t::new(SmallU::new((*b).try_into().unwrap()));
+            let c = a + b;
+            to_raw(c.val().val() as u128)
+        }};
+        (hi, $t:ident) => {{
+            let a = $t::new((*a).try_into().unwrap());
+            let b = $t::new((*b).try_into().unwrap());
+            let c = a + b;
+            to_raw(c.val() as u128)
+        }};
+    }
+    match tower_level {
+        0 => add_for_binary_field!(lo, B1),
+        1 => add_for_binary_field!(lo, B2),
+        2 => add_for_binary_field!(lo, B4),
+        3 => add_for_binary_field!(hi, B8),
+        4 => add_for_binary_field!(hi, B16),
+        5 => add_for_binary_field!(hi, B32),
+        6 => add_for_binary_field!(hi, B64),
+        7 => add_for_binary_field!(hi, B128),
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
This patch ports part of the Rust code for Aiur synthesis, to Lean already migrating to Archon.

Synthesizing the multiplication `CircuitModule`, however, will be left to another patch because it will require new Archon API.