### PR TITLE
chore: simplify archon

### DIFF
--- a/Ix/Aiur/Constraints.lean
+++ b/Ix/Aiur/Constraints.lean
@@ -46,7 +46,7 @@ structure Constraints where
   recvs : Array (Channel × ArithExpr × Array ArithExpr)
   requires : Array (Channel × ArithExpr × OracleIdx × Array ArithExpr)
   topmostSelector : ArithExpr
-  io : Array OracleIdx
+  io : Array OracleOrConst
   multiplicity : OracleIdx
 
 def blockSelector (block : Bytecode.Block) (columns : Columns) : ArithExpr :=
@@ -63,7 +63,7 @@ def new (function : Bytecode.Function) (layout : Layout) (columns : Columns) : C
     recvs := #[]
     requires := #[]
     topmostSelector := blockSelector function.body columns
-    io := columns.inputs ++ columns.outputs
+    io := columns.inputs ++ columns.outputs |>.map .oracle
     multiplicity := columns.multiplicity }
 
 @[inline] def pushUnique (constraints : Constraints) (expr : ArithExpr) : Constraints :=

--- a/Ix/Archon/Circuit.lean
+++ b/Ix/Archon/Circuit.lean
@@ -2,6 +2,7 @@ import Blake3
 import Ix.Archon.ArithExpr
 import Ix.Archon.OracleIdx
 import Ix.Archon.RelativeHeight
+import Ix.Archon.OracleOrConst
 import Ix.Archon.Transparent
 import Ix.Archon.Witness
 import Ix.Binius.Common
@@ -32,7 +33,7 @@ opaque initWitnessModule : @& CircuitModule → WitnessModule
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_flush"]
 opaque flush : CircuitModule → Binius.FlushDirection → Binius.ChannelId →
-  (selector : OracleIdx) → @& Array OracleIdx → (multiplicity : UInt64) → CircuitModule
+  (selector : OracleIdx) → @& Array OracleOrConst → (multiplicity : UInt64) → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_assert_zero"]
@@ -44,14 +45,9 @@ opaque assertZero : CircuitModule → @& String → @& Array OracleIdx →
 opaque assertNotZero : CircuitModule → OracleIdx → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
-@[never_extract, extern "c_rs_circuit_module_assert_dynamic_exp"]
-opaque assertDynamicExp : CircuitModule → (expBits : @& Array OracleIdx) →
-  (result : OracleIdx) → (base : OracleIdx) → CircuitModule
-
-/-- **Invalidates** the input `CircuitModule` -/
-@[never_extract, extern "c_rs_circuit_module_assert_static_exp"]
-opaque assertStaticExp : CircuitModule → (expBits : @& Array OracleIdx) →
-  (result : OracleIdx) → (base : @& UInt128) → (baseTF : TowerField) → CircuitModule
+@[never_extract, extern "c_rs_circuit_module_assert_exp"]
+opaque assertExp : CircuitModule → (expBits : @& Array OracleIdx) →
+  (result : OracleIdx) → (base : @& OracleOrConst) → CircuitModule
 
 /-- **Invalidates** the input `CircuitModule` -/
 @[never_extract, extern "c_rs_circuit_module_add_committed"]

--- a/Ix/Archon/OracleOrConst.lean
+++ b/Ix/Archon/OracleOrConst.lean
@@ -1,0 +1,33 @@
+import Ix.Archon.OracleIdx
+import Ix.Archon.TowerField
+import Ix.Unsigned
+
+namespace Archon
+
+inductive OracleOrConst
+  | oracle : OracleIdx → OracleOrConst
+  | const : UInt128 → TowerField → OracleOrConst
+  deriving Inhabited
+
+namespace OracleOrConst
+
+def toString : OracleOrConst → String
+  | oracle o => s!"Oracle({o.toUSize})"
+  | const base tf => s!"Const({base}, {tf})"
+
+instance : ToString OracleOrConst := ⟨toString⟩
+
+def toBytes : @& OracleOrConst → ByteArray
+  | oracle o => ⟨#[0]⟩ ++ o.toUSize.toLEBytes
+  | const base tf => ⟨#[1]⟩ ++ base.toLEBytes |>.push tf.logDegree.toUInt8
+
+/--
+Function meant for testing that tells whether the Lean→Rust mapping of OracleOrConst
+results on the same expression as deserializing the provided bytes.
+-/
+@[extern "rs_oracle_or_const_is_equivalent_to_bytes"]
+opaque isEquivalentToBytes : @& OracleOrConst → @& ByteArray → Bool
+
+end OracleOrConst
+
+end Archon

--- a/Ix/Archon/TowerField.lean
+++ b/Ix/Archon/TowerField.lean
@@ -4,6 +4,7 @@ namespace Archon
 
 inductive TowerField
   | b1 | b2 | b4 | b8 | b16 | b32 | b64 | b128
