### PR TITLE
feat: Aiur `Unit` type and `assert_eq!` operation

### DIFF
--- a/Ix/Aiur/Bytecode.lean
+++ b/Ix/Aiur/Bytecode.lean
@@ -16,6 +16,7 @@ inductive Op
   | call : FunIdx → Array ValIdx → (outputSize : Nat) → Op
   | store : Array ValIdx → Op
   | load : (size : Nat) → ValIdx → Op
+  | assertEq : Array ValIdx → Array ValIdx → Op
   | ioGetInfo : Array ValIdx → Op
   | ioSetInfo : Array ValIdx → ValIdx → ValIdx → Op
   | ioRead : ValIdx → Nat → Op

--- a/Ix/Aiur/Check.lean
+++ b/Ix/Aiur/Check.lean
@@ -205,6 +205,13 @@ partial def inferTerm : Term → CheckM TypedTerm
   | .ann typ term => do
     let inner ← checkNoEscape term typ
     pure $ .mk (.evaluates typ) inner
+  | .assertEq a b ret => do
+    -- `a` and `b` must have the same type.
+    let (typ, a) ← inferNoEscape a
+    let b ← checkNoEscape b typ
+    let ret ← inferTerm ret
+    let assertEq := .assertEq (.mk (.evaluates typ) a) (.mk (.evaluates typ) b) ret
+    pure $ .mk (.evaluates ret.typ.unwrap) assertEq
   | .ioGetInfo key => do
     let (typ, keyInner) ← inferNoEscape key
     match typ with

--- a/Ix/Aiur/Compile.lean
+++ b/Ix/Aiur/Compile.lean
@@ -94,6 +94,7 @@ def opLayout : Bytecode.Op → LayoutM Unit
     bumpAuxiliaries size
     bumpLookups
     addMemSize size
+  | .assertEq .. => pure ()
   | .ioGetInfo _ => do
     pushDegrees #[1, 1]
     bumpAuxiliaries 2
@@ -358,6 +359,11 @@ partial def toIndex
   --   let op := .trace str arr
   --   modify (fun state => { state with ops := state.ops.push op})
   --   pure arr
+  | .assertEq a b ret => do
+    let a ← toIndex layoutMap bindings a
+    let b ← toIndex layoutMap bindings b
+    modify fun stt => { stt with ops := stt.ops.push (.assertEq a b) }
+    toIndex layoutMap bindings ret
   | .ioGetInfo key => do
     let key ← toIndex layoutMap bindings key
     pushOp (.ioGetInfo key) 2

--- a/Ix/Aiur/Meta.lean
+++ b/Ix/Aiur/Meta.lean
@@ -106,6 +106,7 @@ syntax "set" "(" trm ", " num ", " trm ")"                    : trm
 syntax "store" "(" trm ")"                                    : trm
 syntax "load" "(" trm ")"                                     : trm
 syntax "ptr_val" "(" trm ")"                                  : trm
+syntax "assert_eq!" "(" trm ", " trm ")" ";" (trm)?           : trm
 syntax trm ": " typ                                           : trm
 syntax "io_get_info" "(" trm ")"                              : trm
 syntax "io_set_info" "(" trm ", " trm ", " trm ")" ";" (trm)? : trm
@@ -174,6 +175,8 @@ partial def elabTrm : ElabStxCat `trm
     mkAppM ``Term.load #[← elabTrm a]
   | `(trm| ptr_val($a:trm)) => do
     mkAppM ``Term.ptrVal #[← elabTrm a]
