### PR TITLE
Kernel refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Ix/IxVM.lean
+++ b/Ix/IxVM.lean
@@ -26,8 +26,8 @@ def entrypoints := ⟦
         let (idx, len) = io_get_info([n_minus_1]);
         let bytes = #read_byte_stream(idx, len);
         let (const, rest) = get_constant(bytes);
-        assert_eq!(rest, List.Nil);
-        let bytes2 = put_constant(const, List.Nil);
+        assert_eq!(load(rest), ListNode.Nil);
+        let bytes2 = put_constant(const, store(ListNode.Nil));
         assert_eq!(bytes, bytes2);
         ixon_serde_test(n_minus_1),
     }
@@ -138,8 +138,8 @@ def entrypoints := ⟦
         let (idx, len) = io_get_info([n_minus_1]);
         let bytes = #read_byte_stream(idx, len);
         let (const, rest) = get_constant(bytes);
-        assert_eq!(rest, List.Nil);
-        let bytes2 = put_constant(const, List.Nil);
+        assert_eq!(load(rest), ListNode.Nil);
+        let bytes2 = put_constant(const, store(ListNode.Nil));
         assert_eq!(blake3(bytes), blake3(bytes2));
         ixon_serde_blake3_bench(n_minus_1),
     }

--- a/Ix/IxVM/Blake3.lean
+++ b/Ix/IxVM/Blake3.lean
@@ -99,8 +99,9 @@ def blake3 := ⟦
     let CHUNK_END = 2;
     let PARENT = 4;
     let ROOT = 8;
-    match (input, block_index, chunk_index) {
-      (List.Nil, 0, 0) =>
+    let input_node = load(input);
+    match (input_node, block_index, chunk_index) {
+      (ListNode.Nil, 0, 0) =>
         match chunk_count {
           [0, 0, 0, 0, 0, 0, 0, 0] =>
             let flags = ROOT + CHUNK_START + CHUNK_END;
@@ -108,14 +109,13 @@ def blake3 := ⟦
           _ => layer,
         },
 
-      (List.Nil, 0, _) => Layer.Push(store(layer), block_digest),
+      (ListNode.Nil, 0, _) => Layer.Push(store(layer), block_digest),
 
-      (List.Nil, _, _) =>
+      (ListNode.Nil, _, _) =>
         let flags = CHUNK_END + u64_is_zero(chunk_count) * ROOT + eq_zero(chunk_index - block_index) * CHUNK_START;
         Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, block_index, flags)),
 
-      (List.Cons(head, input_ptr), 63, 1023) =>
-        let input = load(input_ptr);
+      (ListNode.Cons(head, input), 63, 1023) =>
         let flags = ROOT * list_is_empty(input) * u64_is_zero(chunk_count) + CHUNK_END;
         let block_buffer = assign_block_value(block_buffer, block_index, head);
         let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
@@ -123,8 +123,7 @@ def blake3 := ⟦
         let layer = Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, 64, flags));
         blake3_compress_chunks(input, empty_buffer, 0, 0, relaxed_u64_succ(chunk_count), IV, layer),
 
-      (List.Cons(head, input_ptr), 63, _) =>
-        let input = load(input_ptr);
+      (ListNode.Cons(head, input), 63, _) =>
         let block_buffer = assign_block_value(block_buffer, block_index, head);
         let chunk_end_flag = list_is_empty(input) * CHUNK_END;
         let root_flag = list_is_empty(input) * u64_is_zero(chunk_count) * ROOT;
@@ -148,8 +147,7 @@ def blake3 := ⟦
             layer
         ),
 