+  deriving Inhabited
 
 def TowerField.logDegree : TowerField → USize
   | .b1 => 0

--- a/Ix/Binius/Common.lean
+++ b/Ix/Binius/Common.lean
@@ -6,7 +6,6 @@ structure ChannelId where
   toUSize : USize
   deriving Inhabited
 
--- We can delete this later if we don't need it
 structure ChannelAllocator where
   nextId : USize
 

--- a/Tests/Aiur.lean
+++ b/Tests/Aiur.lean
@@ -145,12 +145,11 @@ where
     let (x, circuitModule) := circuitModule.addPacked "x-bits-packed" xBits 6
     let (y, circuitModule) := circuitModule.addPacked "y-bits-packed" yBits 6
     let (z, circuitModule) := circuitModule.addPacked "z-bits-packed" zBits 6
-    let args := #[x, y, z]
-    let (ones, circuitModule) := circuitModule.addTransparent "ones" (.const 1) .base
+    let args := #[x, y, z].map .oracle
     let circuitModule := circuitModule.flush .push channelId CircuitModule.selector
-      (args.push ones) 1
+      (args.push (.const 1 .b1)) 1
     let circuitModule := circuitModule.flush .pull channelId CircuitModule.selector
-      (args.push multiplicity) 1
+      (args.push (.oracle multiplicity)) 1
     (circuitModule.popNamespace, #[xBits, yBits, multiplicity])
   populate entries oracles witnessModule :=
     if entries.isEmpty then (witnessModule, .inactive) else

--- a/c/archon.c
+++ b/c/archon.c
@@ -216,7 +216,7 @@ extern lean_obj_res c_rs_circuit_module_flush(
     bool direction_pull,
     size_t channel_id,
     size_t selector,
-    b_lean_obj_arg oracle_idxs,
+    b_lean_obj_arg values,
     uint64_t multiplicity
 ) {
     linear_object *linear = validated_linear(l_circuit);
@@ -225,7 +225,7 @@ extern lean_obj_res c_rs_circuit_module_flush(
         direction_pull,
         channel_id,
         selector,
-        oracle_idxs,
+        values,
         multiplicity
     );
     linear_object *new_linear = linear_bump(linear);
@@ -260,37 +260,18 @@ extern lean_obj_res c_rs_circuit_module_assert_not_zero(
     return alloc_lean_linear_object(new_linear);
 }
 
-extern lean_obj_res c_rs_circuit_module_assert_dynamic_exp(
+extern lean_obj_res c_rs_circuit_module_assert_exp(
     lean_obj_arg l_circuit,
     b_lean_obj_arg exp_bits,
     size_t result,
-    size_t base
+    b_lean_obj_arg base
 ) {
     linear_object *linear = validated_linear(l_circuit);
-    rs_circuit_module_assert_dynamic_exp(
+    rs_circuit_module_assert_exp(
         get_object_ref(linear),
         exp_bits,
         result,
         base
-    );
-    linear_object *new_linear = linear_bump(linear);
-    return alloc_lean_linear_object(new_linear);
-}
-
-extern lean_obj_res c_rs_circuit_module_assert_static_exp(
-    lean_obj_arg l_circuit,
-    b_lean_obj_arg exp_bits,
-    size_t result,
-    b_lean_obj_arg base,
-    uint8_t base_tower_level
-) {
-    linear_object *linear = validated_linear(l_circuit);
-    rs_circuit_module_assert_static_exp(
-        get_object_ref(linear),
-        exp_bits,
-        result,
-        lean_get_external_data(base),
-        base_tower_level
     );
     linear_object *new_linear = linear_bump(linear);
     return alloc_lean_linear_object(new_linear);

--- a/c/rust.h
+++ b/c/rust.h
@@ -37,8 +37,7 @@ void rs_circuit_module_assert_zero(
     void*, char const*, b_lean_obj_arg, b_lean_obj_arg
 );
 void rs_circuit_module_assert_not_zero(void*, size_t);
-void rs_circuit_module_assert_dynamic_exp(void*, b_lean_obj_arg, size_t, size_t);
-void rs_circuit_module_assert_static_exp(void*, b_lean_obj_arg, size_t, uint8_t*, uint8_t);
+void rs_circuit_module_assert_exp(void*, b_lean_obj_arg, size_t, b_lean_obj_arg);
 size_t rs_circuit_module_add_committed(void*, char const *, uint8_t, b_lean_obj_arg);
 size_t rs_circuit_module_add_transparent(void*, char const *, b_lean_obj_arg, b_lean_obj_arg);
 size_t rs_circuit_module_add_linear_combination(

--- a/src/archon/canonical.rs
+++ b/src/archon/canonical.rs
@@ -5,7 +5,7 @@ use binius_utils::checked_arithmetics::log2_strict_usize;
 use super::{
     OracleIdx, OracleInfo, OracleKind, RelativeHeight,
     arith_expr::ArithExpr,
-    circuit::{ArchonExp, ArchonFlush, ArchonOracleOrConst, CircuitModule, Constraint},
+    circuit::{CircuitModule, Constraint, Exp, Flush, OracleOrConst},
     transparent::Transparent,
 };
 
@@ -242,16 +242,16 @@ impl Canonical for FlushDirection {
     }
 }
 
-impl Canonical for ArchonFlush {
+impl Canonical for Flush {
     fn size(&self) -> usize {
         let Self {
-            oracles,
+            values,
             channel_id,
             direction,
             selector,
             multiplicity,
         } = self;
-        Canonical::size(oracles)
+        Canonical::size(values)
             + Canonical::size(channel_id)
             + Canonical::size(direction)
             + Canonical::size(selector)
@@ -259,13 +259,13 @@ impl Canonical for ArchonFlush {
     }
     fn write(&self, buffer: &mut Vec<u8>) {
         let Self {
-            oracles,
+            values,
             channel_id,
             direction,
             selector,
             multiplicity,
         } = self;
-        Canonical::write(oracles, buffer);
+        Canonical::write(values, buffer);
         Canonical::write(channel_id, buffer);
         Canonical::write(direction, buffer);
         Canonical::write(selector, buffer);
@@ -338,7 +338,7 @@ impl Canonical for Constraint {
     }
 }
 
-impl Canonical for ArchonOracleOrConst {
+impl Canonical for OracleOrConst {
     fn size(&self) -> usize {
         match self {
             Self::Oracle(o) => 1 + Canonical::size(o),
@@ -362,7 +362,7 @@ impl Canonical for ArchonOracleOrConst {
     }
 }
 
-impl Canonical for ArchonExp {
+impl Canonical for Exp {
     fn size(&self) -> usize {
         let Self {
             exp_bits,

--- a/src/lean/ffi/archon/mod.rs
+++ b/src/lean/ffi/archon/mod.rs
@@ -1,6 +1,7 @@
 pub mod arith_expr;
 pub mod circuit;
 pub mod module_mode;
+pub mod oracle_or_const;
 pub mod protocol;
 pub mod relative_height;
 pub mod transparent;

--- a/src/lean/ffi/archon/oracle_or_const.rs
+++ b/src/lean/ffi/archon/oracle_or_const.rs
@@ -1,0 +1,55 @@
+use binius_field::BinaryField128b;
+
+use crate::{
+    archon::{OracleIdx, circuit::OracleOrConst},
+    lean::{
+        ctor::LeanCtorObject,
+        ffi::{archon::boxed_usize_ptr_to_oracle_idx, as_ref_unsafe, external_ptr_to_u128},
+        sarray::LeanSArrayObject,
+    },
+};
+
+pub(super) fn lean_ctor_ptr_to_oracle_or_const(ctor: *const LeanCtorObject) -> OracleOrConst {
+    let ctor = as_ref_unsafe(ctor);
+    match ctor.tag() {
+        0 => {
+            let [oracle_idx_ptr] = ctor.objs();
+            OracleOrConst::Oracle(boxed_usize_ptr_to_oracle_idx(oracle_idx_ptr))
+        }
+        1 => {
+            let [base_ptr, tower_level_ptr] = ctor.objs();
+            let base = BinaryField128b::new(external_ptr_to_u128(base_ptr));
+            let tower_level = tower_level_ptr as usize;
+            OracleOrConst::Const { base, tower_level }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn oracle_or_const_from_bytes(bytes: &[u8]) -> OracleOrConst {
+    match bytes[0] {
+        0 => {
+            let mut oracle_idx_bytes = [0; size_of::<usize>()];
+            oracle_idx_bytes.copy_from_slice(&bytes[1..]);
+            let oracle_idx = OracleIdx(usize::from_le_bytes(oracle_idx_bytes));
+            OracleOrConst::Oracle(oracle_idx)
+        }
+        1 => {
+            let mut base_u128_bytes = [0; size_of::<u128>()];
+            base_u128_bytes.copy_from_slice(&bytes[1..size_of::<u128>() + 1]);
+            let base = BinaryField128b::new(u128::from_le_bytes(base_u128_bytes));
+            let tower_level = bytes[size_of::<u128>() + 1] as usize;
+            OracleOrConst::Const { base, tower_level }
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn rs_oracle_or_const_is_equivalent_to_bytes(
+    oracle_or_const_ptr: *const LeanCtorObject,
+    bytes: &LeanSArrayObject,
+) -> bool {
+    lean_ctor_ptr_to_oracle_or_const(oracle_or_const_ptr)
+        == oracle_or_const_from_bytes(bytes.data())
+}


### PR DESCRIPTION
* Archon flush values are now of `OracleOrConst`, following the Binius design more closely.
* Unify Archon exponentials by using `OracleOrConst` as the type for the base.

Closes #165