+  | `(trm| assert_eq!($a:trm, $b:trm); $[$ret:trm]?) => do
+    mkAppM ``Term.assertEq #[← elabTrm a, ← elabTrm b, ← elabRet ret]
   | `(trm| $v:trm : $t:typ) => do
     mkAppM ``Term.ann #[← elabTyp t, ← elabTrm v]
   | `(trm| io_get_info($key:trm)) => do

--- a/Ix/Aiur/Term.lean
+++ b/Ix/Aiur/Term.lean
@@ -80,6 +80,7 @@ inductive Term
   | load : Term → Term
   | ptrVal : Term → Term
   | ann : Typ → Term → Term
+  | assertEq : Term → Term → (ret : Term) → Term
   | ioGetInfo : (key : Term) → Term
   | ioSetInfo : (key : Term) → (idx : Term) → (len : Term) → (ret : Term) → Term
   | ioRead : (idx : Term) → (len : Nat) → Term
@@ -132,6 +133,7 @@ inductive TypedTermInner
   | store : TypedTerm → TypedTermInner
   | load : TypedTerm → TypedTermInner
   | ptrVal : TypedTerm → TypedTermInner
+  | assertEq : TypedTerm → TypedTerm → TypedTerm → TypedTermInner
   | ioGetInfo : TypedTerm → TypedTermInner
   | ioSetInfo : TypedTerm → TypedTerm → TypedTerm → TypedTerm → TypedTermInner
   | ioRead : TypedTerm → Nat → TypedTermInner

--- a/Tests/Aiur.lean
+++ b/Tests/Aiur.lean
@@ -1,4 +1,3 @@
-import LSpec
 import Tests.Common
 import Ix.Aiur.Meta
 
@@ -129,6 +128,10 @@ def toplevel := ⟦
     set(arr, 1, (0, 0))
   }
 
+  fn assert_eq_trivial() {
+    assert_eq!([1, 2, 3], [1, 2, 3]);
+  }
+
   fn read_write_io() {
     let (idx, len) = io_get_info([0]);
     let xs: [G; 4] = io_read(idx, 4);
@@ -174,6 +177,7 @@ def aiurTestCases : List AiurTestCase := [
     ⟨`deconstruct_tuple, #[1, 2, 3, 4, 5], #[2, 4], default, default⟩,
     ⟨`deconstruct_array, #[1, 2, 3, 4, 5], #[2, 4], default, default⟩,
     ⟨`array_set, #[1, 1, 2, 2, 3, 3], #[1, 1, 0, 0, 3, 3], default, default⟩,
+    ⟨`assert_eq_trivial, #[], #[], default, default⟩,
     ⟨`read_write_io, #[], #[],
       ⟨#[1, 2, 3, 4], .ofList [(#[0], ⟨0, 4⟩)]⟩,
       ⟨#[1, 2, 3, 4, 1, 2, 3, 4], .ofList [(#[0], ⟨0, 4⟩), (#[1], ⟨0, 8⟩)]⟩⟩,

--- a/src/aiur/bytecode.rs
+++ b/src/aiur/bytecode.rs
@@ -44,6 +44,7 @@ pub enum Op {
     Call(FunIdx, Vec<ValIdx>, usize),
     Store(Vec<ValIdx>),
     Load(usize, ValIdx),
+    AssertEq(Vec<ValIdx>, Vec<ValIdx>),
     IOGetInfo(Vec<ValIdx>),
     IOSetInfo(Vec<ValIdx>, ValIdx, ValIdx),
     IORead(ValIdx, usize),

--- a/src/aiur/constraints.rs
+++ b/src/aiur/constraints.rs
@@ -318,6 +318,17 @@ impl Op {
                 combine_lookup_args(lookup, lookup_args);
                 lookup.multiplicity += sel.clone();
             }
+            Op::AssertEq(xs, ys) => {
+                assert_eq!(xs.len(), ys.len());
+                for (x, y) in xs.iter().zip(ys) {
+                    let (x, _) = &state.map[*x];
+                    let (y, _) = &state.map[*y];
+                    state
+                        .constraints
+                        .zeros
+                        .push(sel.clone() * (x.clone() - y.clone()));
+                }
+            }
             Op::IOGetInfo(_) => (0..2).for_each(|_| {
                 let col = state.next_auxiliary();
                 state.map.push((col, 1));
@@ -326,7 +337,6 @@ impl Op {
                 let col = state.next_auxiliary();
                 state.map.push((col, 1));
             }),
-            Op::IOSetInfo(..) | Op::IOWrite(_) => (),
             Op::U8BitDecomposition(byte) => bytes1_constraints(
                 *byte,
                 &Bytes1Op::BitDecomposition,
@@ -354,6 +364,7 @@ impl Op {
             Op::U8Add(i, j) => {
                 bytes2_constraints(*i, *j, &Bytes2Op::Add, u8_add_channel(), sel.clone(), state)
             }
+            Op::IOSetInfo(..) | Op::IOWrite(_) => (),
         }
     }
 }

--- a/src/aiur/execute.rs
+++ b/src/aiur/execute.rs
@@ -191,6 +191,12 @@ impl Function {
                     result.multiplicity += G::ONE;
                     map.extend(args);
                 }
+                ExecEntry::Op(Op::AssertEq(xs, ys)) => {
+                    assert_eq!(xs.len(), ys.len());
+                    for (x, y) in xs.iter().zip(ys) {
+                        assert_eq!(map[*x], map[*y]);
+                    }
+                }
                 ExecEntry::Op(Op::IOGetInfo(key)) => {
                     let key = key.iter().map(|v| map[*v]).collect::<Vec<_>>();
                     let IOKeyInfo { idx, len } = io_buffer.get_info(&key);

--- a/src/aiur/trace.rs
+++ b/src/aiur/trace.rs
@@ -308,7 +308,6 @@ impl Op {
                     slice.push_auxiliary(index, f);
                 }
             }
-            Op::IOSetInfo(..) | Op::IOWrite(_) => (),
             Op::U8BitDecomposition(byte) => {
                 let (byte, _) = map[*byte];
                 let bits = Bytes1::bit_decompose(&byte);
@@ -356,6 +355,7 @@ impl Op {
                 let lookup_args = vec![u8_add_channel(), i, j, r, o];
                 slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
             }
+            Op::AssertEq(..) | Op::IOSetInfo(..) | Op::IOWrite(_) => (),
         }
     }
 }

