### PR TITLE
fix: `lean_unbox` macro didn't really mimic `lean.h`

### DIFF
--- a/Tests/Common.lean
+++ b/Tests/Common.lean
@@ -3,6 +3,9 @@ import Ix.Unsigned
 
 open LSpec SlimCheck Gen
 
+def genUInt32 : Gen UInt32 :=
+  UInt32.ofNat <$> choose Nat 0 0xFFFFFFFF
+
 def genUInt64 : Gen UInt64 :=
   UInt64.ofNat <$> choose Nat 0 0xFFFFFFFFFFFFFFFF
 

--- a/Tests/FFIConsistency.lean
+++ b/Tests/FFIConsistency.lean
@@ -8,6 +8,26 @@ open LSpec SlimCheck Gen
 
 open Archon Binius
 
+/- Array UInt32 -/
+
+def genArrayUInt32 : Gen $ Array UInt32 := do
+  let numValues ← choose Nat 1 8
+  let mut values := Array.mkEmpty numValues
+  for _ in [:numValues] do
+    values := values.push $ ← genUInt32
+  pure values
+
+@[extern "rs_boxed_u32s_are_equivalent_to_bytes"]
+opaque boxedUInt32sAreEquivalentToBytes : @& Array UInt32 → @& ByteArray → Bool
+
+def arrayUInt32sToBytes (arr : Array UInt32) : ByteArray :=
+  arr.foldl (init := .mkEmpty (4 * arr.size)) fun acc u => acc ++ u.toLEBytes
+
+instance : Shrinkable (Array UInt32) where
+  shrink _ := []
+
+instance : SampleableExt (Array UInt32) := SampleableExt.mkSelfContained genArrayUInt32
+
 /- Boundary -/
 
 def genBoundary : Gen Boundary := do
@@ -69,6 +89,8 @@ instance : SampleableExt Transparent := SampleableExt.mkSelfContained genTranspa
 /- Suite -/
 
 def Tests.FFIConsistency.suite := [
+    check "Boxed UInt32s are unboxed correctly in Rust"
+      (∀ arr : Array UInt32, boxedUInt32sAreEquivalentToBytes arr (arrayUInt32sToBytes arr)),
     check "ArithExpr Lean->Rust mapping matches the deserialized bytes"
       (∀ expr : ArithExpr, expr.isEquivalentToBytes expr.toBytes),
     check "Boundary Lean->Rust mapping matches the deserialized bytes"


### PR DESCRIPTION
We need to cast the pointer to `usize` before performing the shift.