### PR TITLE
ci: Fix valgrind ignored test

### DIFF
--- a/.github/workflows/ignored.yml
+++ b/.github/workflows/ignored.yml
@@ -2,7 +2,7 @@ name: Extended CI tests
 
 on:
   push:
-    branches: [main, ci-valgrind]
+    branches: main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ignored.yml
+++ b/.github/workflows/ignored.yml
@@ -2,7 +2,7 @@ name: Extended CI tests
 
 on:
   push:
-    branches: main
+    branches: [main, ci-valgrind]
   workflow_dispatch:
 
 permissions:

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -84,9 +84,9 @@ def ignoredRunners (env : Lean.Environment) : List (String × IO UInt32) := [
 ]
 
 def main (args : List String) : IO UInt32 := do
-  let env ← get_env!
   -- Special case: rust-compile diagnostic
   if args.contains "rust-compile" then
+    let env ← get_env!
     IO.println s!"Loaded environment with {env.constants.toList.length} constants"
     let result := tmpDecodeConstMap env.constants.toList
     IO.println s!"Rust compiled: {result}"
@@ -109,6 +109,7 @@ def main (args : List String) : IO UInt32 := do
   -- Run ignored tests when --ignored or --include-ignored is specified
   if runIgnored || includeIgnored then
     let mut result ← LSpec.lspecIO ignoredSuites filterArgs
+    let env ← get_env!
     let ignored := ignoredRunners env
     let filtered := if filterArgs.isEmpty then ignored
       else filterArgs.filterMap fun arg => ignored.find? fun (key, _) => key == arg


### PR DESCRIPTION
The FFI tests don't need `get_env!`, but it's currently called on all tests. When Lean modules are imported as compact regions they are not explicitly freed by the Lean runtime in favor of letting the OS free this memory more efficiently. This appears as a leak in Valgrind despite it being intended behavior, so this PR removes `get_env!` from the FFI test path which runs under Valgrind.

Successful run: https://github.com/argumentcomputer/ix/actions/runs/24248431304