-      (List.Cons(head, input_ptr), _, _) =>
-        let input = load(input_ptr);
+      (ListNode.Cons(head, input), _, _) =>
         let block_buffer = assign_block_value(block_buffer, block_index, head);
         blake3_compress_chunks(
             input,

--- a/Ix/IxVM/ByteStream.lean
+++ b/Ix/IxVM/ByteStream.lean
@@ -12,11 +12,11 @@ def byteStream := ⟦
 
   fn read_byte_stream(idx: G, len: G) -> ByteStream {
     match len {
-      0 => List.Nil,
+      0 => store(ListNode.Nil),
       _ =>
         let tail = read_byte_stream(idx + 1, len - 1);
         let [byte] = io_read(idx, 1);
-        List.Cons(byte, store(tail)),
+        store(ListNode.Cons(byte, tail)),
     }
   }
 

--- a/Ix/IxVM/Convert.lean
+++ b/Ix/IxVM/Convert.lean
@@ -144,57 +144,57 @@ def convert := ⟦
     match e {
       Expr.Srt(univ_idx) =>
         let u = load(list_lookup_u64(univs, univ_idx));
-        KExpr.Srt(store(convert_univ(u))),
+        store(KExprNode.Srt(store(convert_univ(u)))),
 
       Expr.Var(idx) =>
-        KExpr.BVar(flatten_u64(idx)),
+        store(KExprNode.BVar(flatten_u64(idx))),
 
       Expr.Ref(ref_idx, &univ_idxs) =>
         let const_idx = list_lookup(ref_idxs, flatten_u64(ref_idx));
         let levels = convert_univ_idxs(univ_idxs, univs);
-        KExpr.Const(const_idx, store(levels)),
+        store(KExprNode.Const(const_idx, store(levels))),
 
       Expr.Rec(rec_idx, &univ_idxs) =>
         let const_idx = list_lookup(recur_idxs, flatten_u64(rec_idx));
         let levels = convert_univ_idxs(univ_idxs, univs);
-        KExpr.Const(const_idx, store(levels)),
+        store(KExprNode.Const(const_idx, store(levels))),
 
       Expr.Prj(type_ref_idx, field_idx, &inner) =>
         let type_idx = list_lookup(ref_idxs, flatten_u64(type_ref_idx));
-        KExpr.Proj(
+        store(KExprNode.Proj(
           type_idx,
           flatten_u64(field_idx),
-          store(convert_expr(inner, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
+          convert_expr(inner, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
 
       Expr.Str(blob_ref_idx) =>
         let bs = list_lookup_u64(lit_blobs, blob_ref_idx);
-        KExpr.Lit(KLiteral.Str(bs)),
+        store(KExprNode.Lit(KLiteral.Str(bs))),
 
       Expr.Nat(blob_ref_idx) =>
         let bs = list_lookup_u64(lit_blobs, blob_ref_idx);
         let limbs = bytes_to_limbs(bs);
-        KExpr.Lit(KLiteral.Nat(store(limbs))),
+        store(KExprNode.Lit(KLiteral.Nat(store(limbs)))),
 
       Expr.App(&f, &a) =>
-        KExpr.App(
-          store(convert_expr(f, sharing, ref_idxs, recur_idxs, lit_blobs, univs)),
-          store(convert_expr(a, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
+        store(KExprNode.App(
+          convert_expr(f, sharing, ref_idxs, recur_idxs, lit_blobs, univs),
+          convert_expr(a, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
 
       Expr.Lam(&ty, &body) =>
-        KExpr.Lam(
-          store(convert_expr(ty, sharing, ref_idxs, recur_idxs, lit_blobs, univs)),
-          store(convert_expr(body, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
+        store(KExprNode.Lam(
+          convert_expr(ty, sharing, ref_idxs, recur_idxs, lit_blobs, univs),
+          convert_expr(body, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
 
       Expr.All(&ty, &body) =>
-        KExpr.Forall(
-          store(convert_expr(ty, sharing, ref_idxs, recur_idxs, lit_blobs, univs)),
-          store(convert_expr(body, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
+        store(KExprNode.Forall(
+          convert_expr(ty, sharing, ref_idxs, recur_idxs, lit_blobs, univs),
+          convert_expr(body, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
 
       Expr.Let(_, &ty, &val, &body) =>
-        KExpr.Let(
-          store(convert_expr(ty, sharing, ref_idxs, recur_idxs, lit_blobs, univs)),
-          store(convert_expr(val, sharing, ref_idxs, recur_idxs, lit_blobs, univs)),
-          store(convert_expr(body, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
+        store(KExprNode.Let(
+          convert_expr(ty, sharing, ref_idxs, recur_idxs, lit_blobs, univs),
+          convert_expr(val, sharing, ref_idxs, recur_idxs, lit_blobs, univs),
+          convert_expr(body, sharing, ref_idxs, recur_idxs, lit_blobs, univs))),
 
       Expr.Share(idx) =>
         let shared = load(list_lookup_u64(sharing, idx));

--- a/Ix/IxVM/Convert.lean
+++ b/Ix/IxVM/Convert.lean
@@ -28,7 +28,7 @@ def convert := ⟦
   -- lit_blobs:  maps blob ref index -> raw blob ByteStream
   -- univs:      the constant's universe array
   enum ConvertCtx {
-    Mk(&List‹&Expr›, &List‹G›, &List‹G›, &List‹ByteStream›, &List‹&Univ›)
+    Mk(List‹&Expr›, List‹G›, List‹G›, List‹ByteStream›, List‹&Univ›)
   }
 
   -- What to convert, with kind-specific auxiliary data
@@ -36,8 +36,8 @@ def convert := ⟦
     CKDefn(Definition),
     CKAxio(Axiom),
     CKQuot(Quotient),
-    CKRecr(Recursor, &List‹G›),
-    CKIndc(Inductive, &List‹G›),
+    CKRecr(Recursor, List‹G›),
+    CKIndc(Inductive, List‹G›),
     CKCtor(Constructor, G)
   }
 
@@ -63,11 +63,11 @@ def convert := ⟦
 
   -- Resolve a list of universe indices to a List‹&KLevel›
   fn convert_univ_idxs(idxs: List‹U64›, univs: List‹&Univ›) -> List‹&KLevel› {
-    match idxs {
-      List.Nil => List.Nil,
-      List.Cons(idx, &rest) =>
+    match load(idxs) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(idx, rest) =>
         let u = load(list_lookup_u64(univs, idx));
-        List.Cons(store(convert_univ(u)), store(convert_univ_idxs(rest, univs))),
+        store(ListNode.Cons(store(convert_univ(u)), convert_univ_idxs(rest, univs))),
     }
   }
 
@@ -84,16 +84,16 @@ def convert := ⟦
     match limb {
       -- If this limb is zero and there are no more bytes, return Nil
       _ =>
-        match rest_bytes {
-          List.Nil =>
+        match load(rest_bytes) {
+          ListNode.Nil =>
             let is_zero = u64_is_zero(limb);
             match is_zero {
-              1 => List.Nil,
-              0 => List.Cons(limb, store(List.Nil)),
+              1 => store(ListNode.Nil),
+              0 => store(ListNode.Cons(limb, store(ListNode.Nil))),
             },
           _ =>
             let rest_limbs = bytes_to_limbs(rest_bytes);
-            List.Cons(limb, store(rest_limbs)),
+            store(ListNode.Cons(limb, rest_limbs)),
         },
     }
   }
@@ -103,9 +103,9 @@ def convert := ⟦
     match pos {
       8 => acc,
       _ =>
-        match bytes {
-          List.Nil => acc,
-          List.Cons(byte, &rest) =>
+        match load(bytes) {
+          ListNode.Nil => acc,
+          ListNode.Cons(byte, rest) =>
             let [v0, v1, v2, v3, v4, v5, v6, v7] = acc;
             match pos {
               0 => bytes_to_u64_limb(rest, [byte, v1, v2, v3, v4, v5, v6, v7], 1),
@@ -126,9 +126,9 @@ def convert := ⟦
     match n {
       0 => bytes,
       _ =>
-        match bytes {
-          List.Nil => List.Nil,
-          List.Cons(_, &rest) => skip_bytes(rest, n - 1),
+        match load(bytes) {
+          ListNode.Nil => store(ListNode.Nil),
+          ListNode.Cons(_, rest) => skip_bytes(rest, n - 1),
         },
     }
   }
@@ -149,15 +149,15 @@ def convert := ⟦
       Expr.Var(idx) =>
         store(KExprNode.BVar(flatten_u64(idx))),
 
-      Expr.Ref(ref_idx, &univ_idxs) =>
+      Expr.Ref(ref_idx, univ_idxs) =>
         let const_idx = list_lookup(ref_idxs, flatten_u64(ref_idx));
         let levels = convert_univ_idxs(univ_idxs, univs);
-        store(KExprNode.Const(const_idx, store(levels))),
+        store(KExprNode.Const(const_idx, levels)),
 
-      Expr.Rec(rec_idx, &univ_idxs) =>
+      Expr.Rec(rec_idx, univ_idxs) =>
         let const_idx = list_lookup(recur_idxs, flatten_u64(rec_idx));
         let levels = convert_univ_idxs(univ_idxs, univs);
-        store(KExprNode.Const(const_idx, store(levels))),
+        store(KExprNode.Const(const_idx, levels)),
 
       Expr.Prj(type_ref_idx, field_idx, &inner) =>
         let type_idx = list_lookup(ref_idxs, flatten_u64(type_ref_idx));
@@ -173,7 +173,7 @@ def convert := ⟦
       Expr.Nat(blob_ref_idx) =>
         let bs = list_lookup_u64(lit_blobs, blob_ref_idx);
         let limbs = bytes_to_limbs(bs);
-        store(KExprNode.Lit(KLiteral.Nat(store(limbs)))),
+        store(KExprNode.Lit(KLiteral.Nat(limbs))),
 
       Expr.App(&f, &a) =>
         store(KExprNode.App(
@@ -204,7 +204,7 @@ def convert := ⟦
 
   fn ctx_convert_expr(e: Expr, ctx: ConvertCtx) -> KExpr {
     match ctx {
-      ConvertCtx.Mk(&sharing, &ref_idxs, &recur_idxs, &lit_blobs, &univs) =>
+      ConvertCtx.Mk(sharing, ref_idxs, recur_idxs, lit_blobs, univs) =>
         convert_expr(e, sharing, ref_idxs, recur_idxs, lit_blobs, univs),
     }
   }
@@ -220,18 +220,18 @@ def convert := ⟦
     rule_ctor_idxs: List‹G›,
     ctx: ConvertCtx
   ) -> List‹&KRecRule› {
-    match rules {
-      List.Nil => List.Nil,
-      List.Cons(rule, &rest_rules) =>
+    match load(rules) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(rule, rest_rules) =>
         match rule {
           RecursorRule.Mk(nfields, &rhs) =>
-            match rule_ctor_idxs {
-              List.Cons(ctor_idx, &rest_ctor_idxs) =>
+            match load(rule_ctor_idxs) {
+              ListNode.Cons(ctor_idx, rest_ctor_idxs) =>
                 let krhs = ctx_convert_expr(rhs, ctx);
                 let krule = KRecRule.Mk(ctor_idx, flatten_u64(nfields), store(krhs));
-                List.Cons(
+                store(ListNode.Cons(
                   store(krule),
-                  store(convert_rules(rest_rules, rest_ctor_idxs, ctx))),
+                  convert_rules(rest_rules, rest_ctor_idxs, ctx))),
             },
         },
     }
@@ -280,13 +280,13 @@ def convert := ⟦
 
   fn convert_recursor(r: Recursor, ctx: ConvertCtx, rule_ctor_idxs: List‹G›) -> KConstantInfo {
     match r {
-      Recursor.Mk(k, is_unsafe, lvls, params, indices, motives, minors, &typ, &rules) =>
+      Recursor.Mk(k, is_unsafe, lvls, params, indices, motives, minors, &typ, rules) =>
         let ktyp = ctx_convert_expr(typ, ctx);
         let krules = convert_rules(rules, rule_ctor_idxs, ctx);
         KConstantInfo.Rec(
           flatten_u64(lvls), store(ktyp), flatten_u64(params), flatten_u64(indices),
           flatten_u64(motives), flatten_u64(minors),
-          store(krules), k, is_unsafe),
+          krules, k, is_unsafe),
     }
   }
 
@@ -296,7 +296,7 @@ def convert := ⟦
         let ktyp = ctx_convert_expr(typ, ctx);
         KConstantInfo.Induct(
           flatten_u64(lvls), store(ktyp), flatten_u64(params), flatten_u64(indices),
-          store(ctor_idxs), is_rec, is_refl, is_unsafe),
+          ctor_idxs, is_rec, is_refl, is_unsafe),
     }
   }
 
@@ -322,8 +322,8 @@ def convert := ⟦
           ConvertKind.CKDefn(d) => convert_definition(d, ctx),
           ConvertKind.CKAxio(a) => convert_axiom(a, ctx),
           ConvertKind.CKQuot(q) => convert_quotient(q, ctx),
-          ConvertKind.CKRecr(r, &rule_ctor_idxs) => convert_recursor(r, ctx, rule_ctor_idxs),
-          ConvertKind.CKIndc(ind, &ctor_idxs) => convert_inductive(ind, ctx, ctor_idxs),
+          ConvertKind.CKRecr(r, rule_ctor_idxs) => convert_recursor(r, ctx, rule_ctor_idxs),
+          ConvertKind.CKIndc(ind, ctor_idxs) => convert_inductive(ind, ctx, ctor_idxs),
           ConvertKind.CKCtor(c, induct_idx) => convert_constructor(c, ctx, induct_idx),
         },
     }
@@ -331,11 +331,11 @@ def convert := ⟦
 
   -- Convert a list of resolved inputs to a List‹&KConstantInfo›
   fn convert_all(inputs: List‹&ConvertInput›) -> List‹&KConstantInfo› {
-    match inputs {
-      List.Nil => List.Nil,
-      List.Cons(&input, &rest) =>
+    match load(inputs) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(&input, rest) =>
         let ci = convert_one(input);
-        List.Cons(store(ci), store(convert_all(rest))),
+        store(ListNode.Cons(store(ci), convert_all(rest))),
     }
   }
 ⟧

--- a/Ix/IxVM/Convert.lean
+++ b/Ix/IxVM/Convert.lean
@@ -33,7 +33,7 @@ def convert := ⟦
 
   -- What to convert, with kind-specific auxiliary data
   enum ConvertKind {
-    CKDefn(Definition, KHints),
+    CKDefn(Definition),
     CKAxio(Axiom),
     CKQuot(Quotient),
     CKRecr(Recursor, &List‹G›),
@@ -241,14 +241,14 @@ def convert := ⟦
   -- Per-kind conversion
   -- ============================================================================
 
-  fn convert_definition(d: Definition, ctx: ConvertCtx, hints: KHints) -> KConstantInfo {
+  fn convert_definition(d: Definition, ctx: ConvertCtx) -> KConstantInfo {
     match d {
       Definition.Mk(kind, safety, lvls, &typ, &value) =>
         let ktyp = ctx_convert_expr(typ, ctx);
         let kval = ctx_convert_expr(value, ctx);
         match kind {
           DefKind.Definition =>
-            KConstantInfo.Defn(flatten_u64(lvls), store(ktyp), store(kval), hints, safety),
+            KConstantInfo.Defn(flatten_u64(lvls), store(ktyp), store(kval), safety),
           DefKind.Opaque =>
             match safety {
               DefinitionSafety.Unsafe =>
@@ -319,7 +319,7 @@ def convert := ⟦
     match input {
       ConvertInput.Mk(ctx, kind) =>
         match kind {
-          ConvertKind.CKDefn(d, hints) => convert_definition(d, ctx, hints),
+          ConvertKind.CKDefn(d) => convert_definition(d, ctx),
           ConvertKind.CKAxio(a) => convert_axiom(a, ctx),
           ConvertKind.CKQuot(q) => convert_quotient(q, ctx),
           ConvertKind.CKRecr(r, &rule_ctor_idxs) => convert_recursor(r, ctx, rule_ctor_idxs),

--- a/Ix/IxVM/Convert.lean
+++ b/Ix/IxVM/Convert.lean
@@ -210,27 +210,6 @@ def convert := ⟦
   }
 
   -- ============================================================================
-  -- Enum conversions
-  -- ============================================================================
-
-  fn convert_safety(s: DefinitionSafety) -> KSafety {
-    match s {
-      DefinitionSafety.Unsafe => KSafety.Unsafe,
-      DefinitionSafety.Safe => KSafety.Safe,
-      DefinitionSafety.Partial => KSafety.Partial,
-    }
-  }
-
-  fn convert_quot_kind(k: QuotKind) -> KQuotKind {
-    match k {
-      QuotKind.Typ => KQuotKind.Typ,
-      QuotKind.Ctor => KQuotKind.Ctor,
-      QuotKind.Lift => KQuotKind.Lift,
-      QuotKind.Ind => KQuotKind.Ind,
-    }
-  }
-
-  -- ============================================================================
   -- Recursor rule conversion
   -- ============================================================================
 
@@ -269,7 +248,7 @@ def convert := ⟦
         let kval = ctx_convert_expr(value, ctx);
         match kind {
           DefKind.Definition =>
-            KConstantInfo.Defn(flatten_u64(lvls), store(ktyp), store(kval), hints, convert_safety(safety)),
+            KConstantInfo.Defn(flatten_u64(lvls), store(ktyp), store(kval), hints, safety),
           DefKind.Opaque =>
             match safety {
               DefinitionSafety.Unsafe =>
@@ -295,7 +274,7 @@ def convert := ⟦
     match q {
       Quotient.Mk(kind, lvls, &typ) =>
         let ktyp = ctx_convert_expr(typ, ctx);
-        KConstantInfo.Quot(flatten_u64(lvls), store(ktyp), convert_quot_kind(kind)),
+        KConstantInfo.Quot(flatten_u64(lvls), store(ktyp), kind),
     }
   }
 

--- a/Ix/IxVM/Convert.lean
+++ b/Ix/IxVM/Convert.lean
@@ -213,13 +213,13 @@ def convert := ⟦
   -- Recursor rule conversion
   -- ============================================================================
 
-  -- Convert Ixon List‹RecursorRule› to List‹&KRecRule›.
+  -- Convert Ixon List‹RecursorRule› to List‹KRecRule›.
   -- rule_ctor_idxs provides the kernel constant index for each rule's constructor.
   fn convert_rules(
     rules: List‹RecursorRule›,
     rule_ctor_idxs: List‹G›,
     ctx: ConvertCtx
-  ) -> List‹&KRecRule› {
+  ) -> List‹KRecRule› {
     match load(rules) {
       ListNode.Nil => store(ListNode.Nil),
       ListNode.Cons(rule, rest_rules) =>
@@ -228,9 +228,9 @@ def convert := ⟦
             match load(rule_ctor_idxs) {
               ListNode.Cons(ctor_idx, rest_ctor_idxs) =>
                 let krhs = ctx_convert_expr(rhs, ctx);
-                let krule = KRecRule.Mk(ctor_idx, flatten_u64(nfields), store(krhs));
+                let krule = KRecRule.Mk(ctor_idx, flatten_u64(nfields), krhs);
                 store(ListNode.Cons(
-                  store(krule),
+                  krule,
                   convert_rules(rest_rules, rest_ctor_idxs, ctx))),
             },
         },
@@ -248,16 +248,16 @@ def convert := ⟦
         let kval = ctx_convert_expr(value, ctx);
         match kind {
           DefKind.Definition =>
-            KConstantInfo.Defn(flatten_u64(lvls), store(ktyp), store(kval), safety),
+            KConstantInfo.Defn(flatten_u64(lvls), ktyp, kval, safety),
           DefKind.Opaque =>
             match safety {
               DefinitionSafety.Unsafe =>
-                KConstantInfo.Opaque(flatten_u64(lvls), store(ktyp), store(kval), 1),
+                KConstantInfo.Opaque(flatten_u64(lvls), ktyp, kval, 1),
               _ =>
-                KConstantInfo.Opaque(flatten_u64(lvls), store(ktyp), store(kval), 0),
+                KConstantInfo.Opaque(flatten_u64(lvls), ktyp, kval, 0),
             },
           DefKind.Theorem =>
-            KConstantInfo.Thm(flatten_u64(lvls), store(ktyp), store(kval)),
+            KConstantInfo.Thm(flatten_u64(lvls), ktyp, kval),
         },
     }
   }
@@ -266,7 +266,7 @@ def convert := ⟦
     match a {
       Axiom.Mk(is_unsafe, lvls, &typ) =>
         let ktyp = ctx_convert_expr(typ, ctx);
-        KConstantInfo.Axiom(flatten_u64(lvls), store(ktyp), is_unsafe),
+        KConstantInfo.Axiom(flatten_u64(lvls), ktyp, is_unsafe),
     }
   }
 
@@ -274,7 +274,7 @@ def convert := ⟦
     match q {
       Quotient.Mk(kind, lvls, &typ) =>
         let ktyp = ctx_convert_expr(typ, ctx);
-        KConstantInfo.Quot(flatten_u64(lvls), store(ktyp), kind),
+        KConstantInfo.Quot(flatten_u64(lvls), ktyp, kind),
     }
   }
 
@@ -284,7 +284,7 @@ def convert := ⟦
         let ktyp = ctx_convert_expr(typ, ctx);
         let krules = convert_rules(rules, rule_ctor_idxs, ctx);
         KConstantInfo.Rec(
-          flatten_u64(lvls), store(ktyp), flatten_u64(params), flatten_u64(indices),
+          flatten_u64(lvls), ktyp, flatten_u64(params), flatten_u64(indices),
           flatten_u64(motives), flatten_u64(minors),
           krules, k, is_unsafe),
     }
@@ -295,7 +295,7 @@ def convert := ⟦
       Inductive.Mk(is_rec, is_refl, is_unsafe, lvls, params, indices, _, &typ, _) =>
         let ktyp = ctx_convert_expr(typ, ctx);
         KConstantInfo.Induct(
-          flatten_u64(lvls), store(ktyp), flatten_u64(params), flatten_u64(indices),
+          flatten_u64(lvls), ktyp, flatten_u64(params), flatten_u64(indices),
           ctor_idxs, is_rec, is_refl, is_unsafe),
     }
   }
@@ -305,7 +305,7 @@ def convert := ⟦
       Constructor.Mk(is_unsafe, lvls, cidx, params, fields, &typ) =>
         let ktyp = ctx_convert_expr(typ, ctx);
         KConstantInfo.Ctor(
-          flatten_u64(lvls), store(ktyp), induct_idx, flatten_u64(cidx),
+          flatten_u64(lvls), ktyp, induct_idx, flatten_u64(cidx),
           flatten_u64(params), flatten_u64(fields), is_unsafe),
     }
   }

--- a/Ix/IxVM/Core.lean
+++ b/Ix/IxVM/Core.lean
@@ -6,10 +6,12 @@ public section
 namespace IxVM
 
 def core := ⟦
-  enum List‹T› {
-    Cons(T, &List‹T›),
+  enum ListNode‹T› {
+    Cons(T, List‹T›),
     Nil
   }
+
+  type List‹T› = &ListNode‹T›
 
   enum Option‹T› {
     Some(T),
@@ -17,35 +19,35 @@ def core := ⟦
   }
 
   fn list_length‹T›(list: List‹T›) -> G {
-    match list {
-      List.Nil => 0,
-      List.Cons(_, &rest) => list_length(rest) + 1,
+    match load(list) {
+      ListNode.Nil => 0,
+      ListNode.Cons(_, rest) => list_length(rest) + 1,
     }
   }
 
   fn list_length_u64‹T›(list: List‹T›) -> U64 {
-    match list {
-      List.Nil => [0; 8],
-      List.Cons(_, &rest) => relaxed_u64_succ(list_length_u64(rest)),
+    match load(list) {
+      ListNode.Nil => [0; 8],
+      ListNode.Cons(_, rest) => relaxed_u64_succ(list_length_u64(rest)),
     }
   }
 
   fn list_concat‹T›(a: List‹T›, b: List‹T›) -> List‹T› {
-    match a {
-      List.Nil => b,
-      List.Cons(v, &rest) => List.Cons(v, store(list_concat(rest, b))),
+    match load(a) {
+      ListNode.Nil => b,
+      ListNode.Cons(v, rest) => store(ListNode.Cons(v, list_concat(rest, b))),
     }
   }
 
   fn list_is_empty‹T›(list: List‹T›) -> G {
-    match list {
-      List.Nil => 1,
-      List.Cons(_, _) => 0,
+    match load(list) {
+      ListNode.Nil => 1,
+      ListNode.Cons(_, _) => 0,
     }
   }
 
   fn list_lookup‹T›(list: List‹T›, idx: G) -> T {
-    let List.Cons(v, &rest) = list;
+    let ListNode.Cons(v, rest) = load(list);
     match idx {
       0 => v,
       _ => list_lookup(rest, idx - 1),
@@ -53,7 +55,7 @@ def core := ⟦
   }
 
   fn list_lookup_u64‹T›(list: List‹T›, idx: [G; 8]) -> T {
-    let List.Cons(v, &rest) = list;
+    let ListNode.Cons(v, rest) = load(list);
     let z = u64_is_zero(idx);
     match z {
       1 => v,
@@ -65,24 +67,24 @@ def core := ⟦
     match n {
       0 => list,
       _ =>
-        let List.Cons(_, &rest) = list_drop(list, n - 1);
+        let ListNode.Cons(_, rest) = load(list_drop(list, n - 1));
         rest,
     }
   }
 
   fn list_take‹T›(list: List‹T›, n: G) -> List‹T› {
     match n {
-      0 => List.Nil,
+      0 => store(ListNode.Nil),
       _ =>
-        let List.Cons(v, &rest) = list;
-        List.Cons(v, store(list_take(rest, n - 1))),
+        let ListNode.Cons(v, rest) = load(list);
+        store(ListNode.Cons(v, list_take(rest, n - 1))),
     }
   }
 
   fn list_snoc‹T›(list: List‹T›, v: T) -> List‹T› {
-    match list {
-      List.Nil => List.Cons(v, store(List.Nil)),
-      List.Cons(head, &rest) => List.Cons(head, store(list_snoc(rest, v))),
+    match load(list) {
+      ListNode.Nil => store(ListNode.Cons(v, store(ListNode.Nil))),
+      ListNode.Cons(head, rest) => store(ListNode.Cons(head, list_snoc(rest, v))),
     }
   }
 ⟧

--- a/Ix/IxVM/Ingress.lean
+++ b/Ix/IxVM/Ingress.lean
@@ -530,7 +530,7 @@ def ingress := ⟦
         let input = ConvertInput.Mk(ctx, ConvertKind.CKRecr(recr, store(rule_ctor_idxs)));
         List.Cons(store(input), store(List.Nil)),
       MutConst.Defn(defn) =>
-        let input = ConvertInput.Mk(ctx, ConvertKind.CKDefn(defn, KHints.Abbrev));
+        let input = ConvertInput.Mk(ctx, ConvertKind.CKDefn(defn));
         List.Cons(store(input), store(List.Nil)),
     }
   }
@@ -600,7 +600,7 @@ def ingress := ⟦
                 let lit_blobs = build_lit_blobs(refs, all_addrs);
                 let recur_idxs = List.Cons(pos, store(List.Nil));
                 let ctx = ConvertCtx.Mk(store(sharing), store(ref_idxs), store(recur_idxs), store(lit_blobs), store(univs));
-                let input = ConvertInput.Mk(ctx, ConvertKind.CKDefn(defn, KHints.Abbrev));
+                let input = ConvertInput.Mk(ctx, ConvertKind.CKDefn(defn));
                 List.Cons(store(input),
                   store(build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
               ConstantInfo.Axio(axio) =>

--- a/Ix/IxVM/Ingress.lean
+++ b/Ix/IxVM/Ingress.lean
@@ -213,10 +213,9 @@ def ingress := ⟦
                             match bi {
                               ConstantInfo.Muts(&members) =>
                                 let nctors = count_block_ctors(members);
-                                let is_match = eq_zero(nctors - nrules);
-                                match is_match {
-                                  1 => block_addr,
-                                  0 => find_matching_block_addr(rest, all_addrs, nrules),
+                                match nctors - nrules {
+                                  0 => block_addr,
+                                  _ => find_matching_block_addr(rest, all_addrs, nrules),
                                 },
                               _ => find_matching_block_addr(rest, all_addrs, nrules),
                             },

--- a/Ix/IxVM/Ingress.lean
+++ b/Ix/IxVM/Ingress.lean
@@ -26,7 +26,7 @@ def ingress := ⟦
       addr
     );
     let (constant, rest) = get_constant(bytes);
-    assert_eq!(rest, List.Nil);
+    assert_eq!(load(rest), ListNode.Nil);
     constant
   }
 
@@ -86,18 +86,18 @@ def ingress := ⟦
 
   -- Build lit_blobs by loading and verifying each blob on demand.
   -- A ref is a blob if it's not in all_addrs (the constant address list).
-  -- For constant refs, returns List.Nil (never read by conversion).
+  -- For constant refs, returns an empty ByteStream (never read by conversion).
   fn build_lit_blobs(refs: List‹[G; 32]›, all_addrs: List‹[G; 32]›) -> List‹ByteStream› {
-    match refs {
-      List.Nil => List.Nil,
-      List.Cons(addr, &rest) =>
+    match load(refs) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(addr, rest) =>
         let blob = is_blob(addr, all_addrs);
         match blob {
           1 =>
             let bs = load_verified_blob(addr);
-            List.Cons(bs, store(build_lit_blobs(rest, all_addrs))),
+            store(ListNode.Cons(bs, build_lit_blobs(rest, all_addrs))),
           0 =>
-            List.Cons(List.Nil, store(build_lit_blobs(rest, all_addrs))),
+            store(ListNode.Cons(store(ListNode.Nil), build_lit_blobs(rest, all_addrs))),
         },
     }
   }
@@ -133,9 +133,9 @@ def ingress := ⟦
   -- projection constant (IPrj, CPrj, RPrj, DPrj). Used for standalone
   -- recursors to locate their inductive's block.
   fn find_block_addr_from_refs(refs: List‹[G; 32]›, all_addrs: List‹[G; 32]›) -> [G; 32] {
-    match refs {
-      List.Nil => [0; 32],
-      List.Cons(addr, &rest) =>
+    match load(refs) {
+      ListNode.Nil => [0; 32],
+      ListNode.Cons(addr, rest) =>
         let blob = is_blob(addr, all_addrs);
         match blob {
           1 => find_block_addr_from_refs(rest, all_addrs),
@@ -161,28 +161,28 @@ def ingress := ⟦
 
   fn recr_rule_count(recr: Recursor) -> G {
     match recr {
-      Recursor.Mk(_, _, _, _, _, _, _, _, &rules) =>
+      Recursor.Mk(_, _, _, _, _, _, _, _, rules) =>
         count_recr_rules(rules),
     }
   }
 
   -- Count recursor rules
   fn count_recr_rules(rules: List‹RecursorRule›) -> G {
-    match rules {
-      List.Nil => 0,
-      List.Cons(_, &rest) => count_recr_rules(rest) + 1,
+    match load(rules) {
+      ListNode.Nil => 0,
+      ListNode.Cons(_, rest) => count_recr_rules(rest) + 1,
     }
   }
 
   -- Count constructors in a Muts block's first inductive
   fn count_block_ctors(members: List‹MutConst›) -> G {
-    match members {
-      List.Nil => 0,
-      List.Cons(mc, &rest) =>
+    match load(members) {
+      ListNode.Nil => 0,
+      ListNode.Cons(mc, rest) =>
         match mc {
           MutConst.Indc(ind) =>
             match ind {
-              Inductive.Mk(_, _, _, _, _, _, _, _, &ctors) =>
+              Inductive.Mk(_, _, _, _, _, _, _, _, ctors) =>
                 list_length(ctors),
             },
           _ => count_block_ctors(rest),
@@ -193,9 +193,9 @@ def ingress := ⟦
   -- Find the correct block address for a standalone recursor by matching
   -- the number of recursor rules to the number of constructors in the block.
   fn find_matching_block_addr(refs: List‹[G; 32]›, all_addrs: List‹[G; 32]›, nrules: G) -> [G; 32] {
-    match refs {
-      List.Nil => [0; 32],
-      List.Cons(addr, &rest) =>
+    match load(refs) {
+      ListNode.Nil => [0; 32],
+      ListNode.Cons(addr, rest) =>
         let blob = is_blob(addr, all_addrs);
         match blob {
           1 => find_matching_block_addr(rest, all_addrs, nrules),
@@ -211,7 +211,7 @@ def ingress := ⟦
                         match bc {
                           Constant.Mk(bi, _, _, _) =>
                             match bi {
-                              ConstantInfo.Muts(&members) =>
+                              ConstantInfo.Muts(members) =>
                                 let nctors = count_block_ctors(members);
                                 match nctors - nrules {
                                   0 => block_addr,
@@ -246,7 +246,7 @@ def ingress := ⟦
     match mc {
       MutConst.Indc(ind) =>
         match ind {
-          Inductive.Mk(_, _, _, _, _, _, _, _, &ctors) =>
+          Inductive.Mk(_, _, _, _, _, _, _, _, ctors) =>
             list_length(ctors) + 1,
         },
       MutConst.Recr(_) => 1,
@@ -256,9 +256,9 @@ def ingress := ⟦
 
   -- Count total kernel entries for an entire List‹MutConst›
   fn block_kernel_size(members: List‹MutConst›) -> G {
-    match members {
-      List.Nil => 0,
-      List.Cons(mc, &rest) =>
+    match load(members) {
+      ListNode.Nil => 0,
+      ListNode.Cons(mc, rest) =>
         member_kernel_size(mc) + block_kernel_size(rest),
     }
   }
@@ -269,8 +269,8 @@ def ingress := ⟦
     match target_idx {
       0 => 0,
       _ =>
-        match members {
-          List.Cons(mc, &rest) =>
+        match load(members) {
+          ListNode.Cons(mc, rest) =>
             member_kernel_size(mc) + member_offset(rest, target_idx - 1),
         },
     }
@@ -278,11 +278,11 @@ def ingress := ⟦
 
   -- Look up the kernel position for an address using parallel lists.
   fn lookup_addr_pos(target: [G; 32], all_addrs: List‹[G; 32]›, pos_map: List‹G›) -> G {
-    match all_addrs {
-      List.Nil => 0,
-      List.Cons(addr, &rest_addrs) =>
-        match pos_map {
-          List.Cons(pos, &rest_pos) =>
+    match load(all_addrs) {
+      ListNode.Nil => 0,
+      ListNode.Cons(addr, rest_addrs) =>
+        match load(pos_map) {
+          ListNode.Cons(pos, rest_pos) =>
             let eq = address_eq(target, addr);
             match eq {
               1 => pos,
@@ -294,11 +294,11 @@ def ingress := ⟦
 
   -- Find the start position of a block by its block address.
   fn lookup_block_start(target: [G; 32], block_addrs: List‹[G; 32]›, block_starts: List‹G›) -> G {
-    match block_addrs {
-      List.Nil => 0,
-      List.Cons(addr, &rest_addrs) =>
-        match block_starts {
-          List.Cons(start, &rest_starts) =>
+    match load(block_addrs) {
+      ListNode.Nil => 0,
+      ListNode.Cons(addr, rest_addrs) =>
+        match load(block_starts) {
+          ListNode.Cons(start, rest_starts) =>
             let eq = address_eq(target, addr);
             match eq {
               1 => start,
@@ -317,19 +317,19 @@ def ingress := ⟦
     addrs: List‹[G; 32]›,
     pos: G
   ) -> (List‹[G; 32]›, List‹G›, G) {
-    match consts {
-      List.Nil => (List.Nil, List.Nil, pos),
-      List.Cons(&c, &rest_consts) =>
-        match addrs {
-          List.Cons(addr, &rest_addrs) =>
+    match load(consts) {
+      ListNode.Nil => (store(ListNode.Nil), store(ListNode.Nil), pos),
+      ListNode.Cons(&c, rest_consts) =>
+        match load(addrs) {
+          ListNode.Cons(addr, rest_addrs) =>
             match c {
               Constant.Mk(info, _, _, _) =>
                 match info {
-                  ConstantInfo.Muts(&members) =>
+                  ConstantInfo.Muts(members) =>
                     let size = block_kernel_size(members);
                     let (ba, bs, next) = compute_layout(rest_consts, rest_addrs, pos + size);
-                    (List.Cons(addr, store(ba)),
-                     List.Cons(pos, store(bs)),
+                    (store(ListNode.Cons(addr, ba)),
+                     store(ListNode.Cons(pos, bs)),
                      next),
                   ConstantInfo.IPrj(_) =>
                     compute_layout(rest_consts, rest_addrs, pos),
@@ -364,17 +364,17 @@ def ingress := ⟦
     block_starts: List‹G›,
     pos: G
   ) -> List‹G› {
-    match consts {
-      List.Nil => List.Nil,
-      List.Cons(&c, &rest_consts) =>
-        match addrs {
-          List.Cons(_, &rest_addrs) =>
+    match load(consts) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(&c, rest_consts) =>
+        match load(addrs) {
+          ListNode.Cons(_, rest_addrs) =>
             match c {
               Constant.Mk(info, _, _, _) =>
                 match info {
-                  ConstantInfo.Muts(&members) =>
+                  ConstantInfo.Muts(members) =>
                     let size = block_kernel_size(members);
-                    List.Cons(0, store(build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos + size))),
+                    store(ListNode.Cons(0, build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos + size))),
                   ConstantInfo.IPrj(prj) =>
                     match prj {
                       InductiveProj.Mk(idx, block_addr) =>
@@ -383,10 +383,10 @@ def ingress := ⟦
                         match block_const {
                           Constant.Mk(block_info, _, _, _) =>
                             match block_info {
-                              ConstantInfo.Muts(&members) =>
+                              ConstantInfo.Muts(members) =>
                                 let off = member_offset(members, flatten_u64(idx));
-                                List.Cons(block_start + off,
-                                  store(build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
+                                store(ListNode.Cons(block_start + off,
+                                  build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
                             },
                         },
                     },
@@ -398,10 +398,10 @@ def ingress := ⟦
                         match block_const {
                           Constant.Mk(block_info, _, _, _) =>
                             match block_info {
-                              ConstantInfo.Muts(&members) =>
+                              ConstantInfo.Muts(members) =>
                                 let mem_off = member_offset(members, flatten_u64(idx));
-                                List.Cons(block_start + mem_off + 1 + flatten_u64(cidx),
-                                  store(build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
+                                store(ListNode.Cons(block_start + mem_off + 1 + flatten_u64(cidx),
+                                  build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
                             },
                         },
                     },
@@ -413,10 +413,10 @@ def ingress := ⟦
                         match block_const {
                           Constant.Mk(block_info, _, _, _) =>
                             match block_info {
-                              ConstantInfo.Muts(&members) =>
+                              ConstantInfo.Muts(members) =>
                                 let off = member_offset(members, flatten_u64(idx));
-                                List.Cons(block_start + off,
-                                  store(build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
+                                store(ListNode.Cons(block_start + off,
+                                  build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
                             },
                         },
                     },
@@ -428,16 +428,16 @@ def ingress := ⟦
                         match block_const {
                           Constant.Mk(block_info, _, _, _) =>
                             match block_info {
-                              ConstantInfo.Muts(&members) =>
+                              ConstantInfo.Muts(members) =>
                                 let off = member_offset(members, flatten_u64(idx));
-                                List.Cons(block_start + off,
-                                  store(build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
+                                store(ListNode.Cons(block_start + off,
+                                  build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos))),
                             },
                         },
                     },
                   _ =>
-                    List.Cons(pos,
-                      store(build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos + 1))),
+                    store(ListNode.Cons(pos,
+                      build_pos_map(rest_consts, rest_addrs, block_addrs, block_starts, pos + 1))),
                 },
             },
         },
@@ -449,41 +449,41 @@ def ingress := ⟦
   -- ============================================================================
 
   fn build_ref_idxs_mapped(refs: List‹[G; 32]›, all_addrs: List‹[G; 32]›, pos_map: List‹G›) -> List‹G› {
-    match refs {
-      List.Nil => List.Nil,
-      List.Cons(addr, &rest) =>
+    match load(refs) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(addr, rest) =>
         let pos = lookup_addr_pos(addr, all_addrs, pos_map);
-        List.Cons(pos, store(build_ref_idxs_mapped(rest, all_addrs, pos_map))),
+        store(ListNode.Cons(pos, build_ref_idxs_mapped(rest, all_addrs, pos_map))),
     }
   }
 
   fn build_recur_idxs(members: List‹MutConst›, block_start: G, member_idx: G) -> List‹G› {
-    match members {
-      List.Nil => List.Nil,
-      List.Cons(_, &rest) =>
+    match load(members) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(_, rest) =>
         let off = member_offset(members, member_idx);
-        List.Cons(block_start + off,
-          store(build_recur_idxs(rest, block_start, member_idx + 1))),
+        store(ListNode.Cons(block_start + off,
+          build_recur_idxs(rest, block_start, member_idx + 1))),
     }
   }
 
   fn build_ctor_idxs(num_ctors: G, induct_pos: G, cidx: G) -> List‹G› {
     match num_ctors {
-      0 => List.Nil,
+      0 => store(ListNode.Nil),
       _ =>
-        List.Cons(induct_pos + 1 + cidx,
-          store(build_ctor_idxs(num_ctors - 1, induct_pos, cidx + 1))),
+        store(ListNode.Cons(induct_pos + 1 + cidx,
+          build_ctor_idxs(num_ctors - 1, induct_pos, cidx + 1))),
     }
   }
 
   fn build_rule_ctor_idxs(members: List‹MutConst›, block_start: G, member_idx: G) -> List‹G› {
-    match members {
-      List.Nil => List.Nil,
-      List.Cons(mc, &rest) =>
+    match load(members) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(mc, rest) =>
         match mc {
           MutConst.Indc(ind) =>
             match ind {
-              Inductive.Mk(_, _, _, _, _, _, _, _, &ctors) =>
+              Inductive.Mk(_, _, _, _, _, _, _, _, ctors) =>
                 let num_ctors = list_length(ctors);
                 let induct_pos = block_start + member_offset(members, member_idx);
                 let this_ctors = build_ctor_idxs(num_ctors, induct_pos, 0);
@@ -516,30 +516,30 @@ def ingress := ⟦
     match mc {
       MutConst.Indc(ind) =>
         match ind {
-          Inductive.Mk(_, _, _, _, _, _, _, _, &ctors) =>
+          Inductive.Mk(_, _, _, _, _, _, _, _, ctors) =>
             let num_ctors = list_length(ctors);
             let induct_pos = block_start + member_offset(members, member_idx);
             let ctor_idxs = build_ctor_idxs(num_ctors, induct_pos, 0);
-            let indc_input = ConvertInput.Mk(ctx, ConvertKind.CKIndc(ind, store(ctor_idxs)));
+            let indc_input = ConvertInput.Mk(ctx, ConvertKind.CKIndc(ind, ctor_idxs));
             let ctor_inputs = expand_ctors(ctors, ctx, induct_pos);
-            List.Cons(store(indc_input), store(ctor_inputs)),
+            store(ListNode.Cons(store(indc_input), ctor_inputs)),
         },
       MutConst.Recr(recr) =>
         let rule_ctor_idxs = build_rule_ctor_idxs(members, block_start, 0);
-        let input = ConvertInput.Mk(ctx, ConvertKind.CKRecr(recr, store(rule_ctor_idxs)));
-        List.Cons(store(input), store(List.Nil)),
+        let input = ConvertInput.Mk(ctx, ConvertKind.CKRecr(recr, rule_ctor_idxs));
+        store(ListNode.Cons(store(input), store(ListNode.Nil))),
       MutConst.Defn(defn) =>
         let input = ConvertInput.Mk(ctx, ConvertKind.CKDefn(defn));
-        List.Cons(store(input), store(List.Nil)),
+        store(ListNode.Cons(store(input), store(ListNode.Nil))),
     }
   }
 
   fn expand_ctors(ctors: List‹Constructor›, ctx: ConvertCtx, induct_pos: G) -> List‹&ConvertInput› {
-    match ctors {
-      List.Nil => List.Nil,
-      List.Cons(ctor, &rest) =>
+    match load(ctors) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(ctor, rest) =>
         let input = ConvertInput.Mk(ctx, ConvertKind.CKCtor(ctor, induct_pos));
-        List.Cons(store(input), store(expand_ctors(rest, ctx, induct_pos))),
+        store(ListNode.Cons(store(input), expand_ctors(rest, ctx, induct_pos))),
     }
   }
 
@@ -550,9 +550,9 @@ def ingress := ⟦
     block_start: G,
     member_idx: G
   ) -> List‹&ConvertInput› {
-    match members {
-      List.Nil => List.Nil,
-      List.Cons(mc, &rest) =>
+    match load(members) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(mc, rest) =>
         let this = expand_member(mc, ctx, all_members, block_start, member_idx);
         let more = expand_members(rest, ctx, all_members, block_start, member_idx + 1);
         list_concat(this, more),
@@ -571,18 +571,18 @@ def ingress := ⟦
     block_starts: List‹G›,
     pos: G
   ) -> List‹&ConvertInput› {
-    match consts {
-      List.Nil => List.Nil,
-      List.Cons(&c, &rest) =>
+    match load(consts) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(&c, rest) =>
         match c {
-          Constant.Mk(info, &sharing, &refs, &univs) =>
+          Constant.Mk(info, sharing, refs, univs) =>
             match info {
-              ConstantInfo.Muts(&members) =>
+              ConstantInfo.Muts(members) =>
                 let size = block_kernel_size(members);
                 let ref_idxs = build_ref_idxs_mapped(refs, all_addrs, pos_map);
                 let lit_blobs = build_lit_blobs(refs, all_addrs);
                 let recur_idxs = build_recur_idxs(members, pos, 0);
-                let ctx = ConvertCtx.Mk(store(sharing), store(ref_idxs), store(recur_idxs), store(lit_blobs), store(univs));
+                let ctx = ConvertCtx.Mk(sharing, ref_idxs, recur_idxs, lit_blobs, univs);
                 let expanded = expand_members(members, ctx, members, pos, 0);
                 let more = build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + size);
                 list_concat(expanded, more),
@@ -597,25 +597,25 @@ def ingress := ⟦
               ConstantInfo.Defn(defn) =>
                 let ref_idxs = build_ref_idxs_mapped(refs, all_addrs, pos_map);
                 let lit_blobs = build_lit_blobs(refs, all_addrs);
-                let recur_idxs = List.Cons(pos, store(List.Nil));
-                let ctx = ConvertCtx.Mk(store(sharing), store(ref_idxs), store(recur_idxs), store(lit_blobs), store(univs));
+                let recur_idxs = store(ListNode.Cons(pos, store(ListNode.Nil)));
+                let ctx = ConvertCtx.Mk(sharing, ref_idxs, recur_idxs, lit_blobs, univs);
                 let input = ConvertInput.Mk(ctx, ConvertKind.CKDefn(defn));
-                List.Cons(store(input),
-                  store(build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
+                store(ListNode.Cons(store(input),
+                  build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
               ConstantInfo.Axio(axio) =>
                 let ref_idxs = build_ref_idxs_mapped(refs, all_addrs, pos_map);
                 let lit_blobs = build_lit_blobs(refs, all_addrs);
-                let ctx = ConvertCtx.Mk(store(sharing), store(ref_idxs), store(List.Nil), store(lit_blobs), store(univs));
+                let ctx = ConvertCtx.Mk(sharing, ref_idxs, store(ListNode.Nil), lit_blobs, univs);
                 let input = ConvertInput.Mk(ctx, ConvertKind.CKAxio(axio));
-                List.Cons(store(input),
-                  store(build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
+                store(ListNode.Cons(store(input),
+                  build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
               ConstantInfo.Quot(quot) =>
                 let ref_idxs = build_ref_idxs_mapped(refs, all_addrs, pos_map);
                 let lit_blobs = build_lit_blobs(refs, all_addrs);
-                let ctx = ConvertCtx.Mk(store(sharing), store(ref_idxs), store(List.Nil), store(lit_blobs), store(univs));
+                let ctx = ConvertCtx.Mk(sharing, ref_idxs, store(ListNode.Nil), lit_blobs, univs);
                 let input = ConvertInput.Mk(ctx, ConvertKind.CKQuot(quot));
-                List.Cons(store(input),
-                  store(build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
+                store(ListNode.Cons(store(input),
+                  build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
               ConstantInfo.Recr(recr) =>
                 let ref_idxs = build_ref_idxs_mapped(refs, all_addrs, pos_map);
                 let lit_blobs = build_lit_blobs(refs, all_addrs);
@@ -625,14 +625,14 @@ def ingress := ⟦
                 match block_const {
                   Constant.Mk(block_info, _, _, _) =>
                     match block_info {
-                      ConstantInfo.Muts(&members) =>
-                        let recur_idxs = List.Cons(pos, store(List.Nil));
+                      ConstantInfo.Muts(members) =>
+                        let recur_idxs = store(ListNode.Cons(pos, store(ListNode.Nil)));
                         let bs = lookup_block_start(block_addr, block_addrs, block_starts);
                         let rule_ctor_idxs = build_rule_ctor_idxs(members, bs, 0);
-                        let ctx = ConvertCtx.Mk(store(sharing), store(ref_idxs), store(recur_idxs), store(lit_blobs), store(univs));
-                        let input = ConvertInput.Mk(ctx, ConvertKind.CKRecr(recr, store(rule_ctor_idxs)));
-                        List.Cons(store(input),
-                          store(build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
+                        let ctx = ConvertCtx.Mk(sharing, ref_idxs, recur_idxs, lit_blobs, univs);
+                        let input = ConvertInput.Mk(ctx, ConvertKind.CKRecr(recr, rule_ctor_idxs));
+                        store(ListNode.Cons(store(input),
+                          build_convert_inputs(rest, all_addrs, pos_map, block_addrs, block_starts, pos + 1))),
                     },
                 },
             },
@@ -646,9 +646,9 @@ def ingress := ⟦
 
   -- Check if an address is already in a list
   fn address_in_list(addr: [G; 32], list: List‹[G; 32]›) -> G {
-    match list {
-      List.Nil => 0,
-      List.Cons(a, &rest) =>
+    match load(list) {
+      ListNode.Nil => 0,
+      ListNode.Cons(a, rest) =>
         let eq = address_eq(addr, a);
         match eq {
           1 => 1,
@@ -672,9 +672,9 @@ def ingress := ⟦
     let already = address_in_list(addr, visited_addrs);
     match already {
       1 =>
-        match worklist {
-          List.Nil => (visited_addrs, visited_consts),
-          List.Cons(next, &rest) =>
+        match load(worklist) {
+          ListNode.Nil => (visited_addrs, visited_consts),
+          ListNode.Cons(next, rest) =>
             load_with_deps(next, rest, visited_addrs, visited_consts),
         },
       0 =>
@@ -685,36 +685,36 @@ def ingress := ⟦
         match len {
           0 =>
             -- Blob address: skip (blob values are loaded on demand in build_lit_blobs)
-            match worklist {
-              List.Nil => (visited_addrs, visited_consts),
-              List.Cons(next, &rest) =>
+            match load(worklist) {
+              ListNode.Nil => (visited_addrs, visited_consts),
+              ListNode.Cons(next, rest) =>
                 load_with_deps(next, rest, visited_addrs, visited_consts),
             },
           _ =>
-            let new_addrs = List.Cons(addr, store(visited_addrs));
+            let new_addrs = store(ListNode.Cons(addr, visited_addrs));
             let constant = load_verified_constant(addr);
-            let new_consts = List.Cons(store(constant), store(visited_consts));
+            let new_consts = store(ListNode.Cons(store(constant), visited_consts));
             match constant {
-              Constant.Mk(info, _, &refs, _) =>
+              Constant.Mk(info, _, refs, _) =>
                 let block_addr = get_proj_block_addr(info);
                 match address_eq(block_addr, [0; 32]) {
                   1 =>
-                    let combined_refs = list_concat(refs, List.Nil);
+                    let combined_refs = list_concat(refs, store(ListNode.Nil));
                     let next_worklist = list_concat(combined_refs, worklist);
-                    match next_worklist {
-                      List.Nil => (new_addrs, new_consts),
-                      List.Cons(next, &rest) =>
+                    match load(next_worklist) {
+                      ListNode.Nil => (new_addrs, new_consts),
+                      ListNode.Cons(next, rest) =>
                         load_with_deps(next, rest, new_addrs, new_consts),
                     },
                   0 =>
                     let combined_refs = list_concat(
                       refs,
-                      List.Cons(block_addr, store(List.Nil))
+                      store(ListNode.Cons(block_addr, store(ListNode.Nil)))
                     );
                     let next_worklist = list_concat(combined_refs, worklist);
-                    match next_worklist {
-                      List.Nil => (new_addrs, new_consts),
-                      List.Cons(next, &rest) =>
+                    match load(next_worklist) {
+                      ListNode.Nil => (new_addrs, new_consts),
+                      ListNode.Cons(next, rest) =>
                         load_with_deps(next, rest, new_addrs, new_consts),
                     },
                 },
@@ -727,7 +727,7 @@ def ingress := ⟦
   -- verifies blake3 hashes then converts to kernel types.
   fn ingress(target_addr: [G; 32]) -> List‹&KConstantInfo› {
     let (all_addrs, all_consts) = load_with_deps(
-      target_addr, List.Nil, List.Nil, List.Nil);
+      target_addr, store(ListNode.Nil), store(ListNode.Nil), store(ListNode.Nil));
     let (block_addrs, block_starts, _total) = compute_layout(all_consts, all_addrs, 0);
     let pos_map = build_pos_map(all_consts, all_addrs, block_addrs, block_starts, 0);
     let inputs = build_convert_inputs(all_consts, all_addrs, pos_map, block_addrs, block_starts, 0);
@@ -737,11 +737,11 @@ def ingress := ⟦
   -- Look up a constant's position by its blake3 address.
   -- Returns 0 - 1 (sentinel) if the address is not found.
   fn find_addr_pos(target: [G; 32], all_addrs: List‹[G; 32]›, pos_map: List‹G›) -> G {
-    match all_addrs {
-      List.Nil => 0 - 1,
-      List.Cons(addr, &rest_addrs) =>
-        match pos_map {
-          List.Cons(pos, &rest_pos) =>
+    match load(all_addrs) {
+      ListNode.Nil => 0 - 1,
+      ListNode.Cons(addr, rest_addrs) =>
+        match load(pos_map) {
+          ListNode.Cons(pos, rest_pos) =>
             let eq = address_eq(target, addr);
             match eq {
               1 => pos,
@@ -756,7 +756,7 @@ def ingress := ⟦
   -- Returns (constants, nat_idx, str_idx).
   fn ingress_with_primitives(target_addr: [G; 32]) -> (List‹&KConstantInfo›, G, G) {
     let (all_addrs, all_consts) = load_with_deps(
-      target_addr, List.Nil, List.Nil, List.Nil);
+      target_addr, store(ListNode.Nil), store(ListNode.Nil), store(ListNode.Nil));
     let (block_addrs, block_starts, _total) = compute_layout(all_consts, all_addrs, 0);
     let pos_map = build_pos_map(all_consts, all_addrs, block_addrs, block_starts, 0);
     let inputs = build_convert_inputs(all_consts, all_addrs, pos_map, block_addrs, block_starts, 0);

--- a/Ix/IxVM/Ixon.lean
+++ b/Ix/IxVM/Ixon.lean
@@ -10,8 +10,8 @@ def ixon := ⟦
   enum Expr {
     Srt([G; 8]),
     Var([G; 8]),
-    Ref([G; 8], &List‹U64›),
-    Rec([G; 8], &List‹U64›),
+    Ref([G; 8], List‹U64›),
+    Rec([G; 8], List‹U64›),
     Prj([G; 8], [G; 8], &Expr),
     Str([G; 8]),
     Nat([G; 8]),
@@ -65,7 +65,7 @@ def ixon := ⟦
 
   -- Recursor: (k, is_unsafe, lvls, params, indices, motives, minors, typ, rules)
   enum Recursor {
-    Mk(G, G, [G; 8], [G; 8], [G; 8], [G; 8], [G; 8], &Expr, &List‹RecursorRule›)
+    Mk(G, G, [G; 8], [G; 8], [G; 8], [G; 8], [G; 8], &Expr, List‹RecursorRule›)
   }
 
   -- Axiom: (is_unsafe, lvls, typ)
@@ -85,7 +85,7 @@ def ixon := ⟦
 
   -- Inductive: (recr, refl, is_unsafe, lvls, params, indices, nested, typ, ctors)
   enum Inductive {
-    Mk(G, G, G, [G; 8], [G; 8], [G; 8], [G; 8], &Expr, &List‹Constructor›)
+    Mk(G, G, G, [G; 8], [G; 8], [G; 8], [G; 8], &Expr, List‹Constructor›)
   }
 
   -- InductiveProj: (idx, block_address)
@@ -125,12 +125,12 @@ def ixon := ⟦
     RPrj(RecursorProj),
     IPrj(InductiveProj),
     DPrj(DefinitionProj),
-    Muts(&List‹MutConst›)
+    Muts(List‹MutConst›)
   }
 
   -- Constant: (info, sharing, refs, univs)
   enum Constant {
-    Mk(ConstantInfo, &List‹&Expr›, &List‹[G; 32]›, &List‹&Univ›)
+    Mk(ConstantInfo, List‹&Expr›, List‹[G; 32]›, List‹&Univ›)
   }
 
   -- Blob: decoded literal value associated with a content address

--- a/Ix/IxVM/IxonDeserialize.lean
+++ b/Ix/IxVM/IxonDeserialize.lean
@@ -11,9 +11,9 @@ def ixonDeserialize := ⟦
   -- ============================================================================
 
   fn read_byte(stream: ByteStream) -> (G, ByteStream) {
-    match stream {
-      List.Cons(byte, &rest) => (byte, rest),
-      List.Nil => (0, List.Nil),
+    match load(stream) {
+      ListNode.Cons(byte, rest) => (byte, rest),
+      ListNode.Nil => (0, store(ListNode.Nil)),
     }
   }
 
@@ -89,11 +89,11 @@ def ixonDeserialize := ⟦
   fn get_u64_list(stream: ByteStream, count: [G; 8]) -> (List‹U64›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (val, s) = get_tag0(stream);
         let (rest, s2) = get_u64_list(s, relaxed_u64_pred(count));
-        (List.Cons(val, store(rest)), s2),
+        (store(ListNode.Cons(val, rest)), s2),
     }
   }
 
@@ -157,13 +157,13 @@ def ixonDeserialize := ⟦
       0x2 =>
         let (ref_idx, s2) = get_tag0(s);
         let (univ_list, s3) = get_u64_list(s2, size);
-        (Expr.Ref(ref_idx, store(univ_list)), s3),
+        (Expr.Ref(ref_idx, univ_list), s3),
 
       -- Rec: Tag4(0x3, len) + Tag0(rec_idx) + univ_list
       0x3 =>
         let (rec_idx, s2) = get_tag0(s);
         let (univ_list, s3) = get_u64_list(s2, size);
-        (Expr.Rec(rec_idx, store(univ_list)), s3),
+        (Expr.Rec(rec_idx, univ_list), s3),
 
       -- Prj: Tag4(0x4, field_idx) + Tag0(type_ref_idx) + expr(val)
       0x4 =>
@@ -294,33 +294,33 @@ def ixonDeserialize := ⟦
   fn get_expr_list(stream: ByteStream, count: [G; 8]) -> (List‹&Expr›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (expr, s) = get_expr(stream);
         let (rest, s2) = get_expr_list(s, relaxed_u64_pred(count));
-        (List.Cons(store(expr), store(rest)), s2),
+        (store(ListNode.Cons(store(expr), rest)), s2),
     }
   }
 
   fn get_univ_list(stream: ByteStream, count: [G; 8]) -> (List‹&Univ›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (u, s) = get_univ(stream);
         let (rest, s2) = get_univ_list(s, relaxed_u64_pred(count));
-        (List.Cons(store(u), store(rest)), s2),
+        (store(ListNode.Cons(store(u), rest)), s2),
     }
   }
 
   fn get_address_list(stream: ByteStream, count: [G; 8]) -> (List‹[G; 32]›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (addr, s) = get_address(stream);
         let (rest, s2) = get_address_list(s, relaxed_u64_pred(count));
-        (List.Cons(addr, store(rest)), s2),
+        (store(ListNode.Cons(addr, rest)), s2),
     }
   }
 
@@ -385,11 +385,11 @@ def ixonDeserialize := ⟦
   fn get_recursor_rule_list(stream: ByteStream, count: [G; 8]) -> (List‹RecursorRule›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (rule, s) = get_recursor_rule(stream);
         let (rest, s2) = get_recursor_rule_list(s, relaxed_u64_pred(count));
-        (List.Cons(rule, store(rest)), s2),
+        (store(ListNode.Cons(rule, rest)), s2),
     }
   }
 
@@ -408,7 +408,7 @@ def ixonDeserialize := ⟦
     let (typ, s7) = get_expr(s6);
     let (rules_len, s8) = get_tag0(s7);
     let (rules, s9) = get_recursor_rule_list(s8, rules_len);
-    (Recursor.Mk(k, is_unsafe, lvls, params, indices, motives, minors, store(typ), store(rules)), s9)
+    (Recursor.Mk(k, is_unsafe, lvls, params, indices, motives, minors, store(typ), rules), s9)
   }
 
   -- Axiom: byte(is_unsafe) + Tag0(lvls) + expr(typ)
@@ -453,11 +453,11 @@ def ixonDeserialize := ⟦
   fn get_constructor_list(stream: ByteStream, count: [G; 8]) -> (List‹Constructor›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (ctor, s) = get_constructor(stream);
         let (rest, s2) = get_constructor_list(s, relaxed_u64_pred(count));
-        (List.Cons(ctor, store(rest)), s2),
+        (store(ListNode.Cons(ctor, rest)), s2),
     }
   }
 
@@ -476,7 +476,7 @@ def ixonDeserialize := ⟦
     let (typ, s6) = get_expr(s5);
     let (ctors_len, s7) = get_tag0(s6);
     let (ctors, s8) = get_constructor_list(s7, ctors_len);
-    (Inductive.Mk(recr, refl, is_unsafe, lvls, params, indices, nested, store(typ), store(ctors)), s8)
+    (Inductive.Mk(recr, refl, is_unsafe, lvls, params, indices, nested, store(typ), ctors), s8)
   }
 
   -- ============================================================================
@@ -535,11 +535,11 @@ def ixonDeserialize := ⟦
   fn get_mut_const_list(stream: ByteStream, count: [G; 8]) -> (List‹MutConst›, ByteStream) {
     let is_zero = u64_is_zero(count);
     match is_zero {
-      1 => (List.Nil, stream),
+      1 => (store(ListNode.Nil), stream),
       0 =>
         let (mc, s) = get_mut_const(stream);
         let (rest, s2) = get_mut_const_list(s, relaxed_u64_pred(count));
-        (List.Cons(mc, store(rest)), s2),
+        (store(ListNode.Cons(mc, rest)), s2),
     }
   }
 
@@ -583,7 +583,7 @@ def ixonDeserialize := ⟦
       -- Muts: flag=0xC, size is the entry count
       0xC =>
         let (mutuals, s) = get_mut_const_list(stream, size);
-        (ConstantInfo.Muts(store(mutuals)), s),
+        (ConstantInfo.Muts(mutuals), s),
       -- Non-Muts: flag=0xD, size[0] is the variant number
       0xD =>
         get_constant_info_by_variant(size[0], stream),
@@ -601,7 +601,7 @@ def ixonDeserialize := ⟦
     let (sharing, s3) = get_sharing(s2);
     let (refs, s4) = get_refs(s3);
     let (univs, s5) = get_univs(s4);
-    (Constant.Mk(info, store(sharing), store(refs), store(univs)), s5)
+    (Constant.Mk(info, sharing, refs, univs), s5)
   }
 ⟧
 

--- a/Ix/IxVM/IxonSerialize.lean
+++ b/Ix/IxVM/IxonSerialize.lean
@@ -15,12 +15,12 @@ def ixonSerialize := ⟦
       Expr.Var(idx) => put_tag4(0x1, idx, rest),
 
       -- Ref: Tag4(0x2, len) + Tag0(ref_idx) + univ_list
-      Expr.Ref(ref_idx, &univ_list) =>
+      Expr.Ref(ref_idx, univ_list) =>
         let len = list_length_u64(univ_list);
         put_tag4(0x2, len, put_tag0(ref_idx, put_u64_list(univ_list, rest))),
 
       -- Rec: Tag4(0x3, len) + Tag0(rec_idx) + univ_list
-      Expr.Rec(rec_idx, &univ_list) =>
+      Expr.Rec(rec_idx, univ_list) =>
         let len = list_length_u64(univ_list);
         put_tag4(0x3, len, put_tag0(rec_idx, put_u64_list(univ_list, rest))),
 
@@ -65,7 +65,7 @@ def ixonSerialize := ⟦
       _ =>
         let [b1, b2, b3, b4, b5, b6, b7, b8] = bs;
         let rest_shifted = [b2, b3, b4, b5, b6, b7, b8, 0];
-        List.Cons(b1, store(put_u64_le(rest_shifted, num_bytes - 1, rest))),
+        store(ListNode.Cons(b1, put_u64_le(rest_shifted, num_bytes - 1, rest))),
     }
   }
 
@@ -73,10 +73,10 @@ def ixonSerialize := ⟦
     let byte_count = u64_byte_count(bs);
     let small = u8_less_than(bs[0], 128);
     match (byte_count, small) {
-      (1, 1) => List.Cons(bs[0], store(rest)),
+      (1, 1) => store(ListNode.Cons(bs[0], rest)),
       _ =>
         let head = 128 + (byte_count - 1);
-        List.Cons(head, store(put_u64_le(bs, byte_count, rest))),
+        store(ListNode.Cons(head, put_u64_le(bs, byte_count, rest))),
     }
   }
 
@@ -89,11 +89,11 @@ def ixonSerialize := ⟦
       (1, 1) =>
         -- Single byte: flag in bits 6-7, size in bits 0-4
         let head = flag * 64 + size[0];
-        List.Cons(head, store(rest)),
+        store(ListNode.Cons(head, rest)),
       _ =>
         -- Multi-byte: flag in bits 6-7, large=1 in bit 5, size_bytes-1 in bits 0-4
         let head = flag * 64 + 32 + (byte_count - 1);
-        List.Cons(head, store(put_u64_le(size, byte_count, rest))),
+        store(ListNode.Cons(head, put_u64_le(size, byte_count, rest))),
     }
   }
 
@@ -103,19 +103,19 @@ def ixonSerialize := ⟦
     match (byte_count, small) {
       (1, 1) =>
         let head = flag * 16 + bs[0];
-        List.Cons(head, store(rest)),
+        store(ListNode.Cons(head, rest)),
       _ =>
         let head = flag * 16 + 8 + (byte_count - 1);
-        List.Cons(head, store(put_u64_le(bs, byte_count, rest))),
+        store(ListNode.Cons(head, put_u64_le(bs, byte_count, rest))),
     }
   }
 
   -- Serialize field list (each element as Tag0)
   fn put_u64_list(list: List‹U64›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(idx, rest_list) =>
-        put_tag0(idx, put_u64_list(load(rest_list), rest)),
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(idx, rest_list) =>
+        put_tag0(idx, put_u64_list(rest_list, rest)),
     }
   }
 
@@ -172,38 +172,38 @@ def ixonSerialize := ⟦
 
   -- Write a 32-byte address
   fn put_address(a: [G; 32], rest: ByteStream) -> ByteStream {
-    let list31 = List.Cons(a[31], store(rest));
-    let list30 = List.Cons(a[30], store(list31));
-    let list29 = List.Cons(a[29], store(list30));
-    let list28 = List.Cons(a[28], store(list29));
-    let list27 = List.Cons(a[27], store(list28));
-    let list26 = List.Cons(a[26], store(list27));
-    let list25 = List.Cons(a[25], store(list26));
-    let list24 = List.Cons(a[24], store(list25));
-    let list23 = List.Cons(a[23], store(list24));
-    let list22 = List.Cons(a[22], store(list23));
-    let list21 = List.Cons(a[21], store(list22));
-    let list20 = List.Cons(a[20], store(list21));
-    let list19 = List.Cons(a[19], store(list20));
-    let list18 = List.Cons(a[18], store(list19));
-    let list17 = List.Cons(a[17], store(list18));
-    let list16 = List.Cons(a[16], store(list17));
-    let list15 = List.Cons(a[15], store(list16));
-    let list14 = List.Cons(a[14], store(list15));
-    let list13 = List.Cons(a[13], store(list14));
-    let list12 = List.Cons(a[12], store(list13));
-    let list11 = List.Cons(a[11], store(list12));
-    let list10 = List.Cons(a[10], store(list11));
-    let list9 = List.Cons(a[9], store(list10));
-    let list8 = List.Cons(a[8], store(list9));
-    let list7 = List.Cons(a[7], store(list8));
-    let list6 = List.Cons(a[6], store(list7));
-    let list5 = List.Cons(a[5], store(list6));
-    let list4 = List.Cons(a[4], store(list5));
-    let list3 = List.Cons(a[3], store(list4));
-    let list2 = List.Cons(a[2], store(list3));
-    let list1 = List.Cons(a[1], store(list2));
-    List.Cons(a[0], store(list1))
+    let list31 = store(ListNode.Cons(a[31], rest));
+    let list30 = store(ListNode.Cons(a[30], list31));
+    let list29 = store(ListNode.Cons(a[29], list30));
+    let list28 = store(ListNode.Cons(a[28], list29));
+    let list27 = store(ListNode.Cons(a[27], list28));
+    let list26 = store(ListNode.Cons(a[26], list27));
+    let list25 = store(ListNode.Cons(a[25], list26));
+    let list24 = store(ListNode.Cons(a[24], list25));
+    let list23 = store(ListNode.Cons(a[23], list24));
+    let list22 = store(ListNode.Cons(a[22], list23));
+    let list21 = store(ListNode.Cons(a[21], list22));
+    let list20 = store(ListNode.Cons(a[20], list21));
+    let list19 = store(ListNode.Cons(a[19], list20));
+    let list18 = store(ListNode.Cons(a[18], list19));
+    let list17 = store(ListNode.Cons(a[17], list18));
+    let list16 = store(ListNode.Cons(a[16], list17));
+    let list15 = store(ListNode.Cons(a[15], list16));
+    let list14 = store(ListNode.Cons(a[14], list15));
+    let list13 = store(ListNode.Cons(a[13], list14));
+    let list12 = store(ListNode.Cons(a[12], list13));
+    let list11 = store(ListNode.Cons(a[11], list12));
+    let list10 = store(ListNode.Cons(a[10], list11));
+    let list9 = store(ListNode.Cons(a[9], list10));
+    let list8 = store(ListNode.Cons(a[8], list9));
+    let list7 = store(ListNode.Cons(a[7], list8));
+    let list6 = store(ListNode.Cons(a[6], list7));
+    let list5 = store(ListNode.Cons(a[5], list6));
+    let list4 = store(ListNode.Cons(a[4], list5));
+    let list3 = store(ListNode.Cons(a[3], list4));
+    let list2 = store(ListNode.Cons(a[2], list3));
+    let list1 = store(ListNode.Cons(a[1], list2));
+    store(ListNode.Cons(a[0], list1))
   }
 
   -- Pack DefKind (2 bits) and DefinitionSafety (2 bits) into a single byte
@@ -245,7 +245,7 @@ def ixonSerialize := ⟦
     match u {
       Univ.Zero =>
         -- Tag2(FLAG_ZERO_SUCC=0, size=0)
-        List.Cons(0, store(rest)),
+        store(ListNode.Cons(0, rest)),
 
       Univ.Succ(_) =>
         -- Count nested Succs for telescope compression
@@ -274,25 +274,25 @@ def ixonSerialize := ⟦
   -- ============================================================================
 
   fn put_expr_list(list: List‹&Expr›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(&expr, &rest_list) =>
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(&expr, rest_list) =>
         put_expr(expr, put_expr_list(rest_list, rest)),
     }
   }
 
   fn put_univ_list(list: List‹&Univ›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(&u, &rest_list) =>
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(&u, rest_list) =>
         put_univ(u, put_univ_list(rest_list, rest)),
     }
   }
 
   fn put_address_list(list: List‹[G; 32]›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(addr, &rest_list) =>
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(addr, rest_list) =>
         put_address(addr, put_address_list(rest_list, rest)),
     }
   }
@@ -303,10 +303,10 @@ def ixonSerialize := ⟦
 
   fn put_quot_kind(kind: QuotKind, rest: ByteStream) -> ByteStream {
     match kind {
-      QuotKind.Typ => List.Cons(0, store(rest)),
-      QuotKind.Ctor => List.Cons(1, store(rest)),
-      QuotKind.Lift => List.Cons(2, store(rest)),
-      QuotKind.Ind => List.Cons(3, store(rest)),
+      QuotKind.Typ => store(ListNode.Cons(0, rest)),
+      QuotKind.Ctor => store(ListNode.Cons(1, rest)),
+      QuotKind.Lift => store(ListNode.Cons(2, rest)),
+      QuotKind.Ind => store(ListNode.Cons(3, rest)),
     }
   }
 
@@ -314,7 +314,7 @@ def ixonSerialize := ⟦
     match defn {
       Definition.Mk(kind, safety, lvls, &typ, &value) =>
         let packed = pack_def_kind_safety(kind, safety);
-        List.Cons(packed, store(put_tag0(lvls, put_expr(typ, put_expr(value, rest))))),
+        store(ListNode.Cons(packed, put_tag0(lvls, put_expr(typ, put_expr(value, rest))))),
     }
   }
 
@@ -326,19 +326,19 @@ def ixonSerialize := ⟦
   }
 
   fn put_recursor_rule_list(list: List‹RecursorRule›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(rule, &rest_list) =>
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(rule, rest_list) =>
         put_recursor_rule(rule, put_recursor_rule_list(rest_list, rest)),
     }
   }
 
   fn put_recursor(recr: Recursor, rest: ByteStream) -> ByteStream {
     match recr {
-      Recursor.Mk(k, is_unsafe, lvls, params, indices, motives, minors, &typ, &rules) =>
+      Recursor.Mk(k, is_unsafe, lvls, params, indices, motives, minors, &typ, rules) =>
         let bools = k + 2 * is_unsafe;
         let rules_len = list_length_u64(rules);
-        List.Cons(bools, store(
+        store(ListNode.Cons(bools,
           put_tag0(lvls,
             put_tag0(params,
               put_tag0(indices,
@@ -353,7 +353,7 @@ def ixonSerialize := ⟦
   fn put_axiom(axim: Axiom, rest: ByteStream) -> ByteStream {
     match axim {
       Axiom.Mk(is_unsafe, lvls, &typ) =>
-        List.Cons(is_unsafe, store(put_tag0(lvls, put_expr(typ, rest)))),
+        store(ListNode.Cons(is_unsafe, put_tag0(lvls, put_expr(typ, rest)))),
     }
   }
 
@@ -367,7 +367,7 @@ def ixonSerialize := ⟦
   fn put_constructor(ctor: Constructor, rest: ByteStream) -> ByteStream {
     match ctor {
       Constructor.Mk(is_unsafe, lvls, cidx, params, fields, &typ) =>
-        List.Cons(is_unsafe, store(
+        store(ListNode.Cons(is_unsafe,
           put_tag0(lvls,
             put_tag0(cidx,
               put_tag0(params,
@@ -377,19 +377,19 @@ def ixonSerialize := ⟦
   }
 
   fn put_constructor_list(list: List‹Constructor›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(ctor, &rest_list) =>
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(ctor, rest_list) =>
         put_constructor(ctor, put_constructor_list(rest_list, rest)),
     }
   }
 
   fn put_inductive(indc: Inductive, rest: ByteStream) -> ByteStream {
     match indc {
-      Inductive.Mk(recr, refl, is_unsafe, lvls, params, indices, nested, &typ, &ctors) =>
+      Inductive.Mk(recr, refl, is_unsafe, lvls, params, indices, nested, &typ, ctors) =>
         let bools = recr + 2 * refl + 4 * is_unsafe;
         let ctors_len = list_length_u64(ctors);
-        List.Cons(bools, store(
+        store(ListNode.Cons(bools,
           put_tag0(lvls,
             put_tag0(params,
               put_tag0(indices,
@@ -431,18 +431,18 @@ def ixonSerialize := ⟦
   fn put_mut_const(mc: MutConst, rest: ByteStream) -> ByteStream {
     match mc {
       MutConst.Defn(defn) =>
-        List.Cons(0, store(put_definition(defn, rest))),
+        store(ListNode.Cons(0, put_definition(defn, rest))),
       MutConst.Indc(indc) =>
-        List.Cons(1, store(put_inductive(indc, rest))),
+        store(ListNode.Cons(1, put_inductive(indc, rest))),
       MutConst.Recr(recr) =>
-        List.Cons(2, store(put_recursor(recr, rest))),
+        store(ListNode.Cons(2, put_recursor(recr, rest))),
     }
   }
 
   fn put_mut_const_list(list: List‹MutConst›, rest: ByteStream) -> ByteStream {
-    match list {
-      List.Nil => rest,
-      List.Cons(mc, &rest_list) =>
+    match load(list) {
+      ListNode.Nil => rest,
+      ListNode.Cons(mc, rest_list) =>
         put_mut_const(mc, put_mut_const_list(rest_list, rest)),
     }
   }
@@ -477,10 +477,10 @@ def ixonSerialize := ⟦
 
   fn put_constant(cnst: Constant, rest: ByteStream) -> ByteStream {
     match cnst {
-      Constant.Mk(info, &sharing, &refs, &univs) =>
+      Constant.Mk(info, sharing, refs, univs) =>
         let up_to_sharing = put_sharing(sharing, put_refs(refs, put_univs(univs, rest)));
         match info {
-          ConstantInfo.Muts(&mutuals) =>
+          ConstantInfo.Muts(mutuals) =>
             -- Use FLAG_MUTS (0xC) with entry count in size field
             let count = list_length_u64(mutuals);
             put_tag4(0xC, count, put_mut_const_list(mutuals, up_to_sharing)),

--- a/Ix/IxVM/KERNEL.md
+++ b/Ix/IxVM/KERNEL.md
@@ -526,13 +526,8 @@ eval(const c [us], env) =
 
 eval(app f a, env) =
   let vf = eval(f, env)
-  match vf with
-  | lam(_, body, lam_env) =>
-      let va = eval(a, env)                -- eager beta
-      eval(body, lam_env ++ [va])          -- O(1) beta!
-  | _ =>
-      let thunk = lazy(a, env)             -- don't evaluate yet
-      apply_val_thunk(vf, thunk)
+  let arg = suspend(a, env)              -- suspend: immediate or thunk
+  apply_val(vf, arg)                     -- force only if needed (in apply_val)
 
 eval(lam A b, env) =
   let dom = eval(A, env)
@@ -557,25 +552,6 @@ to either a `ctor` (for constructors) or a `neutral(const(...), [])`. Definition
 unfolding is deferred to WHNF. This is the "lazy" approach — constants are only
 unfolded when the kernel actually needs to look inside them.
 
-The **eager beta optimization** is important: when the head of an application is already
-a lambda, we skip thunk creation and evaluate the argument directly. The Rust kernel
-collects the full App spine and checks at each step; the Aiur kernel uses a tail match
-on the evaluated function:
-
-```
--- Aiur: k_eval App case
-KExpr.App(&f, &a) =>
-  let vf = k_eval(f, env, top);
-  match vf {
-    KVal.Lam(_, &body, &lam_env) =>
-      let va = k_eval(a, env, top);           -- eager: skip thunk
-      let env2 = KValEnv.Cons(store(va), store(lam_env));
-      k_eval(body, env2, top),
-    _ =>
-      let thunk = KVal.Thunk(store(a), store(env));
-      k_apply(vf, thunk, top),                -- lazy: store thunk
-  }
-```
 
 #### De Bruijn Levels vs Indices
 
@@ -1049,7 +1025,6 @@ termination relies on the well-foundedness of the input declarations.
 | Feature | Lean | Rust | Aiur |
 |---------|------|------|------|
 | Lazy eval (thunks in spines) | ✅ ST.Ref | ✅ RefCell | ✅ KVal.Thunk |
-| Eager beta optimization | ✅ | ✅ | ✅ |
 | Delta unfolding (WHNF) | ✅ | ✅ | ✅ |
 | Iota reduction (recursor) | ✅ | ✅ | ✅ |
 | K-reduction (Prop recursors) | ✅ | ✅ | ✅ |

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -1317,16 +1317,20 @@ def kernel := ⟦
   -- Check definitional equality of two values: first try a quick syntactic check,
   -- then reduce to WHNF and compare structurally
   fn k_is_def_eq(a: KVal, b: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
-    let quick = k_quick_def_eq(a, b);
-    match quick {
-      1 => 1,
-      0 =>
+    let not_eq_ptr = ptr_val(a) - ptr_val(b);
+    match (not_eq_ptr, a, b) {
+      (0, _, _) => 1,
+      (_, &KValNode.Srt(&la), &KValNode.Srt(&lb)) => level_equal(la, lb),
+      (_, &KValNode.Lit(la), &KValNode.Lit(lb)) => literal_eq(la, lb),
+      _ =>
         let a_whnf = k_whnf(a, top);
         let b_whnf = k_whnf(b, top);
-        let quick2 = k_quick_def_eq(a_whnf, b_whnf);
-        match quick2 {
-          1 => 1,
-          0 =>
+        let not_eq_ptr = ptr_val(a_whnf) - ptr_val(b_whnf);
+        match (not_eq_ptr, a_whnf, b_whnf) {
+          (0, _, _) => 1,
+          (_, &KValNode.Srt(&la), &KValNode.Srt(&lb)) => level_equal(la, lb),
+          (_, &KValNode.Lit(la), &KValNode.Lit(lb)) => literal_eq(la, lb),
+          _ =>
             -- Proof irrelevance: a and b share the same type, so if that type is
             -- Prop then both are proofs of the same proposition and are equal.
             let a_type = k_infer_val_type(a_whnf, top, nat_idx, str_idx);
@@ -1345,27 +1349,6 @@ def kernel := ⟦
                   1 => 1,
                 },
             },
-        },
-    }
-  }
-
-  -- Quick syntactic check for definitional equality (sorts and literals only)
-  fn k_quick_def_eq(a: KVal, b: KVal) -> G {
-    match ptr_val(a) - ptr_val(b) {
-      0 => 1,
-      _ =>
-        match load(a) {
-          KValNode.Srt(&la) =>
-            match load(b) {
-              KValNode.Srt(&lb) => level_equal(la, lb),
-              _ => 0,
-            },
-          KValNode.Lit(la) =>
-            match load(b) {
-              KValNode.Lit(lb) => literal_eq(la, lb),
-              _ => 0,
-            },
-          _ => 0,
         },
     }
   }

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -530,7 +530,7 @@ def kernel := ⟦
             let env2 = List.Cons(store(va), store(lam_env));
             k_eval(body, env2, top),
           _ =>
-            let thunk = KVal.Thunk(store(a), store(env));
+            let thunk = suspend(a, env, top);
             k_apply(vf, thunk, top),
         },
 
@@ -560,6 +560,27 @@ def kernel := ⟦
           _ =>
             KVal.Proj(tidx, fidx, store(v), store(List.Nil)),
         },
+    }
+  }
+
+  -- Suspend an expression: evaluate immediately for cheap/structural forms
+  -- (BVar lookup, Srt, Lit, Lam closure, Pi closure); otherwise defer to a thunk.
+  fn suspend(e: KExpr, env: KValEnv, top: List‹&KConstantInfo›) -> KVal {
+    match e {
+      KExpr.BVar(idx) =>
+        load(list_lookup(env, idx)),
+      KExpr.Srt(&l) =>
+        KVal.Srt(store(level_reduce(l))),
+      KExpr.Lit(lit) =>
+        KVal.Lit(lit),
+      KExpr.Lam(&ty, &body) =>
+        let ty_val = k_eval(ty, env, top);
+        KVal.Lam(store(ty_val), store(body), store(env)),
+      KExpr.Forall(&ty, &body) =>
+        let ty_val = k_eval(ty, env, top);
+        KVal.Pi(store(ty_val), store(body), store(env)),
+      _ =>
+        KVal.Thunk(store(e), store(env)),
     }
   }
 

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -521,15 +521,15 @@ def kernel := ⟦
 
       KExpr.App(&f, &a) =>
         let vf = k_eval(f, env, top);
-        let arg = suspend(a, env, top);
+        let arg = suspend(a, env);
         k_apply(vf, arg, top),
 
       KExpr.Lam(&ty, &body) =>
-        let ty_val = k_eval(ty, env, top);
+        let ty_val = suspend(ty, env);
         KVal.Lam(store(ty_val), store(body), store(env)),
 
       KExpr.Forall(&ty, &body) =>
-        let ty_val = k_eval(ty, env, top);
+        let ty_val = suspend(ty, env);
         KVal.Pi(store(ty_val), store(body), store(env)),
 
       KExpr.Let(_, &val, &body) =>
@@ -555,7 +555,7 @@ def kernel := ⟦
 
   -- Suspend an expression: evaluate immediately for cheap/structural forms
   -- (BVar lookup, Srt, Lit, Lam closure, Pi closure); otherwise defer to a thunk.
-  fn suspend(e: KExpr, env: KValEnv, top: List‹&KConstantInfo›) -> KVal {
+  fn suspend(e: KExpr, env: KValEnv) -> KVal {
     match e {
       KExpr.BVar(idx) =>
         load(list_lookup(env, idx)),
@@ -564,10 +564,10 @@ def kernel := ⟦
       KExpr.Lit(lit) =>
         KVal.Lit(lit),
       KExpr.Lam(&ty, &body) =>
-        let ty_val = k_eval(ty, env, top);
+        let ty_val = suspend(ty, env);
         KVal.Lam(store(ty_val), store(body), store(env)),
       KExpr.Forall(&ty, &body) =>
-        let ty_val = k_eval(ty, env, top);
+        let ty_val = suspend(ty, env);
         KVal.Pi(store(ty_val), store(body), store(env)),
       _ =>
         KVal.Thunk(store(e), store(env)),

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -32,7 +32,6 @@ Aiur runtime's function-call caching provides call-by-need semantics: calling
 | Feature                          | Status |
 |----------------------------------|--------|
 | Lazy eval (thunks in spines)     | ✅     |
-| Eager beta optimization          | ✅     |
 | Delta unfolding (WHNF)           | ✅     |
 | Iota reduction (recursor)        | ✅     |
 | K-reduction (Prop recursors)     | ✅     |
@@ -520,19 +519,10 @@ def kernel := ⟦
           _ => KVal.Const(idx, store(lvls), store(List.Nil)),
         },
 
-      -- Eager beta optimization: if the function is a lambda, evaluate arg eagerly
-      -- (skipping thunk allocation). Otherwise create a thunk and accumulate.
       KExpr.App(&f, &a) =>
         let vf = k_eval(f, env, top);
-        match vf {
-          KVal.Lam(_, &body, &lam_env) =>
-            let va = k_eval(a, env, top);
-            let env2 = List.Cons(store(va), store(lam_env));
-            k_eval(body, env2, top),
-          _ =>
-            let thunk = suspend(a, env, top);
-            k_apply(vf, thunk, top),
-        },
+        let arg = suspend(a, env, top);
+        k_apply(vf, arg, top),
 
       KExpr.Lam(&ty, &body) =>
         let ty_val = k_eval(ty, env, top);

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -1314,7 +1314,7 @@ def kernel := ⟦
   -- The most complex part of the kernel. Uses a layered approach:
   --   1. Quick syntactic check (sorts, literals)
   --   2. Reduce both sides to WHNF
-  --   3. Proof irrelevance (both proofs of Props ⟹ compare types)
+  --   3. Proof irrelevance (type is Prop ⟹ equal by irrelevance)
   --   4. Structural comparison (k_is_def_eq_core)
   --   5. Struct eta (s ≡ ⟨s.1, s.2, ...⟩)
   --   6. Unit-like types (one nullary constructor ⟹ all values equal)
@@ -1334,28 +1334,12 @@ def kernel := ⟦
         match quick2 {
           1 => 1,
           0 =>
-            -- Proof irrelevance: if both are proofs (types in Prop), compare types
+            -- Proof irrelevance: a and b share the same type, so if that type is
+            -- Prop then both are proofs of the same proposition and are equal.
             let a_type = k_infer_val_type(a_whnf, top, nat_idx, str_idx);
             let a_is_prop = k_is_prop_val(a_type, top, nat_idx, str_idx);
             match a_is_prop {
-              1 =>
-                let b_type = k_infer_val_type(b_whnf, top, nat_idx, str_idx);
-                let b_is_prop = k_is_prop_val(b_type, top, nat_idx, str_idx);
-                match b_is_prop {
-                  1 =>
-                    k_is_def_eq(a_type, b_type, depth, top, nat_idx, str_idx),
-                  0 =>
-                    let core_res = k_is_def_eq_core(a_whnf, b_whnf, depth, top, nat_idx, str_idx);
-                    match core_res {
-                      0 =>
-                        let eta_res = try_eta_struct(a_whnf, b_whnf, depth, top, nat_idx, str_idx);
-                        match eta_res {
-                          1 => 1,
-                          0 => 0,
-                        },
-                      1 => 1,
-                    },
-                },
+              1 => 1,
               0 =>
                 let core_res = k_is_def_eq_core(a_whnf, b_whnf, depth, top, nat_idx, str_idx);
                 match core_res {

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -80,9 +80,9 @@ def kernel := ⟦
   -- Look up a value in a value environment by de Bruijn index
   -- Find recursor rule by constructor index
   fn rec_rule_try_find(rules: List‹&KRecRule›, ctor_idx: G) -> Option‹&KRecRule› {
-    match rules {
-      List.Nil => Option.None,
-      List.Cons(&rule, &rest) =>
+    match load(rules) {
+      ListNode.Nil => Option.None,
+      ListNode.Cons(&rule, rest) =>
         match rule {
           KRecRule.Mk(idx, nf, &rhs) =>
             match idx - ctor_idx {
@@ -94,8 +94,8 @@ def kernel := ⟦
   }
 
   fn rec_rule_find(rules: List‹&KRecRule›, ctor_idx: G) -> KRecRule {
-    match rules {
-      List.Cons(&rule, &rest) =>
+    match load(rules) {
+      ListNode.Cons(&rule, rest) =>
         match rule {
           KRecRule.Mk(idx, nf, &rhs) =>
             match idx - ctor_idx {
@@ -108,8 +108,8 @@ def kernel := ⟦
 
   -- Extract the ctor_idx from the first rule in a List‹&KRecRule›
   fn rec_rule_first_ctor(rules: List‹&KRecRule›) -> G {
-    match rules {
-      List.Cons(&rule, _) =>
+    match load(rules) {
+      ListNode.Cons(&rule, _) =>
         match rule {
           KRecRule.Mk(ctor_idx, _, _) => ctor_idx,
         },
@@ -458,8 +458,8 @@ def kernel := ⟦
       KExprNode.BVar(i) => store(KExprNode.BVar(i)),
       KExprNode.Srt(&l) =>
         store(KExprNode.Srt(store(level_inst_params(l, params)))),
-      KExprNode.Const(idx, &lvls) =>
-        store(KExprNode.Const(idx, store(level_list_inst(lvls, params)))),
+      KExprNode.Const(idx, lvls) =>
+        store(KExprNode.Const(idx, level_list_inst(lvls, params))),
       KExprNode.App(f, a) =>
         store(KExprNode.App(expr_inst_levels(f, params), expr_inst_levels(a, params))),
       KExprNode.Lam(ty, body) =>
@@ -479,12 +479,12 @@ def kernel := ⟦
 
   -- Substitute level params in a level list
   fn level_list_inst(lvls: List‹&KLevel›, params: List‹&KLevel›) -> List‹&KLevel› {
-    match lvls {
-      List.Nil => List.Nil,
-      List.Cons(&l, &rest) =>
-        List.Cons(
+    match load(lvls) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(&l, rest) =>
+        store(ListNode.Cons(
           store(level_inst_params(l, params)),
-          store(level_list_inst(rest, params))),
+          level_list_inst(rest, params))),
     }
   }
 
@@ -503,7 +503,7 @@ def kernel := ⟦
   -- Force a thunk: if it's a Thunk, evaluate it; otherwise return as-is
   fn k_force(v: KVal, top: List‹&KConstantInfo›) -> KVal {
     match load(v) {
-      KValNode.Thunk(e, &env) => k_eval(e, env, top),
+      KValNode.Thunk(e, env) => k_eval(e, env, top),
       _ => v,
     }
   }
@@ -519,27 +519,27 @@ def kernel := ⟦
 
       -- Eager delta: unfold Defn/Thm during eval. Other constants stay neutral
       -- with empty spine; args accumulate via k_apply.
-      KExprNode.Const(idx, &lvls) =>
+      KExprNode.Const(idx, lvls) =>
         let ci = load(list_lookup(top, idx));
         match ci {
           KConstantInfo.Defn(_, _, &value, _) =>
             let body = expr_inst_levels(value, lvls);
-            k_eval(body, List.Nil, top),
+            k_eval(body, store(ListNode.Nil), top),
           KConstantInfo.Thm(_, _, &value) =>
             let body = expr_inst_levels(value, lvls);
-            k_eval(body, List.Nil, top),
+            k_eval(body, store(ListNode.Nil), top),
           KConstantInfo.Ctor(_, _, _, _, nparams, _, _) =>
-            store(KValNode.Ctor(idx, store(lvls), nparams, store(List.Nil))),
+            store(KValNode.Ctor(idx, lvls, nparams, store(ListNode.Nil))),
           KConstantInfo.Axiom(_, _, _) =>
-            store(KValNode.Axiom(idx, store(lvls), store(List.Nil))),
+            store(KValNode.Axiom(idx, lvls, store(ListNode.Nil))),
           KConstantInfo.Opaque(_, _, _, _) =>
-            store(KValNode.Opaque(idx, store(lvls), store(List.Nil))),
+            store(KValNode.Opaque(idx, lvls, store(ListNode.Nil))),
           KConstantInfo.Quot(_, _, _) =>
-            store(KValNode.Quot(idx, store(lvls), store(List.Nil))),
+            store(KValNode.Quot(idx, lvls, store(ListNode.Nil))),
           KConstantInfo.Induct(_, _, _, _, _, _, _, _) =>
-            store(KValNode.Induct(idx, store(lvls), store(List.Nil))),
+            store(KValNode.Induct(idx, lvls, store(ListNode.Nil))),
           KConstantInfo.Rec(_, _, _, _, _, _, _, _, _) =>
-            store(KValNode.Rec(idx, store(lvls), store(List.Nil))),
+            store(KValNode.Rec(idx, lvls, store(ListNode.Nil))),
         },
 
       KExprNode.App(f, a) =>
@@ -549,15 +549,15 @@ def kernel := ⟦
 
       KExprNode.Lam(ty, body) =>
         let ty_val = suspend(ty, env);
-        store(KValNode.Lam(ty_val, body, store(env))),
+        store(KValNode.Lam(ty_val, body, env)),
 
       KExprNode.Forall(ty, body) =>
         let ty_val = suspend(ty, env);
-        store(KValNode.Pi(ty_val, body, store(env))),
+        store(KValNode.Pi(ty_val, body, env)),
 
       KExprNode.Let(_, val, body) =>
         let v = suspend(val, env);
-        let env2 = List.Cons(v, store(env));
+        let env2 = store(ListNode.Cons(v, env));
         k_eval(body, env2, top),
 
       KExprNode.Lit(lit) =>
@@ -566,12 +566,12 @@ def kernel := ⟦
       KExprNode.Proj(tidx, fidx, e1) =>
         let v = k_eval(e1, env, top);
         match load(v) {
-          KValNode.Ctor(_, _, nparams, &spine) =>
+          KValNode.Ctor(_, _, nparams, spine) =>
             let field_idx = nparams + fidx;
             let field = list_lookup(spine, field_idx);
             k_force(field, top),
           _ =>
-            store(KValNode.Proj(tidx, fidx, v, store(List.Nil))),
+            store(KValNode.Proj(tidx, fidx, v, store(ListNode.Nil))),
         },
     }
   }
@@ -588,47 +588,47 @@ def kernel := ⟦
         store(KValNode.Lit(lit)),
       KExprNode.Lam(ty, body) =>
         let ty_val = suspend(ty, env);
-        store(KValNode.Lam(ty_val, body, store(env))),
+        store(KValNode.Lam(ty_val, body, env)),
       KExprNode.Forall(ty, body) =>
         let ty_val = suspend(ty, env);
-        store(KValNode.Pi(ty_val, body, store(env))),
+        store(KValNode.Pi(ty_val, body, env)),
       _ =>
-        store(KValNode.Thunk(e, store(env))),
+        store(KValNode.Thunk(e, env)),
     }
   }
 
   -- Apply a value to an argument (lazy: arg may be a thunk)
   fn k_apply(f: KVal, arg: KVal, top: List‹&KConstantInfo›) -> KVal {
     match load(f) {
-      KValNode.Lam(_, body, &env) =>
-        let env2 = List.Cons(arg, store(env));
+      KValNode.Lam(_, body, env) =>
+        let env2 = store(ListNode.Cons(arg, env));
         k_eval(body, env2, top),
 
-      KValNode.Ctor(idx, &lvls, nparams, &spine) =>
+      KValNode.Ctor(idx, lvls, nparams, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Ctor(idx, store(lvls), nparams, store(spine2))),
+        store(KValNode.Ctor(idx, lvls, nparams, spine2)),
 
-      KValNode.FVar(lvl, fvar_ty, &spine) =>
+      KValNode.FVar(lvl, fvar_ty, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.FVar(lvl, fvar_ty, store(spine2))),
+        store(KValNode.FVar(lvl, fvar_ty, spine2)),
 
-      KValNode.Axiom(idx, &lvls, &spine) =>
+      KValNode.Axiom(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Axiom(idx, store(lvls), store(spine2))),
+        store(KValNode.Axiom(idx, lvls, spine2)),
 
-      KValNode.Defn(idx, &lvls, &spine) =>
+      KValNode.Defn(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Defn(idx, store(lvls), store(spine2))),
+        store(KValNode.Defn(idx, lvls, spine2)),
 
-      KValNode.Thm(idx, &lvls, &spine) =>
+      KValNode.Thm(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Thm(idx, store(lvls), store(spine2))),
+        store(KValNode.Thm(idx, lvls, spine2)),
 
-      KValNode.Opaque(idx, &lvls, &spine) =>
+      KValNode.Opaque(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Opaque(idx, store(lvls), store(spine2))),
+        store(KValNode.Opaque(idx, lvls, spine2)),
 
-      KValNode.Quot(idx, &lvls, &spine) =>
+      KValNode.Quot(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
         let ci = load(list_lookup(top, idx));
         match ci {
@@ -639,23 +639,23 @@ def kernel := ⟦
               QuotKind.Ind =>
                 k_try_quot_fire(idx, lvls, spine2, 5, 3, top),
               _ =>
-                store(KValNode.Quot(idx, store(lvls), store(spine2))),
+                store(KValNode.Quot(idx, lvls, spine2)),
             },
         },
 
-      KValNode.Induct(idx, &lvls, &spine) =>
+      KValNode.Induct(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Induct(idx, store(lvls), store(spine2))),
+        store(KValNode.Induct(idx, lvls, spine2)),
 
-      KValNode.Rec(idx, &lvls, &spine) =>
+      KValNode.Rec(idx, lvls, spine) =>
         let spine2 = list_snoc(spine, arg);
         k_try_iota_fire(idx, lvls, spine2, top),
 
-      KValNode.Proj(tidx, fidx, sv, &spine) =>
+      KValNode.Proj(tidx, fidx, sv, spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Proj(tidx, fidx, sv, store(spine2))),
+        store(KValNode.Proj(tidx, fidx, sv, spine2)),
 
-      KValNode.Thunk(e, &env) =>
+      KValNode.Thunk(e, env) =>
         let v = k_eval(e, env, top);
         k_apply(v, arg, top),
 
@@ -664,9 +664,9 @@ def kernel := ⟦
 
   -- Apply a value to a list of arguments
   fn k_apply_spine(f: KVal, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
-    match spine {
-      List.Nil => f,
-      List.Cons(v, &rest) =>
+    match load(spine) {
+      ListNode.Nil => f,
+      ListNode.Cons(v, rest) =>
         let f2 = k_apply(f, v, top);
         k_apply_spine(f2, rest, top),
     }
@@ -696,7 +696,7 @@ def kernel := ⟦
   fn k_try_iota_fire(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
     let ci = load(list_lookup(top, idx));
     match ci {
-      KConstantInfo.Rec(_, _, nparams, nindices, nmotives, nminors, &rules, k_flag, _) =>
+      KConstantInfo.Rec(_, _, nparams, nindices, nmotives, nminors, rules, k_flag, _) =>
         let needed = nparams + nmotives + nminors + nindices + 1;
         let spine_len = list_length(spine);
         match spine_len - needed {
@@ -705,16 +705,16 @@ def kernel := ⟦
             let major_raw = list_lookup(spine, maj_idx);
             let major = k_force(major_raw, top);
             match load(major) {
-              KValNode.Ctor(ctor_idx, _, ctor_nparams, &ctor_spine) =>
+              KValNode.Ctor(ctor_idx, _, ctor_nparams, ctor_spine) =>
                 let rule_found = rec_rule_try_find(rules, ctor_idx);
                 match rule_found {
                   Option.None =>
-                    store(KValNode.Rec(idx, store(lvls), store(spine))),
+                    store(KValNode.Rec(idx, lvls, spine)),
                   Option.Some(&rule) =>
                     match rule {
                       KRecRule.Mk(_, nfields, &rhs) =>
                         let rhs_inst = expr_inst_levels(rhs, lvls);
-                        let rhs_val = k_eval(rhs_inst, List.Nil, top);
+                        let rhs_val = k_eval(rhs_inst, store(ListNode.Nil), top);
                         let params_motives_minors = list_take(spine, nparams + nmotives + nminors);
                         let result = k_apply_spine(rhs_val, params_motives_minors, top);
                         let fields = list_drop(ctor_spine, ctor_nparams);
@@ -723,13 +723,13 @@ def kernel := ⟦
                 },
               KValNode.Lit(lit) =>
                 match lit {
-                  KLiteral.Nat(&n) =>
+                  KLiteral.Nat(n) =>
                     -- Nat literal iota: Lit(0) → zero rule, Lit(n+1) → succ rule with Lit(n)
                     let first_ctor_idx = rec_rule_first_ctor(rules);
                     let induct_idx = ctor_induct_idx(first_ctor_idx, top);
                     let ind_ci = load(list_lookup(top, induct_idx));
                     match ind_ci {
-                      KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
+                      KConstantInfo.Induct(_, _, _, _, ctor_indices, _, _, _) =>
                         let pmm_end = nparams + nmotives + nminors;
                         let is_zero = klimbs_is_zero(n);
                         match is_zero {
@@ -739,7 +739,7 @@ def kernel := ⟦
                             match rule {
                               KRecRule.Mk(_, _, &rhs) =>
                                 let rhs_inst = expr_inst_levels(rhs, lvls);
-                                let rhs_val = k_eval(rhs_inst, List.Nil, top);
+                                let rhs_val = k_eval(rhs_inst, store(ListNode.Nil), top);
                                 let pmm = list_take(spine, pmm_end);
                                 k_apply_spine(rhs_val, pmm, top),
                             },
@@ -749,31 +749,31 @@ def kernel := ⟦
                             match rule {
                               KRecRule.Mk(_, _, &rhs) =>
                                 let rhs_inst = expr_inst_levels(rhs, lvls);
-                                let rhs_val = k_eval(rhs_inst, List.Nil, top);
+                                let rhs_val = k_eval(rhs_inst, store(ListNode.Nil), top);
                                 let pmm = list_take(spine, pmm_end);
                                 let result = k_apply_spine(rhs_val, pmm, top);
-                                let pred = store(KValNode.Lit(KLiteral.Nat(store(klimbs_pred(n)))));
-                                let ctor_fields = List.Cons(pred, store(List.Nil));
+                                let pred = store(KValNode.Lit(KLiteral.Nat(klimbs_pred(n))));
+                                let ctor_fields = store(ListNode.Cons(pred, store(ListNode.Nil)));
                                 k_apply_spine(result, ctor_fields, top),
                             },
                         },
                     },
                   KLiteral.Str(_) =>
-                    store(KValNode.Rec(idx, store(lvls), store(spine))),
+                    store(KValNode.Rec(idx, lvls, spine)),
                 },
               _ =>
                 -- K-reduction: for proof-irrelevant (Prop) inductives with k_flag set,
                 -- the minor premise alone is the result (motive, minor at nparams+nmotives).
                 match k_flag {
                   0 =>
-                    store(KValNode.Rec(idx, store(lvls), store(spine))),
+                    store(KValNode.Rec(idx, lvls, spine)),
                   _ =>
                     let minor_idx = nparams + nmotives;
                     list_lookup(spine, minor_idx),
                 },
             },
           _ =>
-            store(KValNode.Rec(idx, store(lvls), store(spine))),
+            store(KValNode.Rec(idx, lvls, spine)),
         },
     }
   }
@@ -797,7 +797,7 @@ def kernel := ⟦
         let major_raw = list_lookup(spine, major_idx);
         let major = k_force(major_raw, top);
         match load(major) {
-          KValNode.Quot(mk_idx, _, &mk_spine) =>
+          KValNode.Quot(mk_idx, _, mk_spine) =>
             let mk_ci = load(list_lookup(top, mk_idx));
             match mk_ci {
               KConstantInfo.Quot(_, _, mk_kind) =>
@@ -806,21 +806,21 @@ def kernel := ⟦
                     -- mk_spine should have >= 3 args: [α, r, a]
                     let mk_len = list_length(mk_spine);
                     match mk_len - 3 {
-                      0 => store(KValNode.Quot(idx, store(lvls), store(spine))),
+                      0 => store(KValNode.Quot(idx, lvls, spine)),
                       _ =>
                         let quot_val_idx = mk_len - 1;
                         let quot_val = list_lookup(mk_spine, quot_val_idx);
                         let f_val = k_force(list_lookup(spine, f_pos), top);
                         k_apply(f_val, quot_val, top),
                     },
-                  _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
+                  _ => store(KValNode.Quot(idx, lvls, spine)),
                 },
-              _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
+              _ => store(KValNode.Quot(idx, lvls, spine)),
             },
-          _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
+          _ => store(KValNode.Quot(idx, lvls, spine)),
         },
       _ =>
-        store(KValNode.Quot(idx, store(lvls), store(spine))),
+        store(KValNode.Quot(idx, lvls, spine)),
     }
   }
 
@@ -836,7 +836,7 @@ def kernel := ⟦
   -- to de Bruijn indices relative to the current depth
   fn k_quote(v: KVal, depth: G, top: List‹&KConstantInfo›) -> KExpr {
     match load(v) {
-      KValNode.Thunk(e, &env) =>
+      KValNode.Thunk(e, env) =>
         let val = k_eval(e, env, top);
         k_quote(val, depth, top),
 
@@ -844,60 +844,60 @@ def kernel := ⟦
 
       KValNode.Lit(lit) => store(KExprNode.Lit(lit)),
 
-      KValNode.Lam(dom, body, &env) =>
+      KValNode.Lam(dom, body, env) =>
         let dom_expr = k_quote(dom, depth, top);
-        let fvar = store(KValNode.FVar(depth, dom, store(List.Nil)));
-        let env2 = List.Cons(fvar, store(env));
+        let fvar = store(KValNode.FVar(depth, dom, store(ListNode.Nil)));
+        let env2 = store(ListNode.Cons(fvar, env));
         let body_val = k_eval(body, env2, top);
         let body_expr = k_quote(body_val, depth + 1, top);
         store(KExprNode.Lam(dom_expr, body_expr)),
 
-      KValNode.Pi(dom, body, &env) =>
+      KValNode.Pi(dom, body, env) =>
         let dom_expr = k_quote(dom, depth, top);
-        let fvar = store(KValNode.FVar(depth, dom, store(List.Nil)));
-        let env2 = List.Cons(fvar, store(env));
+        let fvar = store(KValNode.FVar(depth, dom, store(ListNode.Nil)));
+        let env2 = store(ListNode.Cons(fvar, env));
         let body_val = k_eval(body, env2, top);
         let body_expr = k_quote(body_val, depth + 1, top);
         store(KExprNode.Forall(dom_expr, body_expr)),
 
-      KValNode.Ctor(idx, &lvls, _, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Ctor(idx, lvls, _, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.FVar(lvl, _, &spine) =>
+      KValNode.FVar(lvl, _, spine) =>
         let idx = (depth - 1) - lvl;
         let base = store(KExprNode.BVar(idx));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Axiom(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Axiom(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Defn(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Defn(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Thm(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Thm(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Opaque(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Opaque(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Quot(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Quot(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Induct(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Induct(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Rec(idx, &lvls, &spine) =>
-        let base = store(KExprNode.Const(idx, store(lvls)));
+      KValNode.Rec(idx, lvls, spine) =>
+        let base = store(KExprNode.Const(idx, lvls));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Proj(tidx, fidx, sv, &spine) =>
+      KValNode.Proj(tidx, fidx, sv, spine) =>
         let sv_expr = k_quote(sv, depth, top);
         let base = store(KExprNode.Proj(tidx, fidx, sv_expr));
         quote_spine(base, spine, depth, top),
@@ -906,9 +906,9 @@ def kernel := ⟦
 
   -- Quote a spine of arguments, wrapping each in an EApp around the base expression
   fn quote_spine(base: KExpr, spine: List‹KVal›, depth: G, top: List‹&KConstantInfo›) -> KExpr {
-    match spine {
-      List.Nil => base,
-      List.Cons(v, &rest) =>
+    match load(spine) {
+      ListNode.Nil => base,
+      ListNode.Cons(v, rest) =>
         let arg_expr = k_quote(v, depth, top);
         let app = store(KExprNode.App(base, arg_expr));
         quote_spine(app, rest, depth, top),
@@ -937,12 +937,12 @@ def kernel := ⟦
       KExprNode.Lit(lit) =>
         match lit {
           KLiteral.Nat(_) =>
-            store(KValNode.Induct(nat_idx, store(List.Nil), store(List.Nil))),
+            store(KValNode.Induct(nat_idx, store(ListNode.Nil), store(ListNode.Nil))),
           KLiteral.Str(_) =>
-            store(KValNode.Induct(str_idx, store(List.Nil), store(List.Nil))),
+            store(KValNode.Induct(str_idx, store(ListNode.Nil), store(ListNode.Nil))),
         },
 
-      KExprNode.Const(idx, &lvls) =>
+      KExprNode.Const(idx, lvls) =>
         let ci = load(list_lookup(top, idx));
         let expected = const_num_levels(ci);
         let given = list_length(lvls);
@@ -950,36 +950,36 @@ def kernel := ⟦
         assert_eq!(lvl_eq, 1);
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        k_eval(ty_inst, List.Nil, top),
+        k_eval(ty_inst, store(ListNode.Nil), top),
 
       KExprNode.App(f, a) =>
         let fn_type = k_infer(f, types, env, depth, top, nat_idx, str_idx);
         let fn_type_whnf = k_force(fn_type, top);
 
         match load(fn_type_whnf) {
-          KValNode.Pi(dom, body, &pi_env) =>
+          KValNode.Pi(dom, body, pi_env) =>
             let _ = k_check(a, dom, types, env, depth, top, nat_idx, str_idx);
             let arg_val = suspend(a, env);
-            let pi_env2 = List.Cons(arg_val, store(pi_env));
+            let pi_env2 = store(ListNode.Cons(arg_val, pi_env));
             k_eval(body, pi_env2, top),
         },
 
       KExprNode.Lam(ty, body) =>
         let _ = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let dom_val = k_eval(ty, env, top);
-        let fvar = store(KValNode.FVar(depth, dom_val, store(List.Nil)));
-        let types2 = List.Cons(dom_val, store(types));
-        let env2 = List.Cons(fvar, store(env));
+        let fvar = store(KValNode.FVar(depth, dom_val, store(ListNode.Nil)));
+        let types2 = store(ListNode.Cons(dom_val, types));
+        let env2 = store(ListNode.Cons(fvar, env));
         let body_type = k_infer(body, types2, env2, depth + 1, top, nat_idx, str_idx);
         let body_type_expr = k_quote(body_type, depth + 1, top);
-        store(KValNode.Pi(dom_val, body_type_expr, store(env))),
+        store(KValNode.Pi(dom_val, body_type_expr, env)),
 
       KExprNode.Forall(ty, body) =>
         let dom_level = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let dom_val = k_eval(ty, env, top);
-        let fvar = store(KValNode.FVar(depth, dom_val, store(List.Nil)));
-        let types2 = List.Cons(dom_val, store(types));
-        let env2 = List.Cons(fvar, store(env));
+        let fvar = store(KValNode.FVar(depth, dom_val, store(ListNode.Nil)));
+        let types2 = store(ListNode.Cons(dom_val, types));
+        let env2 = store(ListNode.Cons(fvar, env));
         let body_level = k_ensure_sort(body, types2, env2, depth + 1, top, nat_idx, str_idx);
         let result_level = level_imax(dom_level, body_level);
         store(KValNode.Srt(store(result_level))),
@@ -989,8 +989,8 @@ def kernel := ⟦
         let ty_val = k_eval(ty, env, top);
         let _ = k_check(val, ty_val, types, env, depth, top, nat_idx, str_idx);
         let val_val = suspend(val, env);
-        let types2 = List.Cons(ty_val, store(types));
-        let env2 = List.Cons(val_val, store(env));
+        let types2 = store(ListNode.Cons(ty_val, types));
+        let env2 = store(ListNode.Cons(val_val, env));
         k_infer(body, types2, env2, depth + 1, top, nat_idx, str_idx),
 
       KExprNode.Proj(tidx, fidx, e1) =>
@@ -998,17 +998,17 @@ def kernel := ⟦
         let struct_type = k_infer(e1, types, env, depth, top, nat_idx, str_idx);
         let struct_type_whnf = k_force(struct_type, top);
         match load(struct_type_whnf) {
-          KValNode.Induct(induct_idx, &levels, &params_spine) =>
+          KValNode.Induct(induct_idx, levels, params_spine) =>
             -- Look up inductive to get its single constructor index
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
-              KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
+              KConstantInfo.Induct(_, _, _, _, ctor_indices, _, _, _) =>
                 let ctor_idx = list_lookup(ctor_indices, 0);
                 -- Get the constructor type, instantiate levels, and eval
                 let ctor_ci = load(list_lookup(top, ctor_idx));
                 let ctor_type_expr = const_type(ctor_ci);
                 let ctor_type_inst = expr_inst_levels(ctor_type_expr, levels);
-                let ctor_type_val = k_eval(ctor_type_inst, List.Nil, top);
+                let ctor_type_val = k_eval(ctor_type_inst, store(ListNode.Nil), top);
                 -- Walk past params using values from the inductive's spine
                 let after_params = walk_params(ctor_type_val, params_spine, top);
                 -- Walk past preceding fields using Proj values
@@ -1031,16 +1031,16 @@ def kernel := ⟦
       KExprNode.Lam(ty, body) =>
         let expected_whnf = k_force(expected, top);
         match load(expected_whnf) {
-          KValNode.Pi(pi_dom, pi_body, &pi_env) =>
+          KValNode.Pi(pi_dom, pi_body, pi_env) =>
             -- Check domain matches
             let dom_val = k_eval(ty, env, top);
             let dom_eq = k_is_def_eq(dom_val, pi_dom, depth, top, nat_idx, str_idx);
             assert_eq!(dom_eq, 1);
             -- Push Pi codomain through Lambda body
-            let fvar = store(KValNode.FVar(depth, pi_dom, store(List.Nil)));
-            let types2 = List.Cons(pi_dom, store(types));
-            let env2 = List.Cons(fvar, store(env));
-            let pi_env2 = List.Cons(fvar, store(pi_env));
+            let fvar = store(KValNode.FVar(depth, pi_dom, store(ListNode.Nil)));
+            let types2 = store(ListNode.Cons(pi_dom, types));
+            let env2 = store(ListNode.Cons(fvar, env));
+            let pi_env2 = store(ListNode.Cons(fvar, pi_env));
             let expected_body = k_eval(pi_body, pi_env2, top);
             k_check(body, expected_body, types2, env2, depth + 1, top, nat_idx, str_idx),
         },
@@ -1063,13 +1063,13 @@ def kernel := ⟦
 
   -- Walk past n Pi binders, substituting param values from the spine
   fn walk_params(ct: KVal, params: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
-    match params {
-      List.Nil => ct,
-      List.Cons(param_val, &rest_params) =>
+    match load(params) {
+      ListNode.Nil => ct,
+      ListNode.Cons(param_val, rest_params) =>
         let ct_whnf = k_force(ct, top);
         match load(ct_whnf) {
-          KValNode.Pi(_, body, &pi_env) =>
-            let env2 = List.Cons(param_val, store(pi_env));
+          KValNode.Pi(_, body, pi_env) =>
+            let env2 = store(ListNode.Cons(param_val, pi_env));
             let next = k_eval(body, env2, top);
             walk_params(next, rest_params, top),
         },
@@ -1083,9 +1083,9 @@ def kernel := ⟦
       _ =>
         let ct_whnf = k_force(ct, top);
         match load(ct_whnf) {
-          KValNode.Pi(_, body, &pi_env) =>
-            let proj_val = store(KValNode.Proj(tidx, current_field, struct_val, store(List.Nil)));
-            let env2 = List.Cons(proj_val, store(pi_env));
+          KValNode.Pi(_, body, pi_env) =>
+            let proj_val = store(KValNode.Proj(tidx, current_field, struct_val, store(ListNode.Nil)));
+            let env2 = store(ListNode.Cons(proj_val, pi_env));
             let next = k_eval(body, env2, top);
             walk_fields(next, tidx, current_field + 1, remaining - 1, struct_val, top),
         },
@@ -1103,13 +1103,13 @@ def kernel := ⟦
 
   -- Apply a spine of argument values to a type by walking through Pi-bindings
   fn apply_spine_to_type(ty: KVal, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
-    match spine {
-      List.Nil => ty,
-      List.Cons(arg, &rest) =>
+    match load(spine) {
+      ListNode.Nil => ty,
+      ListNode.Cons(arg, rest) =>
         let ty_whnf = k_force(ty, top);
         match load(ty_whnf) {
-          KValNode.Pi(_, body, &pi_env) =>
-            let env2 = List.Cons(arg, store(pi_env));
+          KValNode.Pi(_, body, pi_env) =>
+            let env2 = store(ListNode.Cons(arg, pi_env));
             let next = k_eval(body, env2, top);
             apply_spine_to_type(next, rest, top),
         },
@@ -1120,76 +1120,76 @@ def kernel := ⟦
   -- Returns Sort 1 as sentinel for cases we can't handle (FVar, Lam, Proj).
   fn k_infer_val_type(v: KVal, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KVal {
     match load(v) {
-      KValNode.Thunk(e, &env) =>
+      KValNode.Thunk(e, env) =>
         let val = k_eval(e, env, top);
         k_infer_val_type(val, top, nat_idx, str_idx),
       KValNode.Srt(&l) => store(KValNode.Srt(store(KLevel.Succ(store(l))))),
       KValNode.Lit(lit) =>
         match lit {
-          KLiteral.Nat(_) => store(KValNode.Induct(nat_idx, store(List.Nil), store(List.Nil))),
-          KLiteral.Str(_) => store(KValNode.Induct(str_idx, store(List.Nil), store(List.Nil))),
+          KLiteral.Nat(_) => store(KValNode.Induct(nat_idx, store(ListNode.Nil), store(ListNode.Nil))),
+          KLiteral.Str(_) => store(KValNode.Induct(str_idx, store(ListNode.Nil), store(ListNode.Nil))),
         },
-      KValNode.Axiom(idx, &lvls, &spine) =>
+      KValNode.Axiom(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Defn(idx, &lvls, &spine) =>
+      KValNode.Defn(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Thm(idx, &lvls, &spine) =>
+      KValNode.Thm(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Opaque(idx, &lvls, &spine) =>
+      KValNode.Opaque(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Quot(idx, &lvls, &spine) =>
+      KValNode.Quot(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Induct(idx, &lvls, &spine) =>
+      KValNode.Induct(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Rec(idx, &lvls, &spine) =>
+      KValNode.Rec(idx, lvls, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Ctor(idx, &lvls, _, &spine) =>
+      KValNode.Ctor(idx, lvls, _, spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
-        let ty_val = k_eval(ty_inst, List.Nil, top);
+        let ty_val = k_eval(ty_inst, store(ListNode.Nil), top);
         apply_spine_to_type(ty_val, spine, top),
-      KValNode.Proj(tidx, fidx, sv, &spine) =>
+      KValNode.Proj(tidx, fidx, sv, spine) =>
         let struct_type = k_infer_val_type(sv, top, nat_idx, str_idx);
         let struct_type_whnf = k_force(struct_type, top);
         match load(struct_type_whnf) {
-          KValNode.Induct(induct_idx, &levels, &params_spine) =>
+          KValNode.Induct(induct_idx, levels, params_spine) =>
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
-              KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
+              KConstantInfo.Induct(_, _, _, _, ctor_indices, _, _, _) =>
                 let ctor_idx = list_lookup(ctor_indices, 0);
                 let ctor_ci = load(list_lookup(top, ctor_idx));
                 let ctor_type_expr = const_type(ctor_ci);
                 let ctor_type_inst = expr_inst_levels(ctor_type_expr, levels);
-                let ctor_type_val = k_eval(ctor_type_inst, List.Nil, top);
+                let ctor_type_val = k_eval(ctor_type_inst, store(ListNode.Nil), top);
                 let after_params = walk_params(ctor_type_val, params_spine, top);
                 let after_fields = walk_fields(after_params, tidx, 0, fidx, sv, top);
                 let result_whnf = k_force(after_fields, top);
@@ -1204,7 +1204,7 @@ def kernel := ⟦
           -- If struct type can't be determined, fall back to sentinel
           _ => store(KValNode.Srt(store(KLevel.Succ(store(KLevel.Zero))))),
         },
-      KValNode.FVar(_, fvar_type, &spine) =>
+      KValNode.FVar(_, fvar_type, spine) =>
         apply_spine_to_type(fvar_type, spine, top),
       -- For Lam, Pi: return Sort 1 as sentinel (never Prop)
       _ => store(KValNode.Srt(store(KLevel.Succ(store(KLevel.Zero))))),
@@ -1248,7 +1248,7 @@ def kernel := ⟦
       _ =>
         let field_idx = nparams + current;
         let field_val = list_lookup(spine, field_idx);
-        let proj_val = store(KValNode.Proj(tidx, current, t, store(List.Nil)));
+        let proj_val = store(KValNode.Proj(tidx, current, t, store(ListNode.Nil)));
         let eq = k_is_def_eq(proj_val, field_val, depth, top, nat_idx, str_idx);
         match eq {
           0 => 0,
@@ -1261,13 +1261,13 @@ def kernel := ⟦
   -- Inlines is_struct_like, ctor_induct_idx, ctor_num_fields to avoid redundant lookups.
   fn try_eta_struct_one(t: KVal, s: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     match load(s) {
-      KValNode.Ctor(ctor_idx, _, nparams, &spine) =>
+      KValNode.Ctor(ctor_idx, _, nparams, spine) =>
         let ctor_ci = load(list_lookup(top, ctor_idx));
         match ctor_ci {
           KConstantInfo.Ctor(_, _, induct_idx, _, _, num_fields, _) =>
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
-              KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
+              KConstantInfo.Induct(_, _, _, _, ctor_indices, _, _, _) =>
                 let num_ctors = list_length(ctor_indices);
                 match num_ctors - 1 {
                   0 =>
@@ -1300,7 +1300,7 @@ def kernel := ⟦
       KValNode.Induct(induct_idx, _, _) =>
         let ci = load(list_lookup(top, induct_idx));
         match ci {
-          KConstantInfo.Induct(_, _, _, nindices, &ctor_indices, _, _, _) =>
+          KConstantInfo.Induct(_, _, _, nindices, ctor_indices, _, _, _) =>
             let zero_indices = eq_zero(nindices);
             let one_ctor = eq_zero(list_length(ctor_indices) - 1);
             match zero_indices * one_ctor {
@@ -1384,24 +1384,24 @@ def kernel := ⟦
 
   -- Check if a KLimbs value is zero (Nil = zero)
   fn klimbs_is_zero(limbs: KLimbs) -> G {
-    match limbs {
-      List.Nil => 1,
-      List.Cons(_, _) => 0,
+    match load(limbs) {
+      ListNode.Nil => 1,
+      ListNode.Cons(_, _) => 0,
     }
   }
 
   -- Compare two KLimbs for equality (limb-by-limb)
   fn klimbs_eq(a: KLimbs, b: KLimbs) -> G {
-    match a {
-      List.Nil =>
-        match b {
-          List.Nil => 1,
+    match load(a) {
+      ListNode.Nil =>
+        match load(b) {
+          ListNode.Nil => 1,
           _ => 0,
         },
-      List.Cons(la, &ra) =>
-        match b {
-          List.Nil => 0,
-          List.Cons(lb, &rb) =>
+      ListNode.Cons(la, ra) =>
+        match load(b) {
+          ListNode.Nil => 0,
+          ListNode.Cons(lb, rb) =>
             let eq = u64_eq(la, lb);
             match eq {
               0 => 0,
@@ -1414,46 +1414,46 @@ def kernel := ⟦
   -- Subtract 1 from a KLimbs bignum. Assumes non-zero input.
   -- Works limb-by-limb: if limb is non-zero, decrement it; else borrow.
   fn klimbs_pred(limbs: KLimbs) -> KLimbs {
-    match limbs {
-      List.Nil => List.Nil,
-      List.Cons(limb, &rest) =>
+    match load(limbs) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(limb, rest) =>
         let is_zero = u64_is_zero(limb);
         match is_zero {
           0 =>
             -- Non-zero limb: decrement it
             let new_limb = relaxed_u64_pred(limb);
             -- If this was the only limb and it became zero, return Nil
-            match rest {
-              List.Nil =>
+            match load(rest) {
+              ListNode.Nil =>
                 let new_zero = u64_is_zero(new_limb);
                 match new_zero {
-                  1 => List.Nil,
-                  0 => List.Cons(new_limb, store(List.Nil)),
+                  1 => store(ListNode.Nil),
+                  0 => store(ListNode.Cons(new_limb, store(ListNode.Nil))),
                 },
-              _ => List.Cons(new_limb, store(rest)),
+              _ => store(ListNode.Cons(new_limb, rest)),
             },
           1 =>
             -- Zero limb: borrow from next, this limb becomes 0xFF..FF
             let new_rest = klimbs_pred(rest);
             -- 0xFFFFFFFFFFFFFFFF = [255, 255, 255, 255, 255, 255, 255, 255]
             let max_u64 = [255, 255, 255, 255, 255, 255, 255, 255];
-            List.Cons(max_u64, store(new_rest)),
+            store(ListNode.Cons(max_u64, new_rest)),
         },
     }
   }
 
   -- Compare two ByteStreams for equality
   fn bytestream_eq(a: ByteStream, b: ByteStream) -> G {
-    match a {
-      List.Nil =>
-        match b {
-          List.Nil => 1,
+    match load(a) {
+      ListNode.Nil =>
+        match load(b) {
+          ListNode.Nil => 1,
           _ => 0,
         },
-      List.Cons(ba, &ra) =>
-        match b {
-          List.Nil => 0,
-          List.Cons(bb, &rb) =>
+      ListNode.Cons(ba, ra) =>
+        match load(b) {
+          ListNode.Nil => 0,
+          ListNode.Cons(bb, rb) =>
             match ba - bb {
               0 => bytestream_eq(ra, rb),
               _ => 0,
@@ -1465,9 +1465,9 @@ def kernel := ⟦
   -- Check equality of two literals
   fn literal_eq(a: KLiteral, b: KLiteral) -> G {
     match a {
-      KLiteral.Nat(&na) =>
+      KLiteral.Nat(na) =>
         match b {
-          KLiteral.Nat(&nb) => klimbs_eq(na, nb),
+          KLiteral.Nat(nb) => klimbs_eq(na, nb),
           _ => 0,
         },
       KLiteral.Str(sa) =>
@@ -1484,7 +1484,7 @@ def kernel := ⟦
     depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G
   ) -> G {
     match lit {
-      KLiteral.Nat(&n) =>
+      KLiteral.Nat(n) =>
         let induct_idx = ctor_induct_idx(ctor_idx, top);
         match induct_idx - nat_idx {
           0 =>
@@ -1499,7 +1499,7 @@ def kernel := ⟦
                 match nfields - 1 {
                   0 =>
                     let pred_val = list_lookup(ctor_spine, nparams);
-                    let pred_lit = store(KValNode.Lit(KLiteral.Nat(store(klimbs_pred(n)))));
+                    let pred_lit = store(KValNode.Lit(KLiteral.Nat(klimbs_pred(n))));
                     k_is_def_eq(pred_lit, pred_val, depth, top, nat_idx, str_idx),
                   _ => 0,
                 },
@@ -1525,14 +1525,14 @@ def kernel := ⟦
           KValNode.Lit(la) =>
             match load(b) {
               KValNode.Lit(lb) => literal_eq(la, lb),
-              KValNode.Ctor(ctor_idx, _, nparams, &ctor_spine) =>
+              KValNode.Ctor(ctor_idx, _, nparams, ctor_spine) =>
                 nat_lit_eq_ctor(la, ctor_idx, nparams, ctor_spine, depth, top, nat_idx, str_idx),
               _ => 0,
             },
 
-          KValNode.FVar(lvl_a, _, &sp_a) =>
+          KValNode.FVar(lvl_a, _, sp_a) =>
             match load(b) {
-              KValNode.FVar(lvl_b, _, &sp_b) =>
+              KValNode.FVar(lvl_b, _, sp_b) =>
                 match lvl_a - lvl_b {
                   0 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                   _ => 0,
@@ -1540,9 +1540,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Axiom(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Axiom(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Axiom(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Axiom(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1555,9 +1555,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Defn(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Defn(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Defn(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Defn(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1570,9 +1570,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Thm(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Thm(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Thm(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Thm(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1585,9 +1585,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Opaque(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Opaque(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Opaque(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Opaque(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1600,9 +1600,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Quot(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Quot(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Quot(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Quot(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1615,9 +1615,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Induct(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Induct(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Induct(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Induct(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1630,9 +1630,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Rec(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Rec(idx_a, lvls_a, sp_a) =>
             match load(b) {
-              KValNode.Rec(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Rec(idx_b, lvls_b, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1645,9 +1645,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
+          KValNode.Ctor(idx_a, lvls_a, nparams_a, sp_a) =>
             match load(b) {
-              KValNode.Ctor(idx_b, &lvls_b, _, &sp_b) =>
+              KValNode.Ctor(idx_b, lvls_b, _, sp_b) =>
                 match idx_a - idx_b {
                   0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
@@ -1662,39 +1662,39 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Lam(dom_a, body_a, &env_a) =>
+          KValNode.Lam(dom_a, body_a, env_a) =>
             match load(b) {
-              KValNode.Lam(dom_b, body_b, &env_b) =>
+              KValNode.Lam(dom_b, body_b, env_b) =>
                 let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
                 match dom_eq {
                   0 => 0,
                   1 =>
-                    let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
-                    let env_a2 = List.Cons(fvar, store(env_a));
-                    let env_b2 = List.Cons(fvar, store(env_b));
+                    let fvar = store(KValNode.FVar(depth, dom_a, store(ListNode.Nil)));
+                    let env_a2 = store(ListNode.Cons(fvar, env_a));
+                    let env_b2 = store(ListNode.Cons(fvar, env_b));
                     let va = k_eval(body_a, env_a2, top);
                     let vb = k_eval(body_b, env_b2, top);
                     k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
                 },
               _ =>
                 -- Eta: lam vs non-lam
-                let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
-                let env_a2 = List.Cons(fvar, store(env_a));
+                let fvar = store(KValNode.FVar(depth, dom_a, store(ListNode.Nil)));
+                let env_a2 = store(ListNode.Cons(fvar, env_a));
                 let va = k_eval(body_a, env_a2, top);
                 let vb = k_apply(b, fvar, top);
                 k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
             },
 
-          KValNode.Pi(dom_a, body_a, &env_a) =>
+          KValNode.Pi(dom_a, body_a, env_a) =>
             match load(b) {
-              KValNode.Pi(dom_b, body_b, &env_b) =>
+              KValNode.Pi(dom_b, body_b, env_b) =>
                 let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
                 match dom_eq {
                   0 => 0,
                   1 =>
-                    let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
-                    let env_a2 = List.Cons(fvar, store(env_a));
-                    let env_b2 = List.Cons(fvar, store(env_b));
+                    let fvar = store(KValNode.FVar(depth, dom_a, store(ListNode.Nil)));
+                    let env_a2 = store(ListNode.Cons(fvar, env_a));
+                    let env_b2 = store(ListNode.Cons(fvar, env_b));
                     let va = k_eval(body_a, env_a2, top);
                     let vb = k_eval(body_b, env_b2, top);
                     k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
@@ -1702,9 +1702,9 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Proj(tidx_a, fidx_a, sv_a, &sp_a) =>
+          KValNode.Proj(tidx_a, fidx_a, sv_a, sp_a) =>
             match load(b) {
-              KValNode.Proj(tidx_b, fidx_b, sv_b, &sp_b) =>
+              KValNode.Proj(tidx_b, fidx_b, sv_b, sp_b) =>
                 let same_tf = eq_zero(tidx_a - tidx_b) * eq_zero(fidx_a - fidx_b);
                 match same_tf {
                   1 =>
@@ -1721,10 +1721,10 @@ def kernel := ⟦
           -- Eta: non-lam vs lam (symmetric case)
           _ =>
             match load(b) {
-              KValNode.Lam(dom_b, body_b, &env_b) =>
-                let fvar = store(KValNode.FVar(depth, dom_b, store(List.Nil)));
+              KValNode.Lam(dom_b, body_b, env_b) =>
+                let fvar = store(KValNode.FVar(depth, dom_b, store(ListNode.Nil)));
                 let va = k_apply(a, fvar, top);
-                let env_b2 = List.Cons(fvar, store(env_b));
+                let env_b2 = store(ListNode.Cons(fvar, env_b));
                 let vb = k_eval(body_b, env_b2, top);
                 k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
               KValNode.Axiom(_, _, _) =>
@@ -1749,16 +1749,16 @@ def kernel := ⟦
 
   -- Pointwise definitional equality of two value spines
   fn k_is_def_eq_spine(a: List‹KVal›, b: List‹KVal›, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
-    match a {
-      List.Nil =>
-        match b {
-          List.Nil => 1,
+    match load(a) {
+      ListNode.Nil =>
+        match load(b) {
+          ListNode.Nil => 1,
           _ => 0,
         },
-      List.Cons(va, &ra) =>
-        match b {
-          List.Nil => 0,
-          List.Cons(vb, &rb) =>
+      ListNode.Cons(va, ra) =>
+        match load(b) {
+          ListNode.Nil => 0,
+          ListNode.Cons(vb, rb) =>
             let eq = k_is_def_eq(va, vb, depth, top, nat_idx, str_idx);
             match eq {
               0 => 0,
@@ -1770,16 +1770,16 @@ def kernel := ⟦
 
   -- Pointwise semantic equality of two level lists
   fn k_is_def_eq_levels(a: List‹&KLevel›, b: List‹&KLevel›) -> G {
-    match a {
-      List.Nil =>
-        match b {
-          List.Nil => 1,
+    match load(a) {
+      ListNode.Nil =>
+        match load(b) {
+          ListNode.Nil => 1,
           _ => 0,
         },
-      List.Cons(&la, &ra) =>
-        match b {
-          List.Nil => 0,
-          List.Cons(&lb, &rb) =>
+      ListNode.Cons(&la, ra) =>
+        match load(b) {
+          ListNode.Nil => 0,
+          ListNode.Cons(&lb, rb) =>
             let eq = level_equal(la, lb);
             match eq {
               0 => 0,
@@ -1802,45 +1802,45 @@ def kernel := ⟦
   fn k_check_const(ci: KConstantInfo, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) {
     match ci {
       KConstantInfo.Axiom(_, &ty, _) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
       KConstantInfo.Defn(_, &ty, &value, _) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx);
-        let ty_val = k_eval(ty, List.Nil, top);
-        k_check(value, ty_val, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx);
+        let ty_val = k_eval(ty, store(ListNode.Nil), top);
+        k_check(value, ty_val, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
       KConstantInfo.Thm(_, &ty, &value) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx);
-        let ty_val = k_eval(ty, List.Nil, top);
-        k_check(value, ty_val, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx);
+        let ty_val = k_eval(ty, store(ListNode.Nil), top);
+        k_check(value, ty_val, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
       KConstantInfo.Opaque(_, &ty, &value, is_unsafe) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx);
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx);
         match is_unsafe {
           1 => (),
           0 =>
-            let ty_val = k_eval(ty, List.Nil, top);
-            k_check(value, ty_val, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+            let ty_val = k_eval(ty, store(ListNode.Nil), top);
+            k_check(value, ty_val, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
         },
 
       KConstantInfo.Quot(_, &ty, _) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
       KConstantInfo.Induct(_, &ty, _, _, _, _, _, _) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
       KConstantInfo.Ctor(_, &ty, _, _, _, _, _) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
       KConstantInfo.Rec(_, &ty, _, _, _, _, _, _, _) =>
-        let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
+        let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
     }
   }
 
   fn k_check_all_go(consts: List‹&KConstantInfo›, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G, idx: G) {
-    match consts {
-      List.Nil => (),
-      List.Cons(&ci, &rest) =>
+    match load(consts) {
+      ListNode.Nil => (),
+      ListNode.Cons(&ci, rest) =>
         let _ = k_check_const(ci, top, nat_idx, str_idx);
         k_check_all_go(rest, top, nat_idx, str_idx, idx + 1),
     }

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -1130,8 +1130,6 @@ def kernel := ⟦
             let env2 = List.Cons(store(arg_forced), store(pi_env));
             let next = k_eval(body, env2, top);
             apply_spine_to_type(next, rest, top),
-          -- If not a Pi, we're stuck; return as-is (sentinel)
-          _ => ty_whnf,
         },
     }
   }

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -974,9 +974,7 @@ def kernel := ⟦
 
         match fn_type_whnf {
           KVal.Pi(&dom, &body, &pi_env) =>
-            let arg_type = k_infer(a, types, env, depth, top, nat_idx, str_idx);
-            let app_eq = k_is_def_eq(arg_type, dom, depth, top, nat_idx, str_idx);
-            assert_eq!(app_eq, 1);
+            let _ = k_check(a, dom, types, env, depth, top, nat_idx, str_idx);
             let arg_val = k_eval(a, env, top);
             let pi_env2 = List.Cons(store(arg_val), store(pi_env));
             k_eval(body, pi_env2, top),
@@ -1005,9 +1003,7 @@ def kernel := ⟦
       KExpr.Let(&ty, &val, &body) =>
         let _ = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let ty_val = k_eval(ty, env, top);
-        let val_type = k_infer(val, types, env, depth, top, nat_idx, str_idx);
-        let let_eq = k_is_def_eq(val_type, ty_val, depth, top, nat_idx, str_idx);
-        assert_eq!(let_eq, 1);
+        let _ = k_check(val, ty_val, types, env, depth, top, nat_idx, str_idx);
         let val_val = k_eval(val, env, top);
         let types2 = List.Cons(store(ty_val), store(types));
         let env2 = List.Cons(store(val_val), store(env));
@@ -1063,11 +1059,6 @@ def kernel := ⟦
             let pi_env2 = List.Cons(store(fvar), store(pi_env));
             let expected_body = k_eval(pi_body, pi_env2, top);
             k_check(body, expected_body, types2, env2, depth + 1, top, nat_idx, str_idx),
-          _ =>
-            -- Expected type is not a Pi after whnf, fall back to infer+compare
-            let inferred = k_infer(e, types, env, depth, top, nat_idx, str_idx);
-            let eq = k_is_def_eq(inferred, expected, depth, top, nat_idx, str_idx);
-            assert_eq!(eq, 1);,
         },
       _ =>
         -- Non-lambda: infer + isDefEq

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -759,7 +759,7 @@ def kernel := ⟦
             match mk_ci {
               KConstantInfo.Quot(_, _, mk_kind) =>
                 match mk_kind {
-                  KQuotKind.Ctor =>
+                  QuotKind.Ctor =>
                     -- mk_spine should have >= 3 args: [α, r, a]
                     -- The quotient value is the last element
                     let mk_len = list_length(mk_spine);
@@ -847,9 +847,9 @@ def kernel := ⟦
                   -- Reduces to: f a extra...
                   KConstantInfo.Quot(_, _, kind) =>
                     match kind {
-                      KQuotKind.Lift =>
+                      QuotKind.Lift =>
                         k_try_quot_reduction(idx2, lvls2, spine2, 6, 3, top),
-                      KQuotKind.Ind =>
+                      QuotKind.Ind =>
                         k_try_quot_reduction(idx2, lvls2, spine2, 5, 3, top),
                       _ => result,
                     },

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -1358,18 +1358,22 @@ def kernel := ⟦
 
   -- Quick syntactic check for definitional equality (sorts and literals only)
   fn k_quick_def_eq(a: KVal, b: KVal) -> G {
-    match load(a) {
-      KValNode.Srt(&la) =>
-        match load(b) {
-          KValNode.Srt(&lb) => level_equal(la, lb),
+    match ptr_val(a) - ptr_val(b) {
+      0 => 1,
+      _ =>
+        match load(a) {
+          KValNode.Srt(&la) =>
+            match load(b) {
+              KValNode.Srt(&lb) => level_equal(la, lb),
+              _ => 0,
+            },
+          KValNode.Lit(la) =>
+            match load(b) {
+              KValNode.Lit(lb) => literal_eq(la, lb),
+              _ => 0,
+            },
           _ => 0,
         },
-      KValNode.Lit(la) =>
-        match load(b) {
-          KValNode.Lit(lb) => literal_eq(la, lb),
-          _ => 0,
-        },
-      _ => 0,
     }
   }
 
@@ -1509,136 +1513,140 @@ def kernel := ⟦
 
   -- Structural definitional equality after WHNF
   fn k_is_def_eq_core(a: KVal, b: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
-    match load(a) {
-      KValNode.Srt(&la) =>
-        match load(b) {
-          KValNode.Srt(&lb) => level_equal(la, lb),
-          _ => 0,
-        },
-
-      KValNode.Lit(la) =>
-        match load(b) {
-          KValNode.Lit(lb) => literal_eq(la, lb),
-          KValNode.Ctor(ctor_idx, _, nparams, &ctor_spine) =>
-            nat_lit_eq_ctor(la, ctor_idx, nparams, ctor_spine, depth, top, nat_idx, str_idx),
-          _ => 0,
-        },
-
-      KValNode.FVar(lvl_a, _, &sp_a) =>
-        match load(b) {
-          KValNode.FVar(lvl_b, _, &sp_b) =>
-            let same_lvl = eq_zero(lvl_a - lvl_b);
-            match same_lvl {
-              1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
-              0 => 0,
-            },
-          _ => 0,
-        },
-
-      KValNode.Const(idx_a, &lvls_a, &sp_a) =>
-        match load(b) {
-          KValNode.Const(idx_b, &lvls_b, &sp_b) =>
-            let same_idx = eq_zero(idx_a - idx_b);
-            match same_idx {
-              1 =>
-                let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
-                match lvls_eq {
-                  1 =>
-                    k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
-                  0 => 0,
-                },
-              0 =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
-            },
-          _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
-        },
-
-      KValNode.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
-        match load(b) {
-          KValNode.Ctor(idx_b, &lvls_b, _, &sp_b) =>
-            let same_idx = eq_zero(idx_a - idx_b);
-            match same_idx {
-              1 =>
-                let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
-                match lvls_eq {
-                  1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
-                  0 => 0,
-                },
-              0 => 0,
-            },
-          KValNode.Lit(lb) =>
-            nat_lit_eq_ctor(lb, idx_a, nparams_a, sp_a, depth, top, nat_idx, str_idx),
-          _ => 0,
-        },
-
-      KValNode.Lam(dom_a, body_a, &env_a) =>
-        match load(b) {
-          KValNode.Lam(dom_b, body_b, &env_b) =>
-            let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
-            match dom_eq {
-              0 => 0,
-              1 =>
-                let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
-                let env_a2 = List.Cons(fvar, store(env_a));
-                let env_b2 = List.Cons(fvar, store(env_b));
-                let va = k_eval(body_a, env_a2, top);
-                let vb = k_eval(body_b, env_b2, top);
-                k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
-            },
-          _ =>
-            -- Eta: lam vs non-lam
-            let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
-            let env_a2 = List.Cons(fvar, store(env_a));
-            let va = k_eval(body_a, env_a2, top);
-            let vb = k_apply(b, fvar, top);
-            k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
-        },
-
-      KValNode.Pi(dom_a, body_a, &env_a) =>
-        match load(b) {
-          KValNode.Pi(dom_b, body_b, &env_b) =>
-            let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
-            match dom_eq {
-              0 => 0,
-              1 =>
-                let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
-                let env_a2 = List.Cons(fvar, store(env_a));
-                let env_b2 = List.Cons(fvar, store(env_b));
-                let va = k_eval(body_a, env_a2, top);
-                let vb = k_eval(body_b, env_b2, top);
-                k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
-            },
-          _ => 0,
-        },
-
-      KValNode.Proj(tidx_a, fidx_a, sv_a, &sp_a) =>
-        match load(b) {
-          KValNode.Proj(tidx_b, fidx_b, sv_b, &sp_b) =>
-            let same_tf = eq_zero(tidx_a - tidx_b) * eq_zero(fidx_a - fidx_b);
-            match same_tf {
-              1 =>
-                let sv_eq = k_is_def_eq(sv_a, sv_b, depth, top, nat_idx, str_idx);
-                match sv_eq {
-                  1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
-                  0 => 0,
-                },
-              0 => 0,
-            },
-          _ => 0,
-        },
-
-      -- Eta: non-lam vs lam (symmetric case)
+    match ptr_val(a) - ptr_val(b) {
+      0 => 1,
       _ =>
-        match load(b) {
-          KValNode.Lam(dom_b, body_b, &env_b) =>
-            let fvar = store(KValNode.FVar(depth, dom_b, store(List.Nil)));
-            let va = k_apply(a, fvar, top);
-            let env_b2 = List.Cons(fvar, store(env_b));
-            let vb = k_eval(body_b, env_b2, top);
-            k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
-          KValNode.Const(_, _, _) =>
-            k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
-          _ => 0,
+        match load(a) {
+          KValNode.Srt(&la) =>
+            match load(b) {
+              KValNode.Srt(&lb) => level_equal(la, lb),
+              _ => 0,
+            },
+
+          KValNode.Lit(la) =>
+            match load(b) {
+              KValNode.Lit(lb) => literal_eq(la, lb),
+              KValNode.Ctor(ctor_idx, _, nparams, &ctor_spine) =>
+                nat_lit_eq_ctor(la, ctor_idx, nparams, ctor_spine, depth, top, nat_idx, str_idx),
+              _ => 0,
+            },
+
+          KValNode.FVar(lvl_a, _, &sp_a) =>
+            match load(b) {
+              KValNode.FVar(lvl_b, _, &sp_b) =>
+                let same_lvl = eq_zero(lvl_a - lvl_b);
+                match same_lvl {
+                  1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                  0 => 0,
+                },
+              _ => 0,
+            },
+
+          KValNode.Const(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Const(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 =>
+                        k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 =>
+                    k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
+            match load(b) {
+              KValNode.Ctor(idx_b, &lvls_b, _, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => 0,
+                },
+              KValNode.Lit(lb) =>
+                nat_lit_eq_ctor(lb, idx_a, nparams_a, sp_a, depth, top, nat_idx, str_idx),
+              _ => 0,
+            },
+
+          KValNode.Lam(dom_a, body_a, &env_a) =>
+            match load(b) {
+              KValNode.Lam(dom_b, body_b, &env_b) =>
+                let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
+                match dom_eq {
+                  0 => 0,
+                  1 =>
+                    let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
+                    let env_a2 = List.Cons(fvar, store(env_a));
+                    let env_b2 = List.Cons(fvar, store(env_b));
+                    let va = k_eval(body_a, env_a2, top);
+                    let vb = k_eval(body_b, env_b2, top);
+                    k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
+                },
+              _ =>
+                -- Eta: lam vs non-lam
+                let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
+                let env_a2 = List.Cons(fvar, store(env_a));
+                let va = k_eval(body_a, env_a2, top);
+                let vb = k_apply(b, fvar, top);
+                k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
+            },
+
+          KValNode.Pi(dom_a, body_a, &env_a) =>
+            match load(b) {
+              KValNode.Pi(dom_b, body_b, &env_b) =>
+                let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
+                match dom_eq {
+                  0 => 0,
+                  1 =>
+                    let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
+                    let env_a2 = List.Cons(fvar, store(env_a));
+                    let env_b2 = List.Cons(fvar, store(env_b));
+                    let va = k_eval(body_a, env_a2, top);
+                    let vb = k_eval(body_b, env_b2, top);
+                    k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
+                },
+              _ => 0,
+            },
+
+          KValNode.Proj(tidx_a, fidx_a, sv_a, &sp_a) =>
+            match load(b) {
+              KValNode.Proj(tidx_b, fidx_b, sv_b, &sp_b) =>
+                let same_tf = eq_zero(tidx_a - tidx_b) * eq_zero(fidx_a - fidx_b);
+                match same_tf {
+                  1 =>
+                    let sv_eq = k_is_def_eq(sv_a, sv_b, depth, top, nat_idx, str_idx);
+                    match sv_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => 0,
+                },
+              _ => 0,
+            },
+
+          -- Eta: non-lam vs lam (symmetric case)
+          _ =>
+            match load(b) {
+              KValNode.Lam(dom_b, body_b, &env_b) =>
+                let fvar = store(KValNode.FVar(depth, dom_b, store(List.Nil)));
+                let va = k_apply(a, fvar, top);
+                let env_b2 = List.Cons(fvar, store(env_b));
+                let vb = k_eval(body_b, env_b2, top);
+                k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
+              KValNode.Const(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
+            },
         },
     }
   }

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -15,24 +15,33 @@ evaluated into semantic values (`KVal`) using closures and environments, giving
 O(1) beta reduction instead of O(|body|) substitution walks. Free variables use
 **de Bruijn levels** (stable under binder entry) rather than indices.
 
-The core is three mutually recursive operations:
-- `k_eval` / `k_whnf`: evaluate expressions and reduce to weak head normal form
+The core operations:
+- `k_eval`: evaluate an expression to a WHNF value (eager delta on Defn/Thm,
+  iota and quotient reduction fire from `k_apply` when a Rec/Quot value's
+  spine reaches the exact required arg count)
+- `k_force`: force a `Thunk` value, returning a WHNF value (identity otherwise)
 - `k_infer` / `k_check`: infer types and bidirectionally check against expected types
-- `k_is_def_eq`: check definitional equality (proof irrelevance, eta, lazy delta)
+- `k_is_def_eq`: check definitional equality (proof irrelevance, eta, structural)
+
+A value is either WHNF or a `Thunk(expr, env)` suspension. `k_eval` always
+returns WHNF. `k_force` drives a Thunk to WHNF. There is no separate WHNF
+function: definitions unfold during evaluation; Rec/Quot reductions fire as
+soon as their spine has the exact required arg count (over-application is
+assumed not to occur, so a stuck Rec/Quot is always under-applied).
 
 ## Aiur Constraints
 
 Aiur circuits have no mutation, no dynamic indexing, and no non-tail matches.
-Instead of explicit caches (WHNF cache, equiv manager, thunk memoization), the
-Aiur runtime's function-call caching provides call-by-need semantics: calling
-`k_eval(expr, env, top)` with the same arguments returns the cached result.
+The Aiur runtime's function-call caching provides call-by-need semantics:
+calling `k_eval(expr, env, top)` with the same arguments returns the cached
+result.
 
 ## Implemented Features
 
 | Feature                          | Status |
 |----------------------------------|--------|
 | Lazy eval (thunks in spines)     | ✅     |
-| Delta unfolding (WHNF)           | ✅     |
+| Eager delta unfolding (Defn/Thm) | ✅     |
 | Iota reduction (recursor)        | ✅     |
 | K-reduction (Prop recursors)     | ✅     |
 | Nat literal iota                 | ✅     |
@@ -49,7 +58,6 @@ Aiur runtime's function-call caching provides call-by-need semantics: calling
 |----------------------------------|--------------------------------------|
 | Nat primitives (add, mul, ...)   | ❌ uses iota (exponential for large) |
 | String primitives                | ❌                                   |
-| Lazy delta (hint-based)          | ⚠️ unfolds both sides                |
 | Inductive block validation       | ❌ trusts input                      |
 | Delta step limit                 | ❌                                   |
 
@@ -485,8 +493,10 @@ def kernel := ⟦
   --
   -- Normalization by Evaluation: expressions (KExpr) are evaluated into semantic
   -- values (KVal) using closures. A lambda captures its environment; applying it
-  -- pushes the argument, giving O(1) beta reduction. Constants evaluate to
-  -- neutrals (no eager delta unfolding) — definition unfolding is deferred to WHNF.
+  -- pushes the argument, giving O(1) beta reduction. Defn/Thm constants unfold
+  -- eagerly during eval; other constants form neutrals whose spines accumulate
+  -- args via k_apply, which fires iota / quotient reduction when a Rec / Quot
+  -- spine reaches its exact required arg count. k_eval always returns WHNF.
   -- Free variables use de Bruijn levels (stable under binder entry).
   -- ============================================================================
 
@@ -507,18 +517,21 @@ def kernel := ⟦
       KExprNode.Srt(&l) =>
         store(KValNode.Srt(store(level_reduce(l)))),
 
-      -- Lazy: no definition unfolding during eval, deferred to WHNF
+      -- Eager delta: unfold Defn/Thm during eval. Other constants stay neutral
+      -- with empty spine; args accumulate via k_apply.
       KExprNode.Const(idx, &lvls) =>
         let ci = load(list_lookup(top, idx));
         match ci {
+          KConstantInfo.Defn(_, _, &value, _) =>
+            let body = expr_inst_levels(value, lvls);
+            k_eval(body, List.Nil, top),
+          KConstantInfo.Thm(_, _, &value) =>
+            let body = expr_inst_levels(value, lvls);
+            k_eval(body, List.Nil, top),
           KConstantInfo.Ctor(_, _, _, _, nparams, _, _) =>
             store(KValNode.Ctor(idx, store(lvls), nparams, store(List.Nil))),
           KConstantInfo.Axiom(_, _, _) =>
             store(KValNode.Axiom(idx, store(lvls), store(List.Nil))),
-          KConstantInfo.Defn(_, _, _, _) =>
-            store(KValNode.Defn(idx, store(lvls), store(List.Nil))),
-          KConstantInfo.Thm(_, _, _) =>
-            store(KValNode.Thm(idx, store(lvls), store(List.Nil))),
           KConstantInfo.Opaque(_, _, _, _) =>
             store(KValNode.Opaque(idx, store(lvls), store(List.Nil))),
           KConstantInfo.Quot(_, _, _) =>
@@ -617,7 +630,18 @@ def kernel := ⟦
 
       KValNode.Quot(idx, &lvls, &spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Quot(idx, store(lvls), store(spine2))),
+        let ci = load(list_lookup(top, idx));
+        match ci {
+          KConstantInfo.Quot(_, _, kind) =>
+            match kind {
+              QuotKind.Lift =>
+                k_try_quot_fire(idx, lvls, spine2, 6, 3, top),
+              QuotKind.Ind =>
+                k_try_quot_fire(idx, lvls, spine2, 5, 3, top),
+              _ =>
+                store(KValNode.Quot(idx, store(lvls), store(spine2))),
+            },
+        },
 
       KValNode.Induct(idx, &lvls, &spine) =>
         let spine2 = list_snoc(spine, arg);
@@ -625,7 +649,7 @@ def kernel := ⟦
 
       KValNode.Rec(idx, &lvls, &spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Rec(idx, store(lvls), store(spine2))),
+        k_try_iota_fire(idx, lvls, spine2, top),
 
       KValNode.Proj(tidx, fidx, sv, &spine) =>
         let spine2 = list_snoc(spine, arg);
@@ -665,19 +689,21 @@ def kernel := ⟦
     }
   }
 
-  -- Try iota reduction: if idx refers to a recursor and the major premise is a
-  -- constructor or Nat literal, apply the matching recursor rule; otherwise return a neutral VConst
-  fn try_iota(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
+  -- Fire iota reduction at exact arg count (called from k_apply on a Rec value
+  -- whose spine just grew by one). Spine is exactly nparams+nmotives+nminors+
+  -- nindices+1 elements when fired; under-application leaves the Rec stuck.
+  -- Assumes no over-application.
+  fn k_try_iota_fire(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
     let ci = load(list_lookup(top, idx));
     match ci {
       KConstantInfo.Rec(_, _, nparams, nindices, nmotives, nminors, &rules, k_flag, _) =>
-        let maj_idx = nparams + nmotives + nminors + nindices;
+        let needed = nparams + nmotives + nminors + nindices + 1;
         let spine_len = list_length(spine);
-        match spine_len - maj_idx {
-          0 => store(KValNode.Rec(idx, store(lvls), store(spine))),
-          _ =>
+        match spine_len - needed {
+          0 =>
+            let maj_idx = needed - 1;
             let major_raw = list_lookup(spine, maj_idx);
-            let major = k_whnf(major_raw, top);
+            let major = k_force(major_raw, top);
             match load(major) {
               KValNode.Ctor(ctor_idx, _, ctor_nparams, &ctor_spine) =>
                 let rule_found = rec_rule_try_find(rules, ctor_idx);
@@ -692,16 +718,13 @@ def kernel := ⟦
                         let params_motives_minors = list_take(spine, nparams + nmotives + nminors);
                         let result = k_apply_spine(rhs_val, params_motives_minors, top);
                         let fields = list_drop(ctor_spine, ctor_nparams);
-                        let result2 = k_apply_spine(result, fields, top);
-                        let remaining = list_drop(spine, maj_idx + 1);
-                        k_apply_spine(result2, remaining, top),
+                        k_apply_spine(result, fields, top),
                     },
                 },
               KValNode.Lit(lit) =>
                 match lit {
                   KLiteral.Nat(&n) =>
                     -- Nat literal iota: Lit(0) → zero rule, Lit(n+1) → succ rule with Lit(n)
-                    -- Derive the inductive idx from the first rule's ctor_idx
                     let first_ctor_idx = rec_rule_first_ctor(rules);
                     let induct_idx = ctor_induct_idx(first_ctor_idx, top);
                     let ind_ci = load(list_lookup(top, induct_idx));
@@ -711,7 +734,6 @@ def kernel := ⟦
                         let is_zero = klimbs_is_zero(n);
                         match is_zero {
                           1 =>
-                            -- Lit(0) → fire zero rule with no ctor fields
                             let zero_ctor_idx = list_lookup(ctor_indices, 0);
                             let rule = rec_rule_find(rules, zero_ctor_idx);
                             match rule {
@@ -719,12 +741,9 @@ def kernel := ⟦
                                 let rhs_inst = expr_inst_levels(rhs, lvls);
                                 let rhs_val = k_eval(rhs_inst, List.Nil, top);
                                 let pmm = list_take(spine, pmm_end);
-                                let result = k_apply_spine(rhs_val, pmm, top);
-                                let remaining = list_drop(spine, maj_idx + 1);
-                                k_apply_spine(result, remaining, top),
+                                k_apply_spine(rhs_val, pmm, top),
                             },
                           0 =>
-                            -- Lit(n+1) → fire succ rule with one field = Lit(n-1)
                             let succ_ctor_idx = list_lookup(ctor_indices, 1);
                             let rule = rec_rule_find(rules, succ_ctor_idx);
                             match rule {
@@ -735,9 +754,7 @@ def kernel := ⟦
                                 let result = k_apply_spine(rhs_val, pmm, top);
                                 let pred = store(KValNode.Lit(KLiteral.Nat(store(klimbs_pred(n)))));
                                 let ctor_fields = List.Cons(pred, store(List.Nil));
-                                let result2 = k_apply_spine(result, ctor_fields, top);
-                                let remaining = list_drop(spine, maj_idx + 1);
-                                k_apply_spine(result2, remaining, top),
+                                k_apply_spine(result, ctor_fields, top),
                             },
                         },
                     },
@@ -746,45 +763,39 @@ def kernel := ⟦
                 },
               _ =>
                 -- K-reduction: for proof-irrelevant (Prop) inductives with k_flag set,
-                -- return the minor premise applied to remaining args after major
+                -- the minor premise alone is the result (motive, minor at nparams+nmotives).
                 match k_flag {
                   0 =>
-                    -- Not a K-recursor, return stuck
                     store(KValNode.Rec(idx, store(lvls), store(spine))),
                   _ =>
-                    -- K-reduction fires: minor is at nparams + nmotives
                     let minor_idx = nparams + nmotives;
-                    let minor = list_lookup(spine, minor_idx);
-                    let remaining = list_drop(spine, maj_idx + 1);
-                    k_apply_spine(minor, remaining, top),
+                    list_lookup(spine, minor_idx),
                 },
             },
+          _ =>
+            store(KValNode.Rec(idx, store(lvls), store(spine))),
         },
-
-      _ => store(KValNode.Rec(idx, store(lvls), store(spine))),
     }
   }
 
-  -- Take the first n elements of a val list
   -- ============================================================================
   -- Quotient reduction
   -- ============================================================================
 
-  -- Try quotient reduction: Quot.lift f h (Quot.mk r a) → f a
-  -- reduce_size is the minimum spine length, f_pos is the index of f in the spine.
-  -- Returns 1 and reduced value via k_whnf if successful, 0 otherwise.
-  -- The idx/lvls/spine are passed through for reconstructing the stuck value on failure.
-  fn k_try_quot_reduction(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›,
+  -- Fire quotient reduction at exact arg count (called from k_apply on a Quot
+  -- value of kind Lift/Ind whose spine just grew by one). For Quot.lift the
+  -- spine is [α, r, β, f, h, ⟨Quot.mk r a⟩] (size 6, f_pos 3); for Quot.ind
+  -- the spine is [α, r, motive, f, ⟨Quot.mk r a⟩] (size 5, f_pos 3).
+  -- Reduces to f a. Assumes no over-application.
+  fn k_try_quot_fire(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›,
       reduce_size: G, f_pos: G, top: List‹&KConstantInfo›) -> KVal {
     let spine_len = list_length(spine);
     match spine_len - reduce_size {
-      0 => store(KValNode.Quot(idx, store(lvls), store(spine))),
-      _ =>
-        -- Force and WHNF the major arg (last of the reduce_size args)
+      0 =>
+        -- Exact arg count: try fire
         let major_idx = reduce_size - 1;
         let major_raw = list_lookup(spine, major_idx);
-        let major = k_whnf(major_raw, top);
-        -- Check if major is a Quot.mk application (a Const with QuotKind.Ctor)
+        let major = k_force(major_raw, top);
         match load(major) {
           KValNode.Quot(mk_idx, _, &mk_spine) =>
             let mk_ci = load(list_lookup(top, mk_idx));
@@ -793,20 +804,14 @@ def kernel := ⟦
                 match mk_kind {
                   QuotKind.Ctor =>
                     -- mk_spine should have >= 3 args: [α, r, a]
-                    -- The quotient value is the last element
                     let mk_len = list_length(mk_spine);
                     match mk_len - 3 {
                       0 => store(KValNode.Quot(idx, store(lvls), store(spine))),
                       _ =>
                         let quot_val_idx = mk_len - 1;
                         let quot_val = list_lookup(mk_spine, quot_val_idx);
-                        -- Apply f (at f_pos) to the quotient value
                         let f_val = k_force(list_lookup(spine, f_pos), top);
-                        let result = k_apply(f_val, quot_val, top);
-                        -- Apply remaining spine args after reduce_size
-                        let remaining = list_drop(spine, reduce_size);
-                        let result2 = k_apply_spine(result, remaining, top);
-                        k_whnf(result2, top),
+                        k_apply(f_val, quot_val, top),
                     },
                   _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
                 },
@@ -814,83 +819,8 @@ def kernel := ⟦
             },
           _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
         },
-    }
-  }
-
-  -- ============================================================================
-  -- WHNF (Weak Head Normal Form)
-  --
-  -- Reduce a value until its outermost constructor is visible. The WHNF loop
-  -- applies projection reduction, iota (recursor on ctor), delta (definition
-  -- unfolding), and quotient reduction, retrying after each successful step.
-  -- Does not reduce under binders or inside arguments.
-  -- ============================================================================
-
-  -- Reduce a value to Weak Head Normal Form by retrying projection, iota, and delta reductions
-
-  fn k_whnf(v: KVal, top: List‹&KConstantInfo›) -> KVal {
-    match load(v) {
-      KValNode.Thunk(e, &env) =>
-        let val = k_eval(e, env, top);
-        k_whnf(val, top),
-
-      KValNode.Proj(tidx, fidx, sv, &spine) =>
-        let sv2 = k_whnf(sv, top);
-        match load(sv2) {
-          KValNode.Ctor(_, _, nparams, &ctor_spine) =>
-            let field_idx = nparams + fidx;
-            let field = list_lookup(ctor_spine, field_idx);
-            let field_forced = k_force(field, top);
-            let result = k_apply_spine(field_forced, spine, top);
-            k_whnf(result, top),
-          _ =>
-            store(KValNode.Proj(tidx, fidx, sv2, store(spine))),
-        },
-
-      KValNode.Rec(idx, &lvls, &spine) =>
-        let result = try_iota(idx, lvls, spine, top);
-        match load(result) {
-          KValNode.Rec(_, _, _) => result,
-          _ => k_whnf(result, top),
-        },
-
-      KValNode.Defn(idx, &lvls, &spine) =>
-        let ci = load(list_lookup(top, idx));
-        match ci {
-          KConstantInfo.Defn(_, _, &value, _) =>
-            let body = expr_inst_levels(value, lvls);
-            let val = k_eval(body, List.Nil, top);
-            let val2 = k_apply_spine(val, spine, top);
-            k_whnf(val2, top),
-        },
-
-      KValNode.Thm(idx, &lvls, &spine) =>
-        let ci = load(list_lookup(top, idx));
-        match ci {
-          KConstantInfo.Thm(_, _, &value) =>
-            let body = expr_inst_levels(value, lvls);
-            let val = k_eval(body, List.Nil, top);
-            let val2 = k_apply_spine(val, spine, top);
-            k_whnf(val2, top),
-        },
-
-      -- Quot.lift: spine has [α, r, β, f, h, ⟨Quot.mk r a⟩, extra...]
-      -- Quot.ind: spine has [α, r, motive, f, ⟨Quot.mk r a⟩, extra...]
-      -- Reduces to: f a extra...
-      KValNode.Quot(idx, &lvls, &spine) =>
-        let ci = load(list_lookup(top, idx));
-        match ci {
-          KConstantInfo.Quot(_, _, kind) =>
-            match kind {
-              QuotKind.Lift =>
-                k_try_quot_reduction(idx, lvls, spine, 6, 3, top),
-              QuotKind.Ind =>
-                k_try_quot_reduction(idx, lvls, spine, 5, 3, top),
-              _ => v,
-            },
-        },
-
-      _ => v,
+      _ =>
+        store(KValNode.Quot(idx, store(lvls), store(spine))),
     }
   }
 
@@ -1024,7 +954,7 @@ def kernel := ⟦
 
       KExprNode.App(f, a) =>
         let fn_type = k_infer(f, types, env, depth, top, nat_idx, str_idx);
-        let fn_type_whnf = k_whnf(fn_type, top);
+        let fn_type_whnf = k_force(fn_type, top);
 
         match load(fn_type_whnf) {
           KValNode.Pi(dom, body, &pi_env) =>
@@ -1064,9 +994,9 @@ def kernel := ⟦
         k_infer(body, types2, env2, depth + 1, top, nat_idx, str_idx),
 
       KExprNode.Proj(tidx, fidx, e1) =>
-        -- Infer struct type and WHNF to expose inductive head
+        -- Infer struct type and force to expose inductive head
         let struct_type = k_infer(e1, types, env, depth, top, nat_idx, str_idx);
-        let struct_type_whnf = k_whnf(struct_type, top);
+        let struct_type_whnf = k_force(struct_type, top);
         match load(struct_type_whnf) {
           KValNode.Induct(induct_idx, &levels, &params_spine) =>
             -- Look up inductive to get its single constructor index
@@ -1085,7 +1015,7 @@ def kernel := ⟦
                 let struct_val = suspend(e1, env);
                 let after_fields = walk_fields(after_params, tidx, 0, fidx, struct_val, top);
                 -- Extract the domain type at field fidx
-                let result_whnf = k_whnf(after_fields, top);
+                let result_whnf = k_force(after_fields, top);
                 match load(result_whnf) {
                   KValNode.Pi(dom, _, _) => dom,
                 },
@@ -1099,7 +1029,7 @@ def kernel := ⟦
   fn k_check(e: KExpr, expected: KVal, types: List‹KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) {
     match load(e) {
       KExprNode.Lam(ty, body) =>
-        let expected_whnf = k_whnf(expected, top);
+        let expected_whnf = k_force(expected, top);
         match load(expected_whnf) {
           KValNode.Pi(pi_dom, pi_body, &pi_env) =>
             -- Check domain matches
@@ -1125,7 +1055,7 @@ def kernel := ⟦
   -- Ensure a type expression evaluates to a Sort, returning the level
   fn k_ensure_sort(e: KExpr, types: List‹KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KLevel {
     let ty = k_infer(e, types, env, depth, top, nat_idx, str_idx);
-    let ty_whnf = k_whnf(ty, top);
+    let ty_whnf = k_force(ty, top);
     match load(ty_whnf) {
       KValNode.Srt(&l) => l,
     }
@@ -1136,7 +1066,7 @@ def kernel := ⟦
     match params {
       List.Nil => ct,
       List.Cons(param_val, &rest_params) =>
-        let ct_whnf = k_whnf(ct, top);
+        let ct_whnf = k_force(ct, top);
         match load(ct_whnf) {
           KValNode.Pi(_, body, &pi_env) =>
             let env2 = List.Cons(param_val, store(pi_env));
@@ -1151,7 +1081,7 @@ def kernel := ⟦
     match remaining {
       0 => ct,
       _ =>
-        let ct_whnf = k_whnf(ct, top);
+        let ct_whnf = k_force(ct, top);
         match load(ct_whnf) {
           KValNode.Pi(_, body, &pi_env) =>
             let proj_val = store(KValNode.Proj(tidx, current_field, struct_val, store(List.Nil)));
@@ -1176,7 +1106,7 @@ def kernel := ⟦
     match spine {
       List.Nil => ty,
       List.Cons(arg, &rest) =>
-        let ty_whnf = k_whnf(ty, top);
+        let ty_whnf = k_force(ty, top);
         match load(ty_whnf) {
           KValNode.Pi(_, body, &pi_env) =>
             let env2 = List.Cons(arg, store(pi_env));
@@ -1249,7 +1179,7 @@ def kernel := ⟦
         apply_spine_to_type(ty_val, spine, top),
       KValNode.Proj(tidx, fidx, sv, &spine) =>
         let struct_type = k_infer_val_type(sv, top, nat_idx, str_idx);
-        let struct_type_whnf = k_whnf(struct_type, top);
+        let struct_type_whnf = k_force(struct_type, top);
         match load(struct_type_whnf) {
           KValNode.Induct(induct_idx, &levels, &params_spine) =>
             let ind_ci = load(list_lookup(top, induct_idx));
@@ -1262,7 +1192,7 @@ def kernel := ⟦
                 let ctor_type_val = k_eval(ctor_type_inst, List.Nil, top);
                 let after_params = walk_params(ctor_type_val, params_spine, top);
                 let after_fields = walk_fields(after_params, tidx, 0, fidx, sv, top);
-                let result_whnf = k_whnf(after_fields, top);
+                let result_whnf = k_force(after_fields, top);
                 match load(result_whnf) {
                   KValNode.Pi(dom, _, _) => apply_spine_to_type(dom, spine, top),
                   -- If not a Pi, return the type itself (could be the final result type)
@@ -1284,7 +1214,7 @@ def kernel := ⟦
   -- Check if a value is a proposition (its type is Sort 0 / Prop)
   fn k_is_prop_val(v: KVal, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     let ty = k_infer_val_type(v, top, nat_idx, str_idx);
-    let ty_whnf = k_whnf(ty, top);
+    let ty_whnf = k_force(ty, top);
     match load(ty_whnf) {
       KValNode.Srt(&l) =>
         match l {
@@ -1365,7 +1295,7 @@ def kernel := ⟦
   -- nullary constructor and no indices, they are definitionally equal.
   -- Examples: True, PUnit, PLift.up for propositions.
   fn is_unit_like_type(ty: KVal, top: List‹&KConstantInfo›) -> G {
-    let ty_whnf = k_whnf(ty, top);
+    let ty_whnf = k_force(ty, top);
     match load(ty_whnf) {
       KValNode.Induct(induct_idx, _, _) =>
         let ci = load(list_lookup(top, induct_idx));
@@ -1400,16 +1330,17 @@ def kernel := ⟦
   --
   -- The most complex part of the kernel. Uses a layered approach:
   --   1. Quick syntactic check (sorts, literals)
-  --   2. Reduce both sides to WHNF
+  --   2. Force both sides (drives any Thunk to its WHNF body)
   --   3. Proof irrelevance (type is Prop ⟹ equal by irrelevance)
   --   4. Structural comparison (k_is_def_eq_core)
   --   5. Struct eta (s ≡ ⟨s.1, s.2, ...⟩)
   --   6. Unit-like types (one nullary constructor ⟹ all values equal)
-  --   7. Lazy delta unfolding (try unfolding constants to make progress)
+  -- Delta unfolding happens eagerly in k_eval, so def-eq sees no unfoldable
+  -- constants and never needs to try a lazy-delta step.
   -- ============================================================================
 
   -- Check definitional equality of two values: first try a quick syntactic check,
-  -- then reduce to WHNF and compare structurally
+  -- then force both sides and compare structurally
   fn k_is_def_eq(a: KVal, b: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     let not_eq_ptr = ptr_val(a) - ptr_val(b);
     match (not_eq_ptr, a, b) {
@@ -1417,8 +1348,8 @@ def kernel := ⟦
       (_, &KValNode.Srt(&la), &KValNode.Srt(&lb)) => level_equal(la, lb),
       (_, &KValNode.Lit(la), &KValNode.Lit(lb)) => literal_eq(la, lb),
       _ =>
-        let a_whnf = k_whnf(a, top);
-        let b_whnf = k_whnf(b, top);
+        let a_whnf = k_force(a, top);
+        let b_whnf = k_force(b, top);
         let not_eq_ptr = ptr_val(a_whnf) - ptr_val(b_whnf);
         match (not_eq_ptr, a_whnf, b_whnf) {
           (0, _, _) => 1,
@@ -1579,7 +1510,7 @@ def kernel := ⟦
     }
   }
 
-  -- Structural definitional equality after WHNF
+  -- Structural definitional equality after force
   fn k_is_def_eq_core(a: KVal, b: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     match ptr_val(a) - ptr_val(b) {
       0 => 1,
@@ -1621,7 +1552,7 @@ def kernel := ⟦
                     },
                   _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Defn(idx_a, &lvls_a, &sp_a) =>
@@ -1634,9 +1565,9 @@ def kernel := ⟦
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                  _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Thm(idx_a, &lvls_a, &sp_a) =>
@@ -1649,9 +1580,9 @@ def kernel := ⟦
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                  _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Opaque(idx_a, &lvls_a, &sp_a) =>
@@ -1666,7 +1597,7 @@ def kernel := ⟦
                     },
                   _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Quot(idx_a, &lvls_a, &sp_a) =>
@@ -1681,7 +1612,7 @@ def kernel := ⟦
                     },
                   _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Induct(idx_a, &lvls_a, &sp_a) =>
@@ -1696,7 +1627,7 @@ def kernel := ⟦
                     },
                   _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Rec(idx_a, &lvls_a, &sp_a) =>
@@ -1711,7 +1642,7 @@ def kernel := ⟦
                     },
                   _ => 0,
                 },
-              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              _ => 0,
             },
 
           KValNode.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
@@ -1797,19 +1728,19 @@ def kernel := ⟦
                 let vb = k_eval(body_b, env_b2, top);
                 k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
               KValNode.Axiom(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               KValNode.Defn(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               KValNode.Thm(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               KValNode.Opaque(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               KValNode.Quot(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               KValNode.Induct(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               KValNode.Rec(_, _, _) =>
-                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                0,
               _ => 0,
             },
         },
@@ -1855,59 +1786,6 @@ def kernel := ⟦
               1 => k_is_def_eq_levels(ra, rb),
             },
         },
-    }
-  }
-
-  -- Lazy delta: try unfolding one or both constants to make progress
-  fn k_lazy_delta(a: KVal, b: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
-    let a_unfolded = try_delta_unfold(a, top);
-    let b_unfolded = try_delta_unfold(b, top);
-    let a_changed = delta_changed(a, a_unfolded);
-    let b_changed = delta_changed(b, b_unfolded);
-    match (a_changed, b_changed) {
-      (0, 0) => 0,
-      _ => k_is_def_eq(a_unfolded, b_unfolded, depth, top, nat_idx, str_idx),
-    }
-  }
-
-  -- Try to delta-unfold a VConst value by looking up its definition and evaluating it;
-  -- returns the original value if it is opaque or not a definition
-  fn try_delta_unfold(v: KVal, top: List‹&KConstantInfo›) -> KVal {
-    match load(v) {
-      KValNode.Defn(idx, &lvls, &spine) =>
-        let ci = load(list_lookup(top, idx));
-        match ci {
-          KConstantInfo.Defn(_, _, &value, _) =>
-            let body = expr_inst_levels(value, lvls);
-            let val = k_eval(body, List.Nil, top);
-            k_apply_spine(val, spine, top),
-        },
-      KValNode.Thm(idx, &lvls, &spine) =>
-        let ci = load(list_lookup(top, idx));
-        match ci {
-          KConstantInfo.Thm(_, _, &value) =>
-            let body = expr_inst_levels(value, lvls);
-            let val = k_eval(body, List.Nil, top);
-            k_apply_spine(val, spine, top),
-        },
-      _ => v,
-    }
-  }
-
-  -- Check whether delta unfolding made progress (i.e., the head constant changed)
-  fn delta_changed(before: KVal, after: KVal) -> G {
-    match load(before) {
-      KValNode.Defn(idx_a, _, _) =>
-        match load(after) {
-          KValNode.Defn(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
-          _ => 1,
-        },
-      KValNode.Thm(idx_a, _, _) =>
-        match load(after) {
-          KValNode.Thm(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
-          _ => 1,
-        },
-      _ => 0,
     }
   }
 

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -77,10 +77,9 @@ def kernel := ⟦
       List.Cons(&rule, &rest) =>
         match rule {
           KRecRule.Mk(idx, nf, &rhs) =>
-            let found = eq_zero(idx - ctor_idx);
-            match found {
-              1 => Option.Some(store(KRecRule.Mk(idx, nf, store(rhs)))),
-              0 => rec_rule_try_find(rest, ctor_idx),
+            match idx - ctor_idx {
+              0 => Option.Some(store(KRecRule.Mk(idx, nf, store(rhs)))),
+              _ => rec_rule_try_find(rest, ctor_idx),
             },
         },
     }
@@ -91,10 +90,9 @@ def kernel := ⟦
       List.Cons(&rule, &rest) =>
         match rule {
           KRecRule.Mk(idx, nf, &rhs) =>
-            let found = eq_zero(idx - ctor_idx);
-            match found {
-              1 => KRecRule.Mk(idx, nf, store(rhs)),
-              0 => rec_rule_find(rest, ctor_idx),
+            match idx - ctor_idx {
+              0 => KRecRule.Mk(idx, nf, store(rhs)),
+              _ => rec_rule_find(rest, ctor_idx),
             },
         },
     }
@@ -247,10 +245,9 @@ def kernel := ⟦
     match l {
       KLevel.Zero => KLevel.Zero,
       KLevel.Param(i) =>
-        let eq = eq_zero(i - p);
-        match eq {
-          1 => repl,
-          0 => KLevel.Param(i),
+        match i - p {
+          0 => repl,
+          _ => KLevel.Param(i),
         },
       KLevel.Succ(&a) =>
         KLevel.Succ(store(level_subst_reduce(a, p, repl))),
@@ -676,10 +673,9 @@ def kernel := ⟦
       KConstantInfo.Rec(_, _, nparams, nindices, nmotives, nminors, &rules, k_flag, _) =>
         let maj_idx = nparams + nmotives + nminors + nindices;
         let spine_len = list_length(spine);
-        let not_have_major = eq_zero(spine_len - maj_idx);
-        match not_have_major {
-          1 => store(KValNode.Rec(idx, store(lvls), store(spine))),
-          0 =>
+        match spine_len - maj_idx {
+          0 => store(KValNode.Rec(idx, store(lvls), store(spine))),
+          _ =>
             let major_raw = list_lookup(spine, maj_idx);
             let major = k_whnf(major_raw, top);
             match load(major) {
@@ -781,10 +777,9 @@ def kernel := ⟦
   fn k_try_quot_reduction(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›,
       reduce_size: G, f_pos: G, top: List‹&KConstantInfo›) -> KVal {
     let spine_len = list_length(spine);
-    let not_enough = eq_zero(spine_len - reduce_size);
-    match not_enough {
-      1 => store(KValNode.Quot(idx, store(lvls), store(spine))),
-      0 =>
+    match spine_len - reduce_size {
+      0 => store(KValNode.Quot(idx, store(lvls), store(spine))),
+      _ =>
         -- Force and WHNF the major arg (last of the reduce_size args)
         let major_idx = reduce_size - 1;
         let major_raw = list_lookup(spine, major_idx);
@@ -800,10 +795,9 @@ def kernel := ⟦
                     -- mk_spine should have >= 3 args: [α, r, a]
                     -- The quotient value is the last element
                     let mk_len = list_length(mk_spine);
-                    let no_args = eq_zero(mk_len - 3);
-                    match no_args {
-                      1 => store(KValNode.Quot(idx, store(lvls), store(spine))),
-                      0 =>
+                    match mk_len - 3 {
+                      0 => store(KValNode.Quot(idx, store(lvls), store(spine))),
+                      _ =>
                         let quot_val_idx = mk_len - 1;
                         let quot_val = list_lookup(mk_spine, quot_val_idx);
                         -- Apply f (at f_pos) to the quotient value
@@ -1345,11 +1339,10 @@ def kernel := ⟦
             match ind_ci {
               KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
                 let num_ctors = list_length(ctor_indices);
-                let is_single = eq_zero(num_ctors - 1);
-                match is_single {
-                  0 => 0,
-                  1 =>
+                match num_ctors - 1 {
+                  0 =>
                     eta_struct_fields(t, spine, nparams, induct_idx, 0, num_fields, depth, top, nat_idx, str_idx),
+                  _ => 0,
                 },
               _ => 0,
             },
@@ -1562,10 +1555,8 @@ def kernel := ⟦
     match lit {
       KLiteral.Nat(&n) =>
         let induct_idx = ctor_induct_idx(ctor_idx, top);
-        let is_nat = eq_zero(induct_idx - nat_idx);
-        match is_nat {
-          0 => 0,
-          1 =>
+        match induct_idx - nat_idx {
+          0 =>
             let nfields = ctor_num_fields(ctor_idx, top);
             let is_zero = klimbs_is_zero(n);
             match is_zero {
@@ -1574,15 +1565,15 @@ def kernel := ⟦
                 eq_zero(nfields),
               0 =>
                 -- Lit(n+1) == Ctor if ctor has 1 field and that field == Lit(n)
-                let has_one = eq_zero(nfields - 1);
-                match has_one {
-                  0 => 0,
-                  1 =>
+                match nfields - 1 {
+                  0 =>
                     let pred_val = list_lookup(ctor_spine, nparams);
                     let pred_lit = store(KValNode.Lit(KLiteral.Nat(store(klimbs_pred(n)))));
                     k_is_def_eq(pred_lit, pred_val, depth, top, nat_idx, str_idx),
+                  _ => 0,
                 },
             },
+          _ => 0,
         },
       KLiteral.Str(_) => 0,
     }
@@ -1611,10 +1602,9 @@ def kernel := ⟦
           KValNode.FVar(lvl_a, _, &sp_a) =>
             match load(b) {
               KValNode.FVar(lvl_b, _, &sp_b) =>
-                let same_lvl = eq_zero(lvl_a - lvl_b);
-                match same_lvl {
-                  1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
-                  0 => 0,
+                match lvl_a - lvl_b {
+                  0 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                  _ => 0,
                 },
               _ => 0,
             },
@@ -1622,15 +1612,14 @@ def kernel := ⟦
           KValNode.Axiom(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Axiom(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => 0,
+                  _ => 0,
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1638,15 +1627,14 @@ def kernel := ⟦
           KValNode.Defn(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Defn(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                  _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1654,15 +1642,14 @@ def kernel := ⟦
           KValNode.Thm(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Thm(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                  _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1670,15 +1657,14 @@ def kernel := ⟦
           KValNode.Opaque(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Opaque(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => 0,
+                  _ => 0,
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1686,15 +1672,14 @@ def kernel := ⟦
           KValNode.Quot(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Quot(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => 0,
+                  _ => 0,
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1702,15 +1687,14 @@ def kernel := ⟦
           KValNode.Induct(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Induct(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => 0,
+                  _ => 0,
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1718,15 +1702,14 @@ def kernel := ⟦
           KValNode.Rec(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
               KValNode.Rec(idx_b, &lvls_b, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => 0,
+                  _ => 0,
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1734,15 +1717,14 @@ def kernel := ⟦
           KValNode.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
             match load(b) {
               KValNode.Ctor(idx_b, &lvls_b, _, &sp_b) =>
-                let same_idx = eq_zero(idx_a - idx_b);
-                match same_idx {
-                  1 =>
+                match idx_a - idx_b {
+                  0 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
                       1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 => 0,
+                  _ => 0,
                 },
               KValNode.Lit(lb) =>
                 nat_lit_eq_ctor(lb, idx_a, nparams_a, sp_a, depth, top, nat_idx, str_idx),

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -118,7 +118,7 @@ def kernel := ⟦
   fn const_type(ci: KConstantInfo) -> KExpr {
     match ci {
       KConstantInfo.Axiom(_, &ty, _) => ty,
-      KConstantInfo.Defn(_, &ty, _, _, _) => ty,
+      KConstantInfo.Defn(_, &ty, _, _) => ty,
       KConstantInfo.Thm(_, &ty, _) => ty,
       KConstantInfo.Opaque(_, &ty, _, _) => ty,
       KConstantInfo.Quot(_, &ty, _) => ty,
@@ -132,7 +132,7 @@ def kernel := ⟦
   fn const_num_levels(ci: KConstantInfo) -> G {
     match ci {
       KConstantInfo.Axiom(n, _, _) => n,
-      KConstantInfo.Defn(n, _, _, _, _) => n,
+      KConstantInfo.Defn(n, _, _, _) => n,
       KConstantInfo.Thm(n, _, _) => n,
       KConstantInfo.Opaque(n, _, _, _) => n,
       KConstantInfo.Quot(n, _, _) => n,
@@ -828,15 +828,11 @@ def kernel := ⟦
                 -- Iota didn't fire; try quotient, then delta
                 let ci = load(list_lookup(top, idx2));
                 match ci {
-                  KConstantInfo.Defn(_, _, &value, hints, _) =>
-                    match hints {
-                      KHints.Opaque => result,
-                      _ =>
-                        let body = expr_inst_levels(value, lvls2);
-                        let val = k_eval(body, List.Nil, top);
-                        let val2 = k_apply_spine(val, spine2, top);
-                        k_whnf(val2, top),
-                    },
+                  KConstantInfo.Defn(_, _, &value, _) =>
+                    let body = expr_inst_levels(value, lvls2);
+                    let val = k_eval(body, List.Nil, top);
+                    let val2 = k_apply_spine(val, spine2, top);
+                    k_whnf(val2, top),
                   KConstantInfo.Thm(_, _, &value) =>
                     let body = expr_inst_levels(value, lvls2);
                     let val = k_eval(body, List.Nil, top);
@@ -1709,18 +1705,10 @@ def kernel := ⟦
       KValNode.Const(idx, &lvls, &spine) =>
         let ci = load(list_lookup(top, idx));
         match ci {
-          KConstantInfo.Defn(_, _, &value, hints, _) =>
-            match hints {
-              KHints.Opaque => v,
-              KHints.Abbrev =>
-                let body = expr_inst_levels(value, lvls);
-                let val = k_eval(body, List.Nil, top);
-                k_apply_spine(val, spine, top),
-              KHints.Regular(_) =>
-                let body = expr_inst_levels(value, lvls);
-                let val = k_eval(body, List.Nil, top);
-                k_apply_spine(val, spine, top),
-            },
+          KConstantInfo.Defn(_, _, &value, _) =>
+            let body = expr_inst_levels(value, lvls);
+            let val = k_eval(body, List.Nil, top);
+            k_apply_spine(val, spine, top),
           KConstantInfo.Thm(_, _, &value) =>
             let body = expr_inst_levels(value, lvls);
             let val = k_eval(body, List.Nil, top);
@@ -1758,7 +1746,7 @@ def kernel := ⟦
       KConstantInfo.Axiom(_, &ty, _) =>
         let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Defn(_, &ty, &value, _, _) =>
+      KConstantInfo.Defn(_, &ty, &value, _) =>
         let _ = k_ensure_sort(ty, List.Nil, List.Nil, 0, top, nat_idx, str_idx);
         let ty_val = k_eval(ty, List.Nil, top);
         k_check(value, ty_val, List.Nil, List.Nil, 0, top, nat_idx, str_idx),

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -516,7 +516,20 @@ def kernel := ⟦
         match ci {
           KConstantInfo.Ctor(_, _, _, _, nparams, _, _) =>
             store(KValNode.Ctor(idx, store(lvls), nparams, store(List.Nil))),
-          _ => store(KValNode.Const(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Axiom(_, _, _) =>
+            store(KValNode.Axiom(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Defn(_, _, _, _) =>
+            store(KValNode.Defn(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Thm(_, _, _) =>
+            store(KValNode.Thm(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Opaque(_, _, _, _) =>
+            store(KValNode.Opaque(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Quot(_, _, _) =>
+            store(KValNode.Quot(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Induct(_, _, _, _, _, _, _, _) =>
+            store(KValNode.Induct(idx, store(lvls), store(List.Nil))),
+          KConstantInfo.Rec(_, _, _, _, _, _, _, _, _) =>
+            store(KValNode.Rec(idx, store(lvls), store(List.Nil))),
         },
 
       KExprNode.App(f, a) =>
@@ -589,9 +602,33 @@ def kernel := ⟦
         let spine2 = list_snoc(spine, arg);
         store(KValNode.FVar(lvl, fvar_ty, store(spine2))),
 
-      KValNode.Const(idx, &lvls, &spine) =>
+      KValNode.Axiom(idx, &lvls, &spine) =>
         let spine2 = list_snoc(spine, arg);
-        store(KValNode.Const(idx, store(lvls), store(spine2))),
+        store(KValNode.Axiom(idx, store(lvls), store(spine2))),
+
+      KValNode.Defn(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Defn(idx, store(lvls), store(spine2))),
+
+      KValNode.Thm(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Thm(idx, store(lvls), store(spine2))),
+
+      KValNode.Opaque(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Opaque(idx, store(lvls), store(spine2))),
+
+      KValNode.Quot(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Quot(idx, store(lvls), store(spine2))),
+
+      KValNode.Induct(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Induct(idx, store(lvls), store(spine2))),
+
+      KValNode.Rec(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Rec(idx, store(lvls), store(spine2))),
 
       KValNode.Proj(tidx, fidx, sv, &spine) =>
         let spine2 = list_snoc(spine, arg);
@@ -641,7 +678,7 @@ def kernel := ⟦
         let spine_len = list_length(spine);
         let not_have_major = eq_zero(spine_len - maj_idx);
         match not_have_major {
-          1 => store(KValNode.Const(idx, store(lvls), store(spine))),
+          1 => store(KValNode.Rec(idx, store(lvls), store(spine))),
           0 =>
             let major_raw = list_lookup(spine, maj_idx);
             let major = k_whnf(major_raw, top);
@@ -650,7 +687,7 @@ def kernel := ⟦
                 let rule_found = rec_rule_try_find(rules, ctor_idx);
                 match rule_found {
                   Option.None =>
-                    store(KValNode.Const(idx, store(lvls), store(spine))),
+                    store(KValNode.Rec(idx, store(lvls), store(spine))),
                   Option.Some(&rule) =>
                     match rule {
                       KRecRule.Mk(_, nfields, &rhs) =>
@@ -709,7 +746,7 @@ def kernel := ⟦
                         },
                     },
                   KLiteral.Str(_) =>
-                    store(KValNode.Const(idx, store(lvls), store(spine))),
+                    store(KValNode.Rec(idx, store(lvls), store(spine))),
                 },
               _ =>
                 -- K-reduction: for proof-irrelevant (Prop) inductives with k_flag set,
@@ -717,7 +754,7 @@ def kernel := ⟦
                 match k_flag {
                   0 =>
                     -- Not a K-recursor, return stuck
-                    store(KValNode.Const(idx, store(lvls), store(spine))),
+                    store(KValNode.Rec(idx, store(lvls), store(spine))),
                   _ =>
                     -- K-reduction fires: minor is at nparams + nmotives
                     let minor_idx = nparams + nmotives;
@@ -728,7 +765,7 @@ def kernel := ⟦
             },
         },
 
-      _ => store(KValNode.Const(idx, store(lvls), store(spine))),
+      _ => store(KValNode.Rec(idx, store(lvls), store(spine))),
     }
   }
 
@@ -746,7 +783,7 @@ def kernel := ⟦
     let spine_len = list_length(spine);
     let not_enough = eq_zero(spine_len - reduce_size);
     match not_enough {
-      1 => store(KValNode.Const(idx, store(lvls), store(spine))),
+      1 => store(KValNode.Quot(idx, store(lvls), store(spine))),
       0 =>
         -- Force and WHNF the major arg (last of the reduce_size args)
         let major_idx = reduce_size - 1;
@@ -754,7 +791,7 @@ def kernel := ⟦
         let major = k_whnf(major_raw, top);
         -- Check if major is a Quot.mk application (a Const with QuotKind.Ctor)
         match load(major) {
-          KValNode.Const(mk_idx, _, &mk_spine) =>
+          KValNode.Quot(mk_idx, _, &mk_spine) =>
             let mk_ci = load(list_lookup(top, mk_idx));
             match mk_ci {
               KConstantInfo.Quot(_, _, mk_kind) =>
@@ -765,7 +802,7 @@ def kernel := ⟦
                     let mk_len = list_length(mk_spine);
                     let no_args = eq_zero(mk_len - 3);
                     match no_args {
-                      1 => store(KValNode.Const(idx, store(lvls), store(spine))),
+                      1 => store(KValNode.Quot(idx, store(lvls), store(spine))),
                       0 =>
                         let quot_val_idx = mk_len - 1;
                         let quot_val = list_lookup(mk_spine, quot_val_idx);
@@ -777,11 +814,11 @@ def kernel := ⟦
                         let result2 = k_apply_spine(result, remaining, top);
                         k_whnf(result2, top),
                     },
-                  _ => store(KValNode.Const(idx, store(lvls), store(spine))),
+                  _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
                 },
-              _ => store(KValNode.Const(idx, store(lvls), store(spine))),
+              _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
             },
-          _ => store(KValNode.Const(idx, store(lvls), store(spine))),
+          _ => store(KValNode.Quot(idx, store(lvls), store(spine))),
         },
     }
   }
@@ -816,43 +853,47 @@ def kernel := ⟦
             store(KValNode.Proj(tidx, fidx, sv2, store(spine))),
         },
 
-      KValNode.Const(idx, &lvls, &spine) =>
-        -- First try iota reduction (recursor on constructor)
+      KValNode.Rec(idx, &lvls, &spine) =>
         let result = try_iota(idx, lvls, spine, top);
         match load(result) {
-          KValNode.Const(idx2, &lvls2, &spine2) =>
-            let same = eq_zero(idx - idx2);
-            match same {
-              0 => k_whnf(result, top),
-              1 =>
-                -- Iota didn't fire; try quotient, then delta
-                let ci = load(list_lookup(top, idx2));
-                match ci {
-                  KConstantInfo.Defn(_, _, &value, _) =>
-                    let body = expr_inst_levels(value, lvls2);
-                    let val = k_eval(body, List.Nil, top);
-                    let val2 = k_apply_spine(val, spine2, top);
-                    k_whnf(val2, top),
-                  KConstantInfo.Thm(_, _, &value) =>
-                    let body = expr_inst_levels(value, lvls2);
-                    let val = k_eval(body, List.Nil, top);
-                    let val2 = k_apply_spine(val, spine2, top);
-                    k_whnf(val2, top),
-                  -- Quot.lift: spine has [α, r, β, f, h, ⟨Quot.mk r a⟩, extra...]
-                  -- Quot.ind: spine has [α, r, motive, f, ⟨Quot.mk r a⟩, extra...]
-                  -- Reduces to: f a extra...
-                  KConstantInfo.Quot(_, _, kind) =>
-                    match kind {
-                      QuotKind.Lift =>
-                        k_try_quot_reduction(idx2, lvls2, spine2, 6, 3, top),
-                      QuotKind.Ind =>
-                        k_try_quot_reduction(idx2, lvls2, spine2, 5, 3, top),
-                      _ => result,
-                    },
-                  _ => result,
-                },
-            },
+          KValNode.Rec(_, _, _) => result,
           _ => k_whnf(result, top),
+        },
+
+      KValNode.Defn(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        match ci {
+          KConstantInfo.Defn(_, _, &value, _) =>
+            let body = expr_inst_levels(value, lvls);
+            let val = k_eval(body, List.Nil, top);
+            let val2 = k_apply_spine(val, spine, top);
+            k_whnf(val2, top),
+        },
+
+      KValNode.Thm(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        match ci {
+          KConstantInfo.Thm(_, _, &value) =>
+            let body = expr_inst_levels(value, lvls);
+            let val = k_eval(body, List.Nil, top);
+            let val2 = k_apply_spine(val, spine, top);
+            k_whnf(val2, top),
+        },
+
+      -- Quot.lift: spine has [α, r, β, f, h, ⟨Quot.mk r a⟩, extra...]
+      -- Quot.ind: spine has [α, r, motive, f, ⟨Quot.mk r a⟩, extra...]
+      -- Reduces to: f a extra...
+      KValNode.Quot(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        match ci {
+          KConstantInfo.Quot(_, _, kind) =>
+            match kind {
+              QuotKind.Lift =>
+                k_try_quot_reduction(idx, lvls, spine, 6, 3, top),
+              QuotKind.Ind =>
+                k_try_quot_reduction(idx, lvls, spine, 5, 3, top),
+              _ => v,
+            },
         },
 
       _ => v,
@@ -904,7 +945,31 @@ def kernel := ⟦
         let base = store(KExprNode.BVar(idx));
         quote_spine(base, spine, depth, top),
 
-      KValNode.Const(idx, &lvls, &spine) =>
+      KValNode.Axiom(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
+        quote_spine(base, spine, depth, top),
+
+      KValNode.Defn(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
+        quote_spine(base, spine, depth, top),
+
+      KValNode.Thm(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
+        quote_spine(base, spine, depth, top),
+
+      KValNode.Opaque(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
+        quote_spine(base, spine, depth, top),
+
+      KValNode.Quot(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
+        quote_spine(base, spine, depth, top),
+
+      KValNode.Induct(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
+        quote_spine(base, spine, depth, top),
+
+      KValNode.Rec(idx, &lvls, &spine) =>
         let base = store(KExprNode.Const(idx, store(lvls)));
         quote_spine(base, spine, depth, top),
 
@@ -948,9 +1013,9 @@ def kernel := ⟦
       KExprNode.Lit(lit) =>
         match lit {
           KLiteral.Nat(_) =>
-            store(KValNode.Const(nat_idx, store(List.Nil), store(List.Nil))),
+            store(KValNode.Induct(nat_idx, store(List.Nil), store(List.Nil))),
           KLiteral.Str(_) =>
-            store(KValNode.Const(str_idx, store(List.Nil), store(List.Nil))),
+            store(KValNode.Induct(str_idx, store(List.Nil), store(List.Nil))),
         },
 
       KExprNode.Const(idx, &lvls) =>
@@ -1009,7 +1074,7 @@ def kernel := ⟦
         let struct_type = k_infer(e1, types, env, depth, top, nat_idx, str_idx);
         let struct_type_whnf = k_whnf(struct_type, top);
         match load(struct_type_whnf) {
-          KValNode.Const(induct_idx, &levels, &params_spine) =>
+          KValNode.Induct(induct_idx, &levels, &params_spine) =>
             -- Look up inductive to get its single constructor index
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
@@ -1137,10 +1202,46 @@ def kernel := ⟦
       KValNode.Srt(&l) => store(KValNode.Srt(store(KLevel.Succ(store(l))))),
       KValNode.Lit(lit) =>
         match lit {
-          KLiteral.Nat(_) => store(KValNode.Const(nat_idx, store(List.Nil), store(List.Nil))),
-          KLiteral.Str(_) => store(KValNode.Const(str_idx, store(List.Nil), store(List.Nil))),
+          KLiteral.Nat(_) => store(KValNode.Induct(nat_idx, store(List.Nil), store(List.Nil))),
+          KLiteral.Str(_) => store(KValNode.Induct(str_idx, store(List.Nil), store(List.Nil))),
         },
-      KValNode.Const(idx, &lvls, &spine) =>
+      KValNode.Axiom(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        let ty = const_type(ci);
+        let ty_inst = expr_inst_levels(ty, lvls);
+        let ty_val = k_eval(ty_inst, List.Nil, top);
+        apply_spine_to_type(ty_val, spine, top),
+      KValNode.Defn(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        let ty = const_type(ci);
+        let ty_inst = expr_inst_levels(ty, lvls);
+        let ty_val = k_eval(ty_inst, List.Nil, top);
+        apply_spine_to_type(ty_val, spine, top),
+      KValNode.Thm(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        let ty = const_type(ci);
+        let ty_inst = expr_inst_levels(ty, lvls);
+        let ty_val = k_eval(ty_inst, List.Nil, top);
+        apply_spine_to_type(ty_val, spine, top),
+      KValNode.Opaque(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        let ty = const_type(ci);
+        let ty_inst = expr_inst_levels(ty, lvls);
+        let ty_val = k_eval(ty_inst, List.Nil, top);
+        apply_spine_to_type(ty_val, spine, top),
+      KValNode.Quot(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        let ty = const_type(ci);
+        let ty_inst = expr_inst_levels(ty, lvls);
+        let ty_val = k_eval(ty_inst, List.Nil, top);
+        apply_spine_to_type(ty_val, spine, top),
+      KValNode.Induct(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        let ty = const_type(ci);
+        let ty_inst = expr_inst_levels(ty, lvls);
+        let ty_val = k_eval(ty_inst, List.Nil, top);
+        apply_spine_to_type(ty_val, spine, top),
+      KValNode.Rec(idx, &lvls, &spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
@@ -1156,7 +1257,7 @@ def kernel := ⟦
         let struct_type = k_infer_val_type(sv, top, nat_idx, str_idx);
         let struct_type_whnf = k_whnf(struct_type, top);
         match load(struct_type_whnf) {
-          KValNode.Const(induct_idx, &levels, &params_spine) =>
+          KValNode.Induct(induct_idx, &levels, &params_spine) =>
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
               KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
@@ -1273,7 +1374,7 @@ def kernel := ⟦
   fn is_unit_like_type(ty: KVal, top: List‹&KConstantInfo›) -> G {
     let ty_whnf = k_whnf(ty, top);
     match load(ty_whnf) {
-      KValNode.Const(induct_idx, _, _) =>
+      KValNode.Induct(induct_idx, _, _) =>
         let ci = load(list_lookup(top, induct_idx));
         match ci {
           KConstantInfo.Induct(_, _, _, nindices, &ctor_indices, _, _, _) =>
@@ -1518,20 +1619,114 @@ def kernel := ⟦
               _ => 0,
             },
 
-          KValNode.Const(idx_a, &lvls_a, &sp_a) =>
+          KValNode.Axiom(idx_a, &lvls_a, &sp_a) =>
             match load(b) {
-              KValNode.Const(idx_b, &lvls_b, &sp_b) =>
+              KValNode.Axiom(idx_b, &lvls_b, &sp_b) =>
                 let same_idx = eq_zero(idx_a - idx_b);
                 match same_idx {
                   1 =>
                     let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
                     match lvls_eq {
-                      1 =>
-                        k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
                       0 => 0,
                     },
-                  0 =>
-                    k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                  0 => 0,
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Defn(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Defn(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Thm(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Thm(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Opaque(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Opaque(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => 0,
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Quot(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Quot(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => 0,
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Induct(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Induct(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => 0,
+                },
+              _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+            },
+
+          KValNode.Rec(idx_a, &lvls_a, &sp_a) =>
+            match load(b) {
+              KValNode.Rec(idx_b, &lvls_b, &sp_b) =>
+                let same_idx = eq_zero(idx_a - idx_b);
+                match same_idx {
+                  1 =>
+                    let lvls_eq = k_is_def_eq_levels(lvls_a, lvls_b);
+                    match lvls_eq {
+                      1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
+                      0 => 0,
+                    },
+                  0 => 0,
                 },
               _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
             },
@@ -1619,7 +1814,19 @@ def kernel := ⟦
                 let env_b2 = List.Cons(fvar, store(env_b));
                 let vb = k_eval(body_b, env_b2, top);
                 k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
-              KValNode.Const(_, _, _) =>
+              KValNode.Axiom(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              KValNode.Defn(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              KValNode.Thm(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              KValNode.Opaque(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              KValNode.Quot(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              KValNode.Induct(_, _, _) =>
+                k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
+              KValNode.Rec(_, _, _) =>
                 k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
               _ => 0,
             },
@@ -1685,18 +1892,21 @@ def kernel := ⟦
   -- returns the original value if it is opaque or not a definition
   fn try_delta_unfold(v: KVal, top: List‹&KConstantInfo›) -> KVal {
     match load(v) {
-      KValNode.Const(idx, &lvls, &spine) =>
+      KValNode.Defn(idx, &lvls, &spine) =>
         let ci = load(list_lookup(top, idx));
         match ci {
           KConstantInfo.Defn(_, _, &value, _) =>
             let body = expr_inst_levels(value, lvls);
             let val = k_eval(body, List.Nil, top);
             k_apply_spine(val, spine, top),
+        },
+      KValNode.Thm(idx, &lvls, &spine) =>
+        let ci = load(list_lookup(top, idx));
+        match ci {
           KConstantInfo.Thm(_, _, &value) =>
             let body = expr_inst_levels(value, lvls);
             let val = k_eval(body, List.Nil, top);
             k_apply_spine(val, spine, top),
-          _ => v,
         },
       _ => v,
     }
@@ -1705,9 +1915,14 @@ def kernel := ⟦
   -- Check whether delta unfolding made progress (i.e., the head constant changed)
   fn delta_changed(before: KVal, after: KVal) -> G {
     match load(before) {
-      KValNode.Const(idx_a, _, _) =>
+      KValNode.Defn(idx_a, _, _) =>
         match load(after) {
-          KValNode.Const(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
+          KValNode.Defn(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
+          _ => 1,
+        },
+      KValNode.Thm(idx_a, _, _) =>
+        match load(after) {
+          KValNode.Thm(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
           _ => 1,
         },
       _ => 0,

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -449,26 +449,26 @@ def kernel := ⟦
 
   -- Substitute all Level.Param(i) -> params[i] in all levels within an expression
   fn expr_inst_levels(e: KExpr, params: List‹&KLevel›) -> KExpr {
-    match e {
-      KExpr.BVar(i) => KExpr.BVar(i),
-      KExpr.Srt(&l) =>
-        KExpr.Srt(store(level_inst_params(l, params))),
-      KExpr.Const(idx, &lvls) =>
-        KExpr.Const(idx, store(level_list_inst(lvls, params))),
-      KExpr.App(&f, &a) =>
-        KExpr.App(store(expr_inst_levels(f, params)), store(expr_inst_levels(a, params))),
-      KExpr.Lam(&ty, &body) =>
-        KExpr.Lam(store(expr_inst_levels(ty, params)), store(expr_inst_levels(body, params))),
-      KExpr.Forall(&ty, &body) =>
-        KExpr.Forall(store(expr_inst_levels(ty, params)), store(expr_inst_levels(body, params))),
-      KExpr.Let(&ty, &val, &body) =>
-        KExpr.Let(
-          store(expr_inst_levels(ty, params)),
-          store(expr_inst_levels(val, params)),
-          store(expr_inst_levels(body, params))),
-      KExpr.Lit(lit) => KExpr.Lit(lit),
-      KExpr.Proj(tidx, fidx, &e1) =>
-        KExpr.Proj(tidx, fidx, store(expr_inst_levels(e1, params))),
+    match load(e) {
+      KExprNode.BVar(i) => store(KExprNode.BVar(i)),
+      KExprNode.Srt(&l) =>
+        store(KExprNode.Srt(store(level_inst_params(l, params)))),
+      KExprNode.Const(idx, &lvls) =>
+        store(KExprNode.Const(idx, store(level_list_inst(lvls, params)))),
+      KExprNode.App(f, a) =>
+        store(KExprNode.App(expr_inst_levels(f, params), expr_inst_levels(a, params))),
+      KExprNode.Lam(ty, body) =>
+        store(KExprNode.Lam(expr_inst_levels(ty, params), expr_inst_levels(body, params))),
+      KExprNode.Forall(ty, body) =>
+        store(KExprNode.Forall(expr_inst_levels(ty, params), expr_inst_levels(body, params))),
+      KExprNode.Let(ty, val, body) =>
+        store(KExprNode.Let(
+          expr_inst_levels(ty, params),
+          expr_inst_levels(val, params),
+          expr_inst_levels(body, params))),
+      KExprNode.Lit(lit) => store(KExprNode.Lit(lit)),
+      KExprNode.Proj(tidx, fidx, e1) =>
+        store(KExprNode.Proj(tidx, fidx, expr_inst_levels(e1, params))),
     }
   }
 
@@ -495,60 +495,60 @@ def kernel := ⟦
 
   -- Force a thunk: if it's a Thunk, evaluate it; otherwise return as-is
   fn k_force(v: KVal, top: List‹&KConstantInfo›) -> KVal {
-    match v {
-      KVal.Thunk(&e, &env) => k_eval(e, env, top),
+    match load(v) {
+      KValNode.Thunk(e, &env) => k_eval(e, env, top),
       _ => v,
     }
   }
 
   -- Evaluate an expression to a value using Normalization by Evaluation (NbE)
   fn k_eval(e: KExpr, env: KValEnv, top: List‹&KConstantInfo›) -> KVal {
-    match e {
-      KExpr.BVar(idx) =>
-        load(list_lookup(env, idx)),
+    match load(e) {
+      KExprNode.BVar(idx) =>
+        list_lookup(env, idx),
 
-      KExpr.Srt(&l) =>
-        KVal.Srt(store(level_reduce(l))),
+      KExprNode.Srt(&l) =>
+        store(KValNode.Srt(store(level_reduce(l)))),
 
       -- Lazy: no definition unfolding during eval, deferred to WHNF
-      KExpr.Const(idx, &lvls) =>
+      KExprNode.Const(idx, &lvls) =>
         let ci = load(list_lookup(top, idx));
         match ci {
           KConstantInfo.Ctor(_, _, _, _, nparams, _, _) =>
-            KVal.Ctor(idx, store(lvls), nparams, store(List.Nil)),
-          _ => KVal.Const(idx, store(lvls), store(List.Nil)),
+            store(KValNode.Ctor(idx, store(lvls), nparams, store(List.Nil))),
+          _ => store(KValNode.Const(idx, store(lvls), store(List.Nil))),
         },
 
-      KExpr.App(&f, &a) =>
+      KExprNode.App(f, a) =>
         let vf = k_eval(f, env, top);
         let arg = suspend(a, env);
         k_apply(vf, arg, top),
 
-      KExpr.Lam(&ty, &body) =>
+      KExprNode.Lam(ty, body) =>
         let ty_val = suspend(ty, env);
-        KVal.Lam(store(ty_val), store(body), store(env)),
+        store(KValNode.Lam(ty_val, body, store(env))),
 
-      KExpr.Forall(&ty, &body) =>
+      KExprNode.Forall(ty, body) =>
         let ty_val = suspend(ty, env);
-        KVal.Pi(store(ty_val), store(body), store(env)),
+        store(KValNode.Pi(ty_val, body, store(env))),
 
-      KExpr.Let(_, &val, &body) =>
+      KExprNode.Let(_, val, body) =>
         let v = k_eval(val, env, top);
-        let env2 = List.Cons(store(v), store(env));
+        let env2 = List.Cons(v, store(env));
         k_eval(body, env2, top),
 
-      KExpr.Lit(lit) =>
-        KVal.Lit(lit),
+      KExprNode.Lit(lit) =>
+        store(KValNode.Lit(lit)),
 
-      KExpr.Proj(tidx, fidx, &e1) =>
+      KExprNode.Proj(tidx, fidx, e1) =>
         let v = k_eval(e1, env, top);
-        match v {
-          KVal.Ctor(_, _, nparams, &spine) =>
+        match load(v) {
+          KValNode.Ctor(_, _, nparams, &spine) =>
             let field_idx = nparams + fidx;
-            let field = load(list_lookup(spine, field_idx));
+            let field = list_lookup(spine, field_idx);
             k_force(field, top),
           _ =>
-            KVal.Proj(tidx, fidx, store(v), store(List.Nil)),
+            store(KValNode.Proj(tidx, fidx, v, store(List.Nil))),
         },
     }
   }
@@ -556,49 +556,49 @@ def kernel := ⟦
   -- Suspend an expression: evaluate immediately for cheap/structural forms
   -- (BVar lookup, Srt, Lit, Lam closure, Pi closure); otherwise defer to a thunk.
   fn suspend(e: KExpr, env: KValEnv) -> KVal {
-    match e {
-      KExpr.BVar(idx) =>
-        load(list_lookup(env, idx)),
-      KExpr.Srt(&l) =>
-        KVal.Srt(store(level_reduce(l))),
-      KExpr.Lit(lit) =>
-        KVal.Lit(lit),
-      KExpr.Lam(&ty, &body) =>
+    match load(e) {
+      KExprNode.BVar(idx) =>
+        list_lookup(env, idx),
+      KExprNode.Srt(&l) =>
+        store(KValNode.Srt(store(level_reduce(l)))),
+      KExprNode.Lit(lit) =>
+        store(KValNode.Lit(lit)),
+      KExprNode.Lam(ty, body) =>
         let ty_val = suspend(ty, env);
-        KVal.Lam(store(ty_val), store(body), store(env)),
-      KExpr.Forall(&ty, &body) =>
+        store(KValNode.Lam(ty_val, body, store(env))),
+      KExprNode.Forall(ty, body) =>
         let ty_val = suspend(ty, env);
-        KVal.Pi(store(ty_val), store(body), store(env)),
+        store(KValNode.Pi(ty_val, body, store(env))),
       _ =>
-        KVal.Thunk(store(e), store(env)),
+        store(KValNode.Thunk(e, store(env))),
     }
   }
 
   -- Apply a value to an argument (lazy: arg may be a thunk)
   fn k_apply(f: KVal, arg: KVal, top: List‹&KConstantInfo›) -> KVal {
-    match f {
-      KVal.Lam(_, &body, &env) =>
+    match load(f) {
+      KValNode.Lam(_, body, &env) =>
         let arg_forced = k_force(arg, top);
-        let env2 = List.Cons(store(arg_forced), store(env));
+        let env2 = List.Cons(arg_forced, store(env));
         k_eval(body, env2, top),
 
-      KVal.Ctor(idx, &lvls, nparams, &spine) =>
-        let spine2 = list_snoc(spine, store(arg));
-        KVal.Ctor(idx, store(lvls), nparams, store(spine2)),
+      KValNode.Ctor(idx, &lvls, nparams, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Ctor(idx, store(lvls), nparams, store(spine2))),
 
-      KVal.FVar(lvl, &fvar_ty, &spine) =>
-        let spine2 = list_snoc(spine, store(arg));
-        KVal.FVar(lvl, store(fvar_ty), store(spine2)),
+      KValNode.FVar(lvl, fvar_ty, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.FVar(lvl, fvar_ty, store(spine2))),
 
-      KVal.Const(idx, &lvls, &spine) =>
-        let spine2 = list_snoc(spine, store(arg));
-        KVal.Const(idx, store(lvls), store(spine2)),
+      KValNode.Const(idx, &lvls, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Const(idx, store(lvls), store(spine2))),
 
-      KVal.Proj(tidx, fidx, &sv, &spine) =>
-        let spine2 = list_snoc(spine, store(arg));
-        KVal.Proj(tidx, fidx, store(sv), store(spine2)),
+      KValNode.Proj(tidx, fidx, sv, &spine) =>
+        let spine2 = list_snoc(spine, arg);
+        store(KValNode.Proj(tidx, fidx, sv, store(spine2))),
 
-      KVal.Thunk(&e, &env) =>
+      KValNode.Thunk(e, &env) =>
         let v = k_eval(e, env, top);
         k_apply(v, arg, top),
 
@@ -606,10 +606,10 @@ def kernel := ⟦
   }
 
   -- Apply a value to a list of arguments
-  fn k_apply_spine(f: KVal, spine: List‹&KVal›, top: List‹&KConstantInfo›) -> KVal {
+  fn k_apply_spine(f: KVal, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
     match spine {
       List.Nil => f,
-      List.Cons(&v, &rest) =>
+      List.Cons(v, &rest) =>
         let f2 = k_apply(f, v, top);
         k_apply_spine(f2, rest, top),
     }
@@ -634,7 +634,7 @@ def kernel := ⟦
 
   -- Try iota reduction: if idx refers to a recursor and the major premise is a
   -- constructor or Nat literal, apply the matching recursor rule; otherwise return a neutral VConst
-  fn try_iota(idx: G, lvls: List‹&KLevel›, spine: List‹&KVal›, top: List‹&KConstantInfo›) -> KVal {
+  fn try_iota(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
     let ci = load(list_lookup(top, idx));
     match ci {
       KConstantInfo.Rec(_, _, nparams, nindices, nmotives, nminors, &rules, k_flag, _) =>
@@ -642,16 +642,16 @@ def kernel := ⟦
         let spine_len = list_length(spine);
         let not_have_major = eq_zero(spine_len - maj_idx);
         match not_have_major {
-          1 => KVal.Const(idx, store(lvls), store(spine)),
+          1 => store(KValNode.Const(idx, store(lvls), store(spine))),
           0 =>
-            let major_raw = load(list_lookup(spine, maj_idx));
+            let major_raw = list_lookup(spine, maj_idx);
             let major = k_whnf(major_raw, top);
-            match major {
-              KVal.Ctor(ctor_idx, _, ctor_nparams, &ctor_spine) =>
+            match load(major) {
+              KValNode.Ctor(ctor_idx, _, ctor_nparams, &ctor_spine) =>
                 let rule_found = rec_rule_try_find(rules, ctor_idx);
                 match rule_found {
                   Option.None =>
-                    KVal.Const(idx, store(lvls), store(spine)),
+                    store(KValNode.Const(idx, store(lvls), store(spine))),
                   Option.Some(&rule) =>
                     match rule {
                       KRecRule.Mk(_, nfields, &rhs) =>
@@ -665,7 +665,7 @@ def kernel := ⟦
                         k_apply_spine(result2, remaining, top),
                     },
                 },
-              KVal.Lit(lit) =>
+              KValNode.Lit(lit) =>
                 match lit {
                   KLiteral.Nat(&n) =>
                     -- Nat literal iota: Lit(0) → zero rule, Lit(n+1) → succ rule with Lit(n)
@@ -701,8 +701,8 @@ def kernel := ⟦
                                 let rhs_val = k_eval(rhs_inst, List.Nil, top);
                                 let pmm = list_take(spine, pmm_end);
                                 let result = k_apply_spine(rhs_val, pmm, top);
-                                let pred = KVal.Lit(KLiteral.Nat(store(klimbs_pred(n))));
-                                let ctor_fields = List.Cons(store(pred), store(List.Nil));
+                                let pred = store(KValNode.Lit(KLiteral.Nat(store(klimbs_pred(n)))));
+                                let ctor_fields = List.Cons(pred, store(List.Nil));
                                 let result2 = k_apply_spine(result, ctor_fields, top);
                                 let remaining = list_drop(spine, maj_idx + 1);
                                 k_apply_spine(result2, remaining, top),
@@ -710,7 +710,7 @@ def kernel := ⟦
                         },
                     },
                   KLiteral.Str(_) =>
-                    KVal.Const(idx, store(lvls), store(spine)),
+                    store(KValNode.Const(idx, store(lvls), store(spine))),
                 },
               _ =>
                 -- K-reduction: for proof-irrelevant (Prop) inductives with k_flag set,
@@ -718,18 +718,18 @@ def kernel := ⟦
                 match k_flag {
                   0 =>
                     -- Not a K-recursor, return stuck
-                    KVal.Const(idx, store(lvls), store(spine)),
+                    store(KValNode.Const(idx, store(lvls), store(spine))),
                   _ =>
                     -- K-reduction fires: minor is at nparams + nmotives
                     let minor_idx = nparams + nmotives;
-                    let minor = load(list_lookup(spine, minor_idx));
+                    let minor = list_lookup(spine, minor_idx);
                     let remaining = list_drop(spine, maj_idx + 1);
                     k_apply_spine(minor, remaining, top),
                 },
             },
         },
 
-      _ => KVal.Const(idx, store(lvls), store(spine)),
+      _ => store(KValNode.Const(idx, store(lvls), store(spine))),
     }
   }
 
@@ -742,20 +742,20 @@ def kernel := ⟦
   -- reduce_size is the minimum spine length, f_pos is the index of f in the spine.
   -- Returns 1 and reduced value via k_whnf if successful, 0 otherwise.
   -- The idx/lvls/spine are passed through for reconstructing the stuck value on failure.
-  fn k_try_quot_reduction(idx: G, lvls: List‹&KLevel›, spine: List‹&KVal›,
+  fn k_try_quot_reduction(idx: G, lvls: List‹&KLevel›, spine: List‹KVal›,
       reduce_size: G, f_pos: G, top: List‹&KConstantInfo›) -> KVal {
     let spine_len = list_length(spine);
     let not_enough = eq_zero(spine_len - reduce_size);
     match not_enough {
-      1 => KVal.Const(idx, store(lvls), store(spine)),
+      1 => store(KValNode.Const(idx, store(lvls), store(spine))),
       0 =>
         -- Force and WHNF the major arg (last of the reduce_size args)
         let major_idx = reduce_size - 1;
-        let major_raw = load(list_lookup(spine, major_idx));
+        let major_raw = list_lookup(spine, major_idx);
         let major = k_whnf(major_raw, top);
         -- Check if major is a Quot.mk application (a Const with QuotKind.Ctor)
-        match major {
-          KVal.Const(mk_idx, _, &mk_spine) =>
+        match load(major) {
+          KValNode.Const(mk_idx, _, &mk_spine) =>
             let mk_ci = load(list_lookup(top, mk_idx));
             match mk_ci {
               KConstantInfo.Quot(_, _, mk_kind) =>
@@ -766,23 +766,23 @@ def kernel := ⟦
                     let mk_len = list_length(mk_spine);
                     let no_args = eq_zero(mk_len - 3);
                     match no_args {
-                      1 => KVal.Const(idx, store(lvls), store(spine)),
+                      1 => store(KValNode.Const(idx, store(lvls), store(spine))),
                       0 =>
                         let quot_val_idx = mk_len - 1;
-                        let quot_val = load(list_lookup(mk_spine, quot_val_idx));
+                        let quot_val = list_lookup(mk_spine, quot_val_idx);
                         -- Apply f (at f_pos) to the quotient value
-                        let f_val = k_force(load(list_lookup(spine, f_pos)), top);
+                        let f_val = k_force(list_lookup(spine, f_pos), top);
                         let result = k_apply(f_val, quot_val, top);
                         -- Apply remaining spine args after reduce_size
                         let remaining = list_drop(spine, reduce_size);
                         let result2 = k_apply_spine(result, remaining, top);
                         k_whnf(result2, top),
                     },
-                  _ => KVal.Const(idx, store(lvls), store(spine)),
+                  _ => store(KValNode.Const(idx, store(lvls), store(spine))),
                 },
-              _ => KVal.Const(idx, store(lvls), store(spine)),
+              _ => store(KValNode.Const(idx, store(lvls), store(spine))),
             },
-          _ => KVal.Const(idx, store(lvls), store(spine)),
+          _ => store(KValNode.Const(idx, store(lvls), store(spine))),
         },
     }
   }
@@ -799,29 +799,29 @@ def kernel := ⟦
   -- Reduce a value to Weak Head Normal Form by retrying projection, iota, and delta reductions
 
   fn k_whnf(v: KVal, top: List‹&KConstantInfo›) -> KVal {
-    match v {
-      KVal.Thunk(&e, &env) =>
+    match load(v) {
+      KValNode.Thunk(e, &env) =>
         let val = k_eval(e, env, top);
         k_whnf(val, top),
 
-      KVal.Proj(tidx, fidx, &sv, &spine) =>
+      KValNode.Proj(tidx, fidx, sv, &spine) =>
         let sv2 = k_whnf(sv, top);
-        match sv2 {
-          KVal.Ctor(_, _, nparams, &ctor_spine) =>
+        match load(sv2) {
+          KValNode.Ctor(_, _, nparams, &ctor_spine) =>
             let field_idx = nparams + fidx;
-            let field = load(list_lookup(ctor_spine, field_idx));
+            let field = list_lookup(ctor_spine, field_idx);
             let field_forced = k_force(field, top);
             let result = k_apply_spine(field_forced, spine, top);
             k_whnf(result, top),
           _ =>
-            KVal.Proj(tidx, fidx, store(sv2), store(spine)),
+            store(KValNode.Proj(tidx, fidx, sv2, store(spine))),
         },
 
-      KVal.Const(idx, &lvls, &spine) =>
+      KValNode.Const(idx, &lvls, &spine) =>
         -- First try iota reduction (recursor on constructor)
         let result = try_iota(idx, lvls, spine, top);
-        match result {
-          KVal.Const(idx2, &lvls2, &spine2) =>
+        match load(result) {
+          KValNode.Const(idx2, &lvls2, &spine2) =>
             let same = eq_zero(idx - idx2);
             match same {
               0 => k_whnf(result, top),
@@ -875,58 +875,58 @@ def kernel := ⟦
   -- Quote a value back into an expression (readback), converting free variables
   -- to de Bruijn indices relative to the current depth
   fn k_quote(v: KVal, depth: G, top: List‹&KConstantInfo›) -> KExpr {
-    match v {
-      KVal.Thunk(&e, &env) =>
+    match load(v) {
+      KValNode.Thunk(e, &env) =>
         let val = k_eval(e, env, top);
         k_quote(val, depth, top),
 
-      KVal.Srt(&l) => KExpr.Srt(store(l)),
+      KValNode.Srt(&l) => store(KExprNode.Srt(store(l))),
 
-      KVal.Lit(lit) => KExpr.Lit(lit),
+      KValNode.Lit(lit) => store(KExprNode.Lit(lit)),
 
-      KVal.Lam(&dom, &body, &env) =>
+      KValNode.Lam(dom, body, &env) =>
         let dom_expr = k_quote(dom, depth, top);
-        let fvar = KVal.FVar(depth, store(dom), store(List.Nil));
-        let env2 = List.Cons(store(fvar), store(env));
+        let fvar = store(KValNode.FVar(depth, dom, store(List.Nil)));
+        let env2 = List.Cons(fvar, store(env));
         let body_val = k_eval(body, env2, top);
         let body_expr = k_quote(body_val, depth + 1, top);
-        KExpr.Lam(store(dom_expr), store(body_expr)),
+        store(KExprNode.Lam(dom_expr, body_expr)),
 
-      KVal.Pi(&dom, &body, &env) =>
+      KValNode.Pi(dom, body, &env) =>
         let dom_expr = k_quote(dom, depth, top);
-        let fvar = KVal.FVar(depth, store(dom), store(List.Nil));
-        let env2 = List.Cons(store(fvar), store(env));
+        let fvar = store(KValNode.FVar(depth, dom, store(List.Nil)));
+        let env2 = List.Cons(fvar, store(env));
         let body_val = k_eval(body, env2, top);
         let body_expr = k_quote(body_val, depth + 1, top);
-        KExpr.Forall(store(dom_expr), store(body_expr)),
+        store(KExprNode.Forall(dom_expr, body_expr)),
 
-      KVal.Ctor(idx, &lvls, _, &spine) =>
-        let base = KExpr.Const(idx, store(lvls));
+      KValNode.Ctor(idx, &lvls, _, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
         quote_spine(base, spine, depth, top),
 
-      KVal.FVar(lvl, &fvar_ty, &spine) =>
+      KValNode.FVar(lvl, _, &spine) =>
         let idx = (depth - 1) - lvl;
-        let base = KExpr.BVar(idx);
+        let base = store(KExprNode.BVar(idx));
         quote_spine(base, spine, depth, top),
 
-      KVal.Const(idx, &lvls, &spine) =>
-        let base = KExpr.Const(idx, store(lvls));
+      KValNode.Const(idx, &lvls, &spine) =>
+        let base = store(KExprNode.Const(idx, store(lvls)));
         quote_spine(base, spine, depth, top),
 
-      KVal.Proj(tidx, fidx, &sv, &spine) =>
+      KValNode.Proj(tidx, fidx, sv, &spine) =>
         let sv_expr = k_quote(sv, depth, top);
-        let base = KExpr.Proj(tidx, fidx, store(sv_expr));
+        let base = store(KExprNode.Proj(tidx, fidx, sv_expr));
         quote_spine(base, spine, depth, top),
     }
   }
 
   -- Quote a spine of arguments, wrapping each in an EApp around the base expression
-  fn quote_spine(base: KExpr, spine: List‹&KVal›, depth: G, top: List‹&KConstantInfo›) -> KExpr {
+  fn quote_spine(base: KExpr, spine: List‹KVal›, depth: G, top: List‹&KConstantInfo›) -> KExpr {
     match spine {
       List.Nil => base,
-      List.Cons(&v, &rest) =>
+      List.Cons(v, &rest) =>
         let arg_expr = k_quote(v, depth, top);
-        let app = KExpr.App(store(base), store(arg_expr));
+        let app = store(KExprNode.App(base, arg_expr));
         quote_spine(app, rest, depth, top),
     }
   }
@@ -942,23 +942,23 @@ def kernel := ⟦
 
   -- Infer the type of an expression under the given type and value environments.
   -- nat_idx/str_idx are the constant indices for the Nat/String types (for literal typing).
-  fn k_infer(e: KExpr, types: List‹&KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KVal {
-    match e {
-      KExpr.BVar(idx) =>
-        load(list_lookup(types, idx)),
+  fn k_infer(e: KExpr, types: List‹KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KVal {
+    match load(e) {
+      KExprNode.BVar(idx) =>
+        list_lookup(types, idx),
 
-      KExpr.Srt(&l) =>
-        KVal.Srt(store(KLevel.Succ(store(l)))),
+      KExprNode.Srt(&l) =>
+        store(KValNode.Srt(store(KLevel.Succ(store(l))))),
 
-      KExpr.Lit(lit) =>
+      KExprNode.Lit(lit) =>
         match lit {
           KLiteral.Nat(_) =>
-            KVal.Const(nat_idx, store(List.Nil), store(List.Nil)),
+            store(KValNode.Const(nat_idx, store(List.Nil), store(List.Nil))),
           KLiteral.Str(_) =>
-            KVal.Const(str_idx, store(List.Nil), store(List.Nil)),
+            store(KValNode.Const(str_idx, store(List.Nil), store(List.Nil))),
         },
 
-      KExpr.Const(idx, &lvls) =>
+      KExprNode.Const(idx, &lvls) =>
         let ci = load(list_lookup(top, idx));
         let expected = const_num_levels(ci);
         let given = list_length(lvls);
@@ -968,53 +968,53 @@ def kernel := ⟦
         let ty_inst = expr_inst_levels(ty, lvls);
         k_eval(ty_inst, List.Nil, top),
 
-      KExpr.App(&f, &a) =>
+      KExprNode.App(f, a) =>
         let fn_type = k_infer(f, types, env, depth, top, nat_idx, str_idx);
         let fn_type_whnf = k_whnf(fn_type, top);
 
-        match fn_type_whnf {
-          KVal.Pi(&dom, &body, &pi_env) =>
+        match load(fn_type_whnf) {
+          KValNode.Pi(dom, body, &pi_env) =>
             let _ = k_check(a, dom, types, env, depth, top, nat_idx, str_idx);
             let arg_val = k_eval(a, env, top);
-            let pi_env2 = List.Cons(store(arg_val), store(pi_env));
+            let pi_env2 = List.Cons(arg_val, store(pi_env));
             k_eval(body, pi_env2, top),
         },
 
-      KExpr.Lam(&ty, &body) =>
+      KExprNode.Lam(ty, body) =>
         let _ = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let dom_val = k_eval(ty, env, top);
-        let fvar = KVal.FVar(depth, store(dom_val), store(List.Nil));
-        let types2 = List.Cons(store(dom_val), store(types));
-        let env2 = List.Cons(store(fvar), store(env));
+        let fvar = store(KValNode.FVar(depth, dom_val, store(List.Nil)));
+        let types2 = List.Cons(dom_val, store(types));
+        let env2 = List.Cons(fvar, store(env));
         let body_type = k_infer(body, types2, env2, depth + 1, top, nat_idx, str_idx);
         let body_type_expr = k_quote(body_type, depth + 1, top);
-        KVal.Pi(store(dom_val), store(body_type_expr), store(env)),
+        store(KValNode.Pi(dom_val, body_type_expr, store(env))),
 
-      KExpr.Forall(&ty, &body) =>
+      KExprNode.Forall(ty, body) =>
         let dom_level = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let dom_val = k_eval(ty, env, top);
-        let fvar = KVal.FVar(depth, store(dom_val), store(List.Nil));
-        let types2 = List.Cons(store(dom_val), store(types));
-        let env2 = List.Cons(store(fvar), store(env));
+        let fvar = store(KValNode.FVar(depth, dom_val, store(List.Nil)));
+        let types2 = List.Cons(dom_val, store(types));
+        let env2 = List.Cons(fvar, store(env));
         let body_level = k_ensure_sort(body, types2, env2, depth + 1, top, nat_idx, str_idx);
         let result_level = level_imax(dom_level, body_level);
-        KVal.Srt(store(result_level)),
+        store(KValNode.Srt(store(result_level))),
 
-      KExpr.Let(&ty, &val, &body) =>
+      KExprNode.Let(ty, val, body) =>
         let _ = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let ty_val = k_eval(ty, env, top);
         let _ = k_check(val, ty_val, types, env, depth, top, nat_idx, str_idx);
         let val_val = k_eval(val, env, top);
-        let types2 = List.Cons(store(ty_val), store(types));
-        let env2 = List.Cons(store(val_val), store(env));
+        let types2 = List.Cons(ty_val, store(types));
+        let env2 = List.Cons(val_val, store(env));
         k_infer(body, types2, env2, depth + 1, top, nat_idx, str_idx),
 
-      KExpr.Proj(tidx, fidx, &e1) =>
+      KExprNode.Proj(tidx, fidx, e1) =>
         -- Infer struct type and WHNF to expose inductive head
         let struct_type = k_infer(e1, types, env, depth, top, nat_idx, str_idx);
         let struct_type_whnf = k_whnf(struct_type, top);
-        match struct_type_whnf {
-          KVal.Const(induct_idx, &levels, &params_spine) =>
+        match load(struct_type_whnf) {
+          KValNode.Const(induct_idx, &levels, &params_spine) =>
             -- Look up inductive to get its single constructor index
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
@@ -1032,8 +1032,8 @@ def kernel := ⟦
                 let after_fields = walk_fields(after_params, tidx, 0, fidx, struct_val, top);
                 -- Extract the domain type at field fidx
                 let result_whnf = k_whnf(after_fields, top);
-                match result_whnf {
-                  KVal.Pi(&dom, _, _) => dom,
+                match load(result_whnf) {
+                  KValNode.Pi(dom, _, _) => dom,
                 },
             },
         },
@@ -1042,21 +1042,21 @@ def kernel := ⟦
 
   -- Bidirectional type checking: check term against expected type.
   -- For Lambda against Pi, pushes the codomain through instead of independently inferring.
-  fn k_check(e: KExpr, expected: KVal, types: List‹&KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) {
-    match e {
-      KExpr.Lam(&ty, &body) =>
+  fn k_check(e: KExpr, expected: KVal, types: List‹KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) {
+    match load(e) {
+      KExprNode.Lam(ty, body) =>
         let expected_whnf = k_whnf(expected, top);
-        match expected_whnf {
-          KVal.Pi(&pi_dom, &pi_body, &pi_env) =>
+        match load(expected_whnf) {
+          KValNode.Pi(pi_dom, pi_body, &pi_env) =>
             -- Check domain matches
             let dom_val = k_eval(ty, env, top);
             let dom_eq = k_is_def_eq(dom_val, pi_dom, depth, top, nat_idx, str_idx);
             assert_eq!(dom_eq, 1);
             -- Push Pi codomain through Lambda body
-            let fvar = KVal.FVar(depth, store(pi_dom), store(List.Nil));
-            let types2 = List.Cons(store(pi_dom), store(types));
-            let env2 = List.Cons(store(fvar), store(env));
-            let pi_env2 = List.Cons(store(fvar), store(pi_env));
+            let fvar = store(KValNode.FVar(depth, pi_dom, store(List.Nil)));
+            let types2 = List.Cons(pi_dom, store(types));
+            let env2 = List.Cons(fvar, store(env));
+            let pi_env2 = List.Cons(fvar, store(pi_env));
             let expected_body = k_eval(pi_body, pi_env2, top);
             k_check(body, expected_body, types2, env2, depth + 1, top, nat_idx, str_idx),
         },
@@ -1069,24 +1069,24 @@ def kernel := ⟦
   }
 
   -- Ensure a type expression evaluates to a Sort, returning the level
-  fn k_ensure_sort(e: KExpr, types: List‹&KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KLevel {
+  fn k_ensure_sort(e: KExpr, types: List‹KVal›, env: KValEnv, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KLevel {
     let ty = k_infer(e, types, env, depth, top, nat_idx, str_idx);
     let ty_whnf = k_whnf(ty, top);
-    match ty_whnf {
-      KVal.Srt(&l) => l,
+    match load(ty_whnf) {
+      KValNode.Srt(&l) => l,
     }
   }
 
   -- Walk past n Pi binders, substituting param values from the spine
-  fn walk_params(ct: KVal, params: List‹&KVal›, top: List‹&KConstantInfo›) -> KVal {
+  fn walk_params(ct: KVal, params: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
     match params {
       List.Nil => ct,
-      List.Cons(&param_val, &rest_params) =>
+      List.Cons(param_val, &rest_params) =>
         let param_forced = k_force(param_val, top);
         let ct_whnf = k_whnf(ct, top);
-        match ct_whnf {
-          KVal.Pi(_, &body, &pi_env) =>
-            let env2 = List.Cons(store(param_forced), store(pi_env));
+        match load(ct_whnf) {
+          KValNode.Pi(_, body, &pi_env) =>
+            let env2 = List.Cons(param_forced, store(pi_env));
             let next = k_eval(body, env2, top);
             walk_params(next, rest_params, top),
         },
@@ -1099,10 +1099,10 @@ def kernel := ⟦
       0 => ct,
       _ =>
         let ct_whnf = k_whnf(ct, top);
-        match ct_whnf {
-          KVal.Pi(_, &body, &pi_env) =>
-            let proj_val = KVal.Proj(tidx, current_field, store(struct_val), store(List.Nil));
-            let env2 = List.Cons(store(proj_val), store(pi_env));
+        match load(ct_whnf) {
+          KValNode.Pi(_, body, &pi_env) =>
+            let proj_val = store(KValNode.Proj(tidx, current_field, struct_val, store(List.Nil)));
+            let env2 = List.Cons(proj_val, store(pi_env));
             let next = k_eval(body, env2, top);
             walk_fields(next, tidx, current_field + 1, remaining - 1, struct_val, top),
         },
@@ -1119,15 +1119,15 @@ def kernel := ⟦
   -- ============================================================================
 
   -- Apply a spine of argument values to a type by walking through Pi-bindings
-  fn apply_spine_to_type(ty: KVal, spine: List‹&KVal›, top: List‹&KConstantInfo›) -> KVal {
+  fn apply_spine_to_type(ty: KVal, spine: List‹KVal›, top: List‹&KConstantInfo›) -> KVal {
     match spine {
       List.Nil => ty,
-      List.Cons(&arg, &rest) =>
+      List.Cons(arg, &rest) =>
         let arg_forced = k_force(arg, top);
         let ty_whnf = k_whnf(ty, top);
-        match ty_whnf {
-          KVal.Pi(_, &body, &pi_env) =>
-            let env2 = List.Cons(store(arg_forced), store(pi_env));
+        match load(ty_whnf) {
+          KValNode.Pi(_, body, &pi_env) =>
+            let env2 = List.Cons(arg_forced, store(pi_env));
             let next = k_eval(body, env2, top);
             apply_spine_to_type(next, rest, top),
         },
@@ -1137,33 +1137,33 @@ def kernel := ⟦
   -- Infer the type of a value (best-effort, no error handling).
   -- Returns Sort 1 as sentinel for cases we can't handle (FVar, Lam, Proj).
   fn k_infer_val_type(v: KVal, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> KVal {
-    match v {
-      KVal.Thunk(&e, &env) =>
+    match load(v) {
+      KValNode.Thunk(e, &env) =>
         let val = k_eval(e, env, top);
         k_infer_val_type(val, top, nat_idx, str_idx),
-      KVal.Srt(&l) => KVal.Srt(store(KLevel.Succ(store(l)))),
-      KVal.Lit(lit) =>
+      KValNode.Srt(&l) => store(KValNode.Srt(store(KLevel.Succ(store(l))))),
+      KValNode.Lit(lit) =>
         match lit {
-          KLiteral.Nat(_) => KVal.Const(nat_idx, store(List.Nil), store(List.Nil)),
-          KLiteral.Str(_) => KVal.Const(str_idx, store(List.Nil), store(List.Nil)),
+          KLiteral.Nat(_) => store(KValNode.Const(nat_idx, store(List.Nil), store(List.Nil))),
+          KLiteral.Str(_) => store(KValNode.Const(str_idx, store(List.Nil), store(List.Nil))),
         },
-      KVal.Const(idx, &lvls, &spine) =>
+      KValNode.Const(idx, &lvls, &spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
         let ty_val = k_eval(ty_inst, List.Nil, top);
         apply_spine_to_type(ty_val, spine, top),
-      KVal.Ctor(idx, &lvls, _, &spine) =>
+      KValNode.Ctor(idx, &lvls, _, &spine) =>
         let ci = load(list_lookup(top, idx));
         let ty = const_type(ci);
         let ty_inst = expr_inst_levels(ty, lvls);
         let ty_val = k_eval(ty_inst, List.Nil, top);
         apply_spine_to_type(ty_val, spine, top),
-      KVal.Proj(tidx, fidx, &sv, &spine) =>
+      KValNode.Proj(tidx, fidx, sv, &spine) =>
         let struct_type = k_infer_val_type(sv, top, nat_idx, str_idx);
         let struct_type_whnf = k_whnf(struct_type, top);
-        match struct_type_whnf {
-          KVal.Const(induct_idx, &levels, &params_spine) =>
+        match load(struct_type_whnf) {
+          KValNode.Const(induct_idx, &levels, &params_spine) =>
             let ind_ci = load(list_lookup(top, induct_idx));
             match ind_ci {
               KConstantInfo.Induct(_, _, _, _, &ctor_indices, _, _, _) =>
@@ -1175,21 +1175,21 @@ def kernel := ⟦
                 let after_params = walk_params(ctor_type_val, params_spine, top);
                 let after_fields = walk_fields(after_params, tidx, 0, fidx, sv, top);
                 let result_whnf = k_whnf(after_fields, top);
-                match result_whnf {
-                  KVal.Pi(&dom, _, _) => apply_spine_to_type(dom, spine, top),
+                match load(result_whnf) {
+                  KValNode.Pi(dom, _, _) => apply_spine_to_type(dom, spine, top),
                   -- If not a Pi, return the type itself (could be the final result type)
                   _ => apply_spine_to_type(result_whnf, spine, top),
                 },
               -- Not an inductive, fall back to sentinel
-              _ => KVal.Srt(store(KLevel.Succ(store(KLevel.Zero)))),
+              _ => store(KValNode.Srt(store(KLevel.Succ(store(KLevel.Zero))))),
             },
           -- If struct type can't be determined, fall back to sentinel
-          _ => KVal.Srt(store(KLevel.Succ(store(KLevel.Zero)))),
+          _ => store(KValNode.Srt(store(KLevel.Succ(store(KLevel.Zero))))),
         },
-      KVal.FVar(_, &fvar_type, &spine) =>
+      KValNode.FVar(_, fvar_type, &spine) =>
         apply_spine_to_type(fvar_type, spine, top),
       -- For Lam, Pi: return Sort 1 as sentinel (never Prop)
-      _ => KVal.Srt(store(KLevel.Succ(store(KLevel.Zero)))),
+      _ => store(KValNode.Srt(store(KLevel.Succ(store(KLevel.Zero))))),
     }
   }
 
@@ -1197,8 +1197,8 @@ def kernel := ⟦
   fn k_is_prop_val(v: KVal, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     let ty = k_infer_val_type(v, top, nat_idx, str_idx);
     let ty_whnf = k_whnf(ty, top);
-    match ty_whnf {
-      KVal.Srt(&l) =>
+    match load(ty_whnf) {
+      KValNode.Srt(&l) =>
         match l {
           KLevel.Zero => 1,
           _ => 0,
@@ -1224,13 +1224,13 @@ def kernel := ⟦
   }
 
   -- Compare each field: Proj(tidx, i, t) vs spine[nparams + i]
-  fn eta_struct_fields(t: KVal, spine: List‹&KVal›, nparams: G, tidx: G, current: G, remaining: G, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
+  fn eta_struct_fields(t: KVal, spine: List‹KVal›, nparams: G, tidx: G, current: G, remaining: G, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     match remaining {
       0 => 1,
       _ =>
         let field_idx = nparams + current;
-        let field_val = load(list_lookup(spine, field_idx));
-        let proj_val = KVal.Proj(tidx, current, store(t), store(List.Nil));
+        let field_val = list_lookup(spine, field_idx);
+        let proj_val = store(KValNode.Proj(tidx, current, t, store(List.Nil)));
         let eq = k_is_def_eq(proj_val, field_val, depth, top, nat_idx, str_idx);
         match eq {
           0 => 0,
@@ -1242,8 +1242,8 @@ def kernel := ⟦
   -- Try struct eta: if s is a Ctor of a struct-like type, compare fields.
   -- Inlines is_struct_like, ctor_induct_idx, ctor_num_fields to avoid redundant lookups.
   fn try_eta_struct_one(t: KVal, s: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
-    match s {
-      KVal.Ctor(ctor_idx, _, nparams, &spine) =>
+    match load(s) {
+      KValNode.Ctor(ctor_idx, _, nparams, &spine) =>
         let ctor_ci = load(list_lookup(top, ctor_idx));
         match ctor_ci {
           KConstantInfo.Ctor(_, _, induct_idx, _, _, num_fields, _) =>
@@ -1279,8 +1279,8 @@ def kernel := ⟦
   -- Examples: True, PUnit, PLift.up for propositions.
   fn is_unit_like_type(ty: KVal, top: List‹&KConstantInfo›) -> G {
     let ty_whnf = k_whnf(ty, top);
-    match ty_whnf {
-      KVal.Const(induct_idx, _, _) =>
+    match load(ty_whnf) {
+      KValNode.Const(induct_idx, _, _) =>
         let ci = load(list_lookup(top, induct_idx));
         match ci {
           KConstantInfo.Induct(_, _, _, nindices, &ctor_indices, _, _, _) =>
@@ -1358,15 +1358,15 @@ def kernel := ⟦
 
   -- Quick syntactic check for definitional equality (sorts and literals only)
   fn k_quick_def_eq(a: KVal, b: KVal) -> G {
-    match a {
-      KVal.Srt(&la) =>
-        match b {
-          KVal.Srt(&lb) => level_equal(la, lb),
+    match load(a) {
+      KValNode.Srt(&la) =>
+        match load(b) {
+          KValNode.Srt(&lb) => level_equal(la, lb),
           _ => 0,
         },
-      KVal.Lit(la) =>
-        match b {
-          KVal.Lit(lb) => literal_eq(la, lb),
+      KValNode.Lit(la) =>
+        match load(b) {
+          KValNode.Lit(lb) => literal_eq(la, lb),
           _ => 0,
         },
       _ => 0,
@@ -1475,7 +1475,7 @@ def kernel := ⟦
 
   -- Compare a Nat literal with a Nat constructor value
   fn nat_lit_eq_ctor(
-    lit: KLiteral, ctor_idx: G, nparams: G, ctor_spine: List‹&KVal›,
+    lit: KLiteral, ctor_idx: G, nparams: G, ctor_spine: List‹KVal›,
     depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G
   ) -> G {
     match lit {
@@ -1497,8 +1497,8 @@ def kernel := ⟦
                 match has_one {
                   0 => 0,
                   1 =>
-                    let pred_val = load(list_lookup(ctor_spine, nparams));
-                    let pred_lit = KVal.Lit(KLiteral.Nat(store(klimbs_pred(n))));
+                    let pred_val = list_lookup(ctor_spine, nparams);
+                    let pred_lit = store(KValNode.Lit(KLiteral.Nat(store(klimbs_pred(n)))));
                     k_is_def_eq(pred_lit, pred_val, depth, top, nat_idx, str_idx),
                 },
             },
@@ -1509,24 +1509,24 @@ def kernel := ⟦
 
   -- Structural definitional equality after WHNF
   fn k_is_def_eq_core(a: KVal, b: KVal, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
-    match a {
-      KVal.Srt(&la) =>
-        match b {
-          KVal.Srt(&lb) => level_equal(la, lb),
+    match load(a) {
+      KValNode.Srt(&la) =>
+        match load(b) {
+          KValNode.Srt(&lb) => level_equal(la, lb),
           _ => 0,
         },
 
-      KVal.Lit(la) =>
-        match b {
-          KVal.Lit(lb) => literal_eq(la, lb),
-          KVal.Ctor(ctor_idx, _, nparams, &ctor_spine) =>
+      KValNode.Lit(la) =>
+        match load(b) {
+          KValNode.Lit(lb) => literal_eq(la, lb),
+          KValNode.Ctor(ctor_idx, _, nparams, &ctor_spine) =>
             nat_lit_eq_ctor(la, ctor_idx, nparams, ctor_spine, depth, top, nat_idx, str_idx),
           _ => 0,
         },
 
-      KVal.FVar(lvl_a, _, &sp_a) =>
-        match b {
-          KVal.FVar(lvl_b, _, &sp_b) =>
+      KValNode.FVar(lvl_a, _, &sp_a) =>
+        match load(b) {
+          KValNode.FVar(lvl_b, _, &sp_b) =>
             let same_lvl = eq_zero(lvl_a - lvl_b);
             match same_lvl {
               1 => k_is_def_eq_spine(sp_a, sp_b, depth, top, nat_idx, str_idx),
@@ -1535,9 +1535,9 @@ def kernel := ⟦
           _ => 0,
         },
 
-      KVal.Const(idx_a, &lvls_a, &sp_a) =>
-        match b {
-          KVal.Const(idx_b, &lvls_b, &sp_b) =>
+      KValNode.Const(idx_a, &lvls_a, &sp_a) =>
+        match load(b) {
+          KValNode.Const(idx_b, &lvls_b, &sp_b) =>
             let same_idx = eq_zero(idx_a - idx_b);
             match same_idx {
               1 =>
@@ -1553,9 +1553,9 @@ def kernel := ⟦
           _ => k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
         },
 
-      KVal.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
-        match b {
-          KVal.Ctor(idx_b, &lvls_b, _, &sp_b) =>
+      KValNode.Ctor(idx_a, &lvls_a, nparams_a, &sp_a) =>
+        match load(b) {
+          KValNode.Ctor(idx_b, &lvls_b, _, &sp_b) =>
             let same_idx = eq_zero(idx_a - idx_b);
             match same_idx {
               1 =>
@@ -1566,44 +1566,44 @@ def kernel := ⟦
                 },
               0 => 0,
             },
-          KVal.Lit(lb) =>
+          KValNode.Lit(lb) =>
             nat_lit_eq_ctor(lb, idx_a, nparams_a, sp_a, depth, top, nat_idx, str_idx),
           _ => 0,
         },
 
-      KVal.Lam(&dom_a, &body_a, &env_a) =>
-        match b {
-          KVal.Lam(&dom_b, &body_b, &env_b) =>
+      KValNode.Lam(dom_a, body_a, &env_a) =>
+        match load(b) {
+          KValNode.Lam(dom_b, body_b, &env_b) =>
             let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
             match dom_eq {
               0 => 0,
               1 =>
-                let fvar = KVal.FVar(depth, store(dom_a), store(List.Nil));
-                let env_a2 = List.Cons(store(fvar), store(env_a));
-                let env_b2 = List.Cons(store(fvar), store(env_b));
+                let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
+                let env_a2 = List.Cons(fvar, store(env_a));
+                let env_b2 = List.Cons(fvar, store(env_b));
                 let va = k_eval(body_a, env_a2, top);
                 let vb = k_eval(body_b, env_b2, top);
                 k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
             },
           _ =>
             -- Eta: lam vs non-lam
-            let fvar = KVal.FVar(depth, store(dom_a), store(List.Nil));
-            let env_a2 = List.Cons(store(fvar), store(env_a));
+            let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
+            let env_a2 = List.Cons(fvar, store(env_a));
             let va = k_eval(body_a, env_a2, top);
             let vb = k_apply(b, fvar, top);
             k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
         },
 
-      KVal.Pi(&dom_a, &body_a, &env_a) =>
-        match b {
-          KVal.Pi(&dom_b, &body_b, &env_b) =>
+      KValNode.Pi(dom_a, body_a, &env_a) =>
+        match load(b) {
+          KValNode.Pi(dom_b, body_b, &env_b) =>
             let dom_eq = k_is_def_eq(dom_a, dom_b, depth, top, nat_idx, str_idx);
             match dom_eq {
               0 => 0,
               1 =>
-                let fvar = KVal.FVar(depth, store(dom_a), store(List.Nil));
-                let env_a2 = List.Cons(store(fvar), store(env_a));
-                let env_b2 = List.Cons(store(fvar), store(env_b));
+                let fvar = store(KValNode.FVar(depth, dom_a, store(List.Nil)));
+                let env_a2 = List.Cons(fvar, store(env_a));
+                let env_b2 = List.Cons(fvar, store(env_b));
                 let va = k_eval(body_a, env_a2, top);
                 let vb = k_eval(body_b, env_b2, top);
                 k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
@@ -1611,9 +1611,9 @@ def kernel := ⟦
           _ => 0,
         },
 
-      KVal.Proj(tidx_a, fidx_a, &sv_a, &sp_a) =>
-        match b {
-          KVal.Proj(tidx_b, fidx_b, &sv_b, &sp_b) =>
+      KValNode.Proj(tidx_a, fidx_a, sv_a, &sp_a) =>
+        match load(b) {
+          KValNode.Proj(tidx_b, fidx_b, sv_b, &sp_b) =>
             let same_tf = eq_zero(tidx_a - tidx_b) * eq_zero(fidx_a - fidx_b);
             match same_tf {
               1 =>
@@ -1629,14 +1629,14 @@ def kernel := ⟦
 
       -- Eta: non-lam vs lam (symmetric case)
       _ =>
-        match b {
-          KVal.Lam(&dom_b, &body_b, &env_b) =>
-            let fvar = KVal.FVar(depth, store(dom_b), store(List.Nil));
+        match load(b) {
+          KValNode.Lam(dom_b, body_b, &env_b) =>
+            let fvar = store(KValNode.FVar(depth, dom_b, store(List.Nil)));
             let va = k_apply(a, fvar, top);
-            let env_b2 = List.Cons(store(fvar), store(env_b));
+            let env_b2 = List.Cons(fvar, store(env_b));
             let vb = k_eval(body_b, env_b2, top);
             k_is_def_eq(va, vb, depth + 1, top, nat_idx, str_idx),
-          KVal.Const(_, _, _) =>
+          KValNode.Const(_, _, _) =>
             k_lazy_delta(a, b, depth, top, nat_idx, str_idx),
           _ => 0,
         },
@@ -1644,17 +1644,17 @@ def kernel := ⟦
   }
 
   -- Pointwise definitional equality of two value spines
-  fn k_is_def_eq_spine(a: List‹&KVal›, b: List‹&KVal›, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
+  fn k_is_def_eq_spine(a: List‹KVal›, b: List‹KVal›, depth: G, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) -> G {
     match a {
       List.Nil =>
         match b {
           List.Nil => 1,
           _ => 0,
         },
-      List.Cons(&va, &ra) =>
+      List.Cons(va, &ra) =>
         match b {
           List.Nil => 0,
-          List.Cons(&vb, &rb) =>
+          List.Cons(vb, &rb) =>
             let eq = k_is_def_eq(va, vb, depth, top, nat_idx, str_idx);
             match eq {
               0 => 0,
@@ -1700,8 +1700,8 @@ def kernel := ⟦
   -- Try to delta-unfold a VConst value by looking up its definition and evaluating it;
   -- returns the original value if it is opaque or not a definition
   fn try_delta_unfold(v: KVal, top: List‹&KConstantInfo›) -> KVal {
-    match v {
-      KVal.Const(idx, &lvls, &spine) =>
+    match load(v) {
+      KValNode.Const(idx, &lvls, &spine) =>
         let ci = load(list_lookup(top, idx));
         match ci {
           KConstantInfo.Defn(_, _, &value, hints, _) =>
@@ -1728,10 +1728,10 @@ def kernel := ⟦
 
   -- Check whether delta unfolding made progress (i.e., the head constant changed)
   fn delta_changed(before: KVal, after: KVal) -> G {
-    match before {
-      KVal.Const(idx_a, _, _) =>
-        match after {
-          KVal.Const(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
+    match load(before) {
+      KValNode.Const(idx_a, _, _) =>
+        match load(after) {
+          KValNode.Const(idx_b, _, _) => 1 - eq_zero(idx_a - idx_b),
           _ => 1,
         },
       _ => 0,

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -505,7 +505,7 @@ def kernel := ⟦
   fn k_eval(e: KExpr, env: KValEnv, top: List‹&KConstantInfo›) -> KVal {
     match load(e) {
       KExprNode.BVar(idx) =>
-        list_lookup(env, idx),
+        k_force(list_lookup(env, idx), top),
 
       KExprNode.Srt(&l) =>
         store(KValNode.Srt(store(level_reduce(l)))),
@@ -533,7 +533,7 @@ def kernel := ⟦
         store(KValNode.Pi(ty_val, body, store(env))),
 
       KExprNode.Let(_, val, body) =>
-        let v = k_eval(val, env, top);
+        let v = suspend(val, env);
         let env2 = List.Cons(v, store(env));
         k_eval(body, env2, top),
 
@@ -578,8 +578,7 @@ def kernel := ⟦
   fn k_apply(f: KVal, arg: KVal, top: List‹&KConstantInfo›) -> KVal {
     match load(f) {
       KValNode.Lam(_, body, &env) =>
-        let arg_forced = k_force(arg, top);
-        let env2 = List.Cons(arg_forced, store(env));
+        let env2 = List.Cons(arg, store(env));
         k_eval(body, env2, top),
 
       KValNode.Ctor(idx, &lvls, nparams, &spine) =>
@@ -975,7 +974,7 @@ def kernel := ⟦
         match load(fn_type_whnf) {
           KValNode.Pi(dom, body, &pi_env) =>
             let _ = k_check(a, dom, types, env, depth, top, nat_idx, str_idx);
-            let arg_val = k_eval(a, env, top);
+            let arg_val = suspend(a, env);
             let pi_env2 = List.Cons(arg_val, store(pi_env));
             k_eval(body, pi_env2, top),
         },
@@ -1004,7 +1003,7 @@ def kernel := ⟦
         let _ = k_ensure_sort(ty, types, env, depth, top, nat_idx, str_idx);
         let ty_val = k_eval(ty, env, top);
         let _ = k_check(val, ty_val, types, env, depth, top, nat_idx, str_idx);
-        let val_val = k_eval(val, env, top);
+        let val_val = suspend(val, env);
         let types2 = List.Cons(ty_val, store(types));
         let env2 = List.Cons(val_val, store(env));
         k_infer(body, types2, env2, depth + 1, top, nat_idx, str_idx),
@@ -1028,7 +1027,7 @@ def kernel := ⟦
                 -- Walk past params using values from the inductive's spine
                 let after_params = walk_params(ctor_type_val, params_spine, top);
                 -- Walk past preceding fields using Proj values
-                let struct_val = k_eval(e1, env, top);
+                let struct_val = suspend(e1, env);
                 let after_fields = walk_fields(after_params, tidx, 0, fidx, struct_val, top);
                 -- Extract the domain type at field fidx
                 let result_whnf = k_whnf(after_fields, top);
@@ -1082,11 +1081,10 @@ def kernel := ⟦
     match params {
       List.Nil => ct,
       List.Cons(param_val, &rest_params) =>
-        let param_forced = k_force(param_val, top);
         let ct_whnf = k_whnf(ct, top);
         match load(ct_whnf) {
           KValNode.Pi(_, body, &pi_env) =>
-            let env2 = List.Cons(param_forced, store(pi_env));
+            let env2 = List.Cons(param_val, store(pi_env));
             let next = k_eval(body, env2, top);
             walk_params(next, rest_params, top),
         },
@@ -1123,11 +1121,10 @@ def kernel := ⟦
     match spine {
       List.Nil => ty,
       List.Cons(arg, &rest) =>
-        let arg_forced = k_force(arg, top);
         let ty_whnf = k_whnf(ty, top);
         match load(ty_whnf) {
           KValNode.Pi(_, body, &pi_env) =>
-            let env2 = List.Cons(arg_forced, store(pi_env));
+            let env2 = List.Cons(arg, store(pi_env));
             let next = k_eval(body, env2, top);
             apply_spine_to_type(next, rest, top),
         },

--- a/Ix/IxVM/Kernel.lean
+++ b/Ix/IxVM/Kernel.lean
@@ -79,37 +79,37 @@ def kernel := ⟦
 
   -- Look up a value in a value environment by de Bruijn index
   -- Find recursor rule by constructor index
-  fn rec_rule_try_find(rules: List‹&KRecRule›, ctor_idx: G) -> Option‹&KRecRule› {
+  fn rec_rule_try_find(rules: List‹KRecRule›, ctor_idx: G) -> Option‹KRecRule› {
     match load(rules) {
       ListNode.Nil => Option.None,
-      ListNode.Cons(&rule, rest) =>
+      ListNode.Cons(rule, rest) =>
         match rule {
-          KRecRule.Mk(idx, nf, &rhs) =>
+          KRecRule.Mk(idx, nf, rhs) =>
             match idx - ctor_idx {
-              0 => Option.Some(store(KRecRule.Mk(idx, nf, store(rhs)))),
+              0 => Option.Some(KRecRule.Mk(idx, nf, rhs)),
               _ => rec_rule_try_find(rest, ctor_idx),
             },
         },
     }
   }
 
-  fn rec_rule_find(rules: List‹&KRecRule›, ctor_idx: G) -> KRecRule {
+  fn rec_rule_find(rules: List‹KRecRule›, ctor_idx: G) -> KRecRule {
     match load(rules) {
-      ListNode.Cons(&rule, rest) =>
+      ListNode.Cons(rule, rest) =>
         match rule {
-          KRecRule.Mk(idx, nf, &rhs) =>
+          KRecRule.Mk(idx, nf, rhs) =>
             match idx - ctor_idx {
-              0 => KRecRule.Mk(idx, nf, store(rhs)),
+              0 => KRecRule.Mk(idx, nf, rhs),
               _ => rec_rule_find(rest, ctor_idx),
             },
         },
     }
   }
 
-  -- Extract the ctor_idx from the first rule in a List‹&KRecRule›
-  fn rec_rule_first_ctor(rules: List‹&KRecRule›) -> G {
+  -- Extract the ctor_idx from the first rule in a List‹KRecRule›
+  fn rec_rule_first_ctor(rules: List‹KRecRule›) -> G {
     match load(rules) {
-      ListNode.Cons(&rule, _) =>
+      ListNode.Cons(rule, _) =>
         match rule {
           KRecRule.Mk(ctor_idx, _, _) => ctor_idx,
         },
@@ -123,14 +123,14 @@ def kernel := ⟦
   -- Extract the type expression from any constant info variant
   fn const_type(ci: KConstantInfo) -> KExpr {
     match ci {
-      KConstantInfo.Axiom(_, &ty, _) => ty,
-      KConstantInfo.Defn(_, &ty, _, _) => ty,
-      KConstantInfo.Thm(_, &ty, _) => ty,
-      KConstantInfo.Opaque(_, &ty, _, _) => ty,
-      KConstantInfo.Quot(_, &ty, _) => ty,
-      KConstantInfo.Induct(_, &ty, _, _, _, _, _, _) => ty,
-      KConstantInfo.Ctor(_, &ty, _, _, _, _, _) => ty,
-      KConstantInfo.Rec(_, &ty, _, _, _, _, _, _, _) => ty,
+      KConstantInfo.Axiom(_, ty, _) => ty,
+      KConstantInfo.Defn(_, ty, _, _) => ty,
+      KConstantInfo.Thm(_, ty, _) => ty,
+      KConstantInfo.Opaque(_, ty, _, _) => ty,
+      KConstantInfo.Quot(_, ty, _) => ty,
+      KConstantInfo.Induct(_, ty, _, _, _, _, _, _) => ty,
+      KConstantInfo.Ctor(_, ty, _, _, _, _, _) => ty,
+      KConstantInfo.Rec(_, ty, _, _, _, _, _, _, _) => ty,
     }
   }
 
@@ -522,10 +522,10 @@ def kernel := ⟦
       KExprNode.Const(idx, lvls) =>
         let ci = load(list_lookup(top, idx));
         match ci {
-          KConstantInfo.Defn(_, _, &value, _) =>
+          KConstantInfo.Defn(_, _, value, _) =>
             let body = expr_inst_levels(value, lvls);
             k_eval(body, store(ListNode.Nil), top),
-          KConstantInfo.Thm(_, _, &value) =>
+          KConstantInfo.Thm(_, _, value) =>
             let body = expr_inst_levels(value, lvls);
             k_eval(body, store(ListNode.Nil), top),
           KConstantInfo.Ctor(_, _, _, _, nparams, _, _) =>
@@ -710,9 +710,9 @@ def kernel := ⟦
                 match rule_found {
                   Option.None =>
                     store(KValNode.Rec(idx, lvls, spine)),
-                  Option.Some(&rule) =>
+                  Option.Some(rule) =>
                     match rule {
-                      KRecRule.Mk(_, nfields, &rhs) =>
+                      KRecRule.Mk(_, nfields, rhs) =>
                         let rhs_inst = expr_inst_levels(rhs, lvls);
                         let rhs_val = k_eval(rhs_inst, store(ListNode.Nil), top);
                         let params_motives_minors = list_take(spine, nparams + nmotives + nminors);
@@ -737,7 +737,7 @@ def kernel := ⟦
                             let zero_ctor_idx = list_lookup(ctor_indices, 0);
                             let rule = rec_rule_find(rules, zero_ctor_idx);
                             match rule {
-                              KRecRule.Mk(_, _, &rhs) =>
+                              KRecRule.Mk(_, _, rhs) =>
                                 let rhs_inst = expr_inst_levels(rhs, lvls);
                                 let rhs_val = k_eval(rhs_inst, store(ListNode.Nil), top);
                                 let pmm = list_take(spine, pmm_end);
@@ -747,7 +747,7 @@ def kernel := ⟦
                             let succ_ctor_idx = list_lookup(ctor_indices, 1);
                             let rule = rec_rule_find(rules, succ_ctor_idx);
                             match rule {
-                              KRecRule.Mk(_, _, &rhs) =>
+                              KRecRule.Mk(_, _, rhs) =>
                                 let rhs_inst = expr_inst_levels(rhs, lvls);
                                 let rhs_val = k_eval(rhs_inst, store(ListNode.Nil), top);
                                 let pmm = list_take(spine, pmm_end);
@@ -1801,20 +1801,20 @@ def kernel := ⟦
   -- nat_idx/str_idx are the constant indices for the Nat/String types.
   fn k_check_const(ci: KConstantInfo, top: List‹&KConstantInfo›, nat_idx: G, str_idx: G) {
     match ci {
-      KConstantInfo.Axiom(_, &ty, _) =>
+      KConstantInfo.Axiom(_, ty, _) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Defn(_, &ty, &value, _) =>
+      KConstantInfo.Defn(_, ty, value, _) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx);
         let ty_val = k_eval(ty, store(ListNode.Nil), top);
         k_check(value, ty_val, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Thm(_, &ty, &value) =>
+      KConstantInfo.Thm(_, ty, value) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx);
         let ty_val = k_eval(ty, store(ListNode.Nil), top);
         k_check(value, ty_val, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Opaque(_, &ty, &value, is_unsafe) =>
+      KConstantInfo.Opaque(_, ty, value, is_unsafe) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx);
         match is_unsafe {
           1 => (),
@@ -1823,16 +1823,16 @@ def kernel := ⟦
             k_check(value, ty_val, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
         },
 
-      KConstantInfo.Quot(_, &ty, _) =>
+      KConstantInfo.Quot(_, ty, _) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Induct(_, &ty, _, _, _, _, _, _) =>
+      KConstantInfo.Induct(_, ty, _, _, _, _, _, _) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Ctor(_, &ty, _, _, _, _, _) =>
+      KConstantInfo.Ctor(_, ty, _, _, _, _, _) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
 
-      KConstantInfo.Rec(_, &ty, _, _, _, _, _, _, _) =>
+      KConstantInfo.Rec(_, ty, _, _, _, _, _, _, _) =>
         let _ = k_ensure_sort(ty, store(ListNode.Nil), store(ListNode.Nil), 0, top, nat_idx, str_idx),
     }
   }

--- a/Ix/IxVM/KernelTypes.lean
+++ b/Ix/IxVM/KernelTypes.lean
@@ -61,7 +61,13 @@ def kernelTypes := ⟦
     Pi(KVal, KExpr, &KValEnv),
     Ctor(G, &List‹&KLevel›, G, &List‹KVal›),
     FVar(G, KVal, &List‹KVal›),
-    Const(G, &List‹&KLevel›, &List‹KVal›),
+    Axiom(G, &List‹&KLevel›, &List‹KVal›),
+    Defn(G, &List‹&KLevel›, &List‹KVal›),
+    Thm(G, &List‹&KLevel›, &List‹KVal›),
+    Opaque(G, &List‹&KLevel›, &List‹KVal›),
+    Quot(G, &List‹&KLevel›, &List‹KVal›),
+    Induct(G, &List‹&KLevel›, &List‹KVal›),
+    Rec(G, &List‹&KLevel›, &List‹KVal›),
     Proj(G, G, KVal, &List‹KVal›),
     Thunk(KExpr, &KValEnv)
   }

--- a/Ix/IxVM/KernelTypes.lean
+++ b/Ix/IxVM/KernelTypes.lean
@@ -36,36 +36,40 @@ def kernelTypes := ⟦
   -- Expressions (de Bruijn indexed, no binder info or names)
   -- ============================================================================
 
-  enum KExpr {
+  enum KExprNode {
     BVar(G),
     Srt(&KLevel),
     Const(G, &List‹&KLevel›),
-    App(&KExpr, &KExpr),
-    Lam(&KExpr, &KExpr),
-    Forall(&KExpr, &KExpr),
-    Let(&KExpr, &KExpr, &KExpr),
+    App(KExpr, KExpr),
+    Lam(KExpr, KExpr),
+    Forall(KExpr, KExpr),
+    Let(KExpr, KExpr, KExpr),
     Lit(KLiteral),
-    Proj(G, G, &KExpr)
+    Proj(G, G, KExpr)
   }
+
+  type KExpr = &KExprNode
 
   -- ============================================================================
   -- Values (NbE semantic domain)
   -- ============================================================================
 
-  enum KVal {
+  enum KValNode {
     Srt(&KLevel),
     Lit(KLiteral),
-    Lam(&KVal, &KExpr, &KValEnv),
-    Pi(&KVal, &KExpr, &KValEnv),
-    Ctor(G, &List‹&KLevel›, G, &List‹&KVal›),
-    FVar(G, &KVal, &List‹&KVal›),
-    Const(G, &List‹&KLevel›, &List‹&KVal›),
-    Proj(G, G, &KVal, &List‹&KVal›),
-    Thunk(&KExpr, &KValEnv)
+    Lam(KVal, KExpr, &KValEnv),
+    Pi(KVal, KExpr, &KValEnv),
+    Ctor(G, &List‹&KLevel›, G, &List‹KVal›),
+    FVar(G, KVal, &List‹KVal›),
+    Const(G, &List‹&KLevel›, &List‹KVal›),
+    Proj(G, G, KVal, &List‹KVal›),
+    Thunk(KExpr, &KValEnv)
   }
 
+  type KVal = &KValNode
+
   -- Value environment (de Bruijn indexed, front = most recent binder)
-  type KValEnv = List‹&KVal›
+  type KValEnv = List‹KVal›
 
   -- ============================================================================
   -- Reducibility Hints

--- a/Ix/IxVM/KernelTypes.lean
+++ b/Ix/IxVM/KernelTypes.lean
@@ -28,7 +28,7 @@ def kernelTypes := ⟦
   type KLimbs = List‹U64›
 
   enum KLiteral {
-    Nat(&KLimbs),
+    Nat(KLimbs),
     Str(ByteStream)
   }
 
@@ -39,7 +39,7 @@ def kernelTypes := ⟦
   enum KExprNode {
     BVar(G),
     Srt(&KLevel),
-    Const(G, &List‹&KLevel›),
+    Const(G, List‹&KLevel›),
     App(KExpr, KExpr),
     Lam(KExpr, KExpr),
     Forall(KExpr, KExpr),
@@ -57,19 +57,19 @@ def kernelTypes := ⟦
   enum KValNode {
     Srt(&KLevel),
     Lit(KLiteral),
-    Lam(KVal, KExpr, &KValEnv),
-    Pi(KVal, KExpr, &KValEnv),
-    Ctor(G, &List‹&KLevel›, G, &List‹KVal›),
-    FVar(G, KVal, &List‹KVal›),
-    Axiom(G, &List‹&KLevel›, &List‹KVal›),
-    Defn(G, &List‹&KLevel›, &List‹KVal›),
-    Thm(G, &List‹&KLevel›, &List‹KVal›),
-    Opaque(G, &List‹&KLevel›, &List‹KVal›),
-    Quot(G, &List‹&KLevel›, &List‹KVal›),
-    Induct(G, &List‹&KLevel›, &List‹KVal›),
-    Rec(G, &List‹&KLevel›, &List‹KVal›),
-    Proj(G, G, KVal, &List‹KVal›),
-    Thunk(KExpr, &KValEnv)
+    Lam(KVal, KExpr, KValEnv),
+    Pi(KVal, KExpr, KValEnv),
+    Ctor(G, List‹&KLevel›, G, List‹KVal›),
+    FVar(G, KVal, List‹KVal›),
+    Axiom(G, List‹&KLevel›, List‹KVal›),
+    Defn(G, List‹&KLevel›, List‹KVal›),
+    Thm(G, List‹&KLevel›, List‹KVal›),
+    Opaque(G, List‹&KLevel›, List‹KVal›),
+    Quot(G, List‹&KLevel›, List‹KVal›),
+    Induct(G, List‹&KLevel›, List‹KVal›),
+    Rec(G, List‹&KLevel›, List‹KVal›),
+    Proj(G, G, KVal, List‹KVal›),
+    Thunk(KExpr, KValEnv)
   }
 
   type KVal = &KValNode
@@ -107,9 +107,9 @@ def kernelTypes := ⟦
     Thm(G, &KExpr, &KExpr),
     Opaque(G, &KExpr, &KExpr, G),
     Quot(G, &KExpr, QuotKind),
-    Induct(G, &KExpr, G, G, &List‹G›, G, G, G),
+    Induct(G, &KExpr, G, G, List‹G›, G, G, G),
     Ctor(G, &KExpr, G, G, G, G, G),
-    Rec(G, &KExpr, G, G, G, G, &List‹&KRecRule›, G, G)
+    Rec(G, &KExpr, G, G, G, G, List‹&KRecRule›, G, G)
   }
 
 ⟧

--- a/Ix/IxVM/KernelTypes.lean
+++ b/Ix/IxVM/KernelTypes.lean
@@ -82,27 +82,6 @@ def kernelTypes := ⟦
   }
 
   -- ============================================================================
-  -- Definition Safety
-  -- ============================================================================
-
-  enum KSafety {
-    Unsafe,
-    Safe,
-    Partial
-  }
-
-  -- ============================================================================
-  -- Quotient Kind
-  -- ============================================================================
-
-  enum KQuotKind {
-    Typ,
-    Ctor,
-    Lift,
-    Ind
-  }
-
-  -- ============================================================================
   -- Recursor Rule: (ctor_const_idx, num_fields, rhs)
   -- ============================================================================
 
@@ -128,10 +107,10 @@ def kernelTypes := ⟦
 
   enum KConstantInfo {
     Axiom(G, &KExpr, G),
-    Defn(G, &KExpr, &KExpr, KHints, KSafety),
+    Defn(G, &KExpr, &KExpr, KHints, DefinitionSafety),
     Thm(G, &KExpr, &KExpr),
     Opaque(G, &KExpr, &KExpr, G),
-    Quot(G, &KExpr, KQuotKind),
+    Quot(G, &KExpr, QuotKind),
     Induct(G, &KExpr, G, G, &List‹G›, G, G, G),
     Ctor(G, &KExpr, G, G, G, G, G),
     Rec(G, &KExpr, G, G, G, G, &List‹&KRecRule›, G, G)

--- a/Ix/IxVM/KernelTypes.lean
+++ b/Ix/IxVM/KernelTypes.lean
@@ -82,7 +82,7 @@ def kernelTypes := ⟦
   -- ============================================================================
 
   enum KRecRule {
-    Mk(G, G, &KExpr)
+    Mk(G, G, KExpr)
   }
 
   -- ============================================================================
@@ -102,14 +102,14 @@ def kernelTypes := ⟦
   -- ============================================================================
 
   enum KConstantInfo {
-    Axiom(G, &KExpr, G),
-    Defn(G, &KExpr, &KExpr, DefinitionSafety),
-    Thm(G, &KExpr, &KExpr),
-    Opaque(G, &KExpr, &KExpr, G),
-    Quot(G, &KExpr, QuotKind),
-    Induct(G, &KExpr, G, G, List‹G›, G, G, G),
-    Ctor(G, &KExpr, G, G, G, G, G),
-    Rec(G, &KExpr, G, G, G, G, List‹&KRecRule›, G, G)
+    Axiom(G, KExpr, G),
+    Defn(G, KExpr, KExpr, DefinitionSafety),
+    Thm(G, KExpr, KExpr),
+    Opaque(G, KExpr, KExpr, G),
+    Quot(G, KExpr, QuotKind),
+    Induct(G, KExpr, G, G, List‹G›, G, G, G),
+    Ctor(G, KExpr, G, G, G, G, G),
+    Rec(G, KExpr, G, G, G, G, List‹KRecRule›, G, G)
   }
 
 ⟧

--- a/Ix/IxVM/KernelTypes.lean
+++ b/Ix/IxVM/KernelTypes.lean
@@ -72,16 +72,6 @@ def kernelTypes := ⟦
   type KValEnv = List‹KVal›
 
   -- ============================================================================
-  -- Reducibility Hints
-  -- ============================================================================
-
-  enum KHints {
-    Opaque,
-    Abbrev,
-    Regular(G)
-  }
-
-  -- ============================================================================
   -- Recursor Rule: (ctor_const_idx, num_fields, rhs)
   -- ============================================================================
 
@@ -107,7 +97,7 @@ def kernelTypes := ⟦
 
   enum KConstantInfo {
     Axiom(G, &KExpr, G),
-    Defn(G, &KExpr, &KExpr, KHints, DefinitionSafety),
+    Defn(G, &KExpr, &KExpr, DefinitionSafety),
     Thm(G, &KExpr, &KExpr),
     Opaque(G, &KExpr, &KExpr, G),
     Quot(G, &KExpr, QuotKind),

--- a/Ix/IxVM/Sha256.lean
+++ b/Ix/IxVM/Sha256.lean
@@ -46,476 +46,476 @@ def sha256 := ⟦
 
   fn sha256_aux(stream: ByteStream, len_be: U64, state: [[G; 4]; 8]) -> [[G; 4]; 8] {
     let W = [[0; 4]; 16];
-    match stream {
-      List.Nil =>
+    match load(stream) {
+      ListNode.Nil =>
         let W = set(W, 0, [0x80, 0, 0, 0]);
         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
         fill_W_and_run_rounds(W, state),
-      List.Cons(b0, &tail) => match tail {
-        List.Nil =>
+      ListNode.Cons(b0, tail) => match load(tail) {
+        ListNode.Nil =>
           let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 8]);
           let W = set(W, 0, [b0, 0x80, 0, 0]);
           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
           fill_W_and_run_rounds(W, state),
-        List.Cons(b1, &tail) => match tail {
-          List.Nil =>
+        ListNode.Cons(b1, tail) => match load(tail) {
+          ListNode.Nil =>
             let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 16]);
             let W = set(W, 0, [b0, b1, 0x80, 0]);
             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
             fill_W_and_run_rounds(W, state),
-          List.Cons(b2, &tail) => match tail {
-            List.Nil =>
+          ListNode.Cons(b2, tail) => match load(tail) {
+            ListNode.Nil =>
               let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 24]);
               let W = set(W, 0, [b0, b1, b2, 0x80]);
               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
               fill_W_and_run_rounds(W, state),
-            List.Cons(b3, &tail) =>
+            ListNode.Cons(b3, tail) =>
               let W = set(W, 0, [b0, b1, b2, b3]);
-              match tail {
-              List.Nil =>
+              match load(tail) {
+              ListNode.Nil =>
                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 32]);
                 let W = set(W, 1, [0x80, 0, 0, 0]);
                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                 fill_W_and_run_rounds(W, state),
-              List.Cons(b4, &tail) => match tail {
-                List.Nil =>
+              ListNode.Cons(b4, tail) => match load(tail) {
+                ListNode.Nil =>
                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 40]);
                   let W = set(W, 1, [b4, 0x80, 0, 0]);
                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                   fill_W_and_run_rounds(W, state),
-                List.Cons(b5, &tail) => match tail {
-                  List.Nil =>
+                ListNode.Cons(b5, tail) => match load(tail) {
+                  ListNode.Nil =>
                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 48]);
                     let W = set(W, 1, [b4, b5, 0x80, 0]);
                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                     fill_W_and_run_rounds(W, state),
-                  List.Cons(b6, &tail) => match tail {
-                    List.Nil =>
+                  ListNode.Cons(b6, tail) => match load(tail) {
+                    ListNode.Nil =>
                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 56]);
                       let W = set(W, 1, [b4, b5, b6, 0x80]);
                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                       fill_W_and_run_rounds(W, state),
-                    List.Cons(b7, &tail) =>
+                    ListNode.Cons(b7, tail) =>
                       let W = set(W, 1, [b4, b5, b6, b7]);
-                      match tail {
-                      List.Nil =>
+                      match load(tail) {
+                      ListNode.Nil =>
                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 64]);
                         let W = set(W, 2, [0x80, 0, 0, 0]);
                         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                         fill_W_and_run_rounds(W, state),
-                      List.Cons(b8, &tail) => match tail {
-                        List.Nil =>
+                      ListNode.Cons(b8, tail) => match load(tail) {
+                        ListNode.Nil =>
                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 72]);
                           let W = set(W, 2, [b8, 0x80, 0, 0]);
                           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                           fill_W_and_run_rounds(W, state),
-                        List.Cons(b9, &tail) => match tail {
-                          List.Nil =>
+                        ListNode.Cons(b9, tail) => match load(tail) {
+                          ListNode.Nil =>
                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 80]);
                             let W = set(W, 2, [b8, b9, 0x80, 0]);
                             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                             fill_W_and_run_rounds(W, state),
-                          List.Cons(b10, &tail) => match tail {
-                            List.Nil =>
+                          ListNode.Cons(b10, tail) => match load(tail) {
+                            ListNode.Nil =>
                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 88]);
                               let W = set(W, 2, [b8, b9, b10, 0x80]);
                               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                               fill_W_and_run_rounds(W, state),
-                            List.Cons(b11, &tail) =>
+                            ListNode.Cons(b11, tail) =>
                               let W = set(W, 2, [b8, b9, b10, b11]);
-                              match tail {
-                              List.Nil =>
+                              match load(tail) {
+                              ListNode.Nil =>
                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 96]);
                                 let W = set(W, 3, [0x80, 0, 0, 0]);
                                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                 fill_W_and_run_rounds(W, state),
-                              List.Cons(b12, &tail) => match tail {
-                                List.Nil =>
+                              ListNode.Cons(b12, tail) => match load(tail) {
+                                ListNode.Nil =>
                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 104]);
                                   let W = set(W, 3, [b12, 0x80, 0, 0]);
                                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                   fill_W_and_run_rounds(W, state),
-                                List.Cons(b13, &tail) => match tail {
-                                  List.Nil =>
+                                ListNode.Cons(b13, tail) => match load(tail) {
+                                  ListNode.Nil =>
                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 112]);
                                     let W = set(W, 3, [b12, b13, 0x80, 0]);
                                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                     fill_W_and_run_rounds(W, state),
-                                  List.Cons(b14, &tail) => match tail {
-                                    List.Nil =>
+                                  ListNode.Cons(b14, tail) => match load(tail) {
+                                    ListNode.Nil =>
                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 120]);
                                       let W = set(W, 3, [b12, b13, b14, 0x80]);
                                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                       fill_W_and_run_rounds(W, state),
-                                    List.Cons(b15, &tail) =>
+                                    ListNode.Cons(b15, tail) =>
                                       let W = set(W, 3, [b12, b13, b14, b15]);
-                                      match tail {
-                                      List.Nil =>
+                                      match load(tail) {
+                                      ListNode.Nil =>
                                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 128]);
                                         let W = set(W, 4, [0x80, 0, 0, 0]);
                                         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                         fill_W_and_run_rounds(W, state),
-                                      List.Cons(b16, &tail) => match tail {
-                                        List.Nil =>
+                                      ListNode.Cons(b16, tail) => match load(tail) {
+                                        ListNode.Nil =>
                                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 136]);
                                           let W = set(W, 4, [b16, 0x80, 0, 0]);
                                           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                           fill_W_and_run_rounds(W, state),
-                                        List.Cons(b17, &tail) => match tail {
-                                          List.Nil =>
+                                        ListNode.Cons(b17, tail) => match load(tail) {
+                                          ListNode.Nil =>
                                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 144]);
                                             let W = set(W, 4, [b16, b17, 0x80, 0]);
                                             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                             fill_W_and_run_rounds(W, state),
-                                          List.Cons(b18, &tail) => match tail {
-                                            List.Nil =>
+                                          ListNode.Cons(b18, tail) => match load(tail) {
+                                            ListNode.Nil =>
                                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 152]);
                                               let W = set(W, 4, [b16, b17, b18, 0x80]);
                                               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                               fill_W_and_run_rounds(W, state),
-                                            List.Cons(b19, &tail) =>
+                                            ListNode.Cons(b19, tail) =>
                                               let W = set(W, 4, [b16, b17, b18, b19]);
-                                              match tail {
-                                              List.Nil =>
+                                              match load(tail) {
+                                              ListNode.Nil =>
                                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 160]);
                                                 let W = set(W, 5, [0x80, 0, 0, 0]);
                                                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                 fill_W_and_run_rounds(W, state),
-                                              List.Cons(b20, &tail) => match tail {
-                                                List.Nil =>
+                                              ListNode.Cons(b20, tail) => match load(tail) {
+                                                ListNode.Nil =>
                                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 168]);
                                                   let W = set(W, 5, [b20, 0x80, 0, 0]);
                                                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                   fill_W_and_run_rounds(W, state),
-                                                List.Cons(b21, &tail) => match tail {
-                                                  List.Nil =>
+                                                ListNode.Cons(b21, tail) => match load(tail) {
+                                                  ListNode.Nil =>
                                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 176]);
                                                     let W = set(W, 5, [b20, b21, 0x80, 0]);
                                                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                     fill_W_and_run_rounds(W, state),
-                                                  List.Cons(b22, &tail) => match tail {
-                                                    List.Nil =>
+                                                  ListNode.Cons(b22, tail) => match load(tail) {
+                                                    ListNode.Nil =>
                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 184]);
                                                       let W = set(W, 5, [b20, b21, b22, 0x80]);
                                                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                       fill_W_and_run_rounds(W, state),
-                                                    List.Cons(b23, &tail) =>
+                                                    ListNode.Cons(b23, tail) =>
                                                       let W = set(W, 5, [b20, b21, b22, b23]);
-                                                      match tail {
-                                                      List.Nil =>
+                                                      match load(tail) {
+                                                      ListNode.Nil =>
                                                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 192]);
                                                         let W = set(W, 6, [0x80, 0, 0, 0]);
                                                         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                         fill_W_and_run_rounds(W, state),
-                                                      List.Cons(b24, &tail) => match tail {
-                                                        List.Nil =>
+                                                      ListNode.Cons(b24, tail) => match load(tail) {
+                                                        ListNode.Nil =>
                                                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 200]);
                                                           let W = set(W, 6, [b24, 0x80, 0, 0]);
                                                           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                           fill_W_and_run_rounds(W, state),
-                                                        List.Cons(b25, &tail) => match tail {
-                                                          List.Nil =>
+                                                        ListNode.Cons(b25, tail) => match load(tail) {
+                                                          ListNode.Nil =>
                                                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 208]);
                                                             let W = set(W, 6, [b24, b25, 0x80, 0]);
                                                             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                             fill_W_and_run_rounds(W, state),
-                                                          List.Cons(b26, &tail) => match tail {
-                                                            List.Nil =>
+                                                          ListNode.Cons(b26, tail) => match load(tail) {
+                                                            ListNode.Nil =>
                                                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 216]);
                                                               let W = set(W, 6, [b24, b25, b26, 0x80]);
                                                               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                               fill_W_and_run_rounds(W, state),
-                                                            List.Cons(b27, &tail) =>
+                                                            ListNode.Cons(b27, tail) =>
                                                               let W = set(W, 6, [b24, b25, b26, b27]);
-                                                              match tail {
-                                                              List.Nil =>
+                                                              match load(tail) {
+                                                              ListNode.Nil =>
                                                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 224]);
                                                                 let W = set(W, 7, [0x80, 0, 0, 0]);
                                                                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                 fill_W_and_run_rounds(W, state),
-                                                              List.Cons(b28, &tail) => match tail {
-                                                                List.Nil =>
+                                                              ListNode.Cons(b28, tail) => match load(tail) {
+                                                                ListNode.Nil =>
                                                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 232]);
                                                                   let W = set(W, 7, [b28, 0x80, 0, 0]);
                                                                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                   fill_W_and_run_rounds(W, state),
-                                                                List.Cons(b29, &tail) => match tail {
-                                                                  List.Nil =>
+                                                                ListNode.Cons(b29, tail) => match load(tail) {
+                                                                  ListNode.Nil =>
                                                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 240]);
                                                                     let W = set(W, 7, [b28, b29, 0x80, 0]);
                                                                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                     fill_W_and_run_rounds(W, state),
-                                                                  List.Cons(b30, &tail) => match tail {
-                                                                    List.Nil =>
+                                                                  ListNode.Cons(b30, tail) => match load(tail) {
+                                                                    ListNode.Nil =>
                                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [0, 248]);
                                                                       let W = set(W, 7, [b28, b29, b30, 0x80]);
                                                                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                       fill_W_and_run_rounds(W, state),
-                                                                    List.Cons(b31, &tail) =>
+                                                                    ListNode.Cons(b31, tail) =>
                                                                       let W = set(W, 7, [b28, b29, b30, b31]);
-                                                                      match tail {
-                                                                      List.Nil =>
+                                                                      match load(tail) {
+                                                                      ListNode.Nil =>
                                                                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 0]);
                                                                         let W = set(W, 8, [0x80, 0, 0, 0]);
                                                                         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                         fill_W_and_run_rounds(W, state),
-                                                                      List.Cons(b32, &tail) => match tail {
-                                                                        List.Nil =>
+                                                                      ListNode.Cons(b32, tail) => match load(tail) {
+                                                                        ListNode.Nil =>
                                                                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 8]);
                                                                           let W = set(W, 8, [b32, 0x80, 0, 0]);
                                                                           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                           fill_W_and_run_rounds(W, state),
-                                                                        List.Cons(b33, &tail) => match tail {
-                                                                          List.Nil =>
+                                                                        ListNode.Cons(b33, tail) => match load(tail) {
+                                                                          ListNode.Nil =>
                                                                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 16]);
                                                                             let W = set(W, 8, [b32, b33, 0x80, 0]);
                                                                             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                             fill_W_and_run_rounds(W, state),
-                                                                          List.Cons(b34, &tail) => match tail {
-                                                                            List.Nil =>
+                                                                          ListNode.Cons(b34, tail) => match load(tail) {
+                                                                            ListNode.Nil =>
                                                                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 24]);
                                                                               let W = set(W, 8, [b32, b33, b34, 0x80]);
                                                                               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                               fill_W_and_run_rounds(W, state),
-                                                                            List.Cons(b35, &tail) =>
+                                                                            ListNode.Cons(b35, tail) =>
                                                                               let W = set(W, 8, [b32, b33, b34, b35]);
-                                                                              match tail {
-                                                                              List.Nil =>
+                                                                              match load(tail) {
+                                                                              ListNode.Nil =>
                                                                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 32]);
                                                                                 let W = set(W, 9, [0x80, 0, 0, 0]);
                                                                                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                 fill_W_and_run_rounds(W, state),
-                                                                              List.Cons(b36, &tail) => match tail {
-                                                                                List.Nil =>
+                                                                              ListNode.Cons(b36, tail) => match load(tail) {
+                                                                                ListNode.Nil =>
                                                                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 40]);
                                                                                   let W = set(W, 9, [b36, 0x80, 0, 0]);
                                                                                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                   fill_W_and_run_rounds(W, state),
-                                                                                List.Cons(b37, &tail) => match tail {
-                                                                                  List.Nil =>
+                                                                                ListNode.Cons(b37, tail) => match load(tail) {
+                                                                                  ListNode.Nil =>
                                                                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 48]);
                                                                                     let W = set(W, 9, [b36, b37, 0x80, 0]);
                                                                                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                     fill_W_and_run_rounds(W, state),
-                                                                                  List.Cons(b38, &tail) => match tail {
-                                                                                    List.Nil =>
+                                                                                  ListNode.Cons(b38, tail) => match load(tail) {
+                                                                                    ListNode.Nil =>
                                                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 56]);
                                                                                       let W = set(W, 9, [b36, b37, b38, 0x80]);
                                                                                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                       fill_W_and_run_rounds(W, state),
-                                                                                    List.Cons(b39, &tail) =>
+                                                                                    ListNode.Cons(b39, tail) =>
                                                                                       let W = set(W, 9, [b36, b37, b38, b39]);
-                                                                                      match tail {
-                                                                                      List.Nil =>
+                                                                                      match load(tail) {
+                                                                                      ListNode.Nil =>
                                                                                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 64]);
                                                                                         let W = set(W, 10, [0x80, 0, 0, 0]);
                                                                                         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                         fill_W_and_run_rounds(W, state),
-                                                                                      List.Cons(b40, &tail) => match tail {
-                                                                                        List.Nil =>
+                                                                                      ListNode.Cons(b40, tail) => match load(tail) {
+                                                                                        ListNode.Nil =>
                                                                                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 72]);
                                                                                           let W = set(W, 10, [b40, 0x80, 0, 0]);
                                                                                           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                           fill_W_and_run_rounds(W, state),
-                                                                                        List.Cons(b41, &tail) => match tail {
-                                                                                          List.Nil =>
+                                                                                        ListNode.Cons(b41, tail) => match load(tail) {
+                                                                                          ListNode.Nil =>
                                                                                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 80]);
                                                                                             let W = set(W, 10, [b40, b41, 0x80, 0]);
                                                                                             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                             fill_W_and_run_rounds(W, state),
-                                                                                          List.Cons(b42, &tail) => match tail {
-                                                                                            List.Nil =>
+                                                                                          ListNode.Cons(b42, tail) => match load(tail) {
+                                                                                            ListNode.Nil =>
                                                                                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 88]);
                                                                                               let W = set(W, 10, [b40, b41, b42, 0x80]);
                                                                                               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                               fill_W_and_run_rounds(W, state),
-                                                                                            List.Cons(b43, &tail) =>
+                                                                                            ListNode.Cons(b43, tail) =>
                                                                                               let W = set(W, 10, [b40, b41, b42, b43]);
-                                                                                              match tail {
-                                                                                              List.Nil =>
+                                                                                              match load(tail) {
+                                                                                              ListNode.Nil =>
                                                                                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 96]);
                                                                                                 let W = set(W, 11, [0x80, 0, 0, 0]);
                                                                                                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                 fill_W_and_run_rounds(W, state),
-                                                                                              List.Cons(b44, &tail) => match tail {
-                                                                                                List.Nil =>
+                                                                                              ListNode.Cons(b44, tail) => match load(tail) {
+                                                                                                ListNode.Nil =>
                                                                                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 104]);
                                                                                                   let W = set(W, 11, [b44, 0x80, 0, 0]);
                                                                                                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                   fill_W_and_run_rounds(W, state),
-                                                                                                List.Cons(b45, &tail) => match tail {
-                                                                                                  List.Nil =>
+                                                                                                ListNode.Cons(b45, tail) => match load(tail) {
+                                                                                                  ListNode.Nil =>
                                                                                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 112]);
                                                                                                     let W = set(W, 11, [b44, b45, 0x80, 0]);
                                                                                                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                     fill_W_and_run_rounds(W, state),
-                                                                                                  List.Cons(b46, &tail) => match tail {
-                                                                                                    List.Nil =>
+                                                                                                  ListNode.Cons(b46, tail) => match load(tail) {
+                                                                                                    ListNode.Nil =>
                                                                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 120]);
                                                                                                       let W = set(W, 11, [b44, b45, b46, 0x80]);
                                                                                                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                       fill_W_and_run_rounds(W, state),
-                                                                                                    List.Cons(b47, &tail) =>
+                                                                                                    ListNode.Cons(b47, tail) =>
                                                                                                       let W = set(W, 11, [b44, b45, b46, b47]);
-                                                                                                      match tail {
-                                                                                                      List.Nil =>
+                                                                                                      match load(tail) {
+                                                                                                      ListNode.Nil =>
                                                                                                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 128]);
                                                                                                         let W = set(W, 12, [0x80, 0, 0, 0]);
                                                                                                         let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                         let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                         fill_W_and_run_rounds(W, state),
-                                                                                                      List.Cons(b48, &tail) => match tail {
-                                                                                                        List.Nil =>
+                                                                                                      ListNode.Cons(b48, tail) => match load(tail) {
+                                                                                                        ListNode.Nil =>
                                                                                                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 136]);
                                                                                                           let W = set(W, 12, [b48, 0x80, 0, 0]);
                                                                                                           let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                           let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                           fill_W_and_run_rounds(W, state),
-                                                                                                        List.Cons(b49, &tail) => match tail {
-                                                                                                          List.Nil =>
+                                                                                                        ListNode.Cons(b49, tail) => match load(tail) {
+                                                                                                          ListNode.Nil =>
                                                                                                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 144]);
                                                                                                             let W = set(W, 12, [b48, b49, 0x80, 0]);
                                                                                                             let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                             let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                             fill_W_and_run_rounds(W, state),
-                                                                                                          List.Cons(b50, &tail) => match tail {
-                                                                                                            List.Nil =>
+                                                                                                          ListNode.Cons(b50, tail) => match load(tail) {
+                                                                                                            ListNode.Nil =>
                                                                                                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 152]);
                                                                                                               let W = set(W, 12, [b48, b49, b50, 0x80]);
                                                                                                               let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                               let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                               fill_W_and_run_rounds(W, state),
-                                                                                                            List.Cons(b51, &tail) =>
+                                                                                                            ListNode.Cons(b51, tail) =>
                                                                                                               let W = set(W, 12, [b48, b49, b50, b51]);
-                                                                                                              match tail {
-                                                                                                              List.Nil =>
+                                                                                                              match load(tail) {
+                                                                                                              ListNode.Nil =>
                                                                                                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 160]);
                                                                                                                 let W = set(W, 13, [0x80, 0, 0, 0]);
                                                                                                                 let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                                 let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                                 fill_W_and_run_rounds(W, state),
-                                                                                                              List.Cons(b52, &tail) => match tail {
-                                                                                                                List.Nil =>
+                                                                                                              ListNode.Cons(b52, tail) => match load(tail) {
+                                                                                                                ListNode.Nil =>
                                                                                                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 168]);
                                                                                                                   let W = set(W, 13, [b52, 0x80, 0, 0]);
                                                                                                                   let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                                   let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                                   fill_W_and_run_rounds(W, state),
-                                                                                                                List.Cons(b53, &tail) => match tail {
-                                                                                                                  List.Nil =>
+                                                                                                                ListNode.Cons(b53, tail) => match load(tail) {
+                                                                                                                  ListNode.Nil =>
                                                                                                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 176]);
                                                                                                                     let W = set(W, 13, [b52, b53, 0x80, 0]);
                                                                                                                     let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                                     let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                                     fill_W_and_run_rounds(W, state),
-                                                                                                                  List.Cons(b54, &tail) => match tail {
-                                                                                                                    List.Nil =>
+                                                                                                                  ListNode.Cons(b54, tail) => match load(tail) {
+                                                                                                                    ListNode.Nil =>
                                                                                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 184]);
                                                                                                                       let W = set(W, 13, [b52, b53, b54, 0x80]);
                                                                                                                       let W = set(W, 14, [len_be[0], len_be[1], len_be[2], len_be[3]]);
                                                                                                                       let W = set(W, 15, [len_be[4], len_be[5], len_be[6], len_be[7]]);
                                                                                                                       fill_W_and_run_rounds(W, state),
-                                                                                                                    List.Cons(b55, &tail) =>
+                                                                                                                    ListNode.Cons(b55, tail) =>
                                                                                                                       let W = set(W, 13, [b52, b53, b54, b55]);
-                                                                                                                      match tail {
-                                                                                                                      List.Nil =>
+                                                                                                                      match load(tail) {
+                                                                                                                      ListNode.Nil =>
                                                                                                                         let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 192]);
                                                                                                                         let W = set(W, 14, [0x80, 0, 0, 0]);
                                                                                                                         let state = fill_W_and_run_rounds(W, state);
                                                                                                                         fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                      List.Cons(b56, &tail) => match tail {
-                                                                                                                        List.Nil =>
+                                                                                                                      ListNode.Cons(b56, tail) => match load(tail) {
+                                                                                                                        ListNode.Nil =>
                                                                                                                           let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 200]);
                                                                                                                           let W = set(W, 14, [b56, 0x80, 0, 0]);
                                                                                                                           let state = fill_W_and_run_rounds(W, state);
                                                                                                                           fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                        List.Cons(b57, &tail) => match tail {
-                                                                                                                          List.Nil =>
+                                                                                                                        ListNode.Cons(b57, tail) => match load(tail) {
+                                                                                                                          ListNode.Nil =>
                                                                                                                             let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 208]);
                                                                                                                             let W = set(W, 14, [b56, b57, 0x80, 0]);
                                                                                                                             let state = fill_W_and_run_rounds(W, state);
                                                                                                                             fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                          List.Cons(b58, &tail) => match tail {
-                                                                                                                            List.Nil =>
+                                                                                                                          ListNode.Cons(b58, tail) => match load(tail) {
+                                                                                                                            ListNode.Nil =>
                                                                                                                               let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 216]);
                                                                                                                               let W = set(W, 14, [b56, b57, b58, 0x80]);
                                                                                                                               let state = fill_W_and_run_rounds(W, state);
                                                                                                                               fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                            List.Cons(b59, &tail) =>
+                                                                                                                            ListNode.Cons(b59, tail) =>
                                                                                                                               let W = set(W, 14, [b56, b57, b58, b59]);
-                                                                                                                              match tail {
-                                                                                                                              List.Nil =>
+                                                                                                                              match load(tail) {
+                                                                                                                              ListNode.Nil =>
                                                                                                                                 let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 224]);
                                                                                                                                 let W = set(W, 15, [0x80, 0, 0, 0]);
                                                                                                                                 let state = fill_W_and_run_rounds(W, state);
                                                                                                                                 fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                              List.Cons(b60, &tail) => match tail {
-                                                                                                                                List.Nil =>
+                                                                                                                              ListNode.Cons(b60, tail) => match load(tail) {
+                                                                                                                                ListNode.Nil =>
                                                                                                                                   let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 232]);
                                                                                                                                   let W = set(W, 15, [b60, 0x80, 0, 0]);
                                                                                                                                   let state = fill_W_and_run_rounds(W, state);
                                                                                                                                   fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                                List.Cons(b61, &tail) => match tail {
-                                                                                                                                  List.Nil =>
+                                                                                                                                ListNode.Cons(b61, tail) => match load(tail) {
+                                                                                                                                  ListNode.Nil =>
                                                                                                                                     let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 240]);
                                                                                                                                     let W = set(W, 15, [b60, b61, 0x80, 0]);
                                                                                                                                     let state = fill_W_and_run_rounds(W, state);
                                                                                                                                     fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                                  List.Cons(b62, &tail) => match tail {
-                                                                                                                                    List.Nil =>
+                                                                                                                                  ListNode.Cons(b62, tail) => match load(tail) {
+                                                                                                                                    ListNode.Nil =>
                                                                                                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [1, 248]);
                                                                                                                                       let W = set(W, 15, [b60, b61, b62, 0x80]);
                                                                                                                                       let state = fill_W_and_run_rounds(W, state);
                                                                                                                                       fill_W_with_length_and_run_rounds(len_be, state),
-                                                                                                                                    List.Cons(b63, &tail) =>
+                                                                                                                                    ListNode.Cons(b63, tail) =>
                                                                                                                                       let len_be = relaxed_u64_be_add_2_bytes(len_be, [2, 0]);
                                                                                                                                       let W = set(W, 15, [b60, b61, b62, b63]);
                                                                                                                                       let state = fill_W_and_run_rounds(W, state);


### PR DESCRIPTION
# feat(kernel): Kernel refactor

## Summary

Major refactor of the Lean 4 kernel type checker (`Ix/IxVM/Kernel.lean` and supporting files). The changes overhaul evaluation strategy and value representation across the kernel circuit following the general strategy of #35

### Evaluation strategy

- **Lazy reduction changes**: introduced `suspend` / `k_force` to create thunked values; constants evaluate to neutrals and reduce lazily. Also fixed a bunch of instances of eager evaluation
- **Eager delta reduction**: `k_eval` now unfolds `Defn`/`Thm` constants eagerly instead of deferring to a separate WHNF pass; lazy delta unfolding removed from definitional equality.
- **Iota and quotient reduction at application time**: `k_try_iota_fire` and `k_try_quot_fire` fire as soon as a `Rec`/`Quot` spine reaches the exact required arg count, eliminating `k_whnf` entirely.
- **Lazy codomain values**: Pi codomain instantiated lazily during type checking.
- **Bidirectional checking**: `k_check` used directly instead of `k_infer` + equality where type is known.

### Value representation

- **`KExpr = &KExprNode`, `KVal = &KValNode`**: explicit pointer aliases; field types updated throughout (`KConstantInfo`, `KRecRule`).
- **`KValNode.Const` split**: monolithic `Const` neutral replaced by dedicated variants `Defn`, `Thm`, `Opaque`, `Rec`, `Induct`, `Quot`, `Ctor`, `Axiom` — enabling pattern-directed reduction without runtime dispatch on constant kind.
- **Removed `KHints`, `KSafety`, `KQuoteKind`**: redundant wrapper types eliminated; constants carry only what the kernel needs.
- **`List‹T› = &ListNode‹T›`**: `List` is now a pointer alias; `ListNode` is the actual enum. All list construction and pattern matching updated across `Kernel.lean`, `IxonSerialize.lean`, `Sha256.lean`, and other IxVM files.
- **Pointer equality check**: fast-path in `k_is_def_eq` using `ptr_val` before structural comparison.

### Cleanup

- `k_quick_def` inlined.
- Impossible sentinel values removed from equality.
- `eq_zero` guard instances removed where unnecessary.
- `KSafety`/`KQuoteKind` conversion functions deleted.

## Files changed

| File | Change |
|------|--------|
| `Ix/IxVM/Kernel.lean` | Core evaluation, reduction, equality, type checking |
| `Ix/IxVM/KernelTypes.lean` | Value/expr type definitions, pointer aliases |
| `Ix/IxVM/Convert.lean` | Ixon → kernel conversion, KRecRule/KExpr field types |
| `Ix/IxVM/Core.lean` | `ListNode` enum + `List` pointer alias |
| `Ix/IxVM/IxonSerialize.lean` | List construction updated |
| `Ix/IxVM/Sha256.lean` | List pattern matching updated |
| `Ix/IxVM/Ingress.lean` | List construction updated |

## Results
On main:
```
Typechecking Nat.add_comm
=== Circuit Statistics ===
Circuits: 232
Total width: 23086
Total FFT cost: 304209365
```
On this branch:
```
Typechecking Nat.add_comm
=== Circuit Statistics ===
Circuits: 226
Total width: 18374
Total FFT cost: 222952248
```

## Observations
- Changing ADTs to pointers resulted in a massive reduction in the width of the circuits. In particular, this allowed equality to check for pointer equality.
- Lazy delta was removed for now, since it looks like it's more trouble than help. This means eval now reduces to whnf. Perhaps we will have to bring it back, but I suspect the best way will be to use some sort of non-deterministic strategy, similar to how I plan to solve the issue of proof irrelevance. This also had a substantial positive impact on cost