### PR TITLE
feat: Aiur arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1002,9 +1002,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2113,7 +2113,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=35adf6f1dd4739628dbdd535ce7a726209c993e2#35adf6f1dd4739628dbdd535ce7a726209c993e2"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=333f41f21034b0b5cda2c5682a6b9cb7ac085ef3#333f41f21034b0b5cda2c5682a6b9cb7ac085ef3"
 dependencies = [
  "bincode",
  "p3-air",
@@ -3394,9 +3394,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef838cd981b5c46e9e91e20e4623e43b29b5c251eb245b34da0cbd2da09ab27"
+checksum = "59b38b05028f398f08bea4691640503ec25fcb60b82fb61ce1f8fd1f4fccd3f7"
 dependencies = [
  "libc",
 ]
@@ -3886,9 +3886,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -4415,15 +4415,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.15.4",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -5499,9 +5498,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 anyhow = "1"
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "35adf6f1dd4739628dbdd535ce7a726209c993e2" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "333f41f21034b0b5cda2c5682a6b9cb7ac085ef3" }
 rayon = "1"
 rustc-hash = "2"
 indexmap = { version = "2", features = ["rayon"] }

--- a/Ix/Aiur/Meta.lean
+++ b/Ix/Aiur/Meta.lean
@@ -60,6 +60,7 @@ partial def elabPattern : ElabStxCat `pattern
 declare_syntax_cat                               typ
 syntax "G"                                     : typ
 syntax "(" typ (", " typ)* ")"                 : typ
+syntax "[" typ "; " num "]"                    : typ
 syntax "&" typ                                 : typ
 syntax ("." noWs)? ident                       : typ
 syntax "fn" "(" ")" " -> " typ                 : typ
@@ -69,6 +70,8 @@ partial def elabTyp : ElabStxCat `typ
   | `(typ| G) => pure $ mkConst ``Typ.field
   | `(typ| ($t:typ $[, $ts:typ]*)) => do
     mkAppM ``Typ.tuple #[← elabList t ts elabTyp ``Typ true]
+  | `(typ| [$t:typ; $n:num]) => do
+    mkAppM ``Typ.array #[← elabTyp t, mkNatLit n.getNat]
   | `(typ| &$t:typ) => do
     mkAppM ``Typ.pointer #[← elabTyp t]
   | `(typ| $[.]?$i:ident) => do
@@ -84,6 +87,7 @@ declare_syntax_cat                                          trm
 syntax ("." noWs)? ident                                  : trm
 syntax num                                                : trm
 syntax "(" trm (", " trm)* ")"                            : trm
+syntax "[" trm (", " trm)* "]"                            : trm
 syntax "return " trm                                      : trm
 syntax "let " pattern " = " trm "; " trm                  : trm
 syntax "match " trm " { " (pattern " => " trm ", ")+ " }" : trm
@@ -92,8 +96,9 @@ syntax ("." noWs)? ident "(" trm (", " trm)* ")"          : trm
 syntax "add" "(" trm ", " trm ")"                         : trm
 syntax "sub" "(" trm ", " trm ")"                         : trm
 syntax "mul" "(" trm ", " trm ")"                         : trm
-syntax "get" "(" trm ", " num ")"                         : trm
-syntax "slice" "(" trm ", " num ", " num ")"              : trm
+syntax "proj" "(" trm ", " num ")"                        : trm
+syntax trm "[" num "]"                                    : trm
+syntax trm "[" num ".." num "]"                           : trm
 syntax "store" "(" trm ")"                                : trm
 syntax "load" "(" trm ")"                                 : trm
 syntax "ptr_val" "(" trm ")"                              : trm
@@ -113,6 +118,9 @@ partial def elabTrm : ElabStxCat `trm
     mkAppM ``Term.data #[data]
   | `(trm| ($t:trm $[, $ts:trm]*)) => do
     let data ← mkAppM ``Data.tuple #[← elabList t ts elabTrm ``Term true]
+    mkAppM ``Term.data #[data]
+  | `(trm| [$t:trm $[, $ts:trm]*]) => do
+    let data ← mkAppM ``Data.array #[← elabList t ts elabTrm ``Term true]
     mkAppM ``Term.data #[data]
   | `(trm| return $t:trm) => do
     mkAppM ``Term.ret #[← elabTrm t]
@@ -136,10 +144,12 @@ partial def elabTrm : ElabStxCat `trm
     mkAppM ``Term.sub #[← elabTrm a, ← elabTrm b]
   | `(trm| mul($a:trm, $b:trm)) => do
     mkAppM ``Term.mul #[← elabTrm a, ← elabTrm b]
-  | `(trm| get($a:trm, $i:num)) => do
-    mkAppM ``Term.get #[← elabTrm a, toExpr i.getNat]
-  | `(trm| slice($a:trm, $i:num, $j:num)) => do
-    mkAppM ``Term.slice #[← elabTrm a, toExpr i.getNat, toExpr j.getNat]
+  | `(trm| proj($a:trm, $i:num)) => do
+    mkAppM ``Term.proj #[← elabTrm a, toExpr i.getNat]
+  | `(trm| $t:trm[$i:num]) => do
+    mkAppM ``Term.get #[← elabTrm t, toExpr i.getNat]
+  | `(trm| $t:trm[$i:num .. $j:num]) => do
+    mkAppM ``Term.slice #[← elabTrm t, toExpr i.getNat, toExpr j.getNat]
   | `(trm| store($a:trm)) => do
     mkAppM ``Term.store #[← elabTrm a]
   | `(trm| load($a:trm)) => do

--- a/Tests/Aiur.lean
+++ b/Tests/Aiur.lean
@@ -107,8 +107,14 @@ def toplevel := ⟦
     }
   }
 
-  fn slice_and_get(as: (G, G, G, G)) -> G {
-    get(slice(as, 1, 4), 2)
+  fn projections(as: (G, G, G, G, G)) -> (G, G) {
+    (proj(as, 1), proj(as, 3))
+  }
+
+  fn slice_and_get(as: [G; 5]) -> [G; 2] {
+    let left = as[0 .. 2];
+    let right = as[3 .. 5];
+    [left[1], right[0]]
   }
 ⟧
 
@@ -137,7 +143,8 @@ def testCases : List TestCase := [
     ⟨`fibonacci, #[0], #[1]⟩,
     ⟨`fibonacci, #[1], #[1]⟩,
     ⟨`fibonacci, #[6], #[13]⟩,
-    ⟨`slice_and_get, #[1, 2, 3, 4], #[4]⟩,
+    ⟨`projections, #[1, 2, 3, 4, 5], #[2, 4]⟩,
+    ⟨`slice_and_get, #[1, 2, 3, 4, 5], #[2, 4]⟩,
   ]
 
 def commitmentParameters : Aiur.CommitmentParameters := {


### PR DESCRIPTION
Arrays are slices of data with static sizes uniform types across their inner elements.

This patch:
* Renames the `get` tuple operation to `proj`
* Gets rid of the `slice` operation for tuples
* Implements support for Arrays on the Aiur frontend
* Add support for the syntax `[a, b, c, ...]` for initialization
* Add support for the syntax `a[i]` for the `get` operation
* Add support for the syntax `a[i .. j]` for the `slice` operation

This patch also fixes a few bugs regarding the compilation of tuple projections.