### PR TITLE
feat: Archon witness `parPopulate`

### DIFF
--- a/Ix/Archon/Witness.lean
+++ b/Ix/Archon/Witness.lean
@@ -54,6 +54,10 @@ opaque pushUInt128sTo : WitnessModule → @& Array UInt128 → EntryId → Witne
 @[never_extract, extern "c_rs_witness_module_populate"]
 opaque populate : WitnessModule → (height : UInt64) → WitnessModule
 
+/-- **Invalidates** the elements of the input `Array WitnessModule` -/
+@[never_extract, extern "c_rs_witness_module_par_populate"]
+opaque parPopulate : @& Array WitnessModule → (heights : @& Array UInt64) → Array WitnessModule
+
 end WitnessModule
 
 /-- **Invalidates** the elements of the input `Array WitnessModule` -/

--- a/Tests/Archon.lean
+++ b/Tests/Archon.lean
@@ -131,6 +131,26 @@ def proveAndVerify : TestSeq :=
     withExceptOk "Archon prove and verify work"
       (verify #[circuitModule] #[] 1 100 proof) fun _ => .done
 
+def parPopulate : TestSeq :=
+  let c₁ := CircuitModule.new 0
+  let c₂ := CircuitModule.new 1
+  let (o₁, c₁) := c₁.addCommitted "x" .b128
+  let (o₂, c₂) := c₂.addCommitted "x" .b128
+  let c₁ := c₁.freezeOracles
+  let c₂ := c₂.freezeOracles
+  let w₁ := c₁.initWitnessModule
+  let w₂ := c₂.initWitnessModule
+  let (e₁, w₁) := w₁.addEntry
+  let (e₂, w₂) := w₂.addEntry
+  let w₁ := w₁.pushUInt8sTo #[0] e₁
+  let w₂ := w₂.pushUInt8sTo #[0] e₂
+  let w₁ := w₁.bindOracleTo o₁ e₁ .b128
+  let w₂ := w₂.bindOracleTo o₂ e₂ .b128
+  let heights := #[1, 1]
+  let ws := WitnessModule.parPopulate #[w₁, w₂] heights
+  let w := compileWitnessModules ws heights
+  withExceptOk "Parallel population works" (validateWitness #[c₁, c₂] #[] w) fun _ => .done
+
 def versionCircuitModules : TestSeq :=
   let c₁ := CircuitModule.new 0
   let (_, c₁) := c₁.addCommitted "a" .b1
@@ -147,5 +167,6 @@ def Tests.Archon.suite := [
     shifted,
     pushData,
     proveAndVerify,
+    parPopulate,
     versionCircuitModules,
   ]

--- a/c/archon.c
+++ b/c/archon.c
@@ -131,6 +131,24 @@ extern lean_obj_res c_rs_witness_module_populate(lean_obj_arg l_witness, uint64_
     return alloc_lean_linear_object(new_linear);
 }
 
+extern lean_obj_res c_rs_witness_module_par_populate(
+    lean_obj_arg l_witnesses,
+    b_lean_obj_arg heights
+) {
+    size_t size = lean_array_size(l_witnesses);
+    lean_object **witnesses_cptrs = lean_array_cptr(l_witnesses);
+    void *witnesses_ptrs[size];
+    lean_object *new_l_witnesses = lean_alloc_array(size, size);
+    lean_object **new_witnesses_cptrs = lean_array_cptr(new_l_witnesses);
+    for (size_t i = 0; i < size; i++) {
+        linear_object *linear = validated_linear(witnesses_cptrs[i]);
+        witnesses_ptrs[i] = get_object_ref(linear);
+        new_witnesses_cptrs[i] = alloc_lean_linear_object(linear_bump(linear));
+    }
+    rs_witness_module_par_populate(witnesses_ptrs, heights);
+    return new_l_witnesses;
+}
+
 extern lean_obj_res c_rs_compile_witness_modules(
     lean_obj_arg l_witnesses,
     b_lean_obj_arg heights

--- a/c/rust.h
+++ b/c/rust.h
@@ -19,6 +19,7 @@ void rs_witness_module_push_u32s_to(void*, b_lean_obj_arg, size_t);
 void rs_witness_module_push_u64s_to(void*, b_lean_obj_arg, size_t);
 void rs_witness_module_push_u128s_to(void*, b_lean_obj_arg, size_t);
 void rs_witness_module_populate(void*, uint64_t);
+void rs_witness_module_par_populate(void**, b_lean_obj_arg);
 void *rs_compile_witness_modules(void**, b_lean_obj_arg);
 
 void rs_witness_free(void*);


### PR DESCRIPTION
Implement parallel witness population for the Archon bindings in Lean.