### PR TITLE
Add non-tail match support (Yield + MatchContinue)

### DIFF
--- a/Ix/Aiur/Bytecode.lean
+++ b/Ix/Aiur/Bytecode.lean
@@ -42,13 +42,15 @@ mutual
   inductive Ctrl where
     | match : ValIdx → Array (G × Block) → Option Block → Ctrl
     | return : SelIdx → Array ValIdx → Ctrl
+    | yield : SelIdx → Array ValIdx → Ctrl
+    | matchContinue : ValIdx → Array (G × Block) → Option Block
+        → (outputSize : Nat) → (sharedAuxiliaries : Nat) → (sharedLookups : Nat)
+        → Block → Ctrl
     deriving Inhabited, Repr
 
   structure Block where
     ops : Array Op
     ctrl : Ctrl
-    minSelIncluded: SelIdx
-    maxSelExcluded: SelIdx
     deriving Inhabited, Repr
 end
 

--- a/Ix/Aiur/Compiler.lean
+++ b/Ix/Aiur/Compiler.lean
@@ -44,7 +44,14 @@ private partial def Bytecode.Block.collectConstrainedCallees
     match default? with
     | some block => block.collectConstrainedCallees acc
     | none => acc
-  | .return _ _ => acc
+  | .matchContinue _ cases default? _ _ _ continuation =>
+    let acc := cases.foldl (init := acc) fun acc (_, block) =>
+      block.collectConstrainedCallees acc
+    let acc := match default? with
+      | some block => block.collectConstrainedCallees acc
+      | none => acc
+    continuation.collectConstrainedCallees acc
+  | .return _ _ | .yield _ _ => acc
 
 /-- Compute which functions need a circuit. A function needs a circuit iff it is
 reachable from an entry point through a chain of constrained call edges.

--- a/Ix/Aiur/Compiler/Dedup.lean
+++ b/Ix/Aiur/Compiler/Dedup.lean
@@ -32,6 +32,10 @@ mutual
       .match v (branches.map fun (g, b) => (g, skeletonBlock b))
         (def_.map skeletonBlock)
     | .return s vs => .return s vs
+    | .yield s vs => .yield s vs
+    | .matchContinue v branches def_ outputSize sharedAux sharedLookups cont =>
+      .matchContinue v (branches.map fun (g, b) => (g, skeletonBlock b))
+        (def_.map skeletonBlock) outputSize sharedAux sharedLookups (skeletonBlock cont)
 
   partial def skeletonBlock (block : Block) : Block :=
     { block with
@@ -52,6 +56,13 @@ mutual
       | none => acc
       | some b => collectCalleesBlock b acc
     | .return .., acc => acc
+    | .yield .., acc => acc
+    | .matchContinue _ branches def_ _ _ _ cont, acc =>
+      let acc := branches.foldl (fun acc (_, b) => collectCalleesBlock b acc) acc
+      let acc := match def_ with
+        | none => acc
+        | some b => collectCalleesBlock b acc
+      collectCalleesBlock cont acc
 
   partial def collectCalleesBlock (block : Block) (acc : Array FunIdx) : Array FunIdx :=
     let acc := block.ops.foldl (fun acc op => collectCalleesOp op acc) acc
@@ -69,6 +80,10 @@ mutual
       .match v (branches.map fun (g, b) => (g, rewriteBlock f b))
         (def_.map (rewriteBlock f))
     | .return s vs => .return s vs
+    | .yield s vs => .yield s vs
+    | .matchContinue v branches def_ outputSize sharedAux sharedLookups cont =>
+      .matchContinue v (branches.map fun (g, b) => (g, rewriteBlock f b))
+        (def_.map (rewriteBlock f)) outputSize sharedAux sharedLookups (rewriteBlock f cont)
 
   partial def rewriteBlock (f : FunIdx → FunIdx) (block : Block) : Block :=
     { block with

--- a/Ix/Aiur/Compiler/Layout.lean
+++ b/Ix/Aiur/Compiler/Layout.lean
@@ -211,9 +211,7 @@ partial def blockLayout (block : Bytecode.Block) : LayoutM Unit := do
       maximalSharedData := maximalSharedData.maximals defaultBlockSharedData
       setDegrees degrees
     setSharedData maximalSharedData
-  | .return .. =>
-    bumpSelectors
-    bumpLookups
+  | .return .. => bumpSelectors
   | .yield .. => bumpSelectors
   | .matchContinue _ branches defaultBranch outputSize _sharedAux _sharedLookups continuation =>
     let initSharedData ← getSharedData

--- a/Ix/Aiur/Compiler/Layout.lean
+++ b/Ix/Aiur/Compiler/Layout.lean
@@ -214,6 +214,30 @@ partial def blockLayout (block : Bytecode.Block) : LayoutM Unit := do
   | .return .. =>
     bumpSelectors
     bumpLookups
+  | .yield .. => bumpSelectors
+  | .matchContinue _ branches defaultBranch outputSize _sharedAux _sharedLookups continuation =>
+    let initSharedData ← getSharedData
+    let mut maximalSharedData := initSharedData
+    let mut degrees ← getDegrees
+    for (_, block) in branches do
+      setSharedData initSharedData
+      blockLayout block
+      let blockSharedData ← getSharedData
+      maximalSharedData := maximalSharedData.maximals blockSharedData
+      setDegrees degrees
+    if let some defaultBlock := defaultBranch then
+      setSharedData initSharedData
+      bumpAuxiliaries branches.size
+      blockLayout defaultBlock
+      let defaultBlockSharedData ← getSharedData
+      maximalSharedData := maximalSharedData.maximals defaultBlockSharedData
+      setDegrees degrees
+    setSharedData maximalSharedData
+    -- Merge auxiliaries: one per output value
+    bumpAuxiliaries outputSize
+    pushDegrees (.replicate outputSize 1)
+    -- Continuation layout: additive (not maximals)
+    blockLayout continuation
 
 end Bytecode
 

--- a/Ix/Aiur/Compiler/Lower.lean
+++ b/Ix/Aiur/Compiler/Lower.lean
@@ -103,7 +103,7 @@ abbrev CompileM := EStateM String CompilerState
 
 /-- Compute the output degrees for a single-output op from its operand degrees.
     Multi-output ops (size > 1) always produce degree-1 values. -/
-private def opDegree (degrees : Array Nat) (op : Bytecode.Op) (size : Nat) : Array Nat :=
+private def pushOpDegree (degrees : Array Nat) (op : Bytecode.Op) (size : Nat) : Array Nat :=
   if size > 1 then
     (Array.replicate size 1).foldl (init := degrees) (·.push ·)
   else match op with
@@ -121,7 +121,7 @@ def pushOp (op : Bytecode.Op) (size : Nat := 1) : CompileM (Array Bytecode.ValId
     (Array.range' valIdx size, { s with
       valIdx := valIdx + size,
       ops := s.ops.push op,
-      degrees := opDegree s.degrees op size }))
+      degrees := pushOpDegree s.degrees op size }))
 
 def extractOps : CompileM (Array Bytecode.Op) :=
   modifyGet fun s => (s.ops, {s with ops := #[]})
@@ -366,26 +366,8 @@ where
       go layoutMap bindings bod
     | _ => pure none
 
-/-- Count how many `Ctrl.return` leaves a block tree contains. Each Return
-    contributes 1 to the Layout's lookup count (for the function return at
-    slot 0), but the constraint code handles slot 0 separately without
-    incrementing `state.lookup`. So we subtract returns from the Layout's
-    lookup count to get the branch-local lookup count. -/
-partial def countReturns : Bytecode.Block → Nat
-  | ⟨_, .return ..⟩ => 1
-  | ⟨_, .yield ..⟩ => 0
-  | ⟨_, .match _ branches def_⟩ =>
-    let n := branches.foldl (fun acc (_, b) => acc + countReturns b) 0
-    match def_ with | some b => n + countReturns b | none => n
-  | ⟨_, .matchContinue _ branches def_ _ _ _ cont⟩ =>
-    let n := branches.foldl (fun acc (_, b) => acc + countReturns b) 0
-    let n := match def_ with | some b => n + countReturns b | none => n
-    n + countReturns cont
-
-/-- Compute max auxiliaries and effective lookups across all match branches by
-    running blockLayout on each, using the actual degree array from the compiler
-    state. Effective lookups = Layout lookups - Return count (because Return's
-    function return lookup at slot 0 is pre-allocated, not branch-local). -/
+/-- Compute max auxiliaries and lookups across all match branches by running
+    `blockLayout` on each, using the actual degree array from the compiler state. -/
 partial def computeSharedLayout
  (matchCases : Array (G × Bytecode.Block))
  (default : Option Bytecode.Block)
@@ -396,14 +378,12 @@ partial def computeSharedLayout
      .empty, degrees⟩
   let (sharedAux, sharedLookups) := matchCases.foldl (init := (0, 0)) fun (maxA, maxL) (_, block) =>
     let (_, ls) := Bytecode.blockLayout block |>.run initLS
-    let effectiveLookups := ls.functionLayout.lookups - countReturns block
-    (maxA.max ls.functionLayout.auxiliaries, maxL.max effectiveLookups)
+    (maxA.max ls.functionLayout.auxiliaries, maxL.max ls.functionLayout.lookups)
   pure $ match default with
     | some block =>
       let (_, ls) := Bytecode.blockLayout block |>.run initLS
-      let effectiveLookups := ls.functionLayout.lookups - countReturns block
       (sharedAux.max (ls.functionLayout.auxiliaries + matchCases.size),
-       sharedLookups.max effectiveLookups)
+       sharedLookups.max ls.functionLayout.lookups)
     | none => (sharedAux, sharedLookups)
 
 /-- Compile a non-tail match as a `matchContinue` block. Used by both the
