### PR TITLE
feat: `#[unconstrained]` tag for Aiur functions

### DIFF
--- a/Ix/Aiur/Bytecode.lean
+++ b/Ix/Aiur/Bytecode.lean
@@ -61,6 +61,7 @@ structure FunctionLayout where
 structure Function where
   body : Block
   layout: FunctionLayout
+  unconstrained : Bool
   deriving Inhabited, Repr
 
 structure Toplevel where

--- a/Ix/Aiur/Check.lean
+++ b/Ix/Aiur/Check.lean
@@ -447,6 +447,6 @@ def checkFunction (function : Function) : CheckM TypedFunction := do
   let body ← inferTerm function.body
   if let .evaluates typ := body.typ then
     unless typ == function.output do throw $ .typeMismatch typ function.output
-  pure ⟨function.name, function.inputs, function.output, body⟩
+  pure ⟨function.name, function.inputs, function.output, body, function.unconstrained⟩
 
 end Aiur

--- a/Ix/Aiur/Term.lean
+++ b/Ix/Aiur/Term.lean
@@ -177,6 +177,7 @@ structure Function where
   inputs : List (Local × Typ)
   output : Typ
   body : Term
+  unconstrained : Bool
   deriving Repr
 
 structure Toplevel where
@@ -200,6 +201,7 @@ structure TypedFunction where
   inputs : List (Local × Typ)
   output : Typ
   body : TypedTerm
+  unconstrained : Bool
   deriving Repr
 
 inductive TypedDeclaration
@@ -209,6 +211,11 @@ inductive TypedDeclaration
   deriving Repr, Inhabited
 
 abbrev TypedDecls := IndexMap Global TypedDeclaration
+
+def TypedDecls.isUnconstrainedFunction (decls : TypedDecls) (funIdx : Nat) : Bool :=
+  match decls.getByIdx funIdx with
+  | some (_, .function f,) => f.unconstrained
+  | _ => false
 
 mutual
 

--- a/Ix/IxVM.lean
+++ b/Ix/IxVM.lean
@@ -6,6 +6,7 @@ def ixVM := ⟦
     Nil
   }
 
+  #[unconstrained]
   fn read_byte_stream(idx: G, len: G) -> ByteStream {
     match len {
       0 => ByteStream.Nil,

--- a/src/aiur/bytecode.rs
+++ b/src/aiur/bytecode.rs
@@ -10,6 +10,7 @@ pub struct Toplevel {
 pub struct Function {
     pub(crate) body: Block,
     pub(crate) layout: FunctionLayout,
+    pub(crate) unconstrained: bool,
 }
 
 #[derive(Clone, Copy)]

--- a/src/aiur/trace.rs
+++ b/src/aiur/trace.rs
@@ -65,6 +65,7 @@ struct TraceContext<'a> {
     inputs: &'a [G],
     output: &'a [G],
     query_record: &'a QueryRecord,
+    toplevel: &'a Toplevel,
 }
 
 impl Toplevel {
@@ -105,6 +106,7 @@ impl Toplevel {
                     multiplicity: result.multiplicity,
                     output: &result.output,
                     query_record,
+                    toplevel: self,
                 };
                 func.populate_row(index, slice, context, io_buffer);
             });
@@ -260,6 +262,11 @@ impl Op {
                 for f in result.output.iter() {
                     map.push((*f, 1));
                     slice.push_auxiliary(index, *f);
+                }
+                if context.toplevel.functions[*function_index].unconstrained {
+                    // The callee is unconstrained and isn't going to pull its claim.
+                    // Therefore we don't push it.
+                    return;
                 }
                 let lookup = function_lookup(
                     G::ONE,

--- a/src/lean/ffi/aiur/toplevel.rs
+++ b/src/lean/ffi/aiur/toplevel.rs
@@ -211,10 +211,15 @@ fn lean_ctor_to_function_layout(ctor: &LeanCtorObject) -> FunctionLayout {
 
 fn lean_ptr_to_function(ptr: *const c_void) -> Function {
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
-    let [body_ptr, layout_ptr] = ctor.objs();
+    let [body_ptr, layout_ptr, unconstrained_ptr] = ctor.objs();
     let body = lean_ctor_to_block(as_ref_unsafe(body_ptr.cast()));
     let layout = lean_ctor_to_function_layout(as_ref_unsafe(layout_ptr.cast()));
-    Function { body, layout }
+    let unconstrained = unconstrained_ptr as usize != 0;
+    Function {
+        body,
+        layout,
+        unconstrained,
+    }
 }
 
 pub(crate) fn lean_ctor_to_toplevel(ctor: &LeanCtorObject) -> Toplevel {


### PR DESCRIPTION
An unconstrained function has no constraints or lookups.

Extra care must be taken when calling an unconstrained function, as such function is not going to pull any claim. So the caller can't push the claim either.

Furthermore, an unconstrained call must propagate "unconstrainedness". That is, for example, if an unconstrained function calls a properly constrained function, any subconsequent transitive lookup performed through this call must *not* be accounted for.