### PR TITLE
fix: unify `BinderInfo`

### DIFF
--- a/src/ixon.rs
+++ b/src/ixon.rs
@@ -1,4 +1,4 @@
-use crate::lean::nat::*;
+use crate::{lean::nat::*, lean_env::BinderInfo};
 use blake3::Hash;
 use num_bigint::BigUint;
 
@@ -378,15 +378,6 @@ impl Serialize for DefKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BinderInfo {
-    Default,
-    Implicit,
-    StrictImplicit,
-    InstImplicit,
-    AuxDecl,
-}
-
 impl Serialize for BinderInfo {
     fn put(&self, buf: &mut Vec<u8>) {
         match self {
@@ -394,7 +385,6 @@ impl Serialize for BinderInfo {
             Self::Implicit => buf.push(1),
             Self::StrictImplicit => buf.push(2),
             Self::InstImplicit => buf.push(3),
-            Self::AuxDecl => buf.push(4),
         }
     }
 
@@ -407,7 +397,6 @@ impl Serialize for BinderInfo {
                     1 => Ok(Self::Implicit),
                     2 => Ok(Self::StrictImplicit),
                     3 => Ok(Self::InstImplicit),
-                    4 => Ok(Self::AuxDecl),
                     x => Err(format!("get BinderInfo invalid {x}")),
                 }
             }
@@ -1915,12 +1904,11 @@ pub mod tests {
 
     impl Arbitrary for BinderInfo {
         fn arbitrary(g: &mut Gen) -> Self {
-            match u8::arbitrary(g) % 5 {
+            match u8::arbitrary(g) % 4 {
                 0 => Self::Default,
                 1 => Self::Implicit,
                 2 => Self::StrictImplicit,
                 3 => Self::InstImplicit,
-                4 => Self::AuxDecl,
                 _ => unreachable!(),
             }
         }

--- a/src/lean/ffi/ixon.rs
+++ b/src/lean/ffi/ixon.rs
@@ -3,16 +3,17 @@ use std::ffi::c_void;
 
 use crate::{
     ixon::{
-        Axiom, BinderInfo, BuiltIn, CheckClaim, Claim, Comm, Constructor, ConstructorProj,
-        DataValue, DefKind, DefSafety, Definition, DefinitionProj, Env, EvalClaim, Inductive,
-        InductiveProj, Ixon, Metadata, Metadatum, MutConst, Proof, QuotKind, Quotient, Recursor,
-        RecursorProj, RecursorRule, ReducibilityHints, Serialize,
+        Axiom, BuiltIn, CheckClaim, Claim, Comm, Constructor, ConstructorProj, DataValue, DefKind,
+        DefSafety, Definition, DefinitionProj, Env, EvalClaim, Inductive, InductiveProj, Ixon,
+        Metadata, Metadatum, MutConst, Proof, QuotKind, Quotient, Recursor, RecursorProj,
+        RecursorRule, ReducibilityHints, Serialize,
         address::{Address, MetaAddress},
     },
     lean::{
         as_ref_unsafe, collect_list, ctor::LeanCtorObject, lean_is_scalar, nat::Nat,
         sarray::LeanSArrayObject,
     },
+    lean_env::BinderInfo,
     lean_unbox,
 };
 

--- a/src/lean_env/mod.rs
+++ b/src/lean_env/mod.rs
@@ -218,7 +218,7 @@ pub enum Literal {
     StrVal(String),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BinderInfo {
     Default,
     Implicit,


### PR DESCRIPTION
Remove duplicated definition of `BinderInfo`.