### PR TITLE
chore: speed up Aiur elaboration

### DIFF
--- a/Ix/Aiur/Goldilocks.lean
+++ b/Ix/Aiur/Goldilocks.lean
@@ -7,7 +7,7 @@ namespace Aiur
 abbrev gSize : UInt64 := 1 - 2 ^ 32
 abbrev G := { u : UInt64 // u < gSize }
 
-@[inline] def G.ofNat (n : Nat) : G :=
+def G.ofNat (n : Nat) : G :=
   let n := n.toUInt64
   if h : n < gSize then ⟨n, h⟩
   else ⟨n % gSize, UInt64.mod_lt n (by decide)⟩


### PR DESCRIPTION
Inlining `G.ofNat` was making the Aiur elaboration program slow. Removing the `@[inline]` tag from `G.ofNat` speeds up elaboration by 2~3x.