--- a/src/lean/ffi/aiur/toplevel.rs
+++ b/src/lean/ffi/aiur/toplevel.rs
@@ -68,10 +68,17 @@ fn lean_ptr_to_op(ptr: *const c_void) -> Op {
             )
         }
         7 => {
+            let [as_ptr, bs_ptr] = ctor.objs();
+            Op::AssertEq(
+                lean_ptr_to_vec_val_idx(as_ptr),
+                lean_ptr_to_vec_val_idx(bs_ptr),
+            )
+        }
+        8 => {
             let [key_ptr] = ctor.objs();
             Op::IOGetInfo(lean_ptr_to_vec_val_idx(key_ptr))
         }
-        8 => {
+        9 => {
             let [key_ptr, idx_ptr, len_ptr] = ctor.objs();
             Op::IOSetInfo(
                 lean_ptr_to_vec_val_idx(key_ptr),
@@ -79,34 +86,34 @@ fn lean_ptr_to_op(ptr: *const c_void) -> Op {
                 lean_unbox_nat_as_usize(len_ptr),
             )
         }
-        9 => {
+        10 => {
             let [idx_ptr, len_ptr] = ctor.objs();
             Op::IORead(
                 lean_unbox_nat_as_usize(idx_ptr),
                 lean_unbox_nat_as_usize(len_ptr),
             )
         }
-        10 => {
+        11 => {
             let [data_ptr] = ctor.objs();
             Op::IOWrite(lean_ptr_to_vec_val_idx(data_ptr))
         }
-        11 => {
+        12 => {
             let [byte_ptr] = ctor.objs();
             Op::U8BitDecomposition(lean_unbox_nat_as_usize(byte_ptr))
         }
-        12 => {
+        13 => {
             let [byte_ptr] = ctor.objs();
             Op::U8ShiftLeft(lean_unbox_nat_as_usize(byte_ptr))
         }
-        13 => {
+        14 => {
             let [byte_ptr] = ctor.objs();
             Op::U8ShiftRight(lean_unbox_nat_as_usize(byte_ptr))
         }
-        14 => {
+        15 => {
             let [i, j] = ctor.objs().map(lean_unbox_nat_as_usize);
             Op::U8Xor(i, j)
         }
-        15 => {
+        16 => {
             let [i, j] = ctor.objs().map(lean_unbox_nat_as_usize);
             Op::U8Add(i, j)
         }


### PR DESCRIPTION
### First commit

```
feat: introduce the "Unit" type on Aiur frontend

Add a `Term.unit` and its corresponding `Typ.unit` to Aiur's frontned.
This term has size zero. It's meant to be used as the term returned
by functions that "return nothing". For example, a function that simply
writes data to the `IOBuffer`.
```

### Second commit

```
feat: `assert_eq!` Aiur operation

`assert_eq!` in Aiur creates constraints that require equalities
of the corresponding circuit values.

Notably, it's consistent for pointers if they're of the same type
(they point to data of the same width). That is, if `ptr1: &T` and
`ptr2: &T`, then `assert_eq!(ptr1, ptr2)` enforces that the data
they're pointing at must be equal.
```