@@ -617,6 +597,10 @@ def TypedFunction.compile (layoutMap : LayoutMap) (f : TypedFunction) :
   | .error e _ => throw e
   | .ok body _ =>
     let (_, layoutMState) := Bytecode.blockLayout body |>.run (.new inputSize)
+    -- All `return`s share a single lookup slot at the function level.
+    let layoutMState := { layoutMState with functionLayout :=
+      { layoutMState.functionLayout with
+        lookups := layoutMState.functionLayout.lookups + 1 } }
     pure (body, layoutMState)
 
 def TypedDecls.toBytecode (decls : TypedDecls) :

--- a/Ix/Aiur/Compiler/Lower.lean
+++ b/Ix/Aiur/Compiler/Lower.lean
@@ -96,15 +96,32 @@ structure CompilerState where
   valIdx : Bytecode.ValIdx
   ops : Array Bytecode.Op
   selIdx : Bytecode.SelIdx
+  degrees : Array Nat
   deriving Inhabited
 
 abbrev CompileM := EStateM String CompilerState
 
+/-- Compute the output degrees for a single-output op from its operand degrees.
+    Multi-output ops (size > 1) always produce degree-1 values. -/
+private def opDegree (degrees : Array Nat) (op : Bytecode.Op) (size : Nat) : Array Nat :=
+  if size > 1 then
+    (Array.replicate size 1).foldl (init := degrees) (·.push ·)
+  else match op with
+  | .const _ => degrees.push 0
+  | .add a b | .sub a b => degrees.push (degrees[a]!.max degrees[b]!)
+  | .mul a b =>
+    let d := degrees[a]! + degrees[b]!
+    degrees.push (if d < 2 then d else 1)
+  | .eqZero a => degrees.push (if degrees[a]! == 0 then 0 else 1)
+  | _ => degrees.push 1
+
 def pushOp (op : Bytecode.Op) (size : Nat := 1) : CompileM (Array Bytecode.ValIdx) :=
   modifyGet (fun s =>
     let valIdx := s.valIdx
-    let ops := s.ops
-    (Array.range' valIdx size, { s with valIdx := valIdx + size, ops := ops.push op}))
+    (Array.range' valIdx size, { s with
+      valIdx := valIdx + size,
+      ops := s.ops.push op,
+      degrees := opDegree s.degrees op size }))
 
 def extractOps : CompileM (Array Bytecode.Op) :=
   modifyGet fun s => (s.ops, {s with ops := #[]})
@@ -321,38 +338,153 @@ partial def toIndex
 
 mutual
 
+/-- Walk through a TypedTerm's inner let chain to find an embedded `.match`.
+    Returns `some (matchTyp, scrutinee, cases)` if found, `none` otherwise.
+    Along the way, the prefix lets are compiled via `toIndex` and their
+    bindings are accumulated, so when the match is found the bindings map
+    already includes all prefix variables.
+    On `none` return the compiler state is restored (no side effects). -/
+partial def findNonTailMatch
+ (layoutMap : LayoutMap)
+ (bindings : Std.HashMap Local (Array Bytecode.ValIdx))
+ (term : TypedTerm)
+: CompileM (Option (Typ × TypedTerm × List (Pattern × TypedTerm) ×
+    Std.HashMap Local (Array Bytecode.ValIdx))) := do
+  let saved ← get
+  let result ← go layoutMap bindings term
+  if result.isNone then set saved
+  pure result
+where
+  go layoutMap bindings term := do
+    match term.inner with
+    | .match scrutinee cases => pure (some (term.typ, scrutinee, cases, bindings))
+    | .let (.var var) val bod => do
+      let val ← toIndex layoutMap bindings val
+      go layoutMap (bindings.insert var val) bod
+    | .let .wildcard val bod => do
+      let _ ← toIndex layoutMap bindings val
+      go layoutMap bindings bod
+    | _ => pure none
+
+/-- Count how many `Ctrl.return` leaves a block tree contains. Each Return
+    contributes 1 to the Layout's lookup count (for the function return at
+    slot 0), but the constraint code handles slot 0 separately without
+    incrementing `state.lookup`. So we subtract returns from the Layout's
+    lookup count to get the branch-local lookup count. -/
+partial def countReturns : Bytecode.Block → Nat
+  | ⟨_, .return ..⟩ => 1
+  | ⟨_, .yield ..⟩ => 0
+  | ⟨_, .match _ branches def_⟩ =>
+    let n := branches.foldl (fun acc (_, b) => acc + countReturns b) 0
+    match def_ with | some b => n + countReturns b | none => n
+  | ⟨_, .matchContinue _ branches def_ _ _ _ cont⟩ =>
+    let n := branches.foldl (fun acc (_, b) => acc + countReturns b) 0
+    let n := match def_ with | some b => n + countReturns b | none => n
+    n + countReturns cont
+
+/-- Compute max auxiliaries and effective lookups across all match branches by
+    running blockLayout on each, using the actual degree array from the compiler
+    state. Effective lookups = Layout lookups - Return count (because Return's
+    function return lookup at slot 0 is pre-allocated, not branch-local). -/
+partial def computeSharedLayout
+ (matchCases : Array (G × Bytecode.Block))
+ (default : Option Bytecode.Block)
+: CompileM (Nat × Nat) := do
+  let degrees := (← get).degrees
+  let initLS : Bytecode.LayoutMState :=
+    ⟨{ inputSize := 0, selectors := 0, auxiliaries := 0, lookups := 0 },
+     .empty, degrees⟩
+  let (sharedAux, sharedLookups) := matchCases.foldl (init := (0, 0)) fun (maxA, maxL) (_, block) =>
+    let (_, ls) := Bytecode.blockLayout block |>.run initLS
+    let effectiveLookups := ls.functionLayout.lookups - countReturns block
+    (maxA.max ls.functionLayout.auxiliaries, maxL.max effectiveLookups)
+  pure $ match default with
+    | some block =>
+      let (_, ls) := Bytecode.blockLayout block |>.run initLS
+      let effectiveLookups := ls.functionLayout.lookups - countReturns block
+      (sharedAux.max (ls.functionLayout.auxiliaries + matchCases.size),
+       sharedLookups.max effectiveLookups)
+    | none => (sharedAux, sharedLookups)
+
+/-- Compile a non-tail match as a `matchContinue` block. Used by both the
+    `.let (.var _)` and `.let .wildcard` handlers to avoid duplication. -/
+partial def compileMatchContinue
+ (returnTyp : Typ)
+ (layoutMap : LayoutMap)
+ (innerBindings : Std.HashMap Local (Array Bytecode.ValIdx))
+ (scrutinee : TypedTerm)
+ (cases : List (Pattern × TypedTerm))
+ (matchTyp : Typ)
+ (compileContinuation : Nat → CompileM Bytecode.Block)
+: CompileM Bytecode.Block := do
+  let idxs ← toIndex layoutMap innerBindings scrutinee
+  let ops ← extractOps
+  let (matchCases, default) ← cases.foldlM (init := default)
+    (addCase layoutMap innerBindings returnTyp idxs (yieldCtrl := true))
+  let outputSize ← match typSize layoutMap matchTyp with
+    | .error e => throw e
+    | .ok size => pure size
+  let (sharedAux, sharedLookups) ← computeSharedLayout matchCases default
+  modify fun s => { s with
+    valIdx := s.valIdx + outputSize,
+    degrees := (Array.replicate outputSize 1).foldl (init := s.degrees) (·.push ·) }
+  let continuation ← compileContinuation outputSize
+  let ctrl := .matchContinue idxs[0]! matchCases default outputSize sharedAux sharedLookups continuation
+  pure { ops, ctrl }
+
 partial def TypedTerm.compile
  (term : TypedTerm)
  (returnTyp : Typ)
  (layoutMap : LayoutMap)
  (bindings : Std.HashMap Local (Array Bytecode.ValIdx))
+ (yieldCtrl : Bool := false)
 : CompileM Bytecode.Block := match term.inner with
   | .let (.var var) val bod => do
-    let val ← toIndex layoutMap bindings val
-    bod.compile returnTyp layoutMap (bindings.insert var val)
+    match ← findNonTailMatch layoutMap bindings val with
+    | some (matchTyp, scrutinee, cases, innerBindings) =>
+      if val.escapes then
+        -- All branches escape; this is a tail match (bod is dead code)
+        val.compile returnTyp layoutMap bindings
+      else
+        compileMatchContinue returnTyp layoutMap innerBindings scrutinee cases matchTyp
+          fun outputSize => do
+            let mergedStart := (← get).valIdx - outputSize
+            let mergedIdxs := Array.range' mergedStart outputSize
+            bod.compile returnTyp layoutMap (bindings.insert var mergedIdxs) yieldCtrl
+    | none => do
+      let val ← toIndex layoutMap bindings val
+      bod.compile returnTyp layoutMap (bindings.insert var val) yieldCtrl
   | .let .wildcard val bod => do
-    let _ ← toIndex layoutMap bindings val
-    bod.compile returnTyp layoutMap bindings
+    match ← findNonTailMatch layoutMap bindings val with
+    | some (matchTyp, scrutinee, cases, innerBindings) =>
+      if val.escapes then
+        val.compile returnTyp layoutMap bindings
+      else
+        compileMatchContinue returnTyp layoutMap innerBindings scrutinee cases matchTyp
+          fun _ => bod.compile returnTyp layoutMap bindings yieldCtrl
+    | none => do
+      let _ ← toIndex layoutMap bindings val
+      bod.compile returnTyp layoutMap bindings yieldCtrl
   | .let .. => throw "Should not happen after simplifying"
   | .debug label term ret => do
     let term ← term.mapM (toIndex layoutMap bindings)
     modify fun stt => { stt with ops := stt.ops.push (.debug label term) }
-    ret.compile returnTyp layoutMap bindings
+    ret.compile returnTyp layoutMap bindings yieldCtrl
   | .assertEq a b ret => do
     let a ← toIndex layoutMap bindings a
     let b ← toIndex layoutMap bindings b
     modify fun stt => { stt with ops := stt.ops.push (.assertEq a b) }
-    ret.compile returnTyp layoutMap bindings
+    ret.compile returnTyp layoutMap bindings yieldCtrl
   | .ioSetInfo key idx len ret => do
     let key ← toIndex layoutMap bindings key
     let idx ← toIndex layoutMap bindings idx
     let len ← toIndex layoutMap bindings len
     modify fun stt => { stt with ops := stt.ops.push (.ioSetInfo key idx[0]! len[0]!) }
-    ret.compile returnTyp layoutMap bindings
+    ret.compile returnTyp layoutMap bindings yieldCtrl
   | .ioWrite data ret => do
     let data ← toIndex layoutMap bindings data
     modify fun stt => { stt with ops := stt.ops.push (.ioWrite data) }
-    ret.compile returnTyp layoutMap bindings
+    ret.compile returnTyp layoutMap bindings yieldCtrl
   | .match term cases =>
     match term.typ with
     -- Also do this for tuple-like and array-like (one constructor only) datatypes
@@ -371,7 +503,7 @@ partial def TypedTerm.compile
           pure bindings
         let idxs ← toIndex layoutMap bindings term
         let bindings ← bindArgs bindings vars typs idxs
-        branch.compile returnTyp layoutMap bindings
+        branch.compile returnTyp layoutMap bindings yieldCtrl
       | _ => throw "Impossible case"
     | .array typ _ => match cases with
       | [(.array vars, branch)] => do
@@ -388,25 +520,24 @@ partial def TypedTerm.compile
           pure bindings
         let idxs ← toIndex layoutMap bindings term
         let bindings ← bindArgs bindings vars idxs
-        branch.compile returnTyp layoutMap bindings
+        branch.compile returnTyp layoutMap bindings yieldCtrl
       | _ => throw "Impossible case"
     | _ => do
       let idxs ← toIndex layoutMap bindings term
       let ops ← extractOps
-      let minSelIncluded := (← get).selIdx
       let (cases, default) ← cases.foldlM (init := default)
-        (addCase layoutMap bindings returnTyp idxs)
-      let maxSelExcluded := (← get).selIdx
+        (addCase layoutMap bindings returnTyp idxs yieldCtrl)
       let ctrl := .match idxs[0]! cases default
-      pure { ops, ctrl, minSelIncluded, maxSelExcluded }
+      pure { ops, ctrl }
   | .ret term => do
+    -- Explicit return: always uses Ctrl.return regardless of yieldCtrl
     let idxs ← toIndex layoutMap bindings term
     let state ← get
     let state := { state with selIdx := state.selIdx + 1 }
     set state
     let ops := state.ops
     let id := state.selIdx
-    pure { ops, ctrl := .return (id - 1) idxs, minSelIncluded := id - 1, maxSelExcluded := id }
+    pure { ops, ctrl := .return (id - 1) idxs }
   | _ => do
     let idxs ← toIndex layoutMap bindings term
     let state ← get
@@ -414,13 +545,15 @@ partial def TypedTerm.compile
     set state
     let ops := state.ops
     let id := state.selIdx
-    pure { ops, ctrl := .return (id - 1) idxs, minSelIncluded := id - 1, maxSelExcluded := id }
+    let ctrl := if yieldCtrl && !term.escapes then .yield (id - 1) idxs else .return (id - 1) idxs
+    pure { ops, ctrl }
 
 partial def addCase
   (layoutMap : LayoutMap)
   (bindings : Std.HashMap Local (Array Bytecode.ValIdx))
   (returnTyp : Typ)
   (idxs : Array Bytecode.ValIdx)
+  (yieldCtrl : Bool := false)
 : (Array (G × Bytecode.Block) × Option Bytecode.Block) →
   (Pattern × TypedTerm) →
   CompileM (Array (G × Bytecode.Block) × Option Bytecode.Block) := fun (cases, default) (pat, term) =>
@@ -429,7 +562,7 @@ partial def addCase
   match pat with
   | .field g => do
     let initState ← get
-    let term ← term.compile returnTyp layoutMap bindings
+    let term ← term.compile returnTyp layoutMap bindings yieldCtrl
     set { initState with selIdx := (← get).selIdx }
     let cases' := cases.push (g, term)
     pure (cases', default)
@@ -454,13 +587,13 @@ partial def addCase
       pure bindings
     let bindings ← bindArgs bindings pats offsets idxs
     let initState ← get
-    let term ← term.compile returnTyp layoutMap bindings
+    let term ← term.compile returnTyp layoutMap bindings yieldCtrl
     set { initState with selIdx := (← get).selIdx }
     let cases' := cases.push (.ofNat index, term)
     pure (cases', default)
   | .wildcard => do
     let initState ← get
-    let term ← term.compile returnTyp layoutMap bindings
+    let term ← term.compile returnTyp layoutMap bindings yieldCtrl
     set { initState with selIdx := (← get).selIdx }
     pure (cases, .some term)
   | _ => throw "Impossible case"
@@ -479,7 +612,7 @@ def TypedFunction.compile (layoutMap : LayoutMap) (f : TypedFunction) :
         | .ok len => pure len
       let indices := Array.range' valIdx len
       pure (valIdx + len, bindings.insert arg indices)
-  let state := { valIdx, selIdx := 0, ops := #[] }
+  let state := { valIdx, selIdx := 0, ops := #[], degrees := Array.replicate valIdx 1 }
   match f.body.compile f.output layoutMap bindings |>.run state with
   | .error e _ => throw e
   | .ok body _ =>

--- a/Ix/IxVM/KERNEL.md
+++ b/Ix/IxVM/KERNEL.md
@@ -15,8 +15,8 @@ used by `lean4lean` and `nanoda_lib`.
 
 The Lean and Rust implementations are feature-complete reference kernels. The Aiur
 implementation is a work-in-progress circuit targeting zero-knowledge proof generation,
-with significant constraints (no mutation, no dynamic indexing, no non-tail matches)
-but with aggressive function-call caching that provides call-by-need semantics for free.
+with some constraints (no mutation and no dynamic indexing) but with aggressive
+function-call caching that provides call-by-need semantics for free.
 
 ---
 

--- a/Tests/Aiur/Aiur.lean
+++ b/Tests/Aiur/Aiur.lean
@@ -457,6 +457,287 @@ def toplevel := ⟦
     let p = unwrap_or(opt, TPair.Mk(0, 0));
     tpair_first(p) + tpair_second(p)
   }
+
+  ---------------------------------------------------------------------------
+  -- Non-tail match: exercises basic, early return, sequential, and nested
+  -- cases. All paths tested via a single entry point to minimise proof count.
+  ---------------------------------------------------------------------------
+
+  fn ntm_basic(a: G) -> G {
+    let y = match a { 0 => 100, 1 => 200, _ => a * a, };
+    y + 1
+  }
+  fn ntm_early_ret(a: G) -> G {
+    let y = match a { 0 => return 999, _ => a + a, };
+    y * y
+  }
+  fn ntm_sequential(a: G, b: G) -> G {
+    let x = match a { 0 => 1, 1 => 2, _ => a, };
+    let y = match b { 0 => 10, 1 => 20, _ => b, };
+    x + y
+  }
+  fn ntm_nested(a: G, b: G) -> G {
+    let x = match a {
+      0 => match b { 0 => return 0, _ => 42, },
+      _ => 99,
+    };
+    x + 1
+  }
+  -- Pre-branch constant multiplied in a branch (no default).
+  -- c has degree 0; exposes sharedAux over-count when all branches are
+  -- explicit field cases (no inverse-witness auxiliaries to mask the gap).
+  fn ntm_const_mul(a: G) -> G {
+    let c = 5;
+    let x = match a { 0 => c * c, 1 => c * c * c, };
+    x + 1
+  }
+  -- Non-tail match returning a tuple (multi-output merge)
+  fn ntm_tuple(a: G) -> (G, G) {
+    let (x, y) = match a { 0 => (10, 20), 1 => (30, 40), _ => (a, a * a), };
+    (x + 1, y + 1)
+  }
+
+  -- Non-tail match followed by a tail match (continuation is itself a match)
+  fn ntm_then_tail_match(a: G, b: G) -> G {
+    let x = match a { 0 => 100, _ => a, };
+    match b { 0 => x, _ => x + b, }
+  }
+
+  -- Non-tail match with function calls in branches
+  fn ntm_helper(x: G) -> G { x * x + 1 }
+  fn ntm_call_in_branch(a: G) -> G {
+    let x = match a { 0 => ntm_helper(5), _ => ntm_helper(a), };
+    x + 1
+  }
+
+  -- Non-tail match with store/load in branches (lookup gating)
+  fn ntm_store_load(a: G) -> G {
+    let x = match a { 0 => load(store(42)), _ => load(store(a)), };
+    x + 1
+  }
+
+  -- Refutable pattern destructuring in a let (like `let Nat.Succ(&x) = n;`)
+  fn ntm_ctor_let(n: Nat) -> G {
+    let Nat.Succ(&inner) = n;
+    match inner { Nat.Zero => 1, Nat.Succ(_) => 2, }
+  }
+
+  -- Refutable pattern let with a stored enum (Shape through pointer)
+  fn ntm_shape_let() -> G {
+    let s = store(Shape.Rect(3, 4));
+    let Shape.Rect(w, h) = load(s);
+    w + h
+  }
+
+  -- Large match (8 branches, no default) — like const_num_levels
+  fn ntm_large(a: G) -> G {
+    let x = match a {
+      0 => 10, 1 => 20, 2 => 30, 3 => 40,
+      4 => 50, 5 => 60, 6 => 70, 7 => 80,
+    };
+    x + 1
+  }
+
+  -- Non-tail match where one branch has a lookup (store) and another doesn't,
+  -- followed by a continuation that also does a lookup. Tests sharedLookups.
+  fn ntm_mixed_lookups(a: G) -> G {
+    let x = match a {
+      0 => 42,
+      _ => load(store(a)),
+    };
+    load(store(x + 1))
+  }
+
+  -- Non-tail match where branches call different functions with different
+  -- lookup counts. Replicates the IxVM get_constant_info_by_variant pattern.
+  fn ntm_heavy_calls(a: G) -> G { load(store(load(store(a)))) }
+  fn ntm_light_calls(a: G) -> G { a + 1 }
+  fn ntm_asymmetric_lookups(a: G, b: G) -> G {
+    let x = match a {
+      0 => ntm_heavy_calls(b),
+      1 => ntm_light_calls(b),
+      _ => b,
+    };
+    load(store(x))
+  }
+
+  -- Non-tail match inside a tail match branch (like get_constant_info)
+  -- Minimal reproducer: non-tail match inside a tail match branch
+  fn ntm_inside_tail_match(flag: G, a: G) -> G {
+    match flag {
+      0 =>
+        let x = match a { 0 => 100, 1 => 200, };
+        x + 1,
+      _ => a,
+    }
+  }
+
+  -- Explicit branches heavier than default: CKind.B and CKind.E have
+  -- pointer derefs (&Nat) that generate load ops, making those branches
+  -- use more auxiliaries than CKind.A/C/D/F. When the match compiler
+  -- places a light branch as the default, the default has fewer auxiliaries
+  -- than the heavy explicit branches. This catches the bug where
+  -- Ctrl::Match left state.column at the default's level, missing the
+  -- explicit branches' higher water mark.
+  fn ntm_heavy_explicit(flag: G, kind: CKind) -> G {
+    match flag {
+      0 =>
+        let val = match kind {
+          CKind.A(x) => x,
+          CKind.B(x, &extra) =>
+            match extra { Nat.Zero => x, Nat.Succ(_) => x + 10, },
+          CKind.C(x) => x * x,
+          CKind.D(x, y) => x + y,
+          CKind.E(x, &extra) =>
+            match extra { Nat.Zero => x * x, Nat.Succ(_) => x + 100, },
+          CKind.F(x) => x,
+        };
+        val + 1,
+      _ => 0,
+    }
+  }
+
+  -- Replicates const_num_levels: 8-branch non-tail match (no default)
+  -- inside a many-branch outer tail match
+  fn ntm_large_inside_tail(outer: G, inner: G) -> G {
+    match outer {
+      0 => inner,
+      1 => inner + 1,
+      2 =>
+        let x = match inner {
+          0 => 10, 1 => 20, 2 => 30, 3 => 40,
+          4 => 50, 5 => 60, 6 => 70, 7 => 80,
+        };
+        x + 1,
+      _ => inner * inner,
+    }
+  }
+
+  -- Replicates rec_rule_first_ctor: refutable pattern let with pointer deref
+  -- inside a deeply nested tail match. The `let` destructures a stored
+  -- enum value through a pointer.
+  fn ntm_refutable_let_in_match(flag: G) -> G {
+    let list = store(Nat.Succ(store(Nat.Zero)));
+    match flag {
+      0 =>
+        let Nat.Succ(&inner) = load(list);
+        match inner { Nat.Zero => 42, _ => 99, },
+      _ => 0,
+    }
+  }
+
+  -- Replicates convert_all: matchContinue inside List.Cons branch,
+  -- continuation has store + function call
+  -- Replicates convert_all: recursive function with matchContinue inside
+  -- a List.Cons branch, continuation stores + recurses
+  -- Replicates convert_all: recursive list processing with a non-tail match
+  -- in the Cons branch where branches call functions with different lookups
+  -- Replicates convert_all pattern: recursive function with 6-branch
+  -- non-tail match in the Cons branch. Each branch calls a different
+  -- function with different lookup counts. Continuation stores + recurses.
+  fn ntm_cv_a(x: G) -> G { x }
+  fn ntm_cv_b(x: G) -> G { load(store(x)) }
+  fn ntm_cv_c(x: G) -> G { let _ = store(x); load(store(x + 1)) }
+  fn ntm_cv_d(x: G) -> G { x * x }
+  fn ntm_cv_e(x: G) -> G { load(store(load(store(x)))) }
+  fn ntm_cv_f(x: G, y: G) -> G { x + y }
+  -- Replicates convert_all exactly: Cons branch with pointer derefs in
+  -- the pattern, non-tail match with branches that have different arg
+  -- counts (some with pointer derefs), continuation stores + recurses.
+  -- 6-variant enum with pointer fields, matching convert_one's ConvertKind
+  enum CKind {
+    A(G),
+    B(G, &Nat),
+    C(G),
+    D(G, G),
+    E(G, &Nat),
+    F(G)
+  }
+  fn ntm_cv_a2(x: G) -> G { x + 1 }
+  fn ntm_cv_b2(x: G, extra: Nat) -> G {
+    match extra { Nat.Zero => x, Nat.Succ(_) => x + 10, }
+  }
+  fn ntm_cv_c2(x: G) -> G { x * x }
+  fn ntm_cv_d2(x: G, y: G) -> G { x + y }
+  fn ntm_cv_e2(x: G, extra: Nat) -> G {
+    match extra { Nat.Zero => x * x, Nat.Succ(_) => x + 100, }
+  }
+  fn ntm_cv_f2(x: G) -> G { load(store(x)) }
+  fn ntm_convert_all(inputs: Nat, kind: CKind) -> G {
+    match inputs {
+      Nat.Zero => 0,
+      Nat.Succ(&rest) =>
+        let ci = match kind {
+          CKind.A(x) => ntm_cv_a2(x),
+          CKind.B(x, &extra) => ntm_cv_b2(x, extra),
+          CKind.C(x) => ntm_cv_c2(x),
+          CKind.D(x, y) => ntm_cv_d2(x, y),
+          CKind.E(x, &extra) => ntm_cv_e2(x, extra),
+          CKind.F(x) => ntm_cv_f2(x),
+        };
+        let _ = store(ci);
+        ci + ntm_convert_all(rest, kind),
+    }
+  }
+
+  fn ntm_recursive_test() -> G {
+    let zero = Nat.Zero;
+    let one = Nat.Succ(store(Nat.Zero));
+    let two = Nat.Succ(store(Nat.Succ(store(Nat.Zero))));
+    -- Exercise ALL 6 branches AND both Nil/Cons paths of the outer match.
+    -- Multiple iterations to stress shared columns across many trace rows.
+    let r1 = ntm_convert_all(two, CKind.A(10));
+    let r2 = ntm_convert_all(one, CKind.B(5, store(Nat.Succ(store(Nat.Zero)))));
+    let r3 = ntm_convert_all(two, CKind.C(3));
+    let r4 = ntm_convert_all(one, CKind.D(2, 3));
+    let r5 = ntm_convert_all(one, CKind.E(7, store(Nat.Zero)));
+    let r6 = ntm_convert_all(two, CKind.F(4));
+    -- Also call with zero iterations (Nil path only)
+    let r7 = ntm_convert_all(zero, CKind.A(99));
+    r1 + r2 + r3 + r4 + r5 + r6 + r7
+  }
+
+  fn ntm_tuple_sum(a: G) -> G {
+    let (x, y) = ntm_tuple(a);
+    x + y
+  }
+  pub fn non_tail_match() -> G {
+    -- Basic, early return, sequential, nested, const mul
+    let r1 = ntm_basic(0) + ntm_basic(5);
+    let r2 = ntm_early_ret(0) + ntm_early_ret(3);
+    let r3 = ntm_sequential(1, 1);
+    let r4 = ntm_nested(0, 1) + ntm_nested(1, 0);
+    let r5 = ntm_const_mul(0);
+    -- Tuple output, tail-match continuation, calls/store in branches
+    let r6 = ntm_tuple_sum(0);
+    let r7 = ntm_then_tail_match(0, 3);
+    let r8 = ntm_call_in_branch(0);
+    let r9 = ntm_store_load(0);
+    -- Large match, constructor patterns, mixed lookups
+    let r10 = ntm_large(0);
+    let r11 = ntm_ctor_let(Nat.Succ(store(Nat.Zero)));
+    let r12 = ntm_mixed_lookups(0);
+    let r13 = ntm_shape_let();
+    let r14 = ntm_asymmetric_lookups(1, 10);
+    -- matchContinue inside tail match (both branches exercised)
+    let r15 = ntm_inside_tail_match(0, 0) + ntm_inside_tail_match(0, 1)
+            + ntm_inside_tail_match(1, 5);
+    -- Large match inside tail match (all outer+inner branches)
+    let r16 = ntm_large_inside_tail(2, 0) + ntm_large_inside_tail(2, 3)
+            + ntm_large_inside_tail(2, 7) + ntm_large_inside_tail(0, 5)
+            + ntm_large_inside_tail(1, 5) + ntm_large_inside_tail(3, 4);
+    -- Heavy explicit branches (pointer derefs heavier than default)
+    let r17 = ntm_heavy_explicit(0, CKind.B(5, store(Nat.Succ(store(Nat.Zero)))))
+            + ntm_heavy_explicit(0, CKind.A(7)) + ntm_heavy_explicit(1, CKind.A(99));
+    -- Refutable pattern let
+    let r18 = ntm_refutable_let_in_match(0);
+    -- Recursive with all 6 branches + Nil path exercised
+    let r19 = ntm_recursive_test();
+    -- Nested early return (yields 0, sum unchanged)
+    let r20 = ntm_nested(0, 0);
+    r1 + r2 + r3 + r4 + r5 + r6 + r7 + r8 + r9 + r10
+    + r11 + r12 + r13 + r14 + r15 + r16 + r17 + r18 + r19 + r20
+  }
 ⟧
 
 def aiurTestCases : List AiurTestCase := [
@@ -595,6 +876,9 @@ def aiurTestCases : List AiurTestCase := [
     .noIO `template_unwrap_none #[] #[99],
     .noIO `template_pair #[] #[10, 20],
     .noIO `template_nested #[] #[7],
+
+    -- Non-tail match: all patterns in one proof
+    .noIO `non_tail_match #[] #[2281],
   ]
 
 end

--- a/src/aiur/bytecode.rs
+++ b/src/aiur/bytecode.rs
@@ -31,8 +31,6 @@ impl FunctionLayout {
 pub struct Block {
   pub(crate) ops: Vec<Op>,
   pub(crate) ctrl: Ctrl,
-  pub(crate) min_sel_included: SelIdx,
-  pub(crate) max_sel_excluded: SelIdx,
 }
 
 pub enum Op {
@@ -65,6 +63,16 @@ pub enum Op {
 pub enum Ctrl {
   Match(ValIdx, FxIndexMap<G, Block>, Option<Box<Block>>),
   Return(SelIdx, Vec<ValIdx>),
+  Yield(SelIdx, Vec<ValIdx>),
+  MatchContinue(
+    ValIdx,
+    FxIndexMap<G, Block>,
+    Option<Box<Block>>,
+    usize,      // output_size
+    usize,      // shared_auxiliaries
+    usize,      // shared_lookups
+    Box<Block>, // continuation
+  ),
 }
 
 pub type SelIdx = usize;

--- a/src/aiur/constraints.rs
+++ b/src/aiur/constraints.rs
@@ -1,24 +1,27 @@
 use multi_stark::{
-  builder::symbolic::{SymbolicExpression, var},
+  builder::symbolic::{Entry, SymbolicExpression, var},
   lookup::Lookup,
   p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
   p3_field::{Field, PrimeCharacteristicRing},
 };
 use std::{array, ops::Range};
 
-use crate::aiur::{
-  G,
-  bytecode::{Block, Ctrl, Function, FunctionLayout, Op, Toplevel},
-  function_channel,
-  gadgets::{
-    AiurGadget,
-    bytes1::{Bytes1, Bytes1Op},
-    bytes2::{Bytes2, Bytes2Op},
+use crate::{
+  FxIndexMap,
+  aiur::{
+    G,
+    bytecode::{Block, Ctrl, Function, FunctionLayout, Op, Toplevel, ValIdx},
+    function_channel,
+    gadgets::{
+      AiurGadget,
+      bytes1::{Bytes1, Bytes1Op},
+      bytes2::{Bytes2, Bytes2Op},
+    },
+    memory_channel, u8_add_channel, u8_and_channel,
+    u8_bit_decomposition_channel, u8_less_than_channel, u8_or_channel,
+    u8_range_check_channel, u8_shift_left_channel, u8_shift_right_channel,
+    u8_sub_channel, u8_xor_channel,
   },
-  memory_channel, u8_add_channel, u8_and_channel, u8_bit_decomposition_channel,
-  u8_less_than_channel, u8_or_channel, u8_range_check_channel,
-  u8_shift_left_channel, u8_shift_right_channel, u8_sub_channel,
-  u8_xor_channel,
 };
 
 type Expr = SymbolicExpression<G>;
@@ -61,6 +64,9 @@ struct ConstraintState {
   lookups: Vec<Lookup<Expr>>,
   map: Vec<(Expr, Degree)>,
   constraints: Constraints,
+  /// Yield info collected from branches, used by MatchContinue.
+  /// NOT part of save/restore so yields persist across branch restores.
+  yield_info: Vec<(Expr, Vec<(Expr, Degree)>)>,
 }
 
 struct SharedState {
@@ -119,8 +125,10 @@ impl Toplevel {
       map: vec![],
       lookups: vec![Lookup::empty(); function.layout.lookups],
       constraints,
+      yield_info: vec![],
     };
     function.build_constraints(&mut state);
+    simplify_selectors(&mut state.constraints);
     (state.constraints, state.lookups)
   }
 }
@@ -153,15 +161,80 @@ impl Function {
 
 impl Block {
   fn collect_constraints(&self, sel: Expr, state: &mut ConstraintState) {
+    // Boolean constraint for this block's selector
+    let block_sel = self.get_block_selector(state);
+    state
+      .constraints
+      .zeros
+      .push(block_sel.clone() * (Expr::from(G::ONE) - block_sel));
     self.ops.iter().for_each(|op| op.collect_constraints(&sel, state));
     self.ctrl.collect_constraints(sel, state);
   }
 
-  fn get_block_selector(&self, state: &mut ConstraintState) -> Expr {
-    (self.min_sel_included..self.max_sel_excluded)
-      .map(|i| var(state.selector_index(i)))
-      .fold(Expr::Constant(G::ZERO), |var, acc| var + acc)
+  /// Compute this block's selector as the sum of its immediate children's
+  /// selectors. For leaf blocks (Return/Yield) this is the single selector
+  /// variable. For Match/MatchContinue this is the sum of case branch
+  /// selectors — crucially excluding the MatchContinue's continuation,
+  /// whose return selector fires alongside a yield selector and must not
+  /// be double-counted.
+  fn get_block_selector(&self, state: &ConstraintState) -> Expr {
+    match &self.ctrl {
+      Ctrl::Return(sel, _) | Ctrl::Yield(sel, _) => {
+        var(state.selector_index(*sel))
+      },
+      Ctrl::Match(_, cases, def) | Ctrl::MatchContinue(_, cases, def, ..) => {
+        let mut sel = Expr::from(G::ZERO);
+        for branch in cases.values() {
+          sel += branch.get_block_selector(state);
+        }
+        if let Some(branch) = def {
+          sel += branch.get_block_selector(state);
+        }
+        sel
+      },
+    }
   }
+}
+
+/// Process match cases and optional default branch, emitting selector-gated
+/// constraints. Each branch is processed with save/restore so branches share
+/// auxiliary columns. Returns (max_column, max_lookup) across all branches.
+fn collect_branch_constraints(
+  var: ValIdx,
+  cases: &FxIndexMap<G, Block>,
+  def: &Option<Box<Block>>,
+  state: &mut ConstraintState,
+) -> (usize, usize) {
+  let (var, _) = state.map[var].clone();
+  let init = state.save();
+  let mut max_column = init.column;
+  let mut max_lookup = init.lookup;
+  for (&value, branch) in cases.iter() {
+    let branch_sel = branch.get_block_selector(state);
+    state
+      .constraints
+      .zeros
+      .push(branch_sel.clone() * (var.clone() - Expr::from(value)));
+    branch.collect_constraints(branch_sel, state);
+    max_column = max_column.max(state.column);
+    max_lookup = max_lookup.max(state.lookup);
+    state.restore(&init);
+  }
+  if let Some(branch) = def {
+    let branch_sel = branch.get_block_selector(state);
+    for &value in cases.keys() {
+      let inverse = state.next_auxiliary();
+      state.constraints.zeros.push(
+        branch_sel.clone()
+          * ((var.clone() - Expr::from(value)) * inverse - Expr::from(G::ONE)),
+      );
+    }
+    branch.collect_constraints(branch_sel, state);
+    max_column = max_column.max(state.column);
+    max_lookup = max_lookup.max(state.lookup);
+    state.restore(&init);
+  }
+  (max_column, max_lookup)
 }
 
 impl Ctrl {
@@ -187,31 +260,163 @@ impl Ctrl {
         combine_lookup_args(lookup, args);
         // multiplicity is already set
       },
-      Ctrl::Match(var, cases, def) => {
-        let (var, _) = state.map[*var].clone();
-        let init = state.save();
-        for (&value, branch) in cases.iter() {
-          let branch_sel = branch.get_block_selector(state);
-          state
-            .constraints
-            .zeros
-            .push(branch_sel.clone() * (var.clone() - Expr::from(value)));
-          branch.collect_constraints(branch_sel, state);
-          state.restore(&init);
-        }
-        if let Some(branch) = def {
-          let branch_sel = branch.get_block_selector(state);
-          for &value in cases.keys() {
-            let inverse = state.next_auxiliary();
-            state.constraints.zeros.push(
-              branch_sel.clone()
-                * ((var.clone() - Expr::from(value)) * inverse
-                  - Expr::from(G::ONE)),
-            );
-          }
-          branch.collect_constraints(branch_sel, state);
-        }
+      Ctrl::Yield(sel, values) => {
+        let yield_sel = var(state.selector_index(*sel));
+        let yield_vals: Vec<(Expr, Degree)> =
+          values.iter().map(|&v| state.map[v].clone()).collect();
+        state.yield_info.push((yield_sel, yield_vals));
       },
+      Ctrl::Match(var, cases, def) => {
+        let (max_column, max_lookup) =
+          collect_branch_constraints(*var, cases, def, state);
+        state.column = max_column;
+        state.lookup = max_lookup;
+      },
+      Ctrl::MatchContinue(
+        var,
+        cases,
+        def,
+        output_size,
+        _shared_aux,
+        _shared_lookups,
+        continuation,
+      ) => {
+        let yield_info_base = state.yield_info.len();
+        let (max_column, max_lookup) =
+          collect_branch_constraints(*var, cases, def, state);
+
+        // Advance past the shared branch region so merge + continuation
+        // auxiliaries don't collide with branch auxiliaries.
+        state.column = max_column;
+        state.lookup = max_lookup;
+
+        // Collect yield info from branches
+        let yields: Vec<_> =
+          state.yield_info.drain(yield_info_base..).collect();
+
+        // Compute continuation selector = sum of yield selectors
+        let cont_sel = yields
+          .iter()
+          .map(|(sel, _)| sel.clone())
+          .fold(Expr::from(G::ZERO), |a, b| a + b);
+
+        // Merge constraints, gated by the parent selector `sel`. Gating is
+        // required because a matchContinue inside a tail match branch may be
+        // inactive (the other branch was taken). At the OOD evaluation point,
+        // ungated constraints on shared auxiliary columns don't evaluate to 0.
+        for i in 0..*output_size {
+          let merged = state.next_auxiliary();
+          let sum = yields
+            .iter()
+            .map(|(sel_j, vals)| sel_j.clone() * vals[i].0.clone())
+            .fold(Expr::from(G::ZERO), |a, b| a + b);
+          state.constraints.zeros.push(sel.clone() * (merged.clone() - sum));
+          state.map.push((merged, 1));
+        }
+
+        // Link continuation selector to the continuation block's selector
+        let cont_block_sel = continuation.get_block_selector(state);
+        state
+          .constraints
+          .zeros
+          .push(sel.clone() * (cont_block_sel - cont_sel.clone()));
+
+        // Collect constraints for the continuation, gated by cont_sel
+        continuation.collect_constraints(cont_sel, state);
+      },
+    }
+  }
+}
+
+/// If `expr` has the form `Variable(sel) - A` or `A - Variable(sel)` where
+/// `sel` is a selector column (index in `selectors` range), returns
+/// `Some((column_index, A))`.
+fn extract_selector_equality(
+  expr: &Expr,
+  selectors: &Range<usize>,
+) -> Option<(usize, Expr)> {
+  fn is_selector_var(e: &Expr, selectors: &Range<usize>) -> Option<usize> {
+    if let SymbolicExpression::Variable(v) = e
+      && v.entry == (Entry::Main { offset: 0 })
+      && selectors.contains(&v.index)
+    {
+      return Some(v.index);
+    }
+    None
+  }
+  if let SymbolicExpression::Sub { x, y, .. } = expr {
+    if let Some(col) = is_selector_var(x, selectors)
+      && is_selector_var(y, selectors).is_none()
+    {
+      return Some((col, *y.clone()));
+    }
+    if let Some(col) = is_selector_var(y, selectors)
+      && is_selector_var(x, selectors).is_none()
+    {
+      return Some((col, *x.clone()));
+    }
+  }
+  None
+}
+
+/// Replace all occurrences of `var(col)` in `expr` with `replacement`.
+fn substitute_in_expr(expr: &Expr, col: usize, replacement: &Expr) -> Expr {
+  match expr {
+    SymbolicExpression::Variable(v)
+      if v.entry == (Entry::Main { offset: 0 }) && v.index == col =>
+    {
+      replacement.clone()
+    },
+    SymbolicExpression::Variable(_)
+    | SymbolicExpression::Constant(_)
+    | SymbolicExpression::IsFirstRow
+    | SymbolicExpression::IsLastRow
+    | SymbolicExpression::IsTransition => expr.clone(),
+    SymbolicExpression::Add { x, y, degree_multiple } => {
+      SymbolicExpression::Add {
+        x: Box::new(substitute_in_expr(x, col, replacement)),
+        y: Box::new(substitute_in_expr(y, col, replacement)),
+        degree_multiple: *degree_multiple,
+      }
+    },
+    SymbolicExpression::Sub { x, y, degree_multiple } => {
+      SymbolicExpression::Sub {
+        x: Box::new(substitute_in_expr(x, col, replacement)),
+        y: Box::new(substitute_in_expr(y, col, replacement)),
+        degree_multiple: *degree_multiple,
+      }
+    },
+    SymbolicExpression::Neg { x, degree_multiple } => SymbolicExpression::Neg {
+      x: Box::new(substitute_in_expr(x, col, replacement)),
+      degree_multiple: *degree_multiple,
+    },
+    SymbolicExpression::Mul { x, y, degree_multiple } => {
+      SymbolicExpression::Mul {
+        x: Box::new(substitute_in_expr(x, col, replacement)),
+        y: Box::new(substitute_in_expr(y, col, replacement)),
+        degree_multiple: *degree_multiple,
+      }
+    },
+  }
+}
+
+/// Simplify selector constraints: when `sel_i = A`, replace all occurrences of
+/// `sel_i` with `A` and remove the constraint. Repeat until fixpoint.
+fn simplify_selectors(constraints: &mut Constraints) {
+  loop {
+    let sub = constraints
+      .zeros
+      .iter()
+      .find_map(|expr| extract_selector_equality(expr, &constraints.selectors));
+    let Some((col, replacement)) = sub else {
+      break;
+    };
+    constraints.zeros.retain(|expr| {
+      extract_selector_equality(expr, &constraints.selectors)
+        .is_none_or(|(c, _)| c != col)
+    });
+    for expr in &mut constraints.zeros {
+      *expr = substitute_in_expr(expr, col, &replacement);
     }
   }
 }

--- a/src/aiur/constraints.rs
+++ b/src/aiur/constraints.rs
@@ -1,5 +1,5 @@
 use multi_stark::{
-  builder::symbolic::{Entry, SymbolicExpression, var},
+  builder::symbolic::{SymbolicExpression, var},
   lookup::Lookup,
   p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
   p3_field::{Field, PrimeCharacteristicRing},
@@ -128,7 +128,6 @@ impl Toplevel {
       yield_info: vec![],
     };
     function.build_constraints(&mut state);
-    simplify_selectors(&mut state.constraints);
     (state.constraints, state.lookups)
   }
 }
@@ -149,13 +148,7 @@ impl Function {
     // the return lookup occupies the first lookup slot
     state.lookups[0].multiplicity = -multiplicity.clone();
     state.lookup += 1;
-    // the multiplicity can only be set if one and only one selector is set
-    let sel = self.body.get_block_selector(state);
-    state
-      .constraints
-      .zeros
-      .push(multiplicity * (Expr::from(G::ONE) - sel.clone()));
-    self.body.collect_constraints(sel, state);
+    self.body.collect_constraints(self.body.get_block_selector(state), state);
   }
 }
 
@@ -316,107 +309,11 @@ impl Ctrl {
 
         // Link continuation selector to the continuation block's selector
         let cont_block_sel = continuation.get_block_selector(state);
-        state
-          .constraints
-          .zeros
-          .push(sel.clone() * (cont_block_sel - cont_sel.clone()));
+        state.constraints.zeros.push(cont_block_sel - cont_sel.clone());
 
         // Collect constraints for the continuation, gated by cont_sel
         continuation.collect_constraints(cont_sel, state);
       },
-    }
-  }
-}
-
-/// If `expr` has the form `Variable(sel) - A` or `A - Variable(sel)` where
-/// `sel` is a selector column (index in `selectors` range), returns
-/// `Some((column_index, A))`.
-fn extract_selector_equality(
-  expr: &Expr,
-  selectors: &Range<usize>,
-) -> Option<(usize, Expr)> {
-  fn is_selector_var(e: &Expr, selectors: &Range<usize>) -> Option<usize> {
-    if let SymbolicExpression::Variable(v) = e
-      && v.entry == (Entry::Main { offset: 0 })
-      && selectors.contains(&v.index)
-    {
-      return Some(v.index);
-    }
-    None
-  }
-  if let SymbolicExpression::Sub { x, y, .. } = expr {
-    if let Some(col) = is_selector_var(x, selectors)
-      && is_selector_var(y, selectors).is_none()
-    {
-      return Some((col, *y.clone()));
-    }
-    if let Some(col) = is_selector_var(y, selectors)
-      && is_selector_var(x, selectors).is_none()
-    {
-      return Some((col, *x.clone()));
-    }
-  }
-  None
-}
-
-/// Replace all occurrences of `var(col)` in `expr` with `replacement`.
-fn substitute_in_expr(expr: &Expr, col: usize, replacement: &Expr) -> Expr {
-  match expr {
-    SymbolicExpression::Variable(v)
-      if v.entry == (Entry::Main { offset: 0 }) && v.index == col =>
-    {
-      replacement.clone()
-    },
-    SymbolicExpression::Variable(_)
-    | SymbolicExpression::Constant(_)
-    | SymbolicExpression::IsFirstRow
-    | SymbolicExpression::IsLastRow
-    | SymbolicExpression::IsTransition => expr.clone(),
-    SymbolicExpression::Add { x, y, degree_multiple } => {
-      SymbolicExpression::Add {
-        x: Box::new(substitute_in_expr(x, col, replacement)),
-        y: Box::new(substitute_in_expr(y, col, replacement)),
-        degree_multiple: *degree_multiple,
-      }
-    },
-    SymbolicExpression::Sub { x, y, degree_multiple } => {
-      SymbolicExpression::Sub {
-        x: Box::new(substitute_in_expr(x, col, replacement)),
-        y: Box::new(substitute_in_expr(y, col, replacement)),
-        degree_multiple: *degree_multiple,
-      }
-    },
-    SymbolicExpression::Neg { x, degree_multiple } => SymbolicExpression::Neg {
-      x: Box::new(substitute_in_expr(x, col, replacement)),
-      degree_multiple: *degree_multiple,
-    },
-    SymbolicExpression::Mul { x, y, degree_multiple } => {
-      SymbolicExpression::Mul {
-        x: Box::new(substitute_in_expr(x, col, replacement)),
-        y: Box::new(substitute_in_expr(y, col, replacement)),
-        degree_multiple: *degree_multiple,
-      }
-    },
-  }
-}
-
-/// Simplify selector constraints: when `sel_i = A`, replace all occurrences of
-/// `sel_i` with `A` and remove the constraint. Repeat until fixpoint.
-fn simplify_selectors(constraints: &mut Constraints) {
-  loop {
-    let sub = constraints
-      .zeros
-      .iter()
-      .find_map(|expr| extract_selector_equality(expr, &constraints.selectors));
-    let Some((col, replacement)) = sub else {
-      break;
-    };
-    constraints.zeros.retain(|expr| {
-      extract_selector_equality(expr, &constraints.selectors)
-        .is_none_or(|(c, _)| c != col)
-    });
-    for expr in &mut constraints.zeros {
-      *expr = substitute_in_expr(expr, col, &replacement);
     }
   }
 }

--- a/src/aiur/execute.rs
+++ b/src/aiur/execute.rs
@@ -6,7 +6,7 @@ use crate::{
   FxIndexMap,
   aiur::{
     G,
-    bytecode::{Ctrl, FunIdx, Function, Op, Toplevel},
+    bytecode::{Block, Ctrl, FunIdx, Function, Op, Toplevel},
     gadgets::{
       AiurGadget,
       bytes1::{Bytes1, Bytes1Op, Bytes1Queries},
@@ -98,6 +98,12 @@ struct CallerState {
   fun_idx: FunIdx,
   map: Vec<G>,
   unconstrained: bool,
+  continuation_depth: usize,
+}
+
+struct ContinuationState<'a> {
+  block: &'a Block,
+  map_len: usize,
 }
 
 impl Function {
@@ -111,6 +117,7 @@ impl Function {
   ) -> Vec<G> {
     let mut exec_entries_stack = vec![];
     let mut callers_states_stack = vec![];
+    let mut continuation_stack: Vec<ContinuationState<'_>> = vec![];
     macro_rules! push_block_exec_entries {
       ($block:expr) => {
         exec_entries_stack.push(ExecEntry::Ctrl(&$block.ctrl));
@@ -156,6 +163,7 @@ impl Function {
               fun_idx,
               map: saved_map,
               unconstrained,
+              continuation_depth: continuation_stack.len(),
             });
             fun_idx = *callee_idx;
             unconstrained = unconstrained || *op_unconstrained;
@@ -345,6 +353,34 @@ impl Function {
             push_block_exec_entries!(default);
           }
         },
+        ExecEntry::Ctrl(Ctrl::MatchContinue(
+          val_idx,
+          cases,
+          default,
+          _output_size,
+          _shared_aux,
+          _shared_lookups,
+          continuation,
+        )) => {
+          continuation_stack.push(ContinuationState {
+            block: continuation,
+            map_len: map.len(),
+          });
+          let val = &map[*val_idx];
+          if let Some(block) = cases.get(val) {
+            push_block_exec_entries!(block);
+          } else {
+            let default = default.as_ref().expect("No match");
+            push_block_exec_entries!(default);
+          }
+        },
+        ExecEntry::Ctrl(Ctrl::Yield(_, output)) => {
+          let cont = continuation_stack.pop().expect("No continuation");
+          let yielded: Vec<G> = output.iter().map(|&v| map[v]).collect();
+          map.truncate(cont.map_len);
+          map.extend(yielded);
+          push_block_exec_entries!(cont.block);
+        },
         ExecEntry::Ctrl(Ctrl::Return(_, output)) => {
           // Register the query.
           let input_size = toplevel.functions[fun_idx].layout.input_size;
@@ -359,15 +395,16 @@ impl Function {
             fun_idx: caller_idx,
             map: caller_map,
             unconstrained: caller_unconstrained,
+            continuation_depth,
           }) = callers_states_stack.pop()
           {
-            // Recover the state of the caller.
+            continuation_stack.truncate(continuation_depth);
             fun_idx = caller_idx;
             map = caller_map;
             map.extend(output);
             unconstrained = caller_unconstrained;
           } else {
-            // No outer caller. About to exit.
+            continuation_stack.clear();
             assert!(exec_entries_stack.is_empty());
             map = output;
             break;

--- a/src/aiur/trace.rs
+++ b/src/aiur/trace.rs
@@ -10,17 +10,20 @@ use rayon::{
   slice::ParallelSliceMut,
 };
 
-use crate::aiur::{
-  G,
-  bytecode::{Block, Ctrl, Function, Op, Toplevel},
-  execute::{IOBuffer, IOKeyInfo, QueryRecord},
-  function_channel,
-  gadgets::{bytes1::Bytes1, bytes2::Bytes2},
-  memory::Memory,
-  u8_add_channel, u8_and_channel, u8_bit_decomposition_channel,
-  u8_less_than_channel, u8_or_channel, u8_range_check_channel,
-  u8_shift_left_channel, u8_shift_right_channel, u8_sub_channel,
-  u8_xor_channel,
+use crate::{
+  FxIndexMap,
+  aiur::{
+    G,
+    bytecode::{Block, Ctrl, Function, Op, Toplevel},
+    execute::{IOBuffer, IOKeyInfo, QueryRecord},
+    function_channel,
+    gadgets::{bytes1::Bytes1, bytes2::Bytes2},
+    memory::Memory,
+    u8_add_channel, u8_and_channel, u8_bit_decomposition_channel,
+    u8_less_than_channel, u8_or_channel, u8_range_check_channel,
+    u8_shift_left_channel, u8_shift_right_channel, u8_sub_channel,
+    u8_xor_channel,
+  },
 };
 
 struct ColumnIndex {
@@ -144,9 +147,13 @@ impl Function {
       .for_each(|(i, arg)| slice.inputs[i] = *arg);
     // Push the multiplicity
     slice.push_auxiliary(index, context.multiplicity);
-    self.body.populate_row(map, index, slice, context, io_buffer);
+    let _ = self.body.populate_row(map, index, slice, context, io_buffer);
   }
 }
+
+/// `Some(values)` means the block ended with `Yield` (values for the merge).
+/// `None` means the block ended with `Return` (function exited).
+type PopulateResult = Option<Vec<G>>;
 
 impl Block {
   fn populate_row(
@@ -156,13 +163,34 @@ impl Block {
     slice: &mut ColumnMutSlice<'_>,
     context: TraceContext<'_>,
     io_buffer: &IOBuffer,
-  ) {
+  ) -> PopulateResult {
     self
       .ops
       .iter()
       .for_each(|op| op.populate_row(map, index, slice, context, io_buffer));
-    self.ctrl.populate_row(map, index, slice, context, io_buffer);
+    self.ctrl.populate_row(map, index, slice, context, io_buffer)
   }
+}
+
+/// Dispatch a match: look up the value in the cases map, or fall through to the
+/// default (pushing inverse witnesses for each case to prove inequality).
+fn dispatch_branch<'a>(
+  val: G,
+  cases: &'a FxIndexMap<G, Block>,
+  def: &'a Option<Box<Block>>,
+  index: &mut ColumnIndex,
+  slice: &mut ColumnMutSlice<'_>,
+) -> &'a Block {
+  cases
+    .get(&val)
+    .or_else(|| {
+      for &case in cases.keys() {
+        let witness = (val - case).inverse();
+        slice.push_auxiliary(index, witness);
+      }
+      def.as_deref()
+    })
+    .expect("No match")
 }
 
 impl Ctrl {
@@ -173,7 +201,7 @@ impl Ctrl {
     slice: &mut ColumnMutSlice<'_>,
     context: TraceContext<'_>,
     io_buffer: &IOBuffer,
-  ) {
+  ) -> PopulateResult {
     match self {
       Ctrl::Return(sel, _) => {
         slice.selectors[*sel] = G::ONE;
@@ -184,21 +212,47 @@ impl Ctrl {
           context.output,
         );
         slice.lookups[0] = lookup;
+        None
+      },
+      Ctrl::Yield(sel, vals) => {
+        slice.selectors[*sel] = G::ONE;
+        Some(vals.iter().map(|&v| map[v].0).collect())
       },
       Ctrl::Match(var, cases, def) => {
-        let val = map[*var].0;
-        let branch = cases
-          .get(&val)
-          .or_else(|| {
-            for &case in cases.keys() {
-              // the witness shows that val is different from case
-              let witness = (val - case).inverse();
-              slice.push_auxiliary(index, witness);
+        let branch = dispatch_branch(map[*var].0, cases, def, index, slice);
+        branch.populate_row(map, index, slice, context, io_buffer)
+      },
+      Ctrl::MatchContinue(
+        var,
+        cases,
+        def,
+        _output_size,
+        shared_aux,
+        shared_lookups,
+        continuation,
+      ) => {
+        let map_len = map.len();
+        let init_aux = index.auxiliary;
+        let init_lookup = index.lookup;
+
+        let branch = dispatch_branch(map[*var].0, cases, def, index, slice);
+        let result = branch.populate_row(map, index, slice, context, io_buffer);
+        match result {
+          Some(yielded) => {
+            // Advance past the shared branch region. The taken branch may
+            // use fewer auxiliaries/lookups than the max across all branches.
+            index.auxiliary = init_aux + shared_aux;
+            index.lookup = init_lookup + shared_lookups;
+
+            map.truncate(map_len);
+            for &val in &yielded {
+              slice.push_auxiliary(index, val);
+              map.push((val, 1));
             }
-            def.as_deref()
-          })
-          .expect("No match");
-        branch.populate_row(map, index, slice, context, io_buffer);
+            continuation.populate_row(map, index, slice, context, io_buffer)
+          },
+          None => None,
+        }
       },
     }
   }

--- a/src/ffi/aiur/toplevel.rs
+++ b/src/ffi/aiur/toplevel.rs
@@ -168,17 +168,56 @@ fn decode_ctrl(ctor: LeanCtor<LeanBorrowed<'_>>) -> Ctrl {
       let val_idxs = decode_vec_val_idx(val_idxs_obj);
       Ctrl::Return(sel_idx, val_idxs)
     },
+    2 => {
+      let [sel_idx_obj, val_idxs_obj] = ctor.objs::<2>();
+      let sel_idx = lean_unbox_nat_as_usize(&sel_idx_obj);
+      let val_idxs = decode_vec_val_idx(val_idxs_obj);
+      Ctrl::Yield(sel_idx, val_idxs)
+    },
+    3 => {
+      let [
+        val_idx_obj,
+        cases_obj,
+        default_obj,
+        output_size_obj,
+        shared_aux_obj,
+        shared_lookups_obj,
+        cont_obj,
+      ] = ctor.objs::<7>();
+      let val_idx = lean_unbox_nat_as_usize(&val_idx_obj);
+      let vec_cases =
+        cases_obj.as_array().map(|o| decode_g_block_pair(o.as_ctor()));
+      let cases = FxIndexMap::from_iter(vec_cases);
+      let default = if default_obj.is_scalar() {
+        None
+      } else {
+        let inner_ctor = default_obj.as_ctor();
+        let block = decode_block(inner_ctor.get(0).as_ctor());
+        Some(Box::new(block))
+      };
+      let output_size = lean_unbox_nat_as_usize(&output_size_obj);
+      let shared_aux = lean_unbox_nat_as_usize(&shared_aux_obj);
+      let shared_lookups = lean_unbox_nat_as_usize(&shared_lookups_obj);
+      let continuation = Box::new(decode_block(cont_obj.as_ctor()));
+      Ctrl::MatchContinue(
+        val_idx,
+        cases,
+        default,
+        output_size,
+        shared_aux,
+        shared_lookups,
+        continuation,
+      )
+    },
     _ => unreachable!(),
   }
 }
 
 fn decode_block(ctor: LeanCtor<LeanBorrowed<'_>>) -> Block {
-  let [ops_obj, ctrl_obj, min_sel_obj, max_sel_obj] = ctor.objs::<4>();
+  let [ops_obj, ctrl_obj] = ctor.objs::<2>();
   let ops = ops_obj.as_array().map(|o| decode_op(o.as_ctor()));
   let ctrl = decode_ctrl(ctrl_obj.as_ctor());
-  let min_sel_included = lean_unbox_nat_as_usize(&min_sel_obj);
-  let max_sel_excluded = lean_unbox_nat_as_usize(&max_sel_obj);
-  Block { ops, ctrl, min_sel_included, max_sel_excluded }
+  Block { ops, ctrl }
 }
 
 fn decode_function_layout(ctor: LeanCtor<LeanBorrowed<'_>>) -> FunctionLayout {


### PR DESCRIPTION
Enable `let x = match y { 0 => return v, 1 => z }; use(x)` — match expressions in non-tail position, including branches with early returns.

## Bytecode

Two new Ctrl variants: Yield (terminates a non-returning branch, provides values for the merge) and MatchContinue (non-tail match with conditional-select merge and shared continuation block). MatchContinue carries sharedAuxiliaries and sharedLookups fields computed during lowering to align trace and constraint column positions.

## Lowering

findNonTailMatch walks through let chains (introduced by the simplification pass's match compiler) to detect embedded matches. yieldCtrl flag propagates through compile/addCase so non-escaping leaves produce Yield. The `!term.escapes` check is critical: the type checker erases the `.ret` wrapper, so escaping branches are distinguished only by the escapes flag on TypedTerm.

Degree tracking in CompilerState (opDegree mirrors opLayout's logic) provides exact operand degrees for computeSharedLayout, which also uses countReturns to subtract Return's pre-allocated slot-0 lookup from branch lookup counts.

## Constraints

get_block_selector recursively sums immediate children's selectors instead of the min_sel..max_sel range. This is the key fix for the selector double-counting bug: when a matchContinue is inside a tail match branch, the continuation's return selector fires alongside a yield selector. The recursive implementation excludes the continuation by only summing MatchContinue's case/default branches, not its continuation.

Ctrl::Match uses collect_branch_constraints and advances state.column/state.lookup to the branch max. Without this, when explicit branches are heavier than the default (e.g. branches with pointer-deref load ops), the outer scope sees only the default's lower column count, misaligning merge auxiliary positions.

Merge and linking constraints are gated by the parent selector (sel) for correctness when a matchContinue is in an inactive tail match branch — ungated constraints on shared auxiliary columns don't evaluate to 0 at the OOD evaluation point.

Per-block boolean constraints for all block selectors. Selector simplification pass (fixpoint substitution of sel_i = A).

## Execution and trace

Continuation stack with depth tracking in CallerState for correct cleanup on early returns across function boundaries.

populate_row returns Option<Vec<G>> to signal yield vs return. dispatch_branch helper shared by Match and MatchContinue. Trace advances index.auxiliary and index.lookup by sharedAuxiliaries and sharedLookups after the taken branch to skip the shared region.