### PR TITLE
feat: decoding Lean `ConstMap`s in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayref"
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -190,7 +190,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -359,7 +359,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -848,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -902,9 +902,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flume"
@@ -1133,15 +1133,15 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1212,6 +1212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "hashlink"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1256,7 +1262,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1279,7 +1285,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -1409,7 +1415,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.3",
 ]
 
 [[package]]
@@ -1448,7 +1454,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1590,12 +1596,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "rayon",
 ]
 
@@ -1714,7 +1720,7 @@ dependencies = [
  "strum",
  "stun-rs",
  "surge-ping",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tokio-stream",
@@ -1740,7 +1746,7 @@ dependencies = [
  "postcard",
  "rand_core 0.6.4",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "url",
 ]
 
@@ -1787,7 +1793,7 @@ dependencies = [
  "ssh-key",
  "strum",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1819,7 +1825,7 @@ dependencies = [
  "prometheus-client",
  "serde",
  "struct_iterable",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -1837,7 +1843,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -1857,7 +1863,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1910,7 +1916,7 @@ dependencies = [
  "serde",
  "strum",
  "stun-rs",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite-wasm",
@@ -1947,6 +1953,7 @@ dependencies = [
  "iroh-base",
  "iroh-blobs",
  "multi-stark",
+ "num-bigint",
  "rayon",
  "rustc-hash",
  "tiny-keccak",
@@ -1955,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1974,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
@@ -2004,11 +2011,10 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -2063,9 +2069,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "minimal-lexical"
@@ -2095,20 +2101,19 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
- "loom",
+ "equivalent",
  "parking_lot",
  "portable-atomic",
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -2255,7 +2260,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2293,7 +2298,7 @@ dependencies = [
  "rtnetlink 0.14.1",
  "serde",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tokio-util",
@@ -2344,11 +2349,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2448,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2735,9 +2740,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2745,15 +2750,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2764,12 +2769,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2789,20 +2794,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
+checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663"
+checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2810,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4f36811dfe07f7b8573462465d5cb8965fffc2e71ae377a33aecf14c2c9a2f"
+checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2823,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420"
+checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
  "sha2",
@@ -2878,7 +2882,7 @@ dependencies = [
  "lru",
  "self_cell",
  "simple-dns",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "ureq",
  "wasm-bindgen",
@@ -2987,7 +2991,7 @@ dependencies = [
  "serde",
  "smallvec",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tokio-util",
@@ -2997,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "positioned-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8078ce4d22da5e8f57324d985cc9befe40c49ab0507a192d6be9e59584495c9"
+checksum = "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7"
 dependencies = [
  "libc",
  "winapi",
@@ -3066,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "precis-profiles"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4f67f78f50388f03494794766ba824a704db16fb5d400fe8d545fa7bc0d3f1"
+checksum = "31e2768890a47af73a032af9f0cedbddce3c9d06cf8de201d5b8f2436ded7674"
 dependencies = [
  "lazy_static",
  "precis-core",
@@ -3098,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -3217,7 +3221,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -3238,7 +3242,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3260,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -3398,27 +3402,27 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.9.4",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3434,14 +3438,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix",
- "windows 0.62.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3451,9 +3455,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3510,7 +3514,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.3",
 ]
 
 [[package]]
@@ -3640,20 +3644,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.5",
+ "rustls-webpki 0.103.7",
  "subtle",
  "zeroize",
 ]
@@ -3681,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.5"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3766,9 +3770,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.223"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3785,18 +3789,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.223"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.223"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4007,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strength_reduce"
@@ -4196,15 +4200,15 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4218,11 +4222,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -4238,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4258,11 +4262,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
@@ -4353,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -4420,18 +4425,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
  "winnow",
 ]
 
@@ -4609,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-parse"
@@ -4766,27 +4784,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4797,9 +4815,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -4811,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4824,9 +4842,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4834,9 +4852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4847,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -4869,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4893,23 +4911,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.2",
+ "webpki-roots 1.0.3",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "widestring"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -4933,7 +4951,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4949,7 +4967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
 dependencies = [
  "windows-core 0.59.0",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4967,15 +4985,14 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.0",
- "windows-core 0.62.0",
- "windows-future 0.3.0",
- "windows-link 0.2.0",
- "windows-numerics 0.3.0",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -4989,11 +5006,11 @@ dependencies = [
 
 [[package]]
 name = "windows-collections"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5006,7 +5023,7 @@ dependencies = [
  "windows-interface",
  "windows-result 0.3.4",
  "windows-strings 0.3.1",
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -5015,7 +5032,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
+ "windows-implement 0.60.2",
  "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
@@ -5024,15 +5041,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.0",
+ "windows-implement 0.60.2",
  "windows-interface",
- "windows-link 0.2.0",
- "windows-result 0.4.0",
- "windows-strings 0.5.0",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5048,13 +5065,13 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.0",
- "windows-link 0.2.0",
- "windows-threading 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5070,9 +5087,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5081,9 +5098,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5098,9 +5115,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
@@ -5114,12 +5131,12 @@ dependencies = [
 
 [[package]]
 name = "windows-numerics"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.0",
- "windows-link 0.2.0",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5133,11 +5150,11 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5160,11 +5177,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5200,16 +5217,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5245,19 +5262,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5271,11 +5288,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5292,9 +5309,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5310,9 +5327,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5328,9 +5345,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -5340,9 +5357,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5358,9 +5375,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5376,9 +5393,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5394,9 +5411,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5412,9 +5429,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5437,9 +5454,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wmi"
@@ -5451,7 +5468,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "windows 0.59.0",
  "windows-core 0.59.0",
 ]
@@ -5576,9 +5593,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.44.1", optional = true }
 iroh = { version = "0.34.0", optional = true }
 iroh-base = { version = "0.34.0", optional = true }
 iroh-blobs = { version = "0.34.0", features = ["rpc"], optional = true }
+num-bigint = "0.4.6"
 
 [features]
 parallel = ["multi-stark/parallel"]

--- a/src/lean/array.rs
+++ b/src/lean/array.rs
@@ -29,6 +29,11 @@ impl LeanArrayObject {
         self.data().iter().map(|ptr| map_fn(*ptr)).collect()
     }
 
+    #[inline]
+    pub fn to_vec_with<T, C>(&self, map_fn: fn(*const c_void, &mut C) -> T, c: &mut C) -> Vec<T> {
+        self.data().iter().map(|ptr| map_fn(*ptr, c)).collect()
+    }
+
     pub fn set_data(&mut self, data: &[*const c_void]) {
         assert!(self.m_capacity >= data.len());
         self.m_data.copy_from_slice(data);

--- a/src/lean/ffi/lean_env.rs
+++ b/src/lean/ffi/lean_env.rs
@@ -1,0 +1,552 @@
+use std::{ffi::c_void, sync::Arc};
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    lean::{
+        array::LeanArrayObject, as_ref_unsafe, collect_list, collect_list_with,
+        ctor::LeanCtorObject, lean_is_scalar, nat::Nat, string::LeanStringObject,
+    },
+    lean_env::{
+        AxiomVal, BinderInfo, ConstMap, ConstantInfo, ConstantVal, ConstructorVal, DataValue,
+        DefinitionSafety, DefinitionVal, Expr, InductiveVal, Int, Level, Literal, Name, OpaqueVal,
+        QuotKind, QuotVal, RecursorRule, RecursorVal, ReducibilityHints, SourceInfo, Substring,
+        Syntax, SyntaxPreresolved, TheoremVal,
+    },
+    lean_unbox,
+};
+
+// TODO: does caching more help?
+type ExprCache = FxHashMap<*const c_void, Arc<Expr>>;
+
+fn lean_ptr_to_level(ptr: *const c_void) -> Level {
+    if lean_is_scalar(ptr) {
+        return Level::Zero;
+    }
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    match ctor.tag() {
+        1 => {
+            let [u] = ctor.objs().map(lean_ptr_to_level);
+            Level::Succ(u.into())
+        }
+        2 => {
+            let [u, v] = ctor.objs().map(lean_ptr_to_level);
+            Level::Max(u.into(), v.into())
+        }
+        3 => {
+            let [u, v] = ctor.objs().map(lean_ptr_to_level);
+            Level::Imax(u.into(), v.into())
+        }
+        4 => {
+            let [name] = ctor.objs().map(lean_ptr_to_name);
+            Level::Param(name)
+        }
+        5 => {
+            let [name] = ctor.objs().map(lean_ptr_to_name);
+            Level::Mvar(name)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn lean_ptr_to_substring(ptr: *const c_void) -> Substring {
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [str_ptr, start_pos_ptr, stop_pos_ptr] = ctor.objs();
+    let str: &LeanStringObject = as_ref_unsafe(str_ptr.cast());
+    let str = str.as_string();
+    let start_pos = Nat::from_ptr(start_pos_ptr);
+    let stop_pos = Nat::from_ptr(stop_pos_ptr);
+    Substring {
+        str,
+        start_pos,
+        stop_pos,
+    }
+}
+
+fn lean_ptr_to_source_info(ptr: *const c_void) -> SourceInfo {
+    if lean_is_scalar(ptr) {
+        return SourceInfo::None;
+    }
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    match ctor.tag() {
+        0 => {
+            let [leading_ptr, pos_ptr, trailing_ptr, end_pos_ptr] = ctor.objs();
+            let leading = lean_ptr_to_substring(leading_ptr);
+            let pos = Nat::from_ptr(pos_ptr);
+            let trailing = lean_ptr_to_substring(trailing_ptr);
+            let end_pos = Nat::from_ptr(end_pos_ptr);
+            SourceInfo::Original(leading, pos, trailing, end_pos)
+        }
+        1 => {
+            let [pos_ptr, end_pos_ptr, canonical_ptr] = ctor.objs();
+            let pos = Nat::from_ptr(pos_ptr);
+            let end_pos = Nat::from_ptr(end_pos_ptr);
+            let canonical = canonical_ptr as usize == 1;
+            SourceInfo::Synthetic(pos, end_pos, canonical)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn lean_ptr_to_syntax_preresolved(ptr: *const c_void) -> SyntaxPreresolved {
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    match ctor.tag() {
+        0 => {
+            let [name_ptr] = ctor.objs();
+            let name = lean_ptr_to_name(name_ptr);
+            SyntaxPreresolved::Namespace(name)
+        }
+        1 => {
+            let [name_ptr, fields_ptr] = ctor.objs();
+            let name = lean_ptr_to_name(name_ptr);
+            let fields = collect_list(fields_ptr, |ptr| {
+                let str: &LeanStringObject = as_ref_unsafe(ptr.cast());
+                str.as_string()
+            });
+            SyntaxPreresolved::Decl(name, fields)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn lean_ptr_to_syntax(ptr: *const c_void) -> Syntax {
+    if lean_is_scalar(ptr) {
+        return Syntax::Missing;
+    }
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    match ctor.tag() {
+        1 => {
+            let [info_ptr, kind_ptr, args_ptr] = ctor.objs();
+            let info = lean_ptr_to_source_info(info_ptr);
+            let kind = lean_ptr_to_name(kind_ptr);
+            let args_array: &LeanArrayObject = as_ref_unsafe(args_ptr.cast());
+            let args = args_array.to_vec(lean_ptr_to_syntax);
+            Syntax::Node(info, kind, args)
+        }
+        2 => {
+            let [info_ptr, val_ptr] = ctor.objs();
+            let info = lean_ptr_to_source_info(info_ptr);
+            let val_str: &LeanStringObject = as_ref_unsafe(val_ptr.cast());
+            Syntax::Atom(info, val_str.as_string())
+        }
+        3 => {
+            let [info_ptr, raw_val_ptr, val_ptr, preresolved_ptr] = ctor.objs();
+            let info = lean_ptr_to_source_info(info_ptr);
+            let raw_val = lean_ptr_to_substring(raw_val_ptr);
+            let val = lean_ptr_to_name(val_ptr);
+            let preresolved = collect_list(preresolved_ptr, lean_ptr_to_syntax_preresolved);
+            Syntax::Ident(info, raw_val, val, preresolved)
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn lean_ptr_to_name_data_value(ptr: *const c_void) -> (Name, DataValue) {
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [name_ptr, data_value_ptr] = ctor.objs();
+    let name = lean_ptr_to_name(name_ptr);
+    let data_value_ctor: &LeanCtorObject = as_ref_unsafe(data_value_ptr.cast());
+    let [inner_ptr] = data_value_ctor.objs();
+    let data_value = match data_value_ctor.tag() {
+        0 => {
+            let str: &LeanStringObject = as_ref_unsafe(inner_ptr.cast());
+            DataValue::OfString(str.as_string())
+        }
+        1 => DataValue::OfBool(inner_ptr as usize == 1),
+        2 => DataValue::OfName(lean_ptr_to_name(inner_ptr)),
+        3 => DataValue::OfNat(Nat::from_ptr(inner_ptr)),
+        4 => {
+            let int_ctor: &LeanCtorObject = as_ref_unsafe(inner_ptr.cast());
+            let [nat_ptr] = int_ctor.objs();
+            let nat = Nat::from_ptr(nat_ptr);
+            let int = match int_ctor.tag() {
+                0 => Int::OfNat(nat),
+                1 => Int::NegSucc(nat),
+                _ => unreachable!(),
+            };
+            DataValue::OfInt(int)
+        }
+        5 => DataValue::OfSyntax(lean_ptr_to_syntax(inner_ptr).into()),
+        _ => unreachable!(),
+    };
+    (name, data_value)
+}
+
+fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
+    if let Some(e) = cache.get(&ptr) {
+        return e.clone();
+    }
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let expr: Expr = match ctor.tag() {
+        0 => {
+            let [nat_ptr, hash_ptr] = ctor.objs();
+            let nat = Nat::from_ptr(nat_ptr.cast());
+            let hash = hash_ptr as u64;
+            Expr::Bvar(nat, hash)
+        }
+        1 => {
+            let [name_ptr, hash_ptr] = ctor.objs();
+            let name = lean_ptr_to_name(name_ptr);
+            let hash = hash_ptr as u64;
+            Expr::Fvar(name, hash)
+        }
+        2 => {
+            let [name_ptr, hash_ptr] = ctor.objs();
+            let name = lean_ptr_to_name(name_ptr);
+            let hash = hash_ptr as u64;
+            Expr::Mvar(name, hash)
+        }
+        3 => {
+            let [u_ptr, hash_ptr] = ctor.objs();
+            let u = lean_ptr_to_level(u_ptr);
+            let hash = hash_ptr as u64;
+            Expr::Sort(u, hash)
+        }
+        4 => {
+            let [name_ptr, levels_ptr, hash_ptr] = ctor.objs();
+            let name = lean_ptr_to_name(name_ptr);
+            let levels = collect_list(levels_ptr, lean_ptr_to_level);
+            let hash = hash_ptr as u64;
+            Expr::Const(name, levels, hash)
+        }
+        5 => {
+            let [f_ptr, a_ptr, hash_ptr] = ctor.objs();
+            let f = lean_ptr_to_expr(f_ptr, cache);
+            let a = lean_ptr_to_expr(a_ptr, cache);
+            let hash = hash_ptr as u64;
+            Expr::App(f, a, hash)
+        }
+        6 => {
+            let [
+                binder_name_ptr,
+                binder_typ_ptr,
+                body_ptr,
+                hash_ptr,
+                binder_info_ptr,
+            ] = ctor.objs();
+            let binder_name = lean_ptr_to_name(binder_name_ptr);
+            let binder_typ = lean_ptr_to_expr(binder_typ_ptr, cache);
+            let body = lean_ptr_to_expr(body_ptr, cache);
+            let hash = hash_ptr as u64;
+            let binder_info = match binder_info_ptr as usize {
+                0 => BinderInfo::Default,
+                1 => BinderInfo::Implicit,
+                2 => BinderInfo::StrictImplicit,
+                3 => BinderInfo::InstImplicit,
+                _ => unreachable!(),
+            };
+            Expr::Lam(binder_name, binder_typ, body, binder_info, hash)
+        }
+        7 => {
+            let [
+                binder_name_ptr,
+                binder_typ_ptr,
+                body_ptr,
+                hash_ptr,
+                binder_info_ptr,
+            ] = ctor.objs();
+            let binder_name = lean_ptr_to_name(binder_name_ptr);
+            let binder_typ = lean_ptr_to_expr(binder_typ_ptr, cache);
+            let body = lean_ptr_to_expr(body_ptr, cache);
+            let hash = hash_ptr as u64;
+            let binder_info = match binder_info_ptr as usize {
+                0 => BinderInfo::Default,
+                1 => BinderInfo::Implicit,
+                2 => BinderInfo::StrictImplicit,
+                3 => BinderInfo::InstImplicit,
+                _ => unreachable!(),
+            };
+            Expr::ForallE(binder_name, binder_typ, body, binder_info, hash)
+        }
+        8 => {
+            let [
+                decl_name_ptr,
+                typ_ptr,
+                value_ptr,
+                body_ptr,
+                hash_ptr,
+                nondep_ptr,
+            ] = ctor.objs();
+            let decl_name = lean_ptr_to_name(decl_name_ptr);
+            let typ = lean_ptr_to_expr(typ_ptr, cache);
+            let value = lean_ptr_to_expr(value_ptr, cache);
+            let body = lean_ptr_to_expr(body_ptr, cache);
+            let hash = hash_ptr as u64;
+            let nondep = nondep_ptr as usize == 1;
+            Expr::LetE(decl_name, typ, value, body, nondep, hash)
+        }
+        9 => {
+            let [literal_ptr, hash_ptr] = ctor.objs();
+            let literal: &LeanCtorObject = as_ref_unsafe(literal_ptr.cast());
+            let [inner_ptr] = literal.objs();
+            let hash = hash_ptr as u64;
+            match literal.tag() {
+                0 => {
+                    let nat = Nat::from_ptr(inner_ptr);
+                    Expr::Lit(Literal::NatVal(nat), hash)
+                }
+                1 => {
+                    let str: &LeanStringObject = as_ref_unsafe(inner_ptr.cast());
+                    Expr::Lit(Literal::StrVal(str.as_string()), hash)
+                }
+                _ => unreachable!(),
+            }
+        }
+        10 => {
+            let [data_ptr, expr_ptr, hash_ptr] = ctor.objs();
+            let kv_map = collect_list(data_ptr, lean_ptr_to_name_data_value);
+            let expr = lean_ptr_to_expr(expr_ptr, cache);
+            let hash = hash_ptr as u64;
+            Expr::Mdata(kv_map, expr, hash)
+        }
+        11 => {
+            let [typ_name_ptr, idx_ptr, struct_ptr, hash_ptr] = ctor.objs();
+            let typ_name = lean_ptr_to_name(typ_name_ptr);
+            let idx = Nat::from_ptr(idx_ptr);
+            let struct_expr = lean_ptr_to_expr(struct_ptr, cache);
+            let hash = hash_ptr as u64;
+            Expr::Proj(typ_name, idx, struct_expr, hash)
+        }
+        _ => unreachable!(),
+    };
+    let expr_arc = Arc::new(expr);
+    cache.insert(ptr, expr_arc.clone());
+    expr_arc
+}
+
+fn lean_ptr_to_recursor_rule(ptr: *const c_void, cache: &mut ExprCache) -> RecursorRule {
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [ctor_ptr, n_fields_ptr, rhs_ptr] = ctor.objs();
+    let ctor = lean_ptr_to_name(ctor_ptr);
+    let n_fields = Nat::from_ptr(n_fields_ptr);
+    let rhs = lean_ptr_to_expr(rhs_ptr, cache);
+    RecursorRule {
+        ctor,
+        n_fields,
+        rhs,
+    }
+}
+
+fn lean_ptr_to_constant_val(ptr: *const c_void, cache: &mut ExprCache) -> ConstantVal {
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [name_ptr, level_params_ptr, typ_ptr] = ctor.objs();
+    let name = lean_ptr_to_name(name_ptr);
+    let level_params = collect_list(level_params_ptr, lean_ptr_to_name);
+    let typ = lean_ptr_to_expr(typ_ptr, cache);
+    ConstantVal {
+        name,
+        level_params,
+        typ,
+    }
+}
+
+fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> ConstantInfo {
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [inner_val_ptr] = ctor.objs();
+    let inner_val: &LeanCtorObject = as_ref_unsafe(inner_val_ptr.cast());
+    match ctor.tag() {
+        0 => {
+            let [constant_val_ptr, is_unsafe_ptr] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let is_unsafe = is_unsafe_ptr as usize == 1;
+            let axiom_val = AxiomVal {
+                constant_val,
+                is_unsafe,
+            };
+            ConstantInfo::AxiomInfo(axiom_val)
+        }
+        1 => {
+            let [constant_val_ptr, value_ptr, hints_ptr, all_ptr, safety_ptr] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let value = lean_ptr_to_expr(value_ptr, cache);
+            let hints = if lean_is_scalar(hints_ptr) {
+                match lean_unbox!(usize, hints_ptr) {
+                    0 => ReducibilityHints::Opaque,
+                    1 => ReducibilityHints::Abbrev,
+                    _ => unreachable!(),
+                }
+            } else {
+                let hints_ctor: &LeanCtorObject = as_ref_unsafe(hints_ptr.cast());
+                let [height_ptr] = hints_ctor.objs();
+                ReducibilityHints::Regular(height_ptr as u32)
+            };
+            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let safety = match safety_ptr as usize {
+                0 => DefinitionSafety::Unsafe,
+                1 => DefinitionSafety::Safe,
+                2 => DefinitionSafety::Partial,
+                _ => unreachable!(),
+            };
+            ConstantInfo::DefnInfo(DefinitionVal {
+                constant_val,
+                value,
+                hints,
+                safety,
+                all,
+            })
+        }
+        2 => {
+            let [constant_val_ptr, value_ptr, all_ptr] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let value = lean_ptr_to_expr(value_ptr, cache);
+            let all = collect_list(all_ptr, lean_ptr_to_name);
+            ConstantInfo::ThmInfo(TheoremVal {
+                constant_val,
+                value,
+                all,
+            })
+        }
+        3 => {
+            let [constant_val_ptr, value_ptr, all_ptr, is_unsafe_ptr] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let value = lean_ptr_to_expr(value_ptr, cache);
+            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let is_unsafe = is_unsafe_ptr as usize == 1;
+            ConstantInfo::OpaqueInfo(OpaqueVal {
+                constant_val,
+                value,
+                is_unsafe,
+                all,
+            })
+        }
+        4 => {
+            let [constant_val_ptr, kind_ptr] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let kind = match kind_ptr as usize {
+                0 => QuotKind::Type,
+                1 => QuotKind::Ctor,
+                2 => QuotKind::Lift,
+                3 => QuotKind::Ind,
+                _ => unreachable!(),
+            };
+            ConstantInfo::QuotInfo(QuotVal { constant_val, kind })
+        }
+        5 => {
+            let [
+                constant_val_ptr,
+                num_params_ptr,
+                num_indices_ptr,
+                all_ptr,
+                ctors_ptr,
+                num_nested_ptr,
+                bools_ptr,
+            ] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let num_params = Nat::from_ptr(num_params_ptr);
+            let num_indices = Nat::from_ptr(num_indices_ptr);
+            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let ctors = collect_list(ctors_ptr, lean_ptr_to_name);
+            let num_nested = Nat::from_ptr(num_nested_ptr);
+            let [is_rec, is_unsafe, is_reflexive, ..] =
+                (bools_ptr as usize).to_le_bytes().map(|b| b == 1);
+            ConstantInfo::InductInfo(InductiveVal {
+                constant_val,
+                num_params,
+                num_indices,
+                all,
+                ctors,
+                num_nested,
+                is_rec,
+                is_unsafe,
+                is_reflexive,
+            })
+        }
+        6 => {
+            let [
+                constant_val_ptr,
+                induct_ptr,
+                cidx_ptr,
+                num_params_ptr,
+                num_fields_ptr,
+                is_unsafe_ptr,
+            ] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let induct = lean_ptr_to_name(induct_ptr);
+            let cidx = Nat::from_ptr(cidx_ptr);
+            let num_params = Nat::from_ptr(num_params_ptr);
+            let num_fields = Nat::from_ptr(num_fields_ptr);
+            let is_unsafe = is_unsafe_ptr as usize == 1;
+            ConstantInfo::CtorInfo(ConstructorVal {
+                constant_val,
+                induct,
+                cidx,
+                num_params,
+                num_fields,
+                is_unsafe,
+            })
+        }
+        7 => {
+            let [
+                constant_val_ptr,
+                all_ptr,
+                num_params_ptr,
+                num_indices_ptr,
+                num_motives_ptr,
+                num_minors_ptr,
+                rules_ptr,
+                bools_ptr,
+            ] = inner_val.objs();
+            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let num_params = Nat::from_ptr(num_params_ptr);
+            let num_indices = Nat::from_ptr(num_indices_ptr);
+            let num_motives = Nat::from_ptr(num_motives_ptr);
+            let num_minors = Nat::from_ptr(num_minors_ptr);
+            let rules = collect_list_with(rules_ptr, lean_ptr_to_recursor_rule, cache);
+            let [k, is_unsafe, ..] = (bools_ptr as usize).to_le_bytes().map(|b| b == 1);
+            ConstantInfo::RecInfo(RecursorVal {
+                constant_val,
+                all,
+                num_params,
+                num_indices,
+                num_motives,
+                num_minors,
+                rules,
+                k,
+                is_unsafe,
+            })
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn lean_ptr_to_name(ptr: *const c_void) -> Name {
+    if lean_is_scalar(ptr) {
+        return Name::Anonymous;
+    }
+    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [pre_ptr, pos_ptr] = ctor.objs();
+    let pre = lean_ptr_to_name(pre_ptr).into();
+    match ctor.tag() {
+        1 => {
+            let str_obj: &LeanStringObject = as_ref_unsafe(pos_ptr.cast());
+            Name::Str(pre, str_obj.as_string())
+        }
+        2 => Name::Num(pre, Nat::from_ptr(pos_ptr)),
+        _ => unreachable!(),
+    }
+}
+
+fn lean_ptr_to_name_constant_info(
+    ptr: *const c_void,
+    cache: &mut ExprCache,
+) -> (Name, ConstantInfo) {
+    let prod_ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+    let [name_ptr, constant_info_ptr] = prod_ctor.objs();
+    let name = lean_ptr_to_name(name_ptr);
+    let constant_info = lean_ptr_to_constant_info(constant_info_ptr, cache);
+    (name, constant_info)
+}
+
+fn lean_ptr_to_const_map(ptr: *const c_void) -> ConstMap {
+    let array: &LeanArrayObject = as_ref_unsafe(ptr.cast());
+    let mut cache = ExprCache::default();
+    let pairs = array.to_vec_with(lean_ptr_to_name_constant_info, &mut cache);
+    ConstMap::from_iter(pairs)
+}
+
+#[unsafe(no_mangle)]
+fn rs_tmp_decode_const_map(ptr: *const c_void) -> usize {
+    let map = lean_ptr_to_const_map(ptr);
+    map.len()
+}

--- a/src/lean/ffi/mod.rs
+++ b/src/lean/ffi/mod.rs
@@ -11,6 +11,7 @@ pub mod byte_array;
 ))]
 pub mod iroh;
 pub mod keccak;
+pub mod lean_env;
 
 use std::ffi::{CStr, CString, c_char, c_void};
 

--- a/src/lean/nat.rs
+++ b/src/lean/nat.rs
@@ -1,0 +1,68 @@
+use std::ffi::c_void;
+
+use num_bigint::BigUint;
+
+use crate::{
+    lean::{as_ref_unsafe, lean_is_scalar, object::LeanObject},
+    lean_unbox,
+};
+
+#[derive(Hash, PartialEq, Eq, Debug)]
+pub struct Nat(BigUint);
+
+impl Nat {
+    pub fn from_ptr(ptr: *const c_void) -> Nat {
+        if lean_is_scalar(ptr) {
+            let u = lean_unbox!(usize, ptr);
+            Nat(BigUint::from_bytes_le(&u.to_le_bytes()))
+        } else {
+            // Heap-allocated big integer (mpz_object)
+            let obj: &MpzObject = as_ref_unsafe(ptr.cast());
+            Nat(obj.m_value.to_biguint())
+        }
+    }
+
+    #[inline]
+    pub fn from_le_bytes(bytes: &[u8]) -> Nat {
+        Nat(BigUint::from_bytes_le(bytes))
+    }
+
+    #[inline]
+    pub fn to_le_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes_le()
+    }
+}
+
+/// From https://github.com/leanprover/lean4/blob/master/src/runtime/object.h:
+/// ```cpp
+/// struct mpz_object {
+///     lean_object m_header;
+///     mpz         m_value;
+///     mpz_object() {}
+///     explicit mpz_object(mpz const & m):m_value(m) {}
+/// };
+/// ```
+#[repr(C)]
+struct MpzObject {
+    m_header: LeanObject,
+    m_value: Mpz,
+}
+
+#[repr(C)]
+struct Mpz {
+    alloc: i32,
+    size: i32,
+    d: *const u64,
+}
+
+impl Mpz {
+    fn to_biguint(&self) -> BigUint {
+        let nlimbs = self.size.unsigned_abs() as usize;
+        let limbs = unsafe { std::slice::from_raw_parts(self.d, nlimbs) };
+
+        // Convert limbs (little-endian by limb)
+        let bytes: Vec<_> = limbs.iter().flat_map(|&limb| limb.to_le_bytes()).collect();
+
+        BigUint::from_bytes_le(&bytes)
+    }
+}

--- a/src/lean_env.rs
+++ b/src/lean_env.rs
@@ -1,0 +1,240 @@
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
+
+use rustc_hash::FxHashMap;
+
+use crate::lean::nat::Nat;
+
+pub type ConstMap = FxHashMap<Name, ConstantInfo>;
+
+#[derive(Hash, PartialEq, Eq, Debug)]
+pub enum Name {
+    Anonymous,
+    Str(Box<Name>, String),
+    Num(Box<Name>, Nat),
+}
+
+#[derive(Debug)]
+pub enum ConstantInfo {
+    AxiomInfo(AxiomVal),
+    DefnInfo(DefinitionVal),
+    ThmInfo(TheoremVal),
+    OpaqueInfo(OpaqueVal),
+    QuotInfo(QuotVal),
+    InductInfo(InductiveVal),
+    CtorInfo(ConstructorVal),
+    RecInfo(RecursorVal),
+}
+
+#[derive(Debug)]
+pub struct AxiomVal {
+    pub constant_val: ConstantVal,
+    pub is_unsafe: bool,
+}
+
+#[derive(Debug)]
+pub struct DefinitionVal {
+    pub constant_val: ConstantVal,
+    pub value: Arc<Expr>,
+    pub hints: ReducibilityHints,
+    pub safety: DefinitionSafety,
+    pub all: Vec<Name>,
+}
+
+#[derive(Debug)]
+pub struct TheoremVal {
+    pub constant_val: ConstantVal,
+    pub value: Arc<Expr>,
+    pub all: Vec<Name>,
+}
+
+#[derive(Debug)]
+pub struct OpaqueVal {
+    pub constant_val: ConstantVal,
+    pub value: Arc<Expr>,
+    pub is_unsafe: bool,
+    pub all: Vec<Name>,
+}
+
+#[derive(Debug)]
+pub struct QuotVal {
+    pub constant_val: ConstantVal,
+    pub kind: QuotKind,
+}
+
+#[derive(Debug)]
+pub struct InductiveVal {
+    pub constant_val: ConstantVal,
+    pub num_params: Nat,
+    pub num_indices: Nat,
+    pub all: Vec<Name>,
+    pub ctors: Vec<Name>,
+    pub num_nested: Nat,
+    pub is_rec: bool,
+    pub is_unsafe: bool,
+    pub is_reflexive: bool,
+}
+
+#[derive(Debug)]
+pub struct ConstructorVal {
+    pub constant_val: ConstantVal,
+    pub induct: Name,
+    pub cidx: Nat,
+    pub num_params: Nat,
+    pub num_fields: Nat,
+    pub is_unsafe: bool,
+}
+
+#[derive(Debug)]
+pub struct RecursorVal {
+    pub constant_val: ConstantVal,
+    pub all: Vec<Name>,
+    pub num_params: Nat,
+    pub num_indices: Nat,
+    pub num_motives: Nat,
+    pub num_minors: Nat,
+    pub rules: Vec<RecursorRule>,
+    pub k: bool,
+    pub is_unsafe: bool,
+}
+
+#[derive(Debug)]
+pub struct ConstantVal {
+    pub name: Name,
+    pub level_params: Vec<Name>,
+    pub typ: Arc<Expr>,
+}
+
+#[derive(Debug)]
+pub enum Expr {
+    Bvar(Nat, u64),
+    Fvar(Name, u64),
+    Mvar(Name, u64),
+    Sort(Level, u64),
+    Const(Name, Vec<Level>, u64),
+    App(Arc<Expr>, Arc<Expr>, u64),
+    Lam(Name, Arc<Expr>, Arc<Expr>, BinderInfo, u64),
+    ForallE(Name, Arc<Expr>, Arc<Expr>, BinderInfo, u64),
+    LetE(Name, Arc<Expr>, Arc<Expr>, Arc<Expr>, bool, u64),
+    Lit(Literal, u64),
+    Mdata(Vec<(Name, DataValue)>, Arc<Expr>, u64),
+    Proj(Name, Nat, Arc<Expr>, u64),
+}
+
+impl Hash for Expr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Expr::Bvar(_, h)
+            | Expr::Fvar(_, h)
+            | Expr::Mvar(_, h)
+            | Expr::Sort(_, h)
+            | Expr::Const(.., h)
+            | Expr::App(.., h)
+            | Expr::Lam(.., h)
+            | Expr::ForallE(.., h)
+            | Expr::LetE(.., h)
+            | Expr::Lit(_, h)
+            | Expr::Mdata(.., h)
+            | Expr::Proj(.., h) => h.hash(state),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Level {
+    Zero,
+    Succ(Box<Level>),
+    Max(Box<Level>, Box<Level>),
+    Imax(Box<Level>, Box<Level>),
+    Param(Name),
+    Mvar(Name),
+}
+
+#[derive(Debug)]
+pub struct RecursorRule {
+    pub ctor: Name,
+    pub n_fields: Nat,
+    pub rhs: Arc<Expr>,
+}
+
+#[derive(Debug)]
+pub enum QuotKind {
+    Type,
+    Ctor,
+    Lift,
+    Ind,
+}
+
+#[derive(Debug)]
+pub enum ReducibilityHints {
+    Opaque,
+    Abbrev,
+    Regular(u32),
+}
+
+#[derive(Debug)]
+pub enum DefinitionSafety {
+    Unsafe,
+    Safe,
+    Partial,
+}
+
+#[derive(Debug)]
+pub enum Literal {
+    NatVal(Nat),
+    StrVal(String),
+}
+
+#[derive(Debug)]
+pub enum BinderInfo {
+    Default,
+    Implicit,
+    StrictImplicit,
+    InstImplicit,
+}
+
+#[derive(Debug)]
+pub enum Int {
+    OfNat(Nat),
+    NegSucc(Nat),
+}
+
+#[derive(Debug)]
+pub enum DataValue {
+    OfString(String),
+    OfBool(bool),
+    OfName(Name),
+    OfNat(Nat),
+    OfInt(Int),
+    OfSyntax(Box<Syntax>),
+}
+
+#[derive(Debug)]
+pub enum Syntax {
+    Missing,
+    Node(SourceInfo, Name, Vec<Syntax>),
+    Atom(SourceInfo, String),
+    Ident(SourceInfo, Substring, Name, Vec<SyntaxPreresolved>),
+}
+
+#[derive(Debug)]
+pub enum SyntaxPreresolved {
+    Namespace(Name),
+    Decl(Name, Vec<String>),
+}
+
+#[derive(Debug)]
+pub enum SourceInfo {
+    Original(Substring, Nat, Substring, Nat),
+    Synthetic(Nat, Nat, bool),
+    None,
+}
+
+#[derive(Debug)]
+pub struct Substring {
+    pub str: String,
+    pub start_pos: Nat,
+    pub stop_pos: Nat,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod aiur;
 pub mod lean;
+pub mod lean_env;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This patch implements the decoding of Lean `ConstMap`s in Rust, mirroring the Lean data types. This work will be necessary for the Rust implementation of the Ixon compiler.