### PR TITLE
chore: Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: cargo
-    directory: /
+  - package-ecosystem: "cargo"
+    directory: "/"
     pull-request-branch-name:
       separator: "-"
     schedule:
-      interval: weekly
+      interval: "weekly"
     groups:
       rust-dependencies:
         patterns:
           - "*"
+        # Group all updates into one PR to reduce clutter
         update-types:
+          - "major"
           - "minor"
           - "patch"
     allow:
       # Update both direct and indirect dependencies
       - dependency-type: "all"
-    open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Groups Rust crate updates into a single PR, regardless of whether it's a major, minor, or patch version update. Before this, major version updates (including pre-1.0 crates) would create one PR per crate, which added unnecessary clutter.

Also removes the 5 PR limit as that is the default.