### PR TITLE
feat: compute SCCs on Lean constants

### DIFF
--- a/src/aiur/bytecode.rs
+++ b/src/aiur/bytecode.rs
@@ -1,5 +1,4 @@
-use indexmap::IndexMap;
-use rustc_hash::FxBuildHasher;
+use crate::FxIndexMap;
 
 use super::G;
 
@@ -26,8 +25,6 @@ impl FunctionLayout {
         self.input_size + self.selectors + self.auxiliaries
     }
 }
-
-pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 pub struct Block {
     pub(crate) ops: Vec<Op>,

--- a/src/aiur/execute.rs
+++ b/src/aiur/execute.rs
@@ -2,13 +2,16 @@ use multi_stark::p3_field::{PrimeCharacteristicRing, PrimeField64};
 use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
-use crate::aiur::{
-    G,
-    bytecode::{Ctrl, FunIdx, Function, FxIndexMap, Op, Toplevel},
-    gadgets::{
-        AiurGadget,
-        bytes1::{Bytes1, Bytes1Op, Bytes1Queries},
-        bytes2::{Bytes2, Bytes2Op, Bytes2Queries},
+use crate::{
+    FxIndexMap,
+    aiur::{
+        G,
+        bytecode::{Ctrl, FunIdx, Function, Op, Toplevel},
+        gadgets::{
+            AiurGadget,
+            bytes1::{Bytes1, Bytes1Op, Bytes1Queries},
+            bytes2::{Bytes2, Bytes2Op, Bytes2Queries},
+        },
     },
 };
 

--- a/src/lean/ffi/aiur/toplevel.rs
+++ b/src/lean/ffi/aiur/toplevel.rs
@@ -3,9 +3,10 @@ use std::ffi::c_void;
 use multi_stark::p3_field::PrimeCharacteristicRing;
 
 use crate::{
+    FxIndexMap,
     aiur::{
         G,
-        bytecode::{Block, Ctrl, Function, FunctionLayout, FxIndexMap, Op, Toplevel, ValIdx},
+        bytecode::{Block, Ctrl, Function, FunctionLayout, Op, Toplevel, ValIdx},
     },
     lean::{
         array::LeanArrayObject,

--- a/src/lean/ffi/lean_env.rs
+++ b/src/lean/ffi/lean_env.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{
     lean::{
-        array::LeanArrayObject, as_ref_unsafe, collect_list, collect_list_with,
+        ListIterator, array::LeanArrayObject, as_ref_unsafe, collect_list, collect_list_with,
         ctor::LeanCtorObject, lean_is_scalar, nat::Nat, string::LeanStringObject,
     },
     lean_env::{
@@ -12,37 +12,41 @@ use crate::{
         DefinitionSafety, DefinitionVal, Expr, InductiveVal, Int, Level, Literal, Name, OpaqueVal,
         QuotKind, QuotVal, RecursorRule, RecursorVal, ReducibilityHints, SourceInfo, Substring,
         Syntax, SyntaxPreresolved, TheoremVal,
+        scc::{NameSet, RefMap, compute_sccs, merge_name_sets},
     },
     lean_unbox,
 };
 
-// TODO: does caching more help?
-type ExprCache = FxHashMap<*const c_void, Arc<Expr>>;
+#[derive(Default)]
+struct Cache {
+    exprs: FxHashMap<*const c_void, (Arc<Expr>, NameSet)>,
+    names: FxHashMap<*const c_void, Arc<Name>>,
+}
 
-fn lean_ptr_to_level(ptr: *const c_void) -> Level {
+fn lean_ptr_to_level(ptr: *const c_void, cache: &mut Cache) -> Level {
     if lean_is_scalar(ptr) {
         return Level::Zero;
     }
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     match ctor.tag() {
         1 => {
-            let [u] = ctor.objs().map(lean_ptr_to_level);
+            let [u] = ctor.objs().map(|ptr| lean_ptr_to_level(ptr, cache));
             Level::Succ(u.into())
         }
         2 => {
-            let [u, v] = ctor.objs().map(lean_ptr_to_level);
+            let [u, v] = ctor.objs().map(|ptr| lean_ptr_to_level(ptr, cache));
             Level::Max(u.into(), v.into())
         }
         3 => {
-            let [u, v] = ctor.objs().map(lean_ptr_to_level);
+            let [u, v] = ctor.objs().map(|ptr| lean_ptr_to_level(ptr, cache));
             Level::Imax(u.into(), v.into())
         }
         4 => {
-            let [name] = ctor.objs().map(lean_ptr_to_name);
+            let [name] = ctor.objs().map(|ptr| lean_ptr_to_name(ptr, cache));
             Level::Param(name)
         }
         5 => {
-            let [name] = ctor.objs().map(lean_ptr_to_name);
+            let [name] = ctor.objs().map(|ptr| lean_ptr_to_name(ptr, cache));
             Level::Mvar(name)
         }
         _ => unreachable!(),
@@ -88,17 +92,17 @@ fn lean_ptr_to_source_info(ptr: *const c_void) -> SourceInfo {
     }
 }
 
-fn lean_ptr_to_syntax_preresolved(ptr: *const c_void) -> SyntaxPreresolved {
+fn lean_ptr_to_syntax_preresolved(ptr: *const c_void, cache: &mut Cache) -> SyntaxPreresolved {
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     match ctor.tag() {
         0 => {
             let [name_ptr] = ctor.objs();
-            let name = lean_ptr_to_name(name_ptr);
+            let name = lean_ptr_to_name(name_ptr, cache);
             SyntaxPreresolved::Namespace(name)
         }
         1 => {
             let [name_ptr, fields_ptr] = ctor.objs();
-            let name = lean_ptr_to_name(name_ptr);
+            let name = lean_ptr_to_name(name_ptr, cache);
             let fields = collect_list(fields_ptr, |ptr| {
                 let str: &LeanStringObject = as_ref_unsafe(ptr.cast());
                 str.as_string()
@@ -109,7 +113,7 @@ fn lean_ptr_to_syntax_preresolved(ptr: *const c_void) -> SyntaxPreresolved {
     }
 }
 
-fn lean_ptr_to_syntax(ptr: *const c_void) -> Syntax {
+fn lean_ptr_to_syntax(ptr: *const c_void, cache: &mut Cache) -> Syntax {
     if lean_is_scalar(ptr) {
         return Syntax::Missing;
     }
@@ -118,9 +122,9 @@ fn lean_ptr_to_syntax(ptr: *const c_void) -> Syntax {
         1 => {
             let [info_ptr, kind_ptr, args_ptr] = ctor.objs();
             let info = lean_ptr_to_source_info(info_ptr);
-            let kind = lean_ptr_to_name(kind_ptr);
+            let kind = lean_ptr_to_name(kind_ptr, cache);
             let args_array: &LeanArrayObject = as_ref_unsafe(args_ptr.cast());
-            let args = args_array.to_vec(lean_ptr_to_syntax);
+            let args = args_array.to_vec_with(lean_ptr_to_syntax, cache);
             Syntax::Node(info, kind, args)
         }
         2 => {
@@ -133,18 +137,19 @@ fn lean_ptr_to_syntax(ptr: *const c_void) -> Syntax {
             let [info_ptr, raw_val_ptr, val_ptr, preresolved_ptr] = ctor.objs();
             let info = lean_ptr_to_source_info(info_ptr);
             let raw_val = lean_ptr_to_substring(raw_val_ptr);
-            let val = lean_ptr_to_name(val_ptr);
-            let preresolved = collect_list(preresolved_ptr, lean_ptr_to_syntax_preresolved);
+            let val = lean_ptr_to_name(val_ptr, cache);
+            let preresolved =
+                collect_list_with(preresolved_ptr, lean_ptr_to_syntax_preresolved, cache);
             Syntax::Ident(info, raw_val, val, preresolved)
         }
         _ => unreachable!(),
     }
 }
 
-fn lean_ptr_to_name_data_value(ptr: *const c_void) -> (Name, DataValue) {
+fn lean_ptr_to_name_data_value(ptr: *const c_void, cache: &mut Cache) -> (Arc<Name>, DataValue) {
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     let [name_ptr, data_value_ptr] = ctor.objs();
-    let name = lean_ptr_to_name(name_ptr);
+    let name = lean_ptr_to_name(name_ptr, cache);
     let data_value_ctor: &LeanCtorObject = as_ref_unsafe(data_value_ptr.cast());
     let [inner_ptr] = data_value_ctor.objs();
     let data_value = match data_value_ctor.tag() {
@@ -153,7 +158,7 @@ fn lean_ptr_to_name_data_value(ptr: *const c_void) -> (Name, DataValue) {
             DataValue::OfString(str.as_string())
         }
         1 => DataValue::OfBool(inner_ptr as usize == 1),
-        2 => DataValue::OfName(lean_ptr_to_name(inner_ptr)),
+        2 => DataValue::OfName(lean_ptr_to_name(inner_ptr, cache)),
         3 => DataValue::OfNat(Nat::from_ptr(inner_ptr)),
         4 => {
             let int_ctor: &LeanCtorObject = as_ref_unsafe(inner_ptr.cast());
@@ -166,55 +171,58 @@ fn lean_ptr_to_name_data_value(ptr: *const c_void) -> (Name, DataValue) {
             };
             DataValue::OfInt(int)
         }
-        5 => DataValue::OfSyntax(lean_ptr_to_syntax(inner_ptr).into()),
+        5 => DataValue::OfSyntax(lean_ptr_to_syntax(inner_ptr, cache).into()),
         _ => unreachable!(),
     };
     (name, data_value)
 }
 
-fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
-    if let Some(e) = cache.get(&ptr) {
-        return e.clone();
+fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut Cache) -> (Arc<Expr>, NameSet) {
+    if let Some(cached) = cache.exprs.get(&ptr) {
+        return cached.clone();
     }
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
-    let expr: Expr = match ctor.tag() {
+    let (expr, name_set) = match ctor.tag() {
         0 => {
             let [nat_ptr, hash_ptr] = ctor.objs();
             let nat = Nat::from_ptr(nat_ptr.cast());
             let hash = hash_ptr as u64;
-            Expr::Bvar(nat, hash)
+            (Arc::new(Expr::Bvar(nat, hash)), NameSet::default())
         }
         1 => {
             let [name_ptr, hash_ptr] = ctor.objs();
-            let name = lean_ptr_to_name(name_ptr);
+            let name = lean_ptr_to_name(name_ptr, cache);
             let hash = hash_ptr as u64;
-            Expr::Fvar(name, hash)
+            (Arc::new(Expr::Fvar(name, hash)), NameSet::default())
         }
         2 => {
             let [name_ptr, hash_ptr] = ctor.objs();
-            let name = lean_ptr_to_name(name_ptr);
+            let name = lean_ptr_to_name(name_ptr, cache);
             let hash = hash_ptr as u64;
-            Expr::Mvar(name, hash)
+            (Arc::new(Expr::Mvar(name, hash)), NameSet::default())
         }
         3 => {
             let [u_ptr, hash_ptr] = ctor.objs();
-            let u = lean_ptr_to_level(u_ptr);
+            let u = lean_ptr_to_level(u_ptr, cache);
             let hash = hash_ptr as u64;
-            Expr::Sort(u, hash)
+            (Arc::new(Expr::Sort(u, hash)), NameSet::default())
         }
         4 => {
             let [name_ptr, levels_ptr, hash_ptr] = ctor.objs();
-            let name = lean_ptr_to_name(name_ptr);
-            let levels = collect_list(levels_ptr, lean_ptr_to_level);
+            let name = lean_ptr_to_name(name_ptr, cache);
+            let levels = collect_list_with(levels_ptr, lean_ptr_to_level, cache);
             let hash = hash_ptr as u64;
-            Expr::Const(name, levels, hash)
+            let expr = Arc::new(Expr::Const(name.clone(), levels, hash));
+            let name_set = NameSet::from_iter([name]);
+            (expr, name_set)
         }
         5 => {
             let [f_ptr, a_ptr, hash_ptr] = ctor.objs();
-            let f = lean_ptr_to_expr(f_ptr, cache);
-            let a = lean_ptr_to_expr(a_ptr, cache);
+            let (f, set_f) = lean_ptr_to_expr(f_ptr, cache);
+            let (a, set_a) = lean_ptr_to_expr(a_ptr, cache);
+            let name_set = merge_name_sets(set_f, set_a);
             let hash = hash_ptr as u64;
-            Expr::App(f, a, hash)
+            (Arc::new(Expr::App(f, a, hash)), name_set)
         }
         6 => {
             let [
@@ -224,9 +232,10 @@ fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
                 hash_ptr,
                 binder_info_ptr,
             ] = ctor.objs();
-            let binder_name = lean_ptr_to_name(binder_name_ptr);
-            let binder_typ = lean_ptr_to_expr(binder_typ_ptr, cache);
-            let body = lean_ptr_to_expr(body_ptr, cache);
+            let binder_name = lean_ptr_to_name(binder_name_ptr, cache);
+            let (binder_typ, binder_set) = lean_ptr_to_expr(binder_typ_ptr, cache);
+            let (body, body_set) = lean_ptr_to_expr(body_ptr, cache);
+            let name_set = merge_name_sets(binder_set, body_set);
             let hash = hash_ptr as u64;
             let binder_info = match binder_info_ptr as usize {
                 0 => BinderInfo::Default,
@@ -235,7 +244,10 @@ fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
                 3 => BinderInfo::InstImplicit,
                 _ => unreachable!(),
             };
-            Expr::Lam(binder_name, binder_typ, body, binder_info, hash)
+            (
+                Arc::new(Expr::Lam(binder_name, binder_typ, body, binder_info, hash)),
+                name_set,
+            )
         }
         7 => {
             let [
@@ -245,9 +257,10 @@ fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
                 hash_ptr,
                 binder_info_ptr,
             ] = ctor.objs();
-            let binder_name = lean_ptr_to_name(binder_name_ptr);
-            let binder_typ = lean_ptr_to_expr(binder_typ_ptr, cache);
-            let body = lean_ptr_to_expr(body_ptr, cache);
+            let binder_name = lean_ptr_to_name(binder_name_ptr, cache);
+            let (binder_typ, binder_set) = lean_ptr_to_expr(binder_typ_ptr, cache);
+            let (body, body_set) = lean_ptr_to_expr(body_ptr, cache);
+            let name_set = merge_name_sets(binder_set, body_set);
             let hash = hash_ptr as u64;
             let binder_info = match binder_info_ptr as usize {
                 0 => BinderInfo::Default,
@@ -256,7 +269,16 @@ fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
                 3 => BinderInfo::InstImplicit,
                 _ => unreachable!(),
             };
-            Expr::ForallE(binder_name, binder_typ, body, binder_info, hash)
+            (
+                Arc::new(Expr::ForallE(
+                    binder_name,
+                    binder_typ,
+                    body,
+                    binder_info,
+                    hash,
+                )),
+                name_set,
+            )
         }
         8 => {
             let [
@@ -267,98 +289,112 @@ fn lean_ptr_to_expr(ptr: *const c_void, cache: &mut ExprCache) -> Arc<Expr> {
                 hash_ptr,
                 nondep_ptr,
             ] = ctor.objs();
-            let decl_name = lean_ptr_to_name(decl_name_ptr);
-            let typ = lean_ptr_to_expr(typ_ptr, cache);
-            let value = lean_ptr_to_expr(value_ptr, cache);
-            let body = lean_ptr_to_expr(body_ptr, cache);
+            let decl_name = lean_ptr_to_name(decl_name_ptr, cache);
+            let (typ, typ_set) = lean_ptr_to_expr(typ_ptr, cache);
+            let (value, value_set) = lean_ptr_to_expr(value_ptr, cache);
+            let (body, body_set) = lean_ptr_to_expr(body_ptr, cache);
+            let name_set = merge_name_sets(typ_set, merge_name_sets(value_set, body_set));
             let hash = hash_ptr as u64;
             let nondep = nondep_ptr as usize == 1;
-            Expr::LetE(decl_name, typ, value, body, nondep, hash)
+            (
+                Arc::new(Expr::LetE(decl_name, typ, value, body, nondep, hash)),
+                name_set,
+            )
         }
         9 => {
             let [literal_ptr, hash_ptr] = ctor.objs();
             let literal: &LeanCtorObject = as_ref_unsafe(literal_ptr.cast());
             let [inner_ptr] = literal.objs();
             let hash = hash_ptr as u64;
-            match literal.tag() {
+            let expr = match literal.tag() {
                 0 => {
                     let nat = Nat::from_ptr(inner_ptr);
-                    Expr::Lit(Literal::NatVal(nat), hash)
+                    Arc::new(Expr::Lit(Literal::NatVal(nat), hash))
                 }
                 1 => {
                     let str: &LeanStringObject = as_ref_unsafe(inner_ptr.cast());
-                    Expr::Lit(Literal::StrVal(str.as_string()), hash)
+                    Arc::new(Expr::Lit(Literal::StrVal(str.as_string()), hash))
                 }
                 _ => unreachable!(),
-            }
+            };
+            (expr, NameSet::default())
         }
         10 => {
             let [data_ptr, expr_ptr, hash_ptr] = ctor.objs();
-            let kv_map = collect_list(data_ptr, lean_ptr_to_name_data_value);
-            let expr = lean_ptr_to_expr(expr_ptr, cache);
+            let kv_map = collect_list_with(data_ptr, lean_ptr_to_name_data_value, cache);
+            let (expr, name_set) = lean_ptr_to_expr(expr_ptr, cache);
             let hash = hash_ptr as u64;
-            Expr::Mdata(kv_map, expr, hash)
+            (Arc::new(Expr::Mdata(kv_map, expr, hash)), name_set)
         }
         11 => {
             let [typ_name_ptr, idx_ptr, struct_ptr, hash_ptr] = ctor.objs();
-            let typ_name = lean_ptr_to_name(typ_name_ptr);
+            let typ_name = lean_ptr_to_name(typ_name_ptr, cache);
             let idx = Nat::from_ptr(idx_ptr);
-            let struct_expr = lean_ptr_to_expr(struct_ptr, cache);
+            let (struct_expr, name_set) = lean_ptr_to_expr(struct_ptr, cache);
             let hash = hash_ptr as u64;
-            Expr::Proj(typ_name, idx, struct_expr, hash)
+            (
+                Arc::new(Expr::Proj(typ_name, idx, struct_expr, hash)),
+                name_set,
+            )
         }
         _ => unreachable!(),
     };
-    let expr_arc = Arc::new(expr);
-    cache.insert(ptr, expr_arc.clone());
-    expr_arc
+    cache.exprs.insert(ptr, (expr.clone(), name_set.clone()));
+    (expr, name_set)
 }
 
-fn lean_ptr_to_recursor_rule(ptr: *const c_void, cache: &mut ExprCache) -> RecursorRule {
+fn lean_ptr_to_recursor_rule(ptr: *const c_void, cache: &mut Cache) -> (RecursorRule, NameSet) {
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     let [ctor_ptr, n_fields_ptr, rhs_ptr] = ctor.objs();
-    let ctor = lean_ptr_to_name(ctor_ptr);
+    let ctor = lean_ptr_to_name(ctor_ptr, cache);
     let n_fields = Nat::from_ptr(n_fields_ptr);
-    let rhs = lean_ptr_to_expr(rhs_ptr, cache);
-    RecursorRule {
-        ctor,
-        n_fields,
-        rhs,
-    }
+    let (rhs, name_set) = lean_ptr_to_expr(rhs_ptr, cache);
+    (
+        RecursorRule {
+            ctor,
+            n_fields,
+            rhs,
+        },
+        name_set,
+    )
 }
 
-fn lean_ptr_to_constant_val(ptr: *const c_void, cache: &mut ExprCache) -> ConstantVal {
+fn lean_ptr_to_constant_val(ptr: *const c_void, cache: &mut Cache) -> (ConstantVal, NameSet) {
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     let [name_ptr, level_params_ptr, typ_ptr] = ctor.objs();
-    let name = lean_ptr_to_name(name_ptr);
-    let level_params = collect_list(level_params_ptr, lean_ptr_to_name);
-    let typ = lean_ptr_to_expr(typ_ptr, cache);
-    ConstantVal {
-        name,
-        level_params,
-        typ,
-    }
+    let name = lean_ptr_to_name(name_ptr, cache);
+    let level_params = collect_list_with(level_params_ptr, lean_ptr_to_name, cache);
+    let (typ, name_set) = lean_ptr_to_expr(typ_ptr, cache);
+    (
+        ConstantVal {
+            name,
+            level_params,
+            typ,
+        },
+        name_set,
+    )
 }
 
-fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> ConstantInfo {
+fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut Cache) -> (ConstantInfo, NameSet) {
     let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     let [inner_val_ptr] = ctor.objs();
     let inner_val: &LeanCtorObject = as_ref_unsafe(inner_val_ptr.cast());
     match ctor.tag() {
         0 => {
             let [constant_val_ptr, is_unsafe_ptr] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let (constant_val, name_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
             let is_unsafe = is_unsafe_ptr as usize == 1;
             let axiom_val = AxiomVal {
                 constant_val,
                 is_unsafe,
             };
-            ConstantInfo::AxiomInfo(axiom_val)
+            (ConstantInfo::AxiomInfo(axiom_val), name_set)
         }
         1 => {
             let [constant_val_ptr, value_ptr, hints_ptr, all_ptr, safety_ptr] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
-            let value = lean_ptr_to_expr(value_ptr, cache);
+            let (constant_val, const_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let (value, value_set) = lean_ptr_to_expr(value_ptr, cache);
+            let name_set = merge_name_sets(const_set, value_set);
             let hints = if lean_is_scalar(hints_ptr) {
                 match lean_unbox!(usize, hints_ptr) {
                     0 => ReducibilityHints::Opaque,
@@ -370,48 +406,59 @@ fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> Const
                 let [height_ptr] = hints_ctor.objs();
                 ReducibilityHints::Regular(height_ptr as u32)
             };
-            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let all = collect_list_with(all_ptr, lean_ptr_to_name, cache);
             let safety = match safety_ptr as usize {
                 0 => DefinitionSafety::Unsafe,
                 1 => DefinitionSafety::Safe,
                 2 => DefinitionSafety::Partial,
                 _ => unreachable!(),
             };
-            ConstantInfo::DefnInfo(DefinitionVal {
-                constant_val,
-                value,
-                hints,
-                safety,
-                all,
-            })
+            (
+                ConstantInfo::DefnInfo(DefinitionVal {
+                    constant_val,
+                    value,
+                    hints,
+                    safety,
+                    all,
+                }),
+                name_set,
+            )
         }
         2 => {
             let [constant_val_ptr, value_ptr, all_ptr] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
-            let value = lean_ptr_to_expr(value_ptr, cache);
-            let all = collect_list(all_ptr, lean_ptr_to_name);
-            ConstantInfo::ThmInfo(TheoremVal {
-                constant_val,
-                value,
-                all,
-            })
+            let (constant_val, const_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let (value, value_set) = lean_ptr_to_expr(value_ptr, cache);
+            let name_set = merge_name_sets(const_set, value_set);
+            let all = collect_list_with(all_ptr, lean_ptr_to_name, cache);
+            (
+                ConstantInfo::ThmInfo(TheoremVal {
+                    constant_val,
+                    value,
+                    all,
+                }),
+                name_set,
+            )
         }
         3 => {
             let [constant_val_ptr, value_ptr, all_ptr, is_unsafe_ptr] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
-            let value = lean_ptr_to_expr(value_ptr, cache);
-            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let (constant_val, const_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let (value, value_set) = lean_ptr_to_expr(value_ptr, cache);
+            let name_set = merge_name_sets(const_set, value_set);
+            let all = collect_list_with(all_ptr, lean_ptr_to_name, cache);
             let is_unsafe = is_unsafe_ptr as usize == 1;
-            ConstantInfo::OpaqueInfo(OpaqueVal {
-                constant_val,
-                value,
-                is_unsafe,
-                all,
-            })
+            (
+                ConstantInfo::OpaqueInfo(OpaqueVal {
+                    constant_val,
+                    value,
+                    is_unsafe,
+                    all,
+                }),
+                name_set,
+            )
         }
         4 => {
             let [constant_val_ptr, kind_ptr] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let (constant_val, name_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
             let kind = match kind_ptr as usize {
                 0 => QuotKind::Type,
                 1 => QuotKind::Ctor,
@@ -419,7 +466,10 @@ fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> Const
                 3 => QuotKind::Ind,
                 _ => unreachable!(),
             };
-            ConstantInfo::QuotInfo(QuotVal { constant_val, kind })
+            (
+                ConstantInfo::QuotInfo(QuotVal { constant_val, kind }),
+                name_set,
+            )
         }
         5 => {
             let [
@@ -431,25 +481,28 @@ fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> Const
                 num_nested_ptr,
                 bools_ptr,
             ] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let (constant_val, name_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
             let num_params = Nat::from_ptr(num_params_ptr);
             let num_indices = Nat::from_ptr(num_indices_ptr);
-            let all = collect_list(all_ptr, lean_ptr_to_name);
-            let ctors = collect_list(ctors_ptr, lean_ptr_to_name);
+            let all = collect_list_with(all_ptr, lean_ptr_to_name, cache);
+            let ctors = collect_list_with(ctors_ptr, lean_ptr_to_name, cache);
             let num_nested = Nat::from_ptr(num_nested_ptr);
             let [is_rec, is_unsafe, is_reflexive, ..] =
                 (bools_ptr as usize).to_le_bytes().map(|b| b == 1);
-            ConstantInfo::InductInfo(InductiveVal {
-                constant_val,
-                num_params,
-                num_indices,
-                all,
-                ctors,
-                num_nested,
-                is_rec,
-                is_unsafe,
-                is_reflexive,
-            })
+            (
+                ConstantInfo::InductInfo(InductiveVal {
+                    constant_val,
+                    num_params,
+                    num_indices,
+                    all,
+                    ctors,
+                    num_nested,
+                    is_rec,
+                    is_unsafe,
+                    is_reflexive,
+                }),
+                name_set,
+            )
         }
         6 => {
             let [
@@ -460,20 +513,23 @@ fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> Const
                 num_fields_ptr,
                 is_unsafe_ptr,
             ] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
-            let induct = lean_ptr_to_name(induct_ptr);
+            let (constant_val, name_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let induct = lean_ptr_to_name(induct_ptr, cache);
             let cidx = Nat::from_ptr(cidx_ptr);
             let num_params = Nat::from_ptr(num_params_ptr);
             let num_fields = Nat::from_ptr(num_fields_ptr);
             let is_unsafe = is_unsafe_ptr as usize == 1;
-            ConstantInfo::CtorInfo(ConstructorVal {
-                constant_val,
-                induct,
-                cidx,
-                num_params,
-                num_fields,
-                is_unsafe,
-            })
+            (
+                ConstantInfo::CtorInfo(ConstructorVal {
+                    constant_val,
+                    induct,
+                    cidx,
+                    num_params,
+                    num_fields,
+                    is_unsafe,
+                }),
+                name_set,
+            )
         }
         7 => {
             let [
@@ -486,67 +542,90 @@ fn lean_ptr_to_constant_info(ptr: *const c_void, cache: &mut ExprCache) -> Const
                 rules_ptr,
                 bools_ptr,
             ] = inner_val.objs();
-            let constant_val = lean_ptr_to_constant_val(constant_val_ptr, cache);
-            let all = collect_list(all_ptr, lean_ptr_to_name);
+            let (constant_val, mut name_set) = lean_ptr_to_constant_val(constant_val_ptr, cache);
+            let all = collect_list_with(all_ptr, lean_ptr_to_name, cache);
             let num_params = Nat::from_ptr(num_params_ptr);
             let num_indices = Nat::from_ptr(num_indices_ptr);
             let num_motives = Nat::from_ptr(num_motives_ptr);
             let num_minors = Nat::from_ptr(num_minors_ptr);
-            let rules = collect_list_with(rules_ptr, lean_ptr_to_recursor_rule, cache);
+            let mut rules = Vec::new();
+            for rule_ptr in ListIterator(rules_ptr) {
+                let (rule, rule_name_set) = lean_ptr_to_recursor_rule(rule_ptr, cache);
+                rules.push(rule);
+                name_set = merge_name_sets(name_set, rule_name_set);
+            }
             let [k, is_unsafe, ..] = (bools_ptr as usize).to_le_bytes().map(|b| b == 1);
-            ConstantInfo::RecInfo(RecursorVal {
-                constant_val,
-                all,
-                num_params,
-                num_indices,
-                num_motives,
-                num_minors,
-                rules,
-                k,
-                is_unsafe,
-            })
+            (
+                ConstantInfo::RecInfo(RecursorVal {
+                    constant_val,
+                    all,
+                    num_params,
+                    num_indices,
+                    num_motives,
+                    num_minors,
+                    rules,
+                    k,
+                    is_unsafe,
+                }),
+                name_set,
+            )
         }
         _ => unreachable!(),
     }
 }
 
-fn lean_ptr_to_name(ptr: *const c_void) -> Name {
-    if lean_is_scalar(ptr) {
-        return Name::Anonymous;
+fn lean_ptr_to_name(ptr: *const c_void, cache: &mut Cache) -> Arc<Name> {
+    if let Some(name) = cache.names.get(&ptr) {
+        return name.clone();
     }
-    let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
-    let [pre_ptr, pos_ptr] = ctor.objs();
-    let pre = lean_ptr_to_name(pre_ptr).into();
-    match ctor.tag() {
-        1 => {
-            let str_obj: &LeanStringObject = as_ref_unsafe(pos_ptr.cast());
-            Name::Str(pre, str_obj.as_string())
+    let name = if lean_is_scalar(ptr) {
+        Name::Anonymous
+    } else {
+        let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+        let [pre_ptr, pos_ptr] = ctor.objs();
+        let pre = lean_ptr_to_name(pre_ptr, cache);
+        match ctor.tag() {
+            1 => {
+                let str_obj: &LeanStringObject = as_ref_unsafe(pos_ptr.cast());
+                Name::mk_str(pre, str_obj.as_string())
+            }
+            2 => Name::mk_num(pre, Nat::from_ptr(pos_ptr)),
+            _ => unreachable!(),
         }
-        2 => Name::Num(pre, Nat::from_ptr(pos_ptr)),
-        _ => unreachable!(),
-    }
+    };
+    let name_arc = Arc::new(name);
+    cache.names.insert(ptr, name_arc.clone());
+    name_arc
 }
 
 fn lean_ptr_to_name_constant_info(
     ptr: *const c_void,
-    cache: &mut ExprCache,
-) -> (Name, ConstantInfo) {
+    cache: &mut Cache,
+) -> (Arc<Name>, ConstantInfo, NameSet) {
     let prod_ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
     let [name_ptr, constant_info_ptr] = prod_ctor.objs();
-    let name = lean_ptr_to_name(name_ptr);
-    let constant_info = lean_ptr_to_constant_info(constant_info_ptr, cache);
-    (name, constant_info)
+    let name = lean_ptr_to_name(name_ptr, cache);
+    let (constant_info, name_set) = lean_ptr_to_constant_info(constant_info_ptr, cache);
+    (name, constant_info, name_set)
 }
 
-fn lean_ptr_to_const_map(ptr: *const c_void) -> ConstMap {
+fn lean_ptr_to_const_map(ptr: *const c_void) -> (ConstMap, RefMap) {
     let array: &LeanArrayObject = as_ref_unsafe(ptr.cast());
-    let mut cache = ExprCache::default();
-    let pairs = array.to_vec_with(lean_ptr_to_name_constant_info, &mut cache);
-    ConstMap::from_iter(pairs)
+    let mut cache = Cache::default();
+    let mut const_map = ConstMap::default();
+    let mut ref_map = RefMap::default();
+    for &ptr in array.data() {
+        let (name, constant_info, name_set) = lean_ptr_to_name_constant_info(ptr, &mut cache);
+        const_map.insert(name.clone(), constant_info);
+        ref_map.insert(name, name_set);
+    }
+    (const_map, ref_map)
 }
 
 #[unsafe(no_mangle)]
-fn rs_tmp_decode_const_map(ptr: *const c_void) -> usize {
-    let map = lean_ptr_to_const_map(ptr);
-    map.len()
+extern "C" fn rs_tmp_decode_const_map(ptr: *const c_void) -> usize {
+    let (const_map, ref_map) = lean_ptr_to_const_map(ptr);
+    let sccs = compute_sccs(&ref_map);
+    assert_eq!(sccs.len(), const_map.len());
+    const_map.len()
 }

--- a/src/lean/mod.rs
+++ b/src/lean/mod.rs
@@ -119,6 +119,22 @@ impl<T> CArray<T> {
     }
 }
 
+pub struct ListIterator(*const c_void);
+
+impl Iterator for ListIterator {
+    type Item = *const c_void;
+    fn next(&mut self) -> Option<Self::Item> {
+        let ptr = self.0;
+        if lean_is_scalar(ptr) {
+            return None;
+        }
+        let ctor: &LeanCtorObject = as_ref_unsafe(ptr.cast());
+        let [head_ptr, tail_ptr] = ctor.objs();
+        self.0 = tail_ptr;
+        Some(head_ptr)
+    }
+}
+
 pub fn collect_list<T>(mut ptr: *const c_void, map_fn: fn(*const c_void) -> T) -> Vec<T> {
     let mut vec = Vec::new();
     while !lean_is_scalar(ptr) {

--- a/src/lean/nat.rs
+++ b/src/lean/nat.rs
@@ -7,7 +7,7 @@ use crate::{
     lean_unbox,
 };
 
-#[derive(Hash, PartialEq, Eq, Debug)]
+#[derive(Hash, PartialEq, Eq, Debug, Clone, PartialOrd, Ord)]
 pub struct Nat(BigUint);
 
 impl Nat {

--- a/src/lean_env/scc.rs
+++ b/src/lean_env/scc.rs
@@ -1,0 +1,231 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+
+use crate::{FxIndexSet, lean_env::Name};
+
+pub type NameSet = FxHashSet<Arc<Name>>;
+
+/// A map from names to name sets.
+pub type RefMap = FxHashMap<Arc<Name>, NameSet>;
+
+pub fn merge_name_sets(mut a: NameSet, mut b: NameSet) -> NameSet {
+    if a.len() < b.len() {
+        b.extend(a);
+        b
+    } else {
+        a.extend(b);
+        a
+    }
+}
+
+/// Compute strongly connected components using an iterative Tarjan’s algorithm.
+/// Returns a map from each node to the set of nodes in its SCC.
+pub fn compute_sccs(ref_map: &RefMap) -> RefMap {
+    macro_rules! neighbors {
+        ($name:expr) => {
+            ref_map.get($name).unwrap().iter().cloned().collect()
+        };
+    }
+
+    struct Frame {
+        node: Arc<Name>,
+        neighbors: Vec<Arc<Name>>,
+        /// Index of the next neighbor to visit.
+        idx: usize,
+    }
+
+    let mut index = FxHashMap::default();
+    let mut lowlink = FxHashMap::default();
+    let mut stack = FxIndexSet::default();
+    let mut next_index = 0usize;
+    let mut result = RefMap::default();
+
+    let mut work = Vec::<Frame>::new();
+
+    for start in ref_map.keys() {
+        if index.contains_key(start) {
+            continue;
+        }
+
+        work.push(Frame {
+            node: start.clone(),
+            neighbors: neighbors!(start),
+            idx: 0,
+        });
+
+        while let Some(frame) = work.last_mut() {
+            let v = &frame.node;
+
+            if !index.contains_key(v) {
+                index.insert(v.clone(), next_index);
+                lowlink.insert(v.clone(), next_index);
+                next_index += 1;
+                stack.insert(v.clone());
+            }
+
+            if frame.idx < frame.neighbors.len() {
+                let w = frame.neighbors[frame.idx].clone();
+                frame.idx += 1;
+
+                if !index.contains_key(&w) {
+                    // Explore new neighbor.
+                    work.push(Frame {
+                        neighbors: neighbors!(&w),
+                        node: w,
+                        idx: 0,
+                    });
+                } else if stack.contains(&w) {
+                    // w is on stack.
+                    let low_v = *lowlink.get(v).unwrap();
+                    let idx_w = *index.get(&w).unwrap();
+                    lowlink.insert(v.clone(), low_v.min(idx_w));
+                }
+            } else {
+                // All neighbors processed. Pop and process.
+                let frame = work.pop().unwrap();
+                let v = frame.node;
+
+                // Update parent's lowlink.
+                if let Some(parent) = work.last_mut() {
+                    let low_parent = *lowlink.get(&parent.node).unwrap();
+                    let low_v = *lowlink.get(&v).unwrap();
+                    lowlink.insert(parent.node.clone(), low_parent.min(low_v));
+                }
+
+                // Root of SCC?
+                if lowlink[&v] == index[&v] {
+                    let mut component = NameSet::default();
+
+                    // Pop nodes from stack until we reach v.
+                    while let Some(node) = stack.pop() {
+                        component.insert(node.clone());
+                        if Arc::ptr_eq(&node, &v) {
+                            break;
+                        }
+                    }
+
+                    // Insert all nodes in the component directly into the result.
+                    for node in &component {
+                        result.insert(node.clone(), component.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn n(s: &str) -> Arc<Name> {
+        Name::mk_str(Name::Anonymous.into(), s.to_string()).into()
+    }
+
+    fn map_of(pairs: &[(&Arc<Name>, &[Arc<Name>])]) -> RefMap {
+        let mut map = RefMap::default();
+        for (k, vs) in pairs {
+            map.insert((*k).clone(), vs.iter().cloned().collect());
+        }
+        map
+    }
+
+    fn scc_to_vec(map: &FxHashMap<Arc<Name>, NameSet>) -> Vec<Vec<Arc<Name>>> {
+        let mut seen = FxIndexSet::default();
+        let mut sccs = Vec::new();
+        for (k, set) in map {
+            if !seen.contains(k) {
+                let mut names: Vec<_> = set.iter().cloned().collect();
+                names.sort();
+                sccs.push(names);
+                seen.extend(set.iter().cloned());
+            }
+        }
+        sccs.sort();
+        sccs
+    }
+
+    #[test]
+    fn single_node() {
+        let a = n("A");
+        let g = map_of(&[(&a, &[])]);
+        let sccs = compute_sccs(&g);
+        assert_eq!(scc_to_vec(&sccs), vec![vec![n("A")]]);
+    }
+
+    #[test]
+    fn simple_cycle() {
+        let a = n("A");
+        let b = n("B");
+        let g = map_of(&[(&a, &[b.clone()]), (&b, &[a.clone()])]);
+        let sccs = compute_sccs(&g);
+        assert_eq!(scc_to_vec(&sccs), vec![vec![n("A"), n("B")]]);
+    }
+
+    #[test]
+    fn chain_no_cycle() {
+        let a = n("A");
+        let b = n("B");
+        let c = n("C");
+        let g = map_of(&[(&a, &[b.clone()]), (&b, &[c.clone()]), (&c, &[])]);
+        let sccs = compute_sccs(&g);
+        assert_eq!(
+            scc_to_vec(&sccs),
+            vec![vec![n("A")], vec![n("B")], vec![n("C")]]
+        );
+    }
+
+    #[test]
+    fn two_cycles_connected() {
+        let a = n("A");
+        let b = n("B");
+        let c = n("C");
+        let d = n("D");
+        let g = map_of(&[
+            (&a, &[b.clone()]),
+            (&b, &[a.clone(), c.clone()]),
+            (&c, &[d.clone()]),
+            (&d, &[c.clone()]),
+        ]);
+        let sccs = compute_sccs(&g);
+        assert_eq!(
+            scc_to_vec(&sccs),
+            vec![vec![n("A"), n("B")], vec![n("C"), n("D")]]
+        );
+    }
+
+    #[test]
+    fn complex_graph() {
+        let a = n("A");
+        let b = n("B");
+        let c = n("C");
+        let d = n("D");
+        let e = n("E");
+        let f = n("F");
+        let g = n("G");
+        let h = n("H");
+
+        let graph = map_of(&[
+            (&a, &[b.clone()]),
+            (&b, &[c.clone(), e.clone(), f.clone()]),
+            (&c, &[d.clone(), g.clone()]),
+            (&d, &[c.clone(), h.clone()]),
+            (&e, &[a.clone(), f.clone()]),
+            (&f, &[g.clone()]),
+            (&g, &[f.clone()]),
+            (&h, &[d.clone(), g.clone()]),
+        ]);
+
+        let sccs = compute_sccs(&graph);
+        assert_eq!(
+            scc_to_vec(&sccs),
+            vec![
+                vec![n("A"), n("B"), n("E")],
+                vec![n("C"), n("D"), n("H")],
+                vec![n("F"), n("G")],
+            ]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,9 @@
+use indexmap::{IndexMap, IndexSet};
+use rustc_hash::FxBuildHasher;
+
 pub mod aiur;
 pub mod lean;
 pub mod lean_env;
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
+pub type FxIndexSet<K> = IndexSet<K, FxBuildHasher>;


### PR DESCRIPTION
Enhance the pipeline to decode Lean constants in Rust so that it also computes the reference graph. Then use the reference graph to compute the strongly connected components.