### PR TITLE
fix: FFI linker order for Nix dev shell

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
       # Ix CLI
       - run: nix build --print-build-logs --accept-flake-config
       - run: nix run .#default -- --help
-
+      # Ix benches
       - run: nix build .#bench-aiur --print-build-logs --accept-flake-config
       - run: nix build .#bench-blake3 --print-build-logs --accept-flake-config
       # Ix tests

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
         packages = {
           # Ix CLI
           default = lib.leanPkg.executable;
+
           # Ix tests
           test = ((lean4-nix.lake { inherit pkgs; }).mkPackage {
             src = ./.;
@@ -68,6 +69,7 @@
             staticLibDeps = [ "${lib.rustPkg}/lib" "${lib.cPkg}/lib" "${lib.blake3C}/lib" ];
           }).executable;
 
+          # Ix benches
           bench-aiur = ((lean4-nix.lake { inherit pkgs; }).mkPackage {
             src = ./.;
             roots = ["Benchmarks.Aiur" "Ix"];
@@ -81,8 +83,10 @@
             deps = [ lib.leanPkg ];
             staticLibDeps = [ "${lib.rustPkg}/lib" "${lib.cPkg}/lib" "${lib.blake3C}/lib" ];
           }).executable;
+
           # Rust static lib, needed for static linking downstream
           rustStaticLib = lib.rustPkg;
+
           # C static lib, needed for static linking downstream
           cStaticLib = lib.cPkg;
         };

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -58,21 +58,6 @@ end IxApplications
 
 section FFI
 
-/-- Build the static lib for the Rust crate -/
-extern_lib ix_rs pkg := do
-  -- Default to `--features parallel`, configured via env var
-  let ixNoPar ← IO.getEnv "IX_NO_PAR"
-  let ixNet ← IO.getEnv "IX_NET"
-  let buildArgs := #["build", "--release"]
-  let args := match (ixNoPar, ixNet) with
-  | (some "1", some "1") => buildArgs ++ ["--features", "net"]
-  | (some "1", _) => buildArgs
-  | (_, some "1") => buildArgs ++ ["--features", "parallel,net"]
-  | _ => buildArgs ++ ["--features", "parallel"]
-  proc { cmd := "cargo", args, cwd := pkg.dir } (quiet := true)
-  let libName := nameToStaticLib "ix_rs"
-  inputBinFile $ pkg.dir / "target" / "release" / libName
-
 /-- Build the static lib for the C files -/
 extern_lib ix_c pkg := do
   let compiler := "gcc"
@@ -103,6 +88,21 @@ extern_lib ix_c pkg := do
 
   let libName := nameToStaticLib "ix_c"
   buildStaticLib (pkg.staticLibDir / libName) buildJobs
+
+/-- Build the static lib for the Rust crate -/
+extern_lib ix_rs pkg := do
+  -- Default to `--features parallel`, configured via env var
+  let ixNoPar ← IO.getEnv "IX_NO_PAR"
+  let ixNet ← IO.getEnv "IX_NET"
+  let buildArgs := #["build", "--release"]
+  let args := match (ixNoPar, ixNet) with
+  | (some "1", some "1") => buildArgs ++ ["--features", "net"]
+  | (some "1", _) => buildArgs
+  | (_, some "1") => buildArgs ++ ["--features", "parallel,net"]
+  | _ => buildArgs ++ ["--features", "parallel"]
+  proc { cmd := "cargo", args, cwd := pkg.dir } (quiet := true)
+  let libName := nameToStaticLib "ix_rs"
+  inputBinFile $ pkg.dir / "target" / "release" / libName
 
 end FFI
 


### PR DESCRIPTION
This PR fixes a linking issue where Lake was linking the `ix_rs` static lib (located at `/target/release/libix_rs.a`) before the `ix_c` static lib (located at `/.lake/build/lib/libix_c.a`), which meant that the Rust functions would be discarded before the `ix_c` library could refer to them, unless any Rust function from `ix_rs` was imported directly by the Lean executable in which case all of the definitions would be made available.

Example error:
```sh
/nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: /home/sam/ix/.lake/build/lib/libix_c.a(aiur.o): in function `c_rs_aiur_proof_to_bytes':
aiur.c:(.text+0x24): undefined reference to `rs_aiur_proof_to_bytes'
/nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: aiur.c:(.text+0x65): undefined reference to `rs_move_bytes'
```

This error only seemed to occur in a NixOS dev shell and not with `nix build`, likely due to different linker behavior between Ubuntu and NixOS's `ld`, which is `GNU ld (GNU Binutils) 2.43.1` in my dev shell.

The solution is to switch the order of the `extern_lib` definitions in `lakefile.lean`, such that `ix_c` goes before `ix_rs`. This means that that `libix_c.a` gets linked before `libix_rs.a` (confirmed with `lake build -v`) and thus has access to the needed Rust definitions. I think it would also work to manually specify the linker args for each `lean_exe` but that would be more verbose.