### PR TITLE
feat: Benchmark throughput, R^2, outlier variance

### DIFF
--- a/Benchmarks/Aiur.lean
+++ b/Benchmarks/Aiur.lean
@@ -122,8 +122,7 @@ def verifyBench : IO $ Array BenchReport := do
   bgroup "nat_fib" {} do
     bench "verify fib 10" (Aiur.AiurSystem.verify system friParameters claim) proof
 
-def main (args : List String) : IO Unit := do
-  setBenchArgs args
+def main : IO Unit := do
   let _ ← toplevelBench
   let _ ← compileBench
   let _ ← buildAiurSystemBench

--- a/Benchmarks/Aiur.lean
+++ b/Benchmarks/Aiur.lean
@@ -3,6 +3,8 @@ import Ix.Aiur.Compiler
 import Ix.Aiur.Protocol
 import Ix.Benchmark.Bench
 
+open BgroupM
+
 def toplevel := ⟦
   enum Nat {
     Zero,
@@ -73,54 +75,57 @@ def proveE2E (name: Lean.Name) : IO UInt32 := do
   | .ok _ => return 0
   | .error e => IO.eprintln e; return 1
 
+/-- Compile `toplevel` once so the per-stage benchmarks can reuse the result. -/
+def compileToplevel : IO Aiur.CompiledToplevel := do
+  match toplevel.compile with
+  | .error e => throw (IO.userError e)
+  | .ok compiled => pure compiled
 
--- End-to-end proof generation and verification benchmark
-def proveE2EBench := bgroup "prove E2E" [
-  benchIO "fib 10" proveE2E `main
-] { samplingMode := .flat }
+-- End-to-end proof generation and verification benchmark. `samplingMode`
+-- defaults to `.auto`, which will fall back to flat for this slow bench.
+def proveE2EBench : IO $ Array BenchReport :=
+  bgroup "prove E2E" {} do
+    benchIO "fib 10" proveE2E `main
 
--- Individual benchmarks of each step from `proveE2E`
+-- Individual benchmarks of each step from `proveE2E`. Each stage has different
+-- `α`/`β` types, so they live in their own `bgroup` even though they share
+-- the `nat_fib` group name on disk.
 
-def toplevelBench := bgroup "nat_fib" [
-  bench "simplify toplevel" Aiur.Toplevel.checkAndSimplify toplevel
-]
+def toplevelBench : IO $ Array BenchReport :=
+  bgroup "nat_fib" {} do
+    bench "simplify toplevel" Aiur.Toplevel.checkAndSimplify toplevel
 
 def compileBench : IO $ Array BenchReport := do
   match toplevel.checkAndSimplify with
   | .error e => throw (IO.userError s!"{repr e}")
   | .ok decls =>
-    bgroup "nat_fib" [
+    bgroup "nat_fib" {} do
       bench "compile decls" Aiur.TypedDecls.toBytecode decls
-    ]
 
 def buildAiurSystemBench : IO $ Array BenchReport := do
-  let compiled ← match toplevel.compile with
-    | .error e => throw (IO.userError e)
-    | .ok compiled => pure compiled
-  bgroup "nat_fib" [
+  let compiled ← compileToplevel
+  bgroup "nat_fib" {} do
     bench "build AiurSystem" (Aiur.AiurSystem.build compiled.bytecode) commitmentParameters
-  ]
 
 def proveBench : IO $ Array BenchReport := do
-  let compiled ← match toplevel.compile with
-    | .error e => throw (IO.userError e)
-    | .ok compiled => pure compiled
+  let compiled ← compileToplevel
   let system := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
   let funIdx := compiled.getFuncIdx `main |>.get!
-  bgroup "nat_fib" [
-    bench "prove fib 10" (Aiur.AiurSystem.prove system friParameters funIdx #[10]) default,
-  ]
+  bgroup "nat_fib" {} do
+    bench "prove fib 10" (Aiur.AiurSystem.prove system friParameters funIdx #[10]) default
 
 def verifyBench : IO $ Array BenchReport := do
-  let compiled ← match toplevel.compile with
-    | .error e => throw (IO.userError e)
-    | .ok compiled => pure compiled
+  let compiled ← compileToplevel
   let system := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
   let funIdx := compiled.getFuncIdx `main |>.get!
   let (claim, proof, _) := system.prove friParameters funIdx #[10] default
-  bgroup "nat_fib" [
+  bgroup "nat_fib" {} do
     bench "verify fib 10" (Aiur.AiurSystem.verify system friParameters claim) proof
-  ]
 
-def main (_args : List String) : IO Unit := do
-  let _result ← proveBench
+def main (args : List String) : IO Unit := do
+  setBenchArgs args
+  let _ ← toplevelBench
+  let _ ← compileBench
+  let _ ← buildAiurSystemBench
+  let _ ← proveBench
+  let _ ← verifyBench

--- a/Benchmarks/Blake3.lean
+++ b/Benchmarks/Blake3.lean
@@ -1,8 +1,11 @@
+import Ix.IxVM.Core
 import Ix.IxVM.ByteStream
 import Ix.IxVM.Blake3
 import Ix.Aiur.Protocol
 import Ix.Aiur.Compiler
 import Ix.Benchmark.Bench
+
+open BgroupM
 
 abbrev dataSizes := #[64, 128, 256, 512, 1024, 2048]
 abbrev numHashesPerProof := #[1, 2, 4, 8, 16, 32]
@@ -20,51 +23,36 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
+def mergedToplevel : Except Aiur.Global Aiur.Toplevel := do
+  let tl ← IxVM.core.merge IxVM.byteStream
+  tl.merge IxVM.blake3
+
 def blake3Bench : IO $ Array BenchReport := do
-  let .ok toplevel := IxVM.byteStream.merge IxVM.blake3
+  let .ok toplevel := mergedToplevel
     | throw (IO.userError "Merging failed")
   let .ok compiled := toplevel.compile
     | throw (IO.userError "Compilation failed")
   let some funIdx := compiled.getFuncIdx `blake3_bench
     | throw (IO.userError "Aiur function not found")
   let aiurSystem := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
+  bgroup "prove blake3" { oneShot := true, avgThroughput := true, report := true } do
+    for dataSize in dataSizes do
+      for numHashes in numHashesPerProof do
+        let ioBuffer := Array.range numHashes |>.foldl
+          (init := default)
+          fun ioBuffer idx =>
+            let data := Array.range dataSize |>.map
+              -- Add `idx` so every preimage is different and avoids memoization.
+              fun i => Aiur.G.ofUInt8 (i + idx).toUInt8
+            let ioKeyInfo := ⟨ioBuffer.data.size, dataSize⟩
+            { ioBuffer with
+                data := ioBuffer.data ++ data
+                map := ioBuffer.map.insert #[.ofNat idx] ioKeyInfo }
+        throughput (.ElementsAndBytes numHashes.toUInt64 (dataSize * numHashes).toUInt64 "hashes")
+        bench s!"dataSize={dataSize} numHashes={numHashes}"
+          (aiurSystem.prove friParameters funIdx #[Aiur.G.ofNat numHashes]) ioBuffer
 
-  let mut benches := Array.emptyWithCapacity $ dataSizes.size * numHashesPerProof.size
-  for dataSize in dataSizes do
-    for numHashes in numHashesPerProof do
-      let ioBuffer := Array.range numHashes |>.foldl
-        (init := default)
-        fun ioBuffer idx =>
-          let data := Array.range dataSize |>.map
-            -- Add `idx` so every preimage is different and avoids memoization.
-            fun i => Aiur.G.ofUInt8 (i + idx).toUInt8
-          let ioKeyInfo := ⟨ioBuffer.data.size, dataSize⟩
-          { ioBuffer with
-              data := ioBuffer.data ++ data
-              map := ioBuffer.map.insert #[.ofNat idx] ioKeyInfo }
-      benches := benches.push <| bench s!"dataSize={dataSize} numHashes={numHashes}" (aiurSystem.prove friParameters funIdx #[Aiur.G.ofNat numHashes]) ioBuffer
-  bgroup "prove blake3" benches.toList { oneShot := true }
-
-def parseFunction (words : List String) (param : String): Option String :=
-  words.find? (·.startsWith param) |> .map (·.dropPrefix param |>.toString)
-
-def main : IO Unit := do
-  let result ← blake3Bench
-  let mut sumWeights := 0.0
-  let mut weightedSum := 0.0
-  for report in result do
-    let words := report.function.splitOn
-    let .some dataSizeStr := parseFunction words "dataSize="
-      | throw $ IO.userError s!"Missing dataSize in: {report.function}"
-    let .some dataSize := dataSizeStr.toNat?
-      | throw $ IO.userError s!"Invalid dataSize: {dataSizeStr}"
-    let .some numHashesStr := parseFunction words "numHashes="
-      | throw $ IO.userError s!"Missing numHashes in: {report.function}"
-    let .some numHashes := numHashesStr.toNat?
-      | throw $ IO.userError s!"Invalid numHashes: {numHashesStr}"
-    let sizeFloat := (dataSize * numHashes).toFloat
-    let throughput := sizeFloat / (report.newBench.getTime.toSeconds )
-    weightedSum := weightedSum + sizeFloat * throughput
-    sumWeights := sumWeights + sizeFloat
-  let avgThroughput := weightedSum / sumWeights
-  println! "Average throughput: {avgThroughput.toUSize} bytes/s"
+def main (args : List String) : IO Unit := do
+  setBenchArgs args
+  let _ ← blake3Bench
+  return

--- a/Benchmarks/Blake3.lean
+++ b/Benchmarks/Blake3.lean
@@ -52,7 +52,6 @@ def blake3Bench : IO $ Array BenchReport := do
         bench s!"dataSize={dataSize} numHashes={numHashes}"
           (aiurSystem.prove friParameters funIdx #[Aiur.G.ofNat numHashes]) ioBuffer
 
-def main (args : List String) : IO Unit := do
-  setBenchArgs args
+def main : IO Unit := do
   let _ ← blake3Bench
   return

--- a/Benchmarks/CheckNatAddComm.lean
+++ b/Benchmarks/CheckNatAddComm.lean
@@ -19,8 +19,7 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
-def main (args : List String) : IO Unit := do
-  setBenchArgs args
+def main : IO Unit := do
   let .ok toplevel := IxVM.ixVM
     | throw (IO.userError "Merging failed")
   let .ok compiled := toplevel.compile

--- a/Benchmarks/CheckNatAddComm.lean
+++ b/Benchmarks/CheckNatAddComm.lean
@@ -4,6 +4,8 @@ import Ix.Aiur.Protocol
 import Ix.Aiur.Compiler
 import Ix.Benchmark.Bench
 
+open BgroupM
+
 def commitmentParameters : Aiur.CommitmentParameters := {
   logBlowup := 1
   capHeight := 0
@@ -17,7 +19,8 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
-def main : IO Unit := do
+def main (args : List String) : IO Unit := do
+  setBenchArgs args
   let .ok toplevel := IxVM.ixVM
     | throw (IO.userError "Merging failed")
   let .ok compiled := toplevel.compile
@@ -54,9 +57,9 @@ def main : IO Unit := do
     | none => panic! "Nat.add_comm not found in Ixon environment"
   let targetAddrBytes : Array Aiur.G := targetAddr.hash.data.map .ofUInt8
 
-  let _report ← oneShotBench "Kernel typechecking"
-    (bench "check Nat.add_comm"
+  let _ ← bgroup "Kernel typechecking" { oneShot := true } do
+    throughput (.Elements ixonEnv.consts.size.toUInt64 "consts")
+    bench "check Nat.add_comm"
       (aiurSystem.prove friParameters funIdx targetAddrBytes)
-      ioBuffer)
-    { oneShot := true }
+      ioBuffer
   return

--- a/Benchmarks/IxVM.lean
+++ b/Benchmarks/IxVM.lean
@@ -19,8 +19,7 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
-def main (args : List String) : IO Unit := do
-  setBenchArgs args
+def main : IO Unit := do
   let .ok toplevel := IxVM.ixVM
     | throw (IO.userError "Merging failed")
   let .ok compiled := toplevel.compile

--- a/Benchmarks/IxVM.lean
+++ b/Benchmarks/IxVM.lean
@@ -4,6 +4,8 @@ import Ix.Aiur.Protocol
 import Ix.Aiur.Compiler
 import Ix.Benchmark.Bench
 
+open BgroupM
+
 def commitmentParameters : Aiur.CommitmentParameters := {
   logBlowup := 1
   capHeight := 0
@@ -17,7 +19,8 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
-def main : IO Unit := do
+def main (args : List String) : IO Unit := do
+  setBenchArgs args
   let .ok toplevel := IxVM.ixVM
     | throw (IO.userError "Merging failed")
   let .ok compiled := toplevel.compile
@@ -36,9 +39,9 @@ def main : IO Unit := do
     let (_, bytes) := Ixon.Serialize.put c |>.run default
     (ioBuffer.extend #[.ofNat i] (bytes.data.map .ofUInt8), i + 1)
 
-  let _report ← oneShotBench "IxVM benchmarks"
-    (bench "serde/blake3 Nat.add_comm"
+  let _ ← bgroup "IxVM benchmarks" { oneShot := true } do
+    throughput (.Elements n.toUInt64 "consts")
+    bench "serde/blake3 Nat.add_comm"
       (aiurSystem.prove friParameters funIdx #[.ofNat n])
-      ioBuffer)
-    { oneShot := true }
+      ioBuffer
   return

--- a/Benchmarks/Sha256.lean
+++ b/Benchmarks/Sha256.lean
@@ -52,7 +52,6 @@ def sha256Bench : IO $ Array BenchReport := do
         bench s!"dataSize={dataSize} numHashes={numHashes}"
           (aiurSystem.prove friParameters funIdx #[Aiur.G.ofNat numHashes]) ioBuffer
 
-def main (args : List String) : IO Unit := do
-  setBenchArgs args
+def main : IO Unit := do
   let _ ← sha256Bench
   return

--- a/Benchmarks/Sha256.lean
+++ b/Benchmarks/Sha256.lean
@@ -1,8 +1,11 @@
+import Ix.IxVM.Core
 import Ix.IxVM.ByteStream
 import Ix.IxVM.Sha256
 import Ix.Aiur.Protocol
 import Ix.Aiur.Compiler
 import Ix.Benchmark.Bench
+
+open BgroupM
 
 abbrev dataSizes := #[64, 128, 256, 512, 1024, 2048]
 abbrev numHashesPerProof := #[1, 2, 4, 8, 16, 32]
@@ -20,45 +23,36 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
+def mergedToplevel : Except Aiur.Global Aiur.Toplevel := do
+  let tl ← IxVM.core.merge IxVM.byteStream
+  tl.merge IxVM.sha256
+
 def sha256Bench : IO $ Array BenchReport := do
-  let .ok toplevel := IxVM.byteStream.merge IxVM.sha256
+  let .ok toplevel := mergedToplevel
     | throw (IO.userError "Merging failed")
   let .ok compiled := toplevel.compile
     | throw (IO.userError "Compilation failed")
   let some funIdx := compiled.getFuncIdx `sha256_bench
     | throw (IO.userError "Aiur function not found")
   let aiurSystem := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
+  bgroup "prove sha256" { oneShot := true, avgThroughput := true, report := true } do
+    for dataSize in dataSizes do
+      for numHashes in numHashesPerProof do
+        let ioBuffer := Array.range numHashes |>.foldl
+          (init := default)
+          fun ioBuffer idx =>
+            let data := Array.range dataSize |>.map
+              -- Add `idx` so every preimage is different and avoids memoization.
+              fun i => Aiur.G.ofUInt8 (i + idx).toUInt8
+            let ioKeyInfo := ⟨ioBuffer.data.size, dataSize⟩
+            { ioBuffer with
+                data := ioBuffer.data ++ data
+                map := ioBuffer.map.insert #[.ofNat idx] ioKeyInfo }
+        throughput (.ElementsAndBytes numHashes.toUInt64 (dataSize * numHashes).toUInt64 "hashes")
+        bench s!"dataSize={dataSize} numHashes={numHashes}"
+          (aiurSystem.prove friParameters funIdx #[Aiur.G.ofNat numHashes]) ioBuffer
 
-  let mut benches := Array.emptyWithCapacity $ dataSizes.size * numHashesPerProof.size
-  for dataSize in dataSizes do
-    for numHashes in numHashesPerProof do
-      let ioBuffer := Array.range numHashes |>.foldl
-        (init := default)
-        fun ioBuffer idx =>
-          let data := Array.range dataSize |>.map
-            -- Add `idx` so every preimage is different and avoids memoization.
-            fun i => Aiur.G.ofUInt8 (i + idx).toUInt8
-          let ioKeyInfo := ⟨ioBuffer.data.size, dataSize⟩
-          { ioBuffer with
-              data := ioBuffer.data ++ data
-              map := ioBuffer.map.insert #[.ofNat idx] ioKeyInfo }
-      benches := benches.push <| bench s!"dataSize={dataSize} numHashes={numHashes}" (aiurSystem.prove friParameters funIdx #[Aiur.G.ofNat numHashes]) ioBuffer
-  bgroup "prove sha256" benches.toList { oneShot := true }
-
-def parseFunction (words : List String) (param : String): Option String :=
-  words.find? (·.startsWith param) |>.map (·.dropPrefix param |>.toString)
-
-def main : IO Unit := do
-  let result ← sha256Bench
-  let mut sumWeights := 0.0
-  let mut weightedSum := 0.0
-  for report in result do
-    let words := report.function.splitOn
-    let dataSize := (parseFunction words "dataSize=").get!.toNat!
-    let numHashes := (parseFunction words "numHashes=").get!.toNat!
-    let sizeFloat := (dataSize * numHashes).toFloat
-    let throughput := sizeFloat / (report.newBench.getTime.toSeconds )
-    weightedSum := weightedSum + sizeFloat * throughput
-    sumWeights := sumWeights + sizeFloat
-  let avgThroughput := weightedSum / sumWeights
-  println! "Average throughput: {avgThroughput.toUSize} bytes/s"
+def main (args : List String) : IO Unit := do
+  setBenchArgs args
+  let _ ← sha256Bench
+  return

--- a/Benchmarks/ShardMap.lean
+++ b/Benchmarks/ShardMap.lean
@@ -2,6 +2,7 @@ import Ix.ShardMap
 import Ix.Benchmark.Bench
 
 open Ix
+open BgroupM
 
 namespace Benchmarks.ShardMap
 
@@ -125,47 +126,50 @@ def distributedWorkload (map : ShardMap Nat Nat) (threads : Nat) (opsPerThread :
 /-- Basic single-threaded operations -/
 def basicBench : IO (Array BenchReport) := do
   IO.println "=== Basic Operations (Single-threaded) ===\n"
-  bgroup "shardmap-basic" [
+  bgroup "shardmap-basic" {} do
     -- Insert throughput
+    throughput (.Elements 1000 "ops")
     benchIO "insert 1K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      insertN map 1000) (),
+      insertN map 1000) ()
+    throughput (.Elements 10000 "ops")
     benchIO "insert 10K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      insertN map 10000) (),
+      insertN map 10000) ()
+    throughput (.Elements 100000 "ops")
     benchIO "insert 100K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      insertN map 100000) (),
+      insertN map 100000) ()
 
     -- Lookup throughput (pre-populated)
+    throughput (.Elements 10000 "ops")
     benchIO "get 10K hits" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       insertN map 10000
-      getN map 10000) (),
+      getN map 10000) ()
     benchIO "get 10K misses" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       insertN map 10000
-      getMissN map 10000 100000) (),
+      getMissN map 10000 100000) ()
 
     -- Remove throughput
     benchIO "remove 10K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       insertN map 10000
       removeN map 10000) ()
-  ]
 
 /-- Compare insertMany vs individual inserts -/
 def bulkBench : IO (Array BenchReport) := do
   IO.println "=== Bulk Operations Comparison ===\n"
   let items10K := genItems 10000
-  bgroup "shardmap-bulk" [
+  bgroup "shardmap-bulk" {} do
+    throughput (.Elements 10000 "ops")
     benchIO "insertMany 10K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      map.insertMany items10K) (),
+      map.insertMany items10K) ()
     benchIO "insert loop 10K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       insertLoop map items10K) ()
-  ]
 
 /-- Concurrent read scaling with SharedMutex -/
 def concurrentReadBench : IO (Array BenchReport) := do
@@ -173,93 +177,99 @@ def concurrentReadBench : IO (Array BenchReport) := do
   -- Pre-populate a shared map
   let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
   insertN map 10000
-  bgroup "shardmap-concurrent-read" [
-    benchIO "read 1 thread" (fun () => concurrentReads map 1 10000) (),
-    benchIO "read 2 threads" (fun () => concurrentReads map 2 5000) (),
-    benchIO "read 4 threads" (fun () => concurrentReads map 4 2500) (),
-    benchIO "read 8 threads" (fun () => concurrentReads map 8 1250) (),
+  -- Every row does 10_000 total reads across its threads, so using a shared
+  -- throughput lets us directly compare ops/s across thread counts.
+  bgroup "shardmap-concurrent-read" {} do
+    throughput (.Elements 10000 "ops")
+    benchIO "read 1 thread" (fun () => concurrentReads map 1 10000) ()
+    benchIO "read 2 threads" (fun () => concurrentReads map 2 5000) ()
+    benchIO "read 4 threads" (fun () => concurrentReads map 4 2500) ()
+    benchIO "read 8 threads" (fun () => concurrentReads map 8 1250) ()
     benchIO "read 16 threads" (fun () => concurrentReads map 16 625) ()
-  ]
 
 /-- Concurrent write scaling -/
 def concurrentWriteBench : IO (Array BenchReport) := do
   IO.println "=== Concurrent Write Scaling ===\n"
-  bgroup "shardmap-concurrent-write" [
+  -- Every row performs 10_000 total writes across its threads.
+  bgroup "shardmap-concurrent-write" {} do
+    throughput (.Elements 10000 "ops")
     benchIO "write 1 thread 10K" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      concurrentWrites map 1 10000) (),
+      concurrentWrites map 1 10000) ()
     benchIO "write 2 threads 5K each" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      concurrentWrites map 2 5000) (),
+      concurrentWrites map 2 5000) ()
     benchIO "write 4 threads 2.5K each" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      concurrentWrites map 4 2500) (),
+      concurrentWrites map 4 2500) ()
     benchIO "write 8 threads 1.25K each" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       concurrentWrites map 8 1250) ()
-  ]
 
 /-- Mixed read/write workload -/
 def mixedWorkloadBench : IO (Array BenchReport) := do
   IO.println "=== Mixed Read/Write Workload (8 threads) ===\n"
-  bgroup "shardmap-mixed" [
+  -- 8 threads * 1000 ops = 8000 total ops per row.
+  bgroup "shardmap-mixed" {} do
+    throughput (.Elements 8000 "ops")
     benchIO "mixed 50/50 8 threads" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      mixedWorkload map 8 1000 0.5) (),
+      mixedWorkload map 8 1000 0.5) ()
     benchIO "mixed 80/20 read/write 8 threads" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      mixedWorkload map 8 1000 0.8) (),
+      mixedWorkload map 8 1000 0.8) ()
     benchIO "mixed 95/5 read/write 8 threads" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       mixedWorkload map 8 1000 0.95) ()
-  ]
 
 /-- Compare different shard configurations -/
 def shardConfigBench : IO (Array BenchReport) := do
   IO.println "=== Shard Configuration Impact (8 threads) ===\n"
-  bgroup "shardmap-shards" [
+  -- `concurrentWorkload` does one insert + one get per op, so 8*1000*2 = 16_000 ops.
+  bgroup "shardmap-shards" {} do
+    throughput (.Elements 16000 "ops")
     benchIO "shardBits=2 (4 shards)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat) (shardBits := 2)
-      concurrentWorkload map 8 1000) (),
+      concurrentWorkload map 8 1000) ()
     benchIO "shardBits=4 (16 shards)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat) (shardBits := 4)
-      concurrentWorkload map 8 1000) (),
+      concurrentWorkload map 8 1000) ()
     benchIO "shardBits=6 (64 shards)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat) (shardBits := 6)
-      concurrentWorkload map 8 1000) (),
+      concurrentWorkload map 8 1000) ()
     benchIO "shardBits=8 (256 shards)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat) (shardBits := 8)
       concurrentWorkload map 8 1000) ()
-  ]
 
 /-- Contention patterns: hot shard vs distributed access -/
 def contentionBench : IO (Array BenchReport) := do
   IO.println "=== Contention Patterns (8 threads) ===\n"
-  bgroup "shardmap-contention" [
+  -- Both workloads do 1 insert + 1 get per op, so 8*500*2 = 8000 total ops.
+  bgroup "shardmap-contention" {} do
+    throughput (.Elements 8000 "ops")
     benchIO "hot shard (worst case)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      hotShardWorkload map 8 500) (),
+      hotShardWorkload map 8 500) ()
     benchIO "distributed (best case)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       distributedWorkload map 8 500) ()
-  ]
 
 /-- Pre-allocated capacity impact -/
 def capacityBench : IO (Array BenchReport) := do
   IO.println "=== Capacity Pre-allocation Impact ===\n"
-  bgroup "shardmap-capacity" [
+  bgroup "shardmap-capacity" {} do
+    throughput (.Elements 10000 "ops")
     benchIO "insert 10K (no prealloc)" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      insertN map 10000) (),
+      insertN map 10000) ()
     benchIO "insert 10K (prealloc 32/shard)" (fun () => do
       let map ← Ix.ShardMap.newWithCapacity (α := Nat) (β := Nat)
         (capacityPerShard := 32)
-      insertN map 10000) (),
+      insertN map 10000) ()
     benchIO "insert 10K (prealloc 64/shard)" (fun () => do
       let map ← Ix.ShardMap.newWithCapacity (α := Nat) (β := Nat)
         (capacityPerShard := 64)
       insertN map 10000) ()
-  ]
 
 /-- Look up N sequential keys using get?Fast (all hits) -/
 def getNFast (map : ShardMap Nat Nat) (n : Nat) : IO Unit := do
@@ -295,45 +305,50 @@ def fastPathBench : IO (Array BenchReport) := do
   IO.println "=== get?Fast vs get? Comparison ===\n"
   let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
   insertN map 10000
-  bgroup "shardmap-fast-path" [
-    -- Single-threaded comparison
-    benchIO "get? 10K (single thread)" (fun () => getN map 10000) (),
-    benchIO "get?Fast 10K (single thread)" (fun () => getNFast map 10000) (),
-    -- Concurrent comparison
-    benchIO "get? 8 threads" (fun () => concurrentReads map 8 1250) (),
-    benchIO "get?Fast 8 threads" (fun () => concurrentReadsFast map 8 1250) (),
-    -- Hot shard comparison (high contention)
+  bgroup "shardmap-fast-path" {} do
+    -- Single-threaded comparison (10_000 reads per row)
+    throughput (.Elements 10000 "ops")
+    benchIO "get? 10K (single thread)" (fun () => getN map 10000) ()
+    benchIO "get?Fast 10K (single thread)" (fun () => getNFast map 10000) ()
+    -- Concurrent comparison (8 * 1250 = 10_000 reads per row)
+    benchIO "get? 8 threads" (fun () => concurrentReads map 8 1250) ()
+    benchIO "get?Fast 8 threads" (fun () => concurrentReadsFast map 8 1250) ()
+    -- Hot shard comparison: 8 * 500 * 2 = 8000 ops (insert + get per iteration)
+    throughput (.Elements 8000 "ops")
     benchIO "hot shard get?" (fun () => do
       let m ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      hotShardWorkload m 8 500) (),
+      hotShardWorkload m 8 500) ()
     benchIO "hot shard get?Fast" (fun () => do
       let m ← Ix.ShardMap.new (α := Nat) (β := Nat)
       hotShardWorkloadFast m 8 500) ()
-  ]
 
 /-- Compare sequential vs parallel insertMany -/
 def parallelInsertBench : IO (Array BenchReport) := do
   IO.println "=== Parallel insertMany Performance ===\n"
   let items50K := genItems 50000
   let items100K := genItems 100000
-  bgroup "shardmap-parallel-insert" [
+  bgroup "shardmap-parallel-insert" {} do
+    throughput (.Elements 50000 "ops")
     benchIO "insertMany 50K items" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      map.insertMany items50K) (),
+      map.insertMany items50K) ()
+    throughput (.Elements 100000 "ops")
     benchIO "insertMany 100K items" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      map.insertMany items100K) (),
+      map.insertMany items100K) ()
+    throughput (.Elements 50000 "ops")
     benchIO "insert loop 50K items" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
-      insertLoop map items50K) (),
+      insertLoop map items50K) ()
+    throughput (.Elements 100000 "ops")
     benchIO "insert loop 100K items" (fun () => do
       let map ← Ix.ShardMap.new (α := Nat) (β := Nat)
       insertLoop map items100K) ()
-  ]
 
 end Benchmarks.ShardMap
 
-def main : IO Unit := do
+def main (args : List String) : IO Unit := do
+  setBenchArgs args
   IO.println "ShardMap Performance Benchmarks\n"
   IO.println "================================\n"
 

--- a/Benchmarks/ShardMap.lean
+++ b/Benchmarks/ShardMap.lean
@@ -347,8 +347,7 @@ def parallelInsertBench : IO (Array BenchReport) := do
 
 end Benchmarks.ShardMap
 
-def main (args : List String) : IO Unit := do
-  setBenchArgs args
+def main : IO Unit := do
   IO.println "ShardMap Performance Benchmarks\n"
   IO.println "================================\n"
 

--- a/Ix/Benchmark/Ansi.lean
+++ b/Ix/Benchmark/Ansi.lean
@@ -1,0 +1,58 @@
+module
+
+public section
+
+/-!
+# ANSI terminal styling for benchmark output
+
+Provides colored/bold/faint text and ephemeral (overwritable) progress lines,
+matching criterion.rs's `CliReport` output style. ANSI colors are always
+enabled (Lake handles terminal capability detection). Ephemeral overwriting
+is disabled in verbose mode so all output is permanent.
+-/
+
+namespace Ansi
+
+def esc := "\x1B"
+def reset := s!"{esc}[0m"
+
+def bold (s : String) : String := s!"{esc}[1m{s}{reset}"
+/-- Dim text via a neutral gray from the 256-color grayscale ramp (index 240). -/
+def faint (s : String) : String := s!"{esc}[38;5;240m{s}{reset}"
+
+/-- DarkGreen foreground (ANSI 256-color index 2) -/
+def green (s : String) : String := s!"{esc}[38;5;2m{s}{reset}"
+/-- DarkRed foreground (ANSI 256-color index 1) -/
+def red (s : String) : String := s!"{esc}[38;5;1m{s}{reset}"
+/-- DarkYellow foreground (ANSI 256-color index 3) -/
+def yellow (s : String) : String := s!"{esc}[38;5;3m{s}{reset}"
+
+/-- Carriage-return + clear-entire-line, used to erase ephemeral progress. -/
+def clearLine := s!"\r{esc}[2K"
+
+end Ansi
+
+/-- Controls ephemeral progress line overwriting. ANSI colors are always on. -/
+structure CliStyle where
+  overwriteEnabled : Bool
+
+namespace CliStyle
+
+/-- Erase the current ephemeral line on stderr. No-op if overwrite is disabled. -/
+def overwrite (s : CliStyle) : IO Unit := do
+  if s.overwriteEnabled then
+    IO.eprint Ansi.clearLine
+
+/-- Print an ephemeral progress message to stderr. If overwrite is enabled,
+    the line has no trailing newline and can be overwritten by the next call.
+    Otherwise falls back to a normal `eprintln`. -/
+def printEphemeral (s : CliStyle) (msg : String) : IO Unit := do
+  if s.overwriteEnabled then
+    IO.eprint s!"\r{Ansi.clearLine}{msg}"
+    (← IO.getStderr).flush
+  else
+    IO.eprintln msg
+
+end CliStyle
+
+end

--- a/Ix/Benchmark/Bench.lean
+++ b/Ix/Benchmark/Bench.lean
@@ -7,13 +7,14 @@ public import Batteries
 
 public import Ix.Benchmark.Serde
 public import Ix.Benchmark.Tukey
+public import Ix.Benchmark.Ansi
 
 public section
 
 open Batteries (RBMap)
 
 /-!
-# Benchmarking library modeled after Criterion in Haskell and Rust
+# Benchmarking library modeled after Criterion in Rust and Haskell
 
 ## Verbosity
 
@@ -63,29 +64,34 @@ def Benchmarkable.getFn (b : Benchmarkable α β) : α → IO β :=
   | .pure f => blackBoxIO f
   | .io f => f
 
--- TODO: According to Criterion.rs docs the warmup iterations should increase linearly until the warmup time is reached, rather than one iteration per time check
-def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) : IO Float := do
-  if bg.config.verbosity != .quiet then
-    IO.println s!"Warming up for {bg.config.warmupTime.floatPretty 2}s"
-  let mut count := 0
+/-- Runs the benchmark repeatedly for `warmupTime` seconds and returns the
+    mean per-iteration time in nanoseconds. Iteration counts increase linearly
+    (1, 2, 3, 4, …) between clock checks to minimize the overhead of
+    `IO.monoNanosNow` syscalls. -/
+def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) (style : CliStyle) (benchId : String) : IO Float := do
+  style.printEphemeral s!"Benchmarking {benchId}: Warming up for {bg.config.warmupTime.floatPretty 2}s"
   let warmupNanos := Cronos.secToNano bg.config.warmupTime
-  let mut elapsed := 0
   let func := bench.getFn
   let startTime ← IO.monoNanosNow
+  let mut totalIters : Nat := 0
+  let mut elapsed : Nat := 0
+  let mut batchSize : Nat := 1
   while elapsed < warmupNanos do
-    let _res ← func bench.arg
+    for _ in List.range batchSize do
+      let _res ← func bench.arg
+    totalIters := totalIters + batchSize
     let now ← IO.monoNanosNow
-    count := count + 1
     elapsed := now - startTime
-  let mean := Float.ofNat elapsed / Float.ofNat count
+    batchSize := batchSize + 1
+  let mean := Float.ofNat elapsed / Float.ofNat (totalIters.max 1)
   return mean
 
-def printRunning (config : Config) (expectedTime : Float) (numIters : Nat) (warningFactor : Nat) : IO Unit := do
-  -- The "Unable to complete" warning is always shown — it's actionable at any verbosity.
+def printRunning (config : Config) (style : CliStyle) (benchId : String) (expectedTime : Float) (numIters : Nat) (warningFactor : Nat) : IO Unit := do
   if warningFactor == 1 then
+    -- Clear the ephemeral line before printing the permanent warning
+    style.overwrite
     IO.eprintln s!"Warning: Unable to complete {config.numSamples} samples in {config.sampleTime.floatPretty 2}s. You may wish to increase target time to {expectedTime.floatPretty 2}s"
-  if config.verbosity != .quiet then
-    IO.println s!"Running {config.numSamples} samples in {expectedTime.floatPretty 2}s ({numIters.natPretty} iterations)\n"
+  style.printEphemeral s!"Benchmarking {benchId}: Collecting {config.numSamples} samples in estimated {expectedTime.floatPretty 2}s ({numIters.natPretty} iterations)"
 
 -- Core sampling loop that runs the benchmark function and returns the array of measured timings
 def runSample (sampleIters : Array Nat) (bench : Benchmarkable α β) : IO (Array Nat) := do
@@ -99,21 +105,21 @@ def runSample (sampleIters : Array Nat) (bench : Benchmarkable α β) : IO (Arra
     timings := timings.push (finish - start)
   return timings
 
--- TODO: Recommend sample count if expectedTime >>> bg.config.sampleTime (i.e. itersPerSample == 1)
 /--
 Runs the sample as a sequence of constant iterations per data point, where the iteration count attempts to fit into the configurable `sampleTime` but cannot be less than 1.
 
 Returns the iteration counts and elapsed time per data point.
 -/
 def BenchGroup.sampleFlat (bg : BenchGroup) (bench : Benchmarkable α β)
-(warmupMean : Float) : IO (Array Nat × Array Nat) := do
+(warmupMean : Float) (style : CliStyle) (benchId : String) : IO (Array Nat × Array Nat) := do
   let targetTime := bg.config.sampleTime.toNanos
   let timePerSample := targetTime / (Float.ofNat bg.config.numSamples)
   let itersPerSample := (timePerSample / warmupMean).ceil.toUInt64.toNat.max 1
   let totalIters := itersPerSample * bg.config.numSamples
   let expectedTime := warmupMean * Float.ofNat itersPerSample * bg.config.numSamples.toSeconds
-  printRunning bg.config expectedTime totalIters itersPerSample
-  --IO.println s!"Flat sample. Iters per sample: {itersPerSample}"
+  printRunning bg.config style benchId expectedTime totalIters itersPerSample
+  if bg.config.verbosity == .verbose then
+    IO.println s!"Flat sample. Iters per sample: {itersPerSample}"
   let sampleIters := Array.replicate bg.config.numSamples itersPerSample
   let timings ← runSample sampleIters bench
   return (sampleIters, timings)
@@ -125,7 +131,7 @@ The sum of this series should be roughly equivalent to the total `sampleTime`.
 
 Returns the iteration counts and elapsed time per sample.
 -/
-def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable α β) (warmupMean : Float) : IO (Array Nat × Array Nat) := do
+def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable α β) (warmupMean : Float) (style : CliStyle) (benchId : String) : IO (Array Nat × Array Nat) := do
   let totalRuns := bg.config.numSamples * (bg.config.numSamples + 1) / 2
   let targetTime := bg.config.sampleTime.toNanos
   -- `d` has a minimum value of 1 if the `warmupMean` is sufficiently large
@@ -133,13 +139,13 @@ def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable α β) (war
   let d := (targetTime / warmupMean / (Float.ofNat totalRuns)).ceil.toUInt64.toNat.max 1
   let expectedTime := (Float.ofNat totalRuns) * (Float.ofNat d) * warmupMean.toSeconds
   let sampleIters := (Array.range bg.config.numSamples).map (fun x => (x + 1) * d)
-  printRunning bg.config expectedTime sampleIters.sum d
-  --IO.println s!"Linear sample. Iters increase by a factor of {d} per sample"
+  printRunning bg.config style benchId expectedTime sampleIters.sum d
+  if bg.config.verbosity == .verbose then
+    IO.println s!"Linear sample. Iters increase by a factor of {d} per sample"
   let timings ← runSample sampleIters bench
   return (sampleIters, timings)
 
-/-- Picks a concrete sampling mode for `.auto`, matching criterion.rs's
-    `SamplingMode::choose_sampling_mode`: choose linear iff the expected total
+/-- Picks a concrete sampling mode for `.auto`: choose linear iff the expected total
     linear-mode time is at most 2× the target sample time, else fall back to
     flat. For `.flat` / `.linear` this returns the user's explicit choice. -/
 def chooseSamplingMode (config : Config) (warmupMean : Float) : SamplingMode :=
@@ -152,12 +158,6 @@ def chooseSamplingMode (config : Config) (warmupMean : Float) : SamplingMode :=
     let d := (targetTime / warmupMean / (Float.ofNat totalRuns)).ceil.toUInt64.toNat.max 1
     let expectedNs := (Float.ofNat totalRuns) * (Float.ofNat d) * warmupMean
     if expectedNs > 2 * targetTime then .flat else .linear
-
-def BenchGroup.sample (bg : BenchGroup) (bench : Benchmarkable α β) (warmupMean : Float) : IO (Array Nat × Array Nat) := do
-  match chooseSamplingMode bg.config warmupMean with
-  | .flat => bg.sampleFlat bench warmupMean
-  | .linear => bg.sampleLinear bench warmupMean
-  | .auto => bg.sampleFlat bench warmupMean  -- unreachable after chooseSamplingMode
 
 structure MeasurementData where
   data : Data
@@ -230,8 +230,8 @@ def BenchGroup.compare (bg : BenchGroup) (baseSample : Data) (baseEstimates : Es
     mode (flat vs linear), since mixing the two through the same bootstrap
     gives misleading confidence intervals. -/
 def BenchGroup.getComparison (bg : BenchGroup) (benchName : String)
-    (avgTimes : Distribution) (config : Config) (resolvedMode : SamplingMode) :
-    IO (Option ComparisonData) := do
+    (avgTimes : Distribution) (config : Config) (resolvedMode : SamplingMode)
+    (style : CliStyle) : IO (Option ComparisonData) := do
   let benchPath := System.mkFilePath [".", ".lake", "benches", bg.name, benchName]
   let fileExt := toString config.serde
   -- Base data is at `new` since we haven't written the latest result to disk yet, which moves the prior data to `base`
@@ -242,10 +242,12 @@ def BenchGroup.getComparison (bg : BenchGroup) (benchName : String)
     let r : SampleRun ← loadFile config.serde (basePath / s!"sample.{fileExt}")
     pure (some r)
   catch _ =>
+    style.overwrite
     IO.eprintln s!"Skipping comparison for {benchName}: failed to parse base sample.{fileExt}"
     pure none
   let some baseRun := baseRun? | return none
   if baseRun.config.samplingMode != resolvedMode then
+    style.overwrite
     IO.eprintln s!"Skipping comparison for {benchName}: base ran in {repr baseRun.config.samplingMode} mode, current run is {repr resolvedMode}"
     return none
   let baseEstimates : Estimates ← loadFile config.serde (basePath / s!"estimates.{fileExt}")
@@ -272,86 +274,103 @@ def compareToThreshold (estimate : Estimate) (noiseThreshold : Float) : Comparis
     ComparisonResult.NonSignificant
 
 
-/-- Right-pads `s` with spaces to reach at least `width` characters. -/
-def padLabel (s : String) (width : Nat) : String :=
-  if s.length ≥ width then s
-  else s ++ String.ofList (List.replicate (width - s.length) ' ')
-
-/-- Criterion.rs-style label column width: minimum 24 chars, grows to fit the longest bench name in a group. -/
-def minLabelWidth : Nat := 24
+/-- Criterion.rs uses a fixed 24-char column for the time/thrpt labels. -/
+def indent24 : String := String.ofList (List.replicate 24 ' ')
 
 def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
-    (m : MeasurementData) (labelWidth : Nat) : IO Unit := do
+    (m : MeasurementData) (style : CliStyle) : IO Unit := do
   let estimates := m.absoluteEstimates
   let typicalEstimate := estimates.slope.getD estimates.mean
   let fullName := s!"{bg.name}/{benchName}"
-  let label := padLabel fullName labelWidth
-  let indent := padLabel "" labelWidth
   let verbosity := bg.config.verbosity
   let ciLb := typicalEstimate.confidenceInterval.lowerBound
   let ciUb := typicalEstimate.confidenceInterval.upperBound
-  let lb := ciLb.formatNanos
-  let pointEst := typicalEstimate.pointEstimate.formatNanos
-  let ub := ciUb.formatNanos
-  -- Append R² to the time line when linear-mode regression data is available.
+
+  -- Name line + time, matching criterion.rs's 24-char column layout:
+  -- Short name (≤ 23 chars): name + pad + time on one line
+  -- Long name (> 23 chars): name on its own line, time on the next
   let r2Suffix := match m.rSquared with
     | some r2 => s!" R²={r2.floatPretty 3}"
     | none => ""
-  IO.println s!"{label}time:   [{lb} {pointEst} {ub}]{r2Suffix}"
+  let timeLine := s!"time:   [{style.faint ciLb.formatNanos} {style.bold typicalEstimate.pointEstimate.formatNanos} {style.faint ciUb.formatNanos}]{r2Suffix}"
+  if fullName.length > 23 then
+    IO.println (style.green fullName)
+    IO.println s!"{indent24}{timeLine}"
+  else
+    let pad := String.ofList (List.replicate (24 - fullName.length) ' ')
+    IO.println s!"{style.green fullName}{pad}{timeLine}"
+
+  -- Throughput line (if present)
   if let some t := m.throughput then
-    -- Higher time ⇒ lower throughput, so the low rate corresponds to the time CI upper bound.
-    let thrptLow := t.formatRate ciUb
-    let thrptPt := t.formatRate typicalEstimate.pointEstimate
-    let thrptHigh := t.formatRate ciLb
-    IO.println s!"{indent}thrpt:  [{thrptLow} {thrptPt} {thrptHigh}]"
-  if let some comp := m.comparison
-  then
-    -- `p > significanceThreshold` means we fail to reject the null hypothesis
-    -- that the two samples come from the same distribution — i.e. no
-    -- statistically significant change.
-    let notSignificant := comp.pValue > comp.significanceThreshold
-    let meanEst := comp.relativeEstimates.mean
-    let fmtSigned (f : Float) : String :=
-      let body := (f * 100).floatPretty 4
-      if f ≥ 0 then s!"+{body}" else body
-    let pointEst := fmtSigned meanEst.pointEstimate
-    let lb := fmtSigned meanEst.confidenceInterval.lowerBound
-    let ub := fmtSigned meanEst.confidenceInterval.upperBound
-    let symbol := if notSignificant then ">" else "<"
-    IO.println s!"{indent}change: [{lb}% {pointEst}% {ub}%] (p = {comp.pValue.floatPretty 2} {symbol} {comp.significanceThreshold.floatPretty 2})"
-    let explanation := if notSignificant
-    then
-      "No change in performance detected"
-    else
-      match compareToThreshold meanEst comp.noiseThreshold with
-      | ComparisonResult.Improved => "Performance has improved"
-      | ComparisonResult.Regressed => "Performance has regressed"
-      | ComparisonResult.NonSignificant => "Change within noise threshold"
-    IO.println s!"{indent}{explanation}"
-  IO.println ""
+    -- Higher time ⇒ lower throughput, so bounds are inverted
+    IO.println s!"{indent24}thrpt:  [{style.faint (t.formatRate ciUb)} {style.bold (t.formatRate typicalEstimate.pointEstimate)} {style.faint (t.formatRate ciLb)}]"
+
+  -- Change section (gated by verbosity, not shown in quiet)
+  if verbosity != .quiet then
+    if let some comp := m.comparison then
+      -- `p > significanceThreshold` means we fail to reject the null hypothesis
+      -- that the two samples come from the same distribution — i.e. no
+      -- statistically significant change.
+      let notSignificant := comp.pValue > comp.significanceThreshold
+      let meanEst := comp.relativeEstimates.mean
+      let fmtSigned (f : Float) : String :=
+        let body := (f * 100).floatPretty 4
+        if f ≥ 0 then s!"+{body}" else body
+
+      -- Determine coloring for point estimate based on comparison result
+      let comparison := if notSignificant then ComparisonResult.NonSignificant
+        else compareToThreshold meanEst comp.noiseThreshold
+      let colorPointEst (s : String) : String := match comparison with
+        | .Improved => style.green (style.bold s)
+        | .Regressed => style.red (style.bold s)
+        | .NonSignificant => s
+
+      let pointEstStr := colorPointEst (fmtSigned meanEst.pointEstimate)
+      let lbStr := style.faint (fmtSigned meanEst.confidenceInterval.lowerBound)
+      let ubStr := style.faint (fmtSigned meanEst.confidenceInterval.upperBound)
+      let pStr := s!"(p = {comp.pValue.floatPretty 2} {if notSignificant then ">" else "<"} {comp.significanceThreshold.floatPretty 2})"
+
+      -- Layout differs depending on whether throughput is present
+      if m.throughput.isSome then
+        -- Throughput present: separate "change:" header, then time: and thrpt: sub-lines
+        let toThrptEst (ratio : Float) : Float := 1.0 / (1.0 + ratio) - 1.0
+        let thrptPointStr := colorPointEst (fmtSigned (toThrptEst meanEst.pointEstimate))
+        let thrptLbStr := style.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.upperBound))
+        let thrptUbStr := style.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.lowerBound))
+        IO.println s!"{String.ofList (List.replicate 17 ' ')}change:"
+        IO.println s!"{indent24}time:   [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
+        IO.println s!"{indent24}thrpt:  [{thrptLbStr}% {thrptPointStr}% {thrptUbStr}%]"
+      else
+        -- No throughput: inline change
+        IO.println s!"{indent24}change: [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
+
+      -- Explanation line
+      let explanation := if notSignificant then
+        "No change in performance detected."
+      else match comparison with
+        | .Improved => s!"Performance has {style.green "improved"}."
+        | .Regressed => s!"Performance has {style.red "regressed"}."
+        | .NonSignificant => "Change within noise threshold."
+      IO.println s!"{indent24}{explanation}"
+
   -- Outlier-variance warning + Tukey breakdown. Verbosity gating matches
   -- Haskell criterion's `Internal.hs:89-92`:
   --   • verbose             → always print the variance line AND breakdown
   --   • normal + > slight   → print the variance line AND breakdown
   --   • normal + ≤ slight   → silent
   --   • quiet               → silent regardless
-  if let some ov := m.outlierVariance then
-    -- `effect > .slight` means moderate or severe.
-    let effectAboveSlight :=
-      match ov.effect with
-      | .moderate | .severe => true
-      | _ => false
-    let showVariance :=
-      verbosity == .verbose
-        || (effectAboveSlight && verbosity != .quiet)
-    if showVariance then
-      if let some outs := m.outliers then
-        Outliers.note outs m.avgTimes.d.size indent
-      let pct := (ov.fraction * 100).floatPretty 0
-      IO.println s!"{indent}variance introduced by outliers: {pct}% ({ov.desc})"
-      IO.println ""
+  if verbosity != .quiet then
+    if let some ov := m.outlierVariance then
+      let effectAboveSlight := match ov.effect with
+        | .moderate | .severe => true
+        | _ => false
+      let showVariance := verbosity == .verbose || (effectAboveSlight && verbosity != .quiet)
+      if showVariance then
+        if let some outs := m.outliers then
+          Outliers.note outs m.avgTimes.d.size style
+        let pct := (ov.fraction * 100).floatPretty 0
+        IO.println s!"variance introduced by outliers: {pct}% ({ov.desc})"
 
--- TODO: Write sampling mode and config in `sample.json` for comparison
 def saveComparison (groupName : String) (benchName : String) (comparison : ComparisonData) (config : Config) : IO Unit := do
   let changePath := System.mkFilePath [".", ".lake", "benches", groupName, benchName, "change"]
   storeFile config.serde comparison.relativeEstimates (changePath / s!"estimates.{toString config.serde}")
@@ -552,17 +571,24 @@ def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
   report.foldl (mkReportPretty' columnWidths) reportPretty
 
 def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
-    (tput : Option Throughput) (config : Config) (labelWidth : Nat) : IO BenchReport := do
+    (tput : Option Throughput) (config : Config) (style : CliStyle) : IO BenchReport := do
+  let benchId := s!"{groupName}/{b.name}"
+  style.printEphemeral s!"Benchmarking {benchId}"
   let start ← IO.monoNanosNow
   let _res ← b.getFn b.arg
   let finish ← IO.monoNanosNow
   let benchTime := finish - start
-  let fullName := s!"{groupName}/{b.name}"
-  let label := padLabel fullName labelWidth
-  let indent := padLabel "" labelWidth
-  IO.println s!"{label}time:   {benchTime.toFloat.formatNanos}"
+  style.overwrite
+  -- Use the same 24-char column layout as sampled mode
+  let timeStr := s!"time:   {style.bold (benchTime.toFloat.formatNanos)}"
+  if benchId.length > 23 then
+    IO.println (style.green benchId)
+    IO.println s!"{indent24}{timeStr}"
+  else
+    let pad := String.ofList (List.replicate (24 - benchId.length) ' ')
+    IO.println s!"{style.green benchId}{pad}{timeStr}"
   if let some t := tput then
-    IO.println s!"{indent}thrpt:  {t.formatRate benchTime.toFloat}"
+    IO.println s!"{indent24}thrpt:  {style.bold (t.formatRate benchTime.toFloat)}"
   let (basePath, newPath) ← mkDirs groupName b.name
   let fileExt := toString config.serde
   let newFile := newPath / s!"one-shot.{fileExt}"
@@ -570,7 +596,7 @@ def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
     let baseBench : OneShot ← loadFile config.serde newFile
     let baseTime := baseBench.benchTime.toFloat
     let percentChange := (benchTime.toFloat - baseTime) / baseTime
-    IO.println s!"{indent}change: {percentChangeToString percentChange}"
+    IO.println s!"{indent24}change: {percentChangeToString percentChange}"
     let _ ← IO.Process.run { cmd := "mv", args := #[newFile.toString, basePath.toString] }
     pure (some baseBench, some percentChange)
   else
@@ -597,8 +623,7 @@ def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
 `bgroup` takes a `BgroupM` do-block instead of a list of pre-built benches so
 the user can interleave `throughput` (which updates the current group config's
 throughput field) with `bench` / `benchIO` registrations. Each registration
-captures a snapshot of `config.throughput` at that moment, mirroring
-criterion.rs's `BenchmarkGroup::throughput` + `bench_function` pattern.
+captures a snapshot of `config.throughput` at that moment.
 -/
 
 /-- Internal state threaded through a `bgroup` do-block. -/
@@ -650,22 +675,17 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
     (action : BgroupM α β Unit) : IO $ Array BenchReport := do
   let config ← getConfigEnv config
   let (_, state) ← action.run { config, benches := #[] }
-  -- The action may have mutated `config.throughput`; re-read it from state but
-  -- keep the rest of `config` fixed.
   let bg : BenchGroup := { name, config }
-  -- Criterion-style label column: max fullName length across the group, at least 24 + 1 pad.
-  let labelWidth := state.benches.foldl
-    (fun w (b, _) => max w s!"{name}/{b.name}".length) minLabelWidth + 1
-  if config.verbosity != .quiet then
-    IO.println s!"Running bench group {name}\n"
+  let style : CliStyle := { colorEnabled := config.color, overwriteEnabled := config.overwrite }
   let mut reports : Array BenchReport := #[]
   for (b, tput) in state.benches do
+    let benchId := s!"{name}/{b.name}"
     let report : BenchReport ← if config.oneShot then do
-      oneShotBench name b tput config labelWidth
+      oneShotBench name b tput config style
     else
-      let warmupMean ← bg.warmup b
-      if bg.config.verbosity != .quiet then
-        IO.println s!"Running {b.name}"
+      -- Ephemeral: "Benchmarking {id}" → overwrite → "Warming up" → overwrite → "Collecting" → overwrite → permanent results
+      style.printEphemeral s!"Benchmarking {benchId}"
+      let warmupMean ← bg.warmup b style benchId
       -- Resolve `.auto` to a concrete mode now so both sampling and the
       -- downstream regression-vs-mean choice see the same decision.
       let resolvedMode := chooseSamplingMode bg.config warmupMean
@@ -673,20 +693,19 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
         let modeName := match resolvedMode with
           | .flat => "flat"
           | .linear => "linear"
-          | .auto => "auto" -- unreachable
+          | .auto => "auto"
         let picked := if bg.config.samplingMode == .auto then " (picked by auto)" else ""
         IO.println s!"Sampling mode: {modeName}{picked}"
-      -- From here on we use `resolvedConfig` (never `.auto`) so that both the
-      -- regression branch below and the `SampleRun` persisted to disk agree on
-      -- exactly which mode this run used.
+      -- From here on use `resolvedConfig` (never `.auto`) so the `SampleRun`
+      -- persisted to disk and the regression branch agree on the actual mode.
       let resolvedConfig := { bg.config with samplingMode := resolvedMode }
-      -- Inner bg needs the resolved config too so its .printResults uses the
-      -- right verbosity, labels, etc.
       let resolvedBg : BenchGroup := { name, config := resolvedConfig }
       let (iters, times) ← match resolvedMode with
-        | .flat => bg.sampleFlat b warmupMean
-        | .linear => bg.sampleLinear b warmupMean
-        | .auto => bg.sampleFlat b warmupMean -- unreachable
+        | .flat => bg.sampleFlat b warmupMean style benchId
+        | .linear => bg.sampleLinear b warmupMean style benchId
+        | .auto => bg.sampleFlat b warmupMean style benchId -- unreachable
+      -- Show "Analyzing" ephemeral while bootstrap runs (matches criterion.rs)
+      style.printEphemeral s!"Benchmarking {benchId}: Analyzing"
       let data := iters.zip times
       let avgTimes : Distribution := { d := data.map (fun (x,y) => Float.ofNat y / Float.ofNat x) }
       let gen ← IO.stdGenRef.get
@@ -700,11 +719,10 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
         distributions := { distributions with slope := .some distribution }
         rSquared := some r2
       -- Outlier analysis: classify per-sample average times and compute the
-      -- variance-inflation metric. Both are consumed by `printResults` under
-      -- the verbosity gate.
+      -- variance-inflation metric (consumed by `printResults` under the verbosity gate).
       let outliers := avgTimes.classifyOutliers
       let ov := outlierVariance estimates.mean estimates.stdDev (Float.ofNat resolvedConfig.numSamples)
-      let comparisonData : Option ComparisonData ← bg.getComparison b.name avgTimes resolvedConfig resolvedMode
+      let comparisonData : Option ComparisonData ← bg.getComparison b.name avgTimes resolvedConfig resolvedMode style
       let measurement : MeasurementData :=  {
         data := { d := data },
         avgTimes,
@@ -716,8 +734,8 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
         outlierVariance := some ov,
         outliers := some outliers
       }
-      resolvedBg.printResults b.name measurement labelWidth
-      IO.println ""
+      style.overwrite
+      resolvedBg.printResults b.name measurement style
       saveMeasurement name b.name measurement resolvedConfig
       let benchReport : BenchReport := {
         function := b.name,

--- a/Ix/Benchmark/Bench.lean
+++ b/Ix/Benchmark/Bench.lean
@@ -5,9 +5,7 @@ public import Ix.Cronos
 public import Ix.Address
 public import Batteries
 
-public import Ix.Benchmark.Serde
-public import Ix.Benchmark.Tukey
-public import Ix.Benchmark.Ansi
+public import Ix.Benchmark.Report
 
 public section
 
@@ -83,13 +81,6 @@ def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) (style : C
   let mean := Float.ofNat elapsed / Float.ofNat (totalIters.max 1)
   return mean
 
-def printRunning (config : Config) (style : CliStyle) (benchId : String) (expectedTime : Float) (numIters : Nat) (warningFactor : Nat) : IO Unit := do
-  if warningFactor == 1 then
-    -- Clear the ephemeral line before printing the permanent warning
-    style.overwrite
-    IO.eprintln s!"Warning: Unable to complete {config.numSamples} samples in {config.sampleTime.floatPretty 2}s. You may wish to increase target time to {expectedTime.floatPretty 2}s"
-  style.printEphemeral s!"Benchmarking {benchId}: Collecting {config.numSamples} samples in estimated {expectedTime.floatPretty 2}s ({numIters.natPretty} iterations)"
-
 -- Core sampling loop that runs the benchmark function and returns the array of measured timings
 def runSample (sampleIters : Array Nat) (bench : Benchmarkable α β) : IO (Array Nat) := do
   let func := bench.getFn
@@ -155,24 +146,6 @@ def chooseSamplingMode (config : Config) (warmupMean : Float) : SamplingMode :=
     let d := (targetTime / warmupMean / (Float.ofNat totalRuns)).ceil.toUInt64.toNat.max 1
     let expectedNs := (Float.ofNat totalRuns) * (Float.ofNat d) * warmupMean
     if expectedNs > 2 * targetTime then .flat else .linear
-
-structure MeasurementData where
-  data : Data
-  avgTimes : Distribution
-  absoluteEstimates : Estimates
-  distributions : Distributions
-  comparison : Option ComparisonData
-  throughput : Option Throughput
-  /-- R² goodness-of-fit for the linear regression, populated only in linear
-      sampling mode. `none` for flat sampling. -/
-  rSquared : Option Float := none
-  /-- Outlier-variance analysis — how much the outliers inflate the sample
-      std-dev estimate. `none` if the analysis was skipped (e.g. degenerate
-      bench). -/
-  outlierVariance : Option OutlierVariance := none
-  /-- Tukey-fence outlier breakdown over the per-sample averaged times. -/
-  outliers : Option Outliers := none
-  deriving Repr
 
 /--
 On-disk payload for `sample.{fmt}`. Carries the raw `(iters, time)` data plus
@@ -251,123 +224,6 @@ def BenchGroup.getComparison (bg : BenchGroup) (benchName : String)
   let gen ← IO.stdGenRef.get
   return some $ bg.compare baseRun.data baseEstimates avgTimes gen
 
-inductive ComparisonResult where
-| Improved
-| Regressed
-| NonSignificant
-
-def compareToThreshold (estimate : Estimate) (noiseThreshold : Float) : ComparisonResult :=
-  let ci := estimate.confidenceInterval
-  let (lb, ub) := (ci.lowerBound, ci.upperBound)
-  let noiseNeg := noiseThreshold.neg
-
-  if lb < noiseNeg && ub < noiseNeg
-  then
-    ComparisonResult.Improved
-  else if lb > noiseThreshold && ub > noiseThreshold
-  then
-    ComparisonResult.Regressed
-  else
-    ComparisonResult.NonSignificant
-
-
-/-- Criterion.rs uses a fixed 24-char column for the time/thrpt labels. -/
-def indent24 : String := String.ofList (List.replicate 24 ' ')
-
-def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
-    (m : MeasurementData) : IO Unit := do
-  let estimates := m.absoluteEstimates
-  let typicalEstimate := estimates.slope.getD estimates.mean
-  let fullName := s!"{bg.name}/{benchName}"
-  let verbosity := bg.config.verbosity
-  let ciLb := typicalEstimate.confidenceInterval.lowerBound
-  let ciUb := typicalEstimate.confidenceInterval.upperBound
-
-  -- Name line + time, matching criterion.rs's 24-char column layout:
-  -- Short name (≤ 23 chars): name + pad + time on one line
-  -- Long name (> 23 chars): name on its own line, time on the next
-  let r2Suffix := match m.rSquared with
-    | some r2 => s!" R²={r2.floatPretty 3}"
-    | none => ""
-  let timeLine := s!"time:   [{Ansi.faint ciLb.formatNanos} {Ansi.bold typicalEstimate.pointEstimate.formatNanos} {Ansi.faint ciUb.formatNanos}]{r2Suffix}"
-  if fullName.length > 23 then
-    IO.println (Ansi.green fullName)
-    IO.println s!"{indent24}{timeLine}"
-  else
-    let pad := String.ofList (List.replicate (24 - fullName.length) ' ')
-    IO.println s!"{Ansi.green fullName}{pad}{timeLine}"
-
-  -- Throughput line (if present)
-  if let some t := m.throughput then
-    -- Higher time ⇒ lower throughput, so bounds are inverted
-    IO.println s!"{indent24}thrpt:  [{Ansi.faint (t.formatRate ciUb)} {Ansi.bold (t.formatRate typicalEstimate.pointEstimate)} {Ansi.faint (t.formatRate ciLb)}]"
-
-  -- Change section (gated by verbosity, not shown in quiet)
-  if verbosity != .quiet then
-    if let some comp := m.comparison then
-      -- `p > significanceThreshold` means we fail to reject the null hypothesis
-      -- that the two samples come from the same distribution — i.e. no
-      -- statistically significant change.
-      let notSignificant := comp.pValue > comp.significanceThreshold
-      let meanEst := comp.relativeEstimates.mean
-      let fmtSigned (f : Float) : String :=
-        let body := (f * 100).floatPretty 4
-        if f ≥ 0 then s!"+{body}" else body
-
-      -- Determine coloring for point estimate based on comparison result
-      let comparison := if notSignificant then ComparisonResult.NonSignificant
-        else compareToThreshold meanEst comp.noiseThreshold
-      let colorPointEst (s : String) : String := match comparison with
-        | .Improved => Ansi.green (Ansi.bold s)
-        | .Regressed => Ansi.red (Ansi.bold s)
-        | .NonSignificant => s
-
-      let pointEstStr := colorPointEst (fmtSigned meanEst.pointEstimate)
-      let lbStr := Ansi.faint (fmtSigned meanEst.confidenceInterval.lowerBound)
-      let ubStr := Ansi.faint (fmtSigned meanEst.confidenceInterval.upperBound)
-      let pStr := s!"(p = {comp.pValue.floatPretty 2} {if notSignificant then ">" else "<"} {comp.significanceThreshold.floatPretty 2})"
-
-      -- Layout differs depending on whether throughput is present
-      if m.throughput.isSome then
-        -- Throughput present: separate "change:" header, then time: and thrpt: sub-lines
-        let toThrptEst (ratio : Float) : Float := 1.0 / (1.0 + ratio) - 1.0
-        let thrptPointStr := colorPointEst (fmtSigned (toThrptEst meanEst.pointEstimate))
-        let thrptLbStr := Ansi.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.upperBound))
-        let thrptUbStr := Ansi.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.lowerBound))
-        IO.println s!"{String.ofList (List.replicate 17 ' ')}change:"
-        IO.println s!"{indent24}time:   [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
-        IO.println s!"{indent24}thrpt:  [{thrptLbStr}% {thrptPointStr}% {thrptUbStr}%]"
-      else
-        -- No throughput: inline change
-        IO.println s!"{indent24}change: [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
-
-      -- Explanation line
-      let explanation := if notSignificant then
-        "No change in performance detected."
-      else match comparison with
-        | .Improved => s!"Performance has {Ansi.green "improved"}."
-        | .Regressed => s!"Performance has {Ansi.red "regressed"}."
-        | .NonSignificant => "Change within noise threshold."
-      IO.println s!"{indent24}{explanation}"
-
-  -- Outlier-variance warning + Tukey breakdown. Verbosity gating matches
-  -- Haskell criterion's `Internal.hs:89-92`:
-  --   • verbose             → always print the variance line AND breakdown
-  --   • normal + > slight   → print the variance line AND breakdown
-  --   • normal + ≤ slight   → silent
-  --   • quiet               → silent regardless
-  if verbosity != .quiet then
-    if let some ov := m.outlierVariance then
-      let effectAboveSlight := match ov.effect with
-        | .moderate | .severe => true
-        | _ => false
-      let showVariance := verbosity == .verbose || (effectAboveSlight && verbosity != .quiet)
-      if showVariance then
-        if let some outs := m.outliers then
-          Outliers.note outs m.avgTimes.d.size
-        let pct := (ov.fraction * 100).floatPretty 0
-        IO.println s!"variance introduced by outliers: {pct}% ({ov.desc})"
-
 def saveComparison (groupName : String) (benchName : String) (comparison : ComparisonData) (config : Config) : IO Unit := do
   let changePath := System.mkFilePath [".", ".lake", "benches", groupName, benchName, "change"]
   storeFile config.serde comparison.relativeEstimates (changePath / s!"estimates.{toString config.serde}")
@@ -402,184 +258,6 @@ def saveMeasurement (groupName : String) (benchName : String) (mData : Measureme
   storeFile config.serde mData.absoluteEstimates newEstimatesFile
   if let some t := mData.throughput then
     storeFile config.serde t newThroughputFile
-
-inductive BenchResult where
-| oneShot : OneShot → BenchResult
-| sample : Estimates → BenchResult
-  deriving Repr
-
-def BenchResult.getTime (bench: BenchResult) : Float :=
-  match bench with
-  | oneShot o => o.benchTime.toFloat
-  | sample s => s.mean.pointEstimate
-
--- TODO: Include input parameters if specified for post-processing
--- E.g. Blake3 bench wants to have `dataSize` and `numHashes`
--- Currently has to parse this from the `function` string
-structure BenchReport where
-  function: String
-  newBench : BenchResult
-  baseBench : Option BenchResult
-  percentChange : Option Float
-  throughput : Option Throughput := none
-
-/-- Rendered display string for a report's throughput, or `"N/A"` if `none`. -/
-def BenchReport.throughputStr (r : BenchReport) : String :=
-  match r.throughput with
-  | some t => t.formatRate r.newBench.getTime
-  | none => "N/A"
-
-/--
-Computes weighted-average throughput rate(s) across a collection of reports.
-Returns `none` if no report has throughput set, or if the reports use more
-than one `Throughput` variant. On success, returns the representative variant,
-the primary weighted-average rate, and (for `ElementsAndBytes`) the secondary
-bytes-weighted-average rate.
--/
-def weightedAverageThroughput (reports : Array BenchReport) :
-    Option (Throughput × Float × Option Float) := Id.run do
-  let mut representative : Option Throughput := none
-  let mut sumQty : Float := 0.0
-  let mut weightedSum : Float := 0.0
-  for r in reports do
-    match r.throughput with
-    | none => pure ()
-    | some t =>
-      match representative with
-      | none => representative := some t
-      | some t0 =>
-        unless t.sameVariant t0 do
-          return none
-      let qty := t.quantity.toNat.toFloat
-      let rate := t.rate r.newBench.getTime
-      sumQty := sumQty + qty
-      weightedSum := weightedSum + qty * rate
-  match representative with
-  | none => return none
-  | some t =>
-    if sumQty == 0 then return none
-    let primaryAvg := weightedSum / sumQty
-    -- For ElementsAndBytes, compute a separate bytes-weighted average
-    let secondaryAvg ← match t with
-      | .ElementsAndBytes _ _ _ => do
-        let mut sumBytes : Float := 0.0
-        let mut weightedBytesSum : Float := 0.0
-        for r in reports do
-          if let some (.ElementsAndBytes _ b _) := r.throughput then
-            let bytes := b.toNat.toFloat
-            let bytesRate := bytes * 1e9 / r.newBench.getTime
-            sumBytes := sumBytes + bytes
-            weightedBytesSum := weightedBytesSum + bytes * bytesRate
-        pure (if sumBytes > 0 then some (weightedBytesSum / sumBytes) else none)
-      | _ => pure none
-    return some (t, primaryAvg, secondaryAvg)
-
-def percentChangeToString (pc : Float) : String :=
-  let rounded := (100 * pc).floatPretty 2
-  if pc < 0 then s!"{rounded.drop 1}% faster"
-  else if pc > 0 then s!"{rounded}% slower"
-  else "No change"
-
-structure ColumnWidths where
-  function : Nat
-  newBench : Nat
-  baseBench : Nat
-  percentChange : Nat
-  /-- `none` ⇒ the Throughput column is not rendered for this group. -/
-  throughput : Option Nat
-
-def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidths :=
-  let fnLen := row.function.length
-  let function := if fnLen > maxWidths.function then fnLen else maxWidths.function
-  let newBenchLen := row.newBench.getTime.formatNanos.length
-  let newBench := if newBenchLen > maxWidths.newBench then newBenchLen else maxWidths.newBench
-  let baseBench := if let some baseBench := row.baseBench then
-    let baseBenchLen := baseBench.getTime.formatNanos.length
-    if baseBenchLen > maxWidths.baseBench then baseBenchLen
-    else maxWidths.baseBench
-  else maxWidths.baseBench
-  let percentChange := if let some percentChange := row.percentChange then
-    let percentChangeStr := percentChangeToString percentChange
-    let percentLen := percentChangeStr.length
-    if percentLen > maxWidths.percentChange then percentLen
-    else maxWidths.percentChange
-  else maxWidths.percentChange
-  let throughput := match maxWidths.throughput with
-    | none => none
-    | some w =>
-      let tStr := row.throughputStr
-      let tLen := tStr.length
-      some (if tLen > w then tLen else w)
-  { function, newBench, baseBench, percentChange, throughput }
-
--- Gets the max lengths of each data type for pretty-printing columns
-def getColumnWidths (report : Array BenchReport) : ColumnWidths :=
-  let hasThroughput := report.any (·.throughput.isSome)
-  let maxWidths : ColumnWidths := {
-    function := "Function".length
-    newBench := "New Benchmark".length
-    baseBench := "Base Benchmark".length
-    percentChange := "% change".length
-    throughput := if hasThroughput then some "Throughput".length else none
-  }
-  report.foldl getColumnWidths' maxWidths
-
--- Centers a string with padded whitespace given the total width
-def padWhitespace (input : String) (width : Nat) : String :=
-  let padWidth := width - input.length
-  let leftPad := padWidth / 2
-  let rightPad := padWidth - leftPad
-  String.ofList (List.replicate leftPad ' ') ++ input ++ (String.ofList (List.replicate rightPad ' '))
-
-def padDashes (width : Nat) : String :=
-  String.ofList (List.replicate width '-')
-
-def mkReportPretty' (columnWidths : ColumnWidths) (reportPretty : String) (row : BenchReport) : String :=
-  let functionStr := padWhitespace row.function columnWidths.function
-  let newBenchStr := row.newBench.getTime.formatNanos
-  let newBenchStr := padWhitespace newBenchStr columnWidths.newBench
-  let baseBenchStr := if let some baseBench := row.baseBench then
-    baseBench.getTime.formatNanos
-  else "None"
-  let baseBenchStr := padWhitespace baseBenchStr columnWidths.baseBench
-  let percentChangeStr := if let some percentChange := row.percentChange then
-    percentChangeToString percentChange
-  else "N/A"
-  let percentChangeStr := padWhitespace percentChangeStr columnWidths.percentChange
-  let throughputCell := match columnWidths.throughput with
-    | none => ""
-    | some w => s!" {padWhitespace row.throughputStr w} |"
-  let rowPretty :=
-    s!"| {functionStr} | {newBenchStr} | {baseBenchStr} | {percentChangeStr} |{throughputCell}\n"
-  reportPretty ++ rowPretty
-
--- TODO: Bold the faster result and faster/slower % change
-/--
-Generates a Markdown table with comparative benchmark timings based on the results on disk.
-Each table row contains the benchmark function name, the new timing, the base timing, the percent change between the two, and (optionally) a throughput rate.
--/
-def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
-  let columnWidths := getColumnWidths report
-  let title := s!"## {groupName}\n\n"
-  let (fn, new, base, percent) := (
-    padWhitespace "Function" columnWidths.function,
-    padWhitespace "New Benchmark" columnWidths.newBench,
-    padWhitespace "Base Benchmark" columnWidths.baseBench,
-    padWhitespace "% change" columnWidths.percentChange
-  )
-  let (d1, d2, d3, d4) := (
-    padDashes columnWidths.function,
-    padDashes columnWidths.newBench,
-    padDashes columnWidths.baseBench,
-    padDashes columnWidths.percentChange
-  )
-  let (throughputHeader, throughputDashes) := match columnWidths.throughput with
-    | none => ("", "")
-    | some w => (s!" {padWhitespace "Throughput" w} |", s!"-{padDashes w}-|")
-  let header := s!"| {fn} | {new} | {base} | {percent} |{throughputHeader}\n"
-  let dashes := s!"|-{d1}-|-{d2}-|-{d3}-|-{d4}-|{throughputDashes}\n"
-  let reportPretty := title ++ header ++ dashes
-  report.foldl (mkReportPretty' columnWidths) reportPretty
 
 def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
     (tput : Option Throughput) (config : Config) (style : CliStyle) : IO BenchReport := do
@@ -711,7 +389,6 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
       -- From here on use `resolvedConfig` (never `.auto`) so the `SampleRun`
       -- persisted to disk and the regression branch agree on the actual mode.
       let resolvedConfig := { bg.config with samplingMode := resolvedMode }
-      let resolvedBg : BenchGroup := { name, config := resolvedConfig }
       let (iters, times) ← match resolvedMode with
         | .flat => bg.sampleFlat b warmupMean style benchId
         | .linear => bg.sampleLinear b warmupMean style benchId
@@ -747,7 +424,7 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
         outliers := some outliers
       }
       style.overwrite
-      resolvedBg.printResults b.name measurement
+      printResults name resolvedConfig b.name measurement
       saveMeasurement name b.name measurement resolvedConfig
       let benchReport : BenchReport := {
         function := b.name,

--- a/Ix/Benchmark/Bench.lean
+++ b/Ix/Benchmark/Bench.lean
@@ -15,6 +15,21 @@ open Batteries (RBMap)
 /-!
 # Benchmarking library modeled after Criterion in Haskell and Rust
 
+## Verbosity
+
+Three levels controlled by `Config.verbosity`, the `BENCH_VERBOSITY` env var,
+or the `-q` / `--quiet` / `-v` / `--verbose` command-line flags
+(CLI > env var > `Config` default). See `getConfigEnv` for the precedence
+rules, and the `Verbosity` enum doc comments for what each level prints.
+
+- `quiet`   — only per-bench summary lines (time / thrpt / change / perf note)
+- `normal`  — default; adds warmup + running lines, plus the variance-introduced-by-outliers warning and Tukey breakdown *only* when the outlier effect is moderate or severe
+- `verbose` — adds R² alongside the time line, and always prints the variance warning + Tukey breakdown regardless of severity
+
+Bench files wanting to pick up the CLI flags should call `setBenchArgs args`
+at the top of `main (args : List String) : IO Unit`. Skipping this only
+disables CLI flags — `Config.verbosity` and `BENCH_VERBOSITY` still work.
+
 ## Limitations
 - Measures time in nanoseconds using `IO.monoNanosNow`, which is less precise than the picoseconds used in Criterion.rs
 -/
@@ -42,25 +57,16 @@ structure Benchmarkable (α β : Type) where
   func : BenchFn α β
   arg : α
 
-/--
-Creates a `Benchmarkable` instance. Use with pure functions, which will later be called with `blackBoxIO` to prevent compiler optimizations.
--/
-def bench (name : String) (fn : α → β) (arg : α) : Benchmarkable α β := { name, func := BenchFn.pure fn, arg }
-
-/--
-Creates a `Benchmarkable` instance. Use with functions that return IO, as they don't need to be black boxed.
--/
-def benchIO (name : String) (fn : α → IO β) (arg : α) : Benchmarkable α β :=  { name, func := BenchFn.io fn, arg }
-
 /-- If the function is pure, we need to wrap it in `blackBoxIO` so that Lean doesn't optimize away the result -/
-def Benchmarkable.getFn ( bench: Benchmarkable α β) : α → IO β :=
-  match bench.func with
+def Benchmarkable.getFn (b : Benchmarkable α β) : α → IO β :=
+  match b.func with
   | .pure f => blackBoxIO f
   | .io f => f
 
 -- TODO: According to Criterion.rs docs the warmup iterations should increase linearly until the warmup time is reached, rather than one iteration per time check
 def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) : IO Float := do
-  IO.println s!"Warming up for {bg.config.warmupTime.floatPretty 2}s"
+  if bg.config.verbosity != .quiet then
+    IO.println s!"Warming up for {bg.config.warmupTime.floatPretty 2}s"
   let mut count := 0
   let warmupNanos := Cronos.secToNano bg.config.warmupTime
   let mut elapsed := 0
@@ -72,13 +78,14 @@ def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) : IO Float
     count := count + 1
     elapsed := now - startTime
   let mean := Float.ofNat elapsed / Float.ofNat count
-  --IO.println s!"{bench.name} warmup avg: {mean}ns"
   return mean
 
 def printRunning (config : Config) (expectedTime : Float) (numIters : Nat) (warningFactor : Nat) : IO Unit := do
+  -- The "Unable to complete" warning is always shown — it's actionable at any verbosity.
   if warningFactor == 1 then
     IO.eprintln s!"Warning: Unable to complete {config.numSamples} samples in {config.sampleTime.floatPretty 2}s. You may wish to increase target time to {expectedTime.floatPretty 2}s"
-  IO.println s!"Running {config.numSamples} samples in {expectedTime.floatPretty 2}s ({numIters.natPretty} iterations)\n"
+  if config.verbosity != .quiet then
+    IO.println s!"Running {config.numSamples} samples in {expectedTime.floatPretty 2}s ({numIters.natPretty} iterations)\n"
 
 -- Core sampling loop that runs the benchmark function and returns the array of measured timings
 def runSample (sampleIters : Array Nat) (bench : Benchmarkable α β) : IO (Array Nat) := do
@@ -131,18 +138,26 @@ def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable α β) (war
   let timings ← runSample sampleIters bench
   return (sampleIters, timings)
 
+/-- Picks a concrete sampling mode for `.auto`, matching criterion.rs's
+    `SamplingMode::choose_sampling_mode`: choose linear iff the expected total
+    linear-mode time is at most 2× the target sample time, else fall back to
+    flat. For `.flat` / `.linear` this returns the user's explicit choice. -/
+def chooseSamplingMode (config : Config) (warmupMean : Float) : SamplingMode :=
+  match config.samplingMode with
+  | .flat => .flat
+  | .linear => .linear
+  | .auto =>
+    let targetTime := config.sampleTime.toNanos
+    let totalRuns := config.numSamples * (config.numSamples + 1) / 2
+    let d := (targetTime / warmupMean / (Float.ofNat totalRuns)).ceil.toUInt64.toNat.max 1
+    let expectedNs := (Float.ofNat totalRuns) * (Float.ofNat d) * warmupMean
+    if expectedNs > 2 * targetTime then .flat else .linear
+
 def BenchGroup.sample (bg : BenchGroup) (bench : Benchmarkable α β) (warmupMean : Float) : IO (Array Nat × Array Nat) := do
-  match bg.config.samplingMode with
+  match chooseSamplingMode bg.config warmupMean with
   | .flat => bg.sampleFlat bench warmupMean
   | .linear => bg.sampleLinear bench warmupMean
-
--- TODO
-inductive Throughput where
-| Bytes (n : UInt64)
-| BytesDecimal (n : UInt64)
-| Elements (n : UInt64)
-| Bits (n : UInt64)
-  deriving Repr
+  | .auto => bg.sampleFlat bench warmupMean  -- unreachable after chooseSamplingMode
 
 structure MeasurementData where
   data : Data
@@ -151,7 +166,43 @@ structure MeasurementData where
   distributions : Distributions
   comparison : Option ComparisonData
   throughput : Option Throughput
+  /-- R² goodness-of-fit for the linear regression, populated only in linear
+      sampling mode. `none` for flat sampling. -/
+  rSquared : Option Float := none
+  /-- Outlier-variance analysis — how much the outliers inflate the sample
+      std-dev estimate. `none` if the analysis was skipped (e.g. degenerate
+      bench). -/
+  outlierVariance : Option OutlierVariance := none
+  /-- Tukey-fence outlier breakdown over the per-sample averaged times. -/
+  outliers : Option Outliers := none
   deriving Repr
+
+/--
+On-disk payload for `sample.{fmt}`. Carries the raw `(iters, time)` data plus
+a snapshot of the `Config` used to collect this run, so that a later run can
+decide whether it's statistically comparable.
+
+`config.samplingMode` is always the resolved mode (`.flat` or `.linear`);
+`.auto` is resolved in `bgroup` before the `SampleRun` is constructed, and the
+`Serialize SamplingMode` instance panics if `.auto` ever reaches disk.
+-/
+structure SampleRun where
+  data : Data
+  config : Config
+  deriving Repr, Lean.ToJson, Lean.FromJson
+
+def putSampleRun (r : SampleRun) : Ixon.PutM Unit := do
+  Ixon.Serialize.put r.data
+  Ixon.Serialize.put r.config
+
+def getSampleRun : Ixon.GetM SampleRun := do
+  let data ← Ixon.Serialize.get
+  let config ← Ixon.Serialize.get
+  return { data, config }
+
+instance : Ixon.Serialize SampleRun where
+  put := putSampleRun
+  get := getSampleRun
 
 /-- Compares bench results against prior run, using T-test to determine statistical significance -/
 def BenchGroup.compare (bg : BenchGroup) (baseSample : Data) (baseEstimates : Estimates) (avgTimes : Distribution) (gen : StdGen) : ComparisonData :=
@@ -174,20 +225,32 @@ def BenchGroup.compare (bg : BenchGroup) (baseSample : Data) (baseEstimates : Es
     baseEstimates
   }
 
--- TODO: Don't compare if different sampling modes were used
-/-- Retrieves prior bench result from disk and runs the comparison -/
-def BenchGroup.getComparison (bg : BenchGroup) (benchName : String) (avgTimes : Distribution) (config: Config) : IO (Option ComparisonData) := do
+/-- Retrieves prior bench result from disk and runs the comparison. Refuses
+    to compare if the base was collected with a different resolved sampling
+    mode (flat vs linear), since mixing the two through the same bootstrap
+    gives misleading confidence intervals. -/
+def BenchGroup.getComparison (bg : BenchGroup) (benchName : String)
+    (avgTimes : Distribution) (config : Config) (resolvedMode : SamplingMode) :
+    IO (Option ComparisonData) := do
   let benchPath := System.mkFilePath [".", ".lake", "benches", bg.name, benchName]
   let fileExt := toString config.serde
   -- Base data is at `new` since we haven't written the latest result to disk yet, which moves the prior data to `base`
   let basePath := benchPath / "new"
-  if (← System.FilePath.pathExists (basePath / s!"estimates.{fileExt}")) then do
-    let baseSample : Data ← loadFile config.serde (basePath / s!"sample.{fileExt}")
-    let baseEstimates : Estimates ← loadFile config.serde (basePath / s!"estimates.{fileExt}")
-    let gen ← IO.stdGenRef.get
-    return some $ bg.compare baseSample baseEstimates avgTimes gen
-  else
+  if !(← System.FilePath.pathExists (basePath / s!"estimates.{fileExt}")) then
     return none
+  let baseRun? : Option SampleRun ← try
+    let r : SampleRun ← loadFile config.serde (basePath / s!"sample.{fileExt}")
+    pure (some r)
+  catch _ =>
+    IO.eprintln s!"Skipping comparison for {benchName}: failed to parse base sample.{fileExt}"
+    pure none
+  let some baseRun := baseRun? | return none
+  if baseRun.config.samplingMode != resolvedMode then
+    IO.eprintln s!"Skipping comparison for {benchName}: base ran in {repr baseRun.config.samplingMode} mode, current run is {repr resolvedMode}"
+    return none
+  let baseEstimates : Estimates ← loadFile config.serde (basePath / s!"estimates.{fileExt}")
+  let gen ← IO.stdGenRef.get
+  return some $ bg.compare baseRun.data baseEstimates avgTimes gen
 
 inductive ComparisonResult where
 | Improved
@@ -209,25 +272,54 @@ def compareToThreshold (estimate : Estimate) (noiseThreshold : Float) : Comparis
     ComparisonResult.NonSignificant
 
 
--- TODO: Print ~24 whitespace characters before time, change, regression
-def BenchGroup.printResults (bg : BenchGroup) (benchName : String) (m : MeasurementData) : IO Unit := do
+/-- Right-pads `s` with spaces to reach at least `width` characters. -/
+def padLabel (s : String) (width : Nat) : String :=
+  if s.length ≥ width then s
+  else s ++ String.ofList (List.replicate (width - s.length) ' ')
+
+/-- Criterion.rs-style label column width: minimum 24 chars, grows to fit the longest bench name in a group. -/
+def minLabelWidth : Nat := 24
+
+def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
+    (m : MeasurementData) (labelWidth : Nat) : IO Unit := do
   let estimates := m.absoluteEstimates
   let typicalEstimate := estimates.slope.getD estimates.mean
-  IO.println s!"{bg.name}/{benchName}"
-  let lb := typicalEstimate.confidenceInterval.lowerBound.formatNanos
+  let fullName := s!"{bg.name}/{benchName}"
+  let label := padLabel fullName labelWidth
+  let indent := padLabel "" labelWidth
+  let verbosity := bg.config.verbosity
+  let ciLb := typicalEstimate.confidenceInterval.lowerBound
+  let ciUb := typicalEstimate.confidenceInterval.upperBound
+  let lb := ciLb.formatNanos
   let pointEst := typicalEstimate.pointEstimate.formatNanos
-  let ub := typicalEstimate.confidenceInterval.upperBound.formatNanos
-  IO.println s!"time:   [{lb} {pointEst} {ub}]"
+  let ub := ciUb.formatNanos
+  -- Append R² to the time line when linear-mode regression data is available.
+  let r2Suffix := match m.rSquared with
+    | some r2 => s!" R²={r2.floatPretty 3}"
+    | none => ""
+  IO.println s!"{label}time:   [{lb} {pointEst} {ub}]{r2Suffix}"
+  if let some t := m.throughput then
+    -- Higher time ⇒ lower throughput, so the low rate corresponds to the time CI upper bound.
+    let thrptLow := t.formatRate ciUb
+    let thrptPt := t.formatRate typicalEstimate.pointEstimate
+    let thrptHigh := t.formatRate ciLb
+    IO.println s!"{indent}thrpt:  [{thrptLow} {thrptPt} {thrptHigh}]"
   if let some comp := m.comparison
   then
-    let diffMean := comp.pValue > comp.significanceThreshold
+    -- `p > significanceThreshold` means we fail to reject the null hypothesis
+    -- that the two samples come from the same distribution — i.e. no
+    -- statistically significant change.
+    let notSignificant := comp.pValue > comp.significanceThreshold
     let meanEst := comp.relativeEstimates.mean
-    let pointEst := (meanEst.pointEstimate * 100).floatPretty 4
-    let lb := (meanEst.confidenceInterval.lowerBound * 100).floatPretty 4
-    let ub := (meanEst.confidenceInterval.upperBound * 100).floatPretty 4
-    let symbol := if diffMean then ">" else "<"
-    IO.println s!"change: [{lb}% {pointEst}% {ub}%] (p = {comp.pValue.floatPretty 2} {symbol} {comp.significanceThreshold.floatPretty 2})"
-    let explanation := if diffMean
+    let fmtSigned (f : Float) : String :=
+      let body := (f * 100).floatPretty 4
+      if f ≥ 0 then s!"+{body}" else body
+    let pointEst := fmtSigned meanEst.pointEstimate
+    let lb := fmtSigned meanEst.confidenceInterval.lowerBound
+    let ub := fmtSigned meanEst.confidenceInterval.upperBound
+    let symbol := if notSignificant then ">" else "<"
+    IO.println s!"{indent}change: [{lb}% {pointEst}% {ub}%] (p = {comp.pValue.floatPretty 2} {symbol} {comp.significanceThreshold.floatPretty 2})"
+    let explanation := if notSignificant
     then
       "No change in performance detected"
     else
@@ -235,9 +327,29 @@ def BenchGroup.printResults (bg : BenchGroup) (benchName : String) (m : Measurem
       | ComparisonResult.Improved => "Performance has improved"
       | ComparisonResult.Regressed => "Performance has regressed"
       | ComparisonResult.NonSignificant => "Change within noise threshold"
-    IO.println explanation
+    IO.println s!"{indent}{explanation}"
   IO.println ""
-  m.avgTimes.tukey
+  -- Outlier-variance warning + Tukey breakdown. Verbosity gating matches
+  -- Haskell criterion's `Internal.hs:89-92`:
+  --   • verbose             → always print the variance line AND breakdown
+  --   • normal + > slight   → print the variance line AND breakdown
+  --   • normal + ≤ slight   → silent
+  --   • quiet               → silent regardless
+  if let some ov := m.outlierVariance then
+    -- `effect > .slight` means moderate or severe.
+    let effectAboveSlight :=
+      match ov.effect with
+      | .moderate | .severe => true
+      | _ => false
+    let showVariance :=
+      verbosity == .verbose
+        || (effectAboveSlight && verbosity != .quiet)
+    if showVariance then
+      if let some outs := m.outliers then
+        Outliers.note outs m.avgTimes.d.size indent
+      let pct := (ov.fraction * 100).floatPretty 0
+      IO.println s!"{indent}variance introduced by outliers: {pct}% ({ov.desc})"
+      IO.println ""
 
 -- TODO: Write sampling mode and config in `sample.json` for comparison
 def saveComparison (groupName : String) (benchName : String) (comparison : ComparisonData) (config : Config) : IO Unit := do
@@ -256,21 +368,25 @@ def moveBaseFile (file : System.FilePath) (baseDir : String) : IO Unit := do
     -- Move prior bench from `new` to `base`
     let _ ← IO.Process.run { cmd := "mv", args := #[file.toString, baseDir] }
 
--- Results are always saved to `.lake/benches/<benchName>/new`. If files of the same serde format already exist from a prior run, move them to `base`
+-- Results are always saved to `.lake/benches/<benchName>/new`. If files of the same serde format already exist from a prior run, move them to `base`.
+-- `config.samplingMode` must be the resolved mode (`.flat` / `.linear`) — callers must never pass `.auto` here.
 def saveMeasurement (groupName : String) (benchName : String) (mData : MeasurementData) (config : Config) : IO Unit := do
   let (basePath, newPath) ← mkDirs groupName benchName
   let baseDir := basePath.toString
   let fileExt := toString config.serde
-  if let some compData := mData.comparison then saveComparison groupName benchName compData config
-  else
-    println! "No compdata"
+  if let some compData := mData.comparison then
+    saveComparison groupName benchName compData config
   let (newEstimatesFile, newSampleFile) := (newPath / s!"estimates.{fileExt}", newPath / s!"sample.{fileExt}")
+  let newThroughputFile := newPath / s!"throughput.{fileExt}"
   moveBaseFile newSampleFile baseDir
   moveBaseFile newEstimatesFile baseDir
-  storeFile config.serde mData.data newSampleFile
+  moveBaseFile newThroughputFile baseDir
+  let sampleRun : SampleRun := { data := mData.data, config }
+  storeFile config.serde sampleRun newSampleFile
   storeFile config.serde mData.absoluteEstimates newEstimatesFile
+  if let some t := mData.throughput then
+    storeFile config.serde t newThroughputFile
 
--- TODO: Use a typeclass instead?
 inductive BenchResult where
 | oneShot : OneShot → BenchResult
 | sample : Estimates → BenchResult
@@ -289,6 +405,44 @@ structure BenchReport where
   newBench : BenchResult
   baseBench : Option BenchResult
   percentChange : Option Float
+  throughput : Option Throughput := none
+
+/-- Rendered display string for a report's throughput, or `"N/A"` if `none`. -/
+def BenchReport.throughputStr (r : BenchReport) : String :=
+  match r.throughput with
+  | some t => t.formatRate r.newBench.getTime
+  | none => "N/A"
+
+/--
+Computes the weighted-average primary throughput rate across a collection of
+reports, weighted by each bench's primary quantity. Returns `none` if no
+report has throughput set, or if the reports use more than one `Throughput`
+variant (averaging across variants — e.g. bytes/s and elements/s — would be
+meaningless). On success, returns the variant of the first throughput-bearing
+report (used to pick display units) together with the averaged rate.
+-/
+def weightedAverageThroughput (reports : Array BenchReport) : Option (Throughput × Float) := Id.run do
+  let mut representative : Option Throughput := none
+  let mut sumQty : Float := 0.0
+  let mut weightedSum : Float := 0.0
+  for r in reports do
+    match r.throughput with
+    | none => pure ()
+    | some t =>
+      match representative with
+      | none => representative := some t
+      | some t0 =>
+        unless t.sameVariant t0 do
+          return none
+      let qty := t.quantity.toNat.toFloat
+      let rate := t.rate r.newBench.getTime
+      sumQty := sumQty + qty
+      weightedSum := weightedSum + qty * rate
+  match representative with
+  | none => return none
+  | some t =>
+    if sumQty == 0 then return none
+    return some (t, weightedSum / sumQty)
 
 def percentChangeToString (pc : Float) : String :=
   let rounded := (100 * pc).floatPretty 2
@@ -301,6 +455,8 @@ structure ColumnWidths where
   newBench : Nat
   baseBench : Nat
   percentChange : Nat
+  /-- `none` ⇒ the Throughput column is not rendered for this group. -/
+  throughput : Option Nat
 
 def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidths :=
   let fnLen := row.function.length
@@ -318,15 +474,23 @@ def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidth
     if percentLen > maxWidths.percentChange then percentLen
     else maxWidths.percentChange
   else maxWidths.percentChange
-  { function, newBench, baseBench, percentChange }
+  let throughput := match maxWidths.throughput with
+    | none => none
+    | some w =>
+      let tStr := row.throughputStr
+      let tLen := tStr.length
+      some (if tLen > w then tLen else w)
+  { function, newBench, baseBench, percentChange, throughput }
 
 -- Gets the max lengths of each data type for pretty-printing columns
 def getColumnWidths (report : Array BenchReport) : ColumnWidths :=
+  let hasThroughput := report.any (·.throughput.isSome)
   let maxWidths : ColumnWidths := {
     function := "Function".length
     newBench := "New Benchmark".length
     baseBench := "Base Benchmark".length
     percentChange := "% change".length
+    throughput := if hasThroughput then some "Throughput".length else none
   }
   report.foldl getColumnWidths' maxWidths
 
@@ -352,14 +516,17 @@ def mkReportPretty' (columnWidths : ColumnWidths) (reportPretty : String) (row :
     percentChangeToString percentChange
   else "N/A"
   let percentChangeStr := padWhitespace percentChangeStr columnWidths.percentChange
+  let throughputCell := match columnWidths.throughput with
+    | none => ""
+    | some w => s!" {padWhitespace row.throughputStr w} |"
   let rowPretty :=
-    s!"| {functionStr} | {newBenchStr} | {baseBenchStr} | {percentChangeStr} |\n"
+    s!"| {functionStr} | {newBenchStr} | {baseBenchStr} | {percentChangeStr} |{throughputCell}\n"
   reportPretty ++ rowPretty
 
 -- TODO: Bold the faster result and faster/slower % change
 /--
 Generates a Markdown table with comparative benchmark timings based on the results on disk.
-Each table row contains the benchmakr function name, the new timing, the base timing, and the percent change between the two.
+Each table row contains the benchmark function name, the new timing, the base timing, the percent change between the two, and (optionally) a throughput rate.
 -/
 def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
   let columnWidths := getColumnWidths report
@@ -370,86 +537,209 @@ def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
     padWhitespace "Base Benchmark" columnWidths.baseBench,
     padWhitespace "% change" columnWidths.percentChange
   )
-  let header := s!"| {fn} | {new} | {base} | {percent} |\n"
   let (d1, d2, d3, d4) := (
     padDashes columnWidths.function,
     padDashes columnWidths.newBench,
     padDashes columnWidths.baseBench,
     padDashes columnWidths.percentChange
   )
-  let dashes := s!"|-{d1}-|-{d2}-|-{d3}-|-{d4}-|\n"
+  let (throughputHeader, throughputDashes) := match columnWidths.throughput with
+    | none => ("", "")
+    | some w => (s!" {padWhitespace "Throughput" w} |", s!"-{padDashes w}-|")
+  let header := s!"| {fn} | {new} | {base} | {percent} |{throughputHeader}\n"
+  let dashes := s!"|-{d1}-|-{d2}-|-{d3}-|-{d4}-|{throughputDashes}\n"
   let reportPretty := title ++ header ++ dashes
   report.foldl (mkReportPretty' columnWidths) reportPretty
 
-def oneShotBench {α β : Type} (groupName : String) (bench: Benchmarkable α β) (config : Config) : IO BenchReport := do
+def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
+    (tput : Option Throughput) (config : Config) (labelWidth : Nat) : IO BenchReport := do
   let start ← IO.monoNanosNow
-  let _res ← bench.getFn bench.arg
+  let _res ← b.getFn b.arg
   let finish ← IO.monoNanosNow
   let benchTime := finish - start
-  IO.println s!"time:   {benchTime.toFloat.formatNanos}"
-  let (basePath, newPath) ← mkDirs groupName bench.name
+  let fullName := s!"{groupName}/{b.name}"
+  let label := padLabel fullName labelWidth
+  let indent := padLabel "" labelWidth
+  IO.println s!"{label}time:   {benchTime.toFloat.formatNanos}"
+  if let some t := tput then
+    IO.println s!"{indent}thrpt:  {t.formatRate benchTime.toFloat}"
+  let (basePath, newPath) ← mkDirs groupName b.name
   let fileExt := toString config.serde
   let newFile := newPath / s!"one-shot.{fileExt}"
   let (baseBench, percentChange) ← if (← System.FilePath.pathExists newFile) then do
     let baseBench : OneShot ← loadFile config.serde newFile
     let baseTime := baseBench.benchTime.toFloat
     let percentChange := (benchTime.toFloat - baseTime) / baseTime
-    IO.println s!"change: {percentChangeToString percentChange}"
+    IO.println s!"{indent}change: {percentChangeToString percentChange}"
     let _ ← IO.Process.run { cmd := "mv", args := #[newFile.toString, basePath.toString] }
     pure (some baseBench, some percentChange)
   else
     let _ ← IO.Process.run { cmd := "mkdir", args := #["-p", newPath.toString] }
     pure (.none, .none)
-  let newBench : OneShot := { benchTime }
+  -- One-shot mode embeds throughput inside the OneShot record so there is no
+  -- separate throughput file on disk — switching between sample and one-shot
+  -- modes never overlaps on the same filename.
+  let newBench : OneShot := { benchTime, throughput := tput }
   IO.println ""
   storeFile config.serde newBench newFile
-  let benchReport : BenchReport := { function := bench.name, newBench := (.oneShot newBench), baseBench := baseBench.map .oneShot, percentChange }
+  let benchReport : BenchReport := {
+    function := b.name,
+    newBench := (.oneShot newBench),
+    baseBench := baseBench.map .oneShot,
+    percentChange,
+    throughput := tput
+  }
   return benchReport
 
+/-!
+## Monadic bgroup builder
+
+`bgroup` takes a `BgroupM` do-block instead of a list of pre-built benches so
+the user can interleave `throughput` (which updates the current group config's
+throughput field) with `bench` / `benchIO` registrations. Each registration
+captures a snapshot of `config.throughput` at that moment, mirroring
+criterion.rs's `BenchmarkGroup::throughput` + `bench_function` pattern.
+-/
+
+/-- Internal state threaded through a `bgroup` do-block. -/
+structure GroupState (α β : Type) where
+  config : Config
+  /-- Registered benches paired with the `config.throughput` snapshot taken at registration time. -/
+  benches : Array (Benchmarkable α β × Option Throughput) := #[]
+
+/-- Monad used inside a `bgroup` do-block. -/
+abbrev BgroupM (α β : Type) := StateT (GroupState α β) IO
+
+namespace BgroupM
+
+/--
+Sets the throughput for subsequent `bench`/`benchIO` calls in the current
+`bgroup`. Prior registrations keep the value they captured at registration time.
+-/
+def throughput (t : Throughput) : BgroupM α β Unit :=
+  modify fun s => { s with config := { s.config with throughput := some t } }
+
+/-- Clears the current throughput so subsequent registrations capture `none`. -/
+def clearThroughput : BgroupM α β Unit :=
+  modify fun s => { s with config := { s.config with throughput := none } }
+
+/--
+Registers a pure benchmark with the current `bgroup`. The pure `fn` is wrapped
+in `blackBoxIO` internally so the compiler cannot optimize its result away.
+-/
+def bench (name : String) (fn : α → β) (arg : α) : BgroupM α β Unit :=
+  modify fun s =>
+    let b : Benchmarkable α β := { name, func := BenchFn.pure fn, arg }
+    { s with benches := s.benches.push (b, s.config.throughput) }
+
+/--
+Registers an `IO`-returning benchmark with the current `bgroup`. `IO` benches are
+not black-boxed because the `IO` return already prevents the optimizer from
+eliminating the call.
+-/
+def benchIO (name : String) (fn : α → IO β) (arg : α) : BgroupM α β Unit :=
+  modify fun s =>
+    let b : Benchmarkable α β := { name, func := BenchFn.io fn, arg }
+    { s with benches := s.benches.push (b, s.config.throughput) }
+
+end BgroupM
+
 -- TODO: Make sure compiler isn't caching partial evaluation result for future runs of the same function (measure first vs subsequent runs)
-/-- Runs each benchmark in a `BenchGroup` and analyzes the results -/
-def bgroup {α β : Type} (name: String) (benches : List (Benchmarkable α β)) (config : Config := {}) : IO $ Array BenchReport := do
+/-- Runs each benchmark registered by `action` and analyzes the results. -/
+def bgroup {α β : Type} (name: String) (config : Config := {})
+    (action : BgroupM α β Unit) : IO $ Array BenchReport := do
   let config ← getConfigEnv config
+  let (_, state) ← action.run { config, benches := #[] }
+  -- The action may have mutated `config.throughput`; re-read it from state but
+  -- keep the rest of `config` fixed.
   let bg : BenchGroup := { name, config }
-  IO.println s!"Running bench group {name}\n"
+  -- Criterion-style label column: max fullName length across the group, at least 24 + 1 pad.
+  let labelWidth := state.benches.foldl
+    (fun w (b, _) => max w s!"{name}/{b.name}".length) minLabelWidth + 1
+  if config.verbosity != .quiet then
+    IO.println s!"Running bench group {name}\n"
   let mut reports : Array BenchReport := #[]
-  for b in benches do
+  for (b, tput) in state.benches do
     let report : BenchReport ← if config.oneShot then do
-      IO.println s!"{bg.name}/{b.name}"
-      oneShotBench name b config
+      oneShotBench name b tput config labelWidth
     else
       let warmupMean ← bg.warmup b
-      IO.println s!"Running {b.name}"
-      let (iters, times) ← bg.sample b warmupMean
+      if bg.config.verbosity != .quiet then
+        IO.println s!"Running {b.name}"
+      -- Resolve `.auto` to a concrete mode now so both sampling and the
+      -- downstream regression-vs-mean choice see the same decision.
+      let resolvedMode := chooseSamplingMode bg.config warmupMean
+      if bg.config.verbosity == .verbose then
+        let modeName := match resolvedMode with
+          | .flat => "flat"
+          | .linear => "linear"
+          | .auto => "auto" -- unreachable
+        let picked := if bg.config.samplingMode == .auto then " (picked by auto)" else ""
+        IO.println s!"Sampling mode: {modeName}{picked}"
+      -- From here on we use `resolvedConfig` (never `.auto`) so that both the
+      -- regression branch below and the `SampleRun` persisted to disk agree on
+      -- exactly which mode this run used.
+      let resolvedConfig := { bg.config with samplingMode := resolvedMode }
+      -- Inner bg needs the resolved config too so its .printResults uses the
+      -- right verbosity, labels, etc.
+      let resolvedBg : BenchGroup := { name, config := resolvedConfig }
+      let (iters, times) ← match resolvedMode with
+        | .flat => bg.sampleFlat b warmupMean
+        | .linear => bg.sampleLinear b warmupMean
+        | .auto => bg.sampleFlat b warmupMean -- unreachable
       let data := iters.zip times
       let avgTimes : Distribution := { d := data.map (fun (x,y) => Float.ofNat y / Float.ofNat x) }
       let gen ← IO.stdGenRef.get
-      let mut (distributions, estimates) := avgTimes.estimates bg.config gen
-      if bg.config.samplingMode == .linear
+      let mut (distributions, estimates) := avgTimes.estimates resolvedConfig gen
+      let mut rSquared : Option Float := none
+      if resolvedMode == .linear
       then
         let data' : Data := { d := data }
-        let (distribution, slope) := data'.regression bg.config gen
+        let (distribution, slope, r2) := data'.regression resolvedConfig gen
         estimates := { estimates with slope := .some slope }
         distributions := { distributions with slope := .some distribution }
-      let comparisonData : Option ComparisonData ← bg.getComparison b.name avgTimes bg.config
-      let measurement :=  {
+        rSquared := some r2
+      -- Outlier analysis: classify per-sample average times and compute the
+      -- variance-inflation metric. Both are consumed by `printResults` under
+      -- the verbosity gate.
+      let outliers := avgTimes.classifyOutliers
+      let ov := outlierVariance estimates.mean estimates.stdDev (Float.ofNat resolvedConfig.numSamples)
+      let comparisonData : Option ComparisonData ← bg.getComparison b.name avgTimes resolvedConfig resolvedMode
+      let measurement : MeasurementData :=  {
         data := { d := data },
         avgTimes,
         absoluteEstimates := estimates,
         distributions,
         comparison := comparisonData
-        throughput := none
+        throughput := tput
+        rSquared,
+        outlierVariance := some ov,
+        outliers := some outliers
       }
-      bg.printResults b.name measurement
+      resolvedBg.printResults b.name measurement labelWidth
       IO.println ""
-      saveMeasurement name b.name measurement config
-      let benchReport : BenchReport := { function := b.name, newBench := (.sample estimates), baseBench := (comparisonData.map (.sample ·.baseEstimates)), percentChange := comparisonData.map (·.relativeEstimates.mean.pointEstimate) }
+      saveMeasurement name b.name measurement resolvedConfig
+      let benchReport : BenchReport := {
+        function := b.name,
+        newBench := (.sample estimates),
+        baseBench := (comparisonData.map (.sample ·.baseEstimates)),
+        percentChange := comparisonData.map (·.relativeEstimates.mean.pointEstimate),
+        throughput := tput
+      }
       pure benchReport
     reports := reports.push report
+  if config.avgThroughput then
+    match weightedAverageThroughput reports with
+    | some (t, avgRate) =>
+      IO.println s!"Average throughput: {t.formatRateValue avgRate}"
+    | none =>
+      IO.eprintln "Average throughput: skipped (no throughput set, or mixed Throughput variants across benches)"
   if config.report then
     let table := mkReportPretty name reports
     IO.println table
-    IO.FS.writeFile (System.mkFilePath [".", s!"benchmark-report-{name}.md"]) table
+    let reportDir := System.mkFilePath [".", ".lake", "benches", name]
+    let _ ← IO.Process.run { cmd := "mkdir", args := #["-p", reportDir.toString] }
+    IO.FS.writeFile (reportDir / "report.md") table
   return reports
 
 end

--- a/Ix/Benchmark/Bench.lean
+++ b/Ix/Benchmark/Bench.lean
@@ -18,18 +18,15 @@ open Batteries (RBMap)
 
 ## Verbosity
 
-Three levels controlled by `Config.verbosity`, the `BENCH_VERBOSITY` env var,
-or the `-q` / `--quiet` / `-v` / `--verbose` command-line flags
-(CLI > env var > `Config` default). See `getConfigEnv` for the precedence
-rules, and the `Verbosity` enum doc comments for what each level prints.
+Three levels controlled by `Config.verbosity` or the `BENCH_VERBOSITY` env var
+(env var overrides `Config` default). See `getConfigEnv` and the `Verbosity`
+enum doc comments for details.
 
 - `quiet`   — only per-bench summary lines (time / thrpt / change / perf note)
 - `normal`  — default; adds warmup + running lines, plus the variance-introduced-by-outliers warning and Tukey breakdown *only* when the outlier effect is moderate or severe
 - `verbose` — adds R² alongside the time line, and always prints the variance warning + Tukey breakdown regardless of severity
 
-Bench files wanting to pick up the CLI flags should call `setBenchArgs args`
-at the top of `main (args : List String) : IO Unit`. Skipping this only
-disables CLI flags — `Config.verbosity` and `BENCH_VERBOSITY` still work.
+Example: `BENCH_VERBOSITY=v lake exe bench-shardmap`
 
 ## Limitations
 - Measures time in nanoseconds using `IO.monoNanosNow`, which is less precise than the picoseconds used in Criterion.rs
@@ -278,7 +275,7 @@ def compareToThreshold (estimate : Estimate) (noiseThreshold : Float) : Comparis
 def indent24 : String := String.ofList (List.replicate 24 ' ')
 
 def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
-    (m : MeasurementData) (style : CliStyle) : IO Unit := do
+    (m : MeasurementData) : IO Unit := do
   let estimates := m.absoluteEstimates
   let typicalEstimate := estimates.slope.getD estimates.mean
   let fullName := s!"{bg.name}/{benchName}"
@@ -292,18 +289,18 @@ def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
   let r2Suffix := match m.rSquared with
     | some r2 => s!" R²={r2.floatPretty 3}"
     | none => ""
-  let timeLine := s!"time:   [{style.faint ciLb.formatNanos} {style.bold typicalEstimate.pointEstimate.formatNanos} {style.faint ciUb.formatNanos}]{r2Suffix}"
+  let timeLine := s!"time:   [{Ansi.faint ciLb.formatNanos} {Ansi.bold typicalEstimate.pointEstimate.formatNanos} {Ansi.faint ciUb.formatNanos}]{r2Suffix}"
   if fullName.length > 23 then
-    IO.println (style.green fullName)
+    IO.println (Ansi.green fullName)
     IO.println s!"{indent24}{timeLine}"
   else
     let pad := String.ofList (List.replicate (24 - fullName.length) ' ')
-    IO.println s!"{style.green fullName}{pad}{timeLine}"
+    IO.println s!"{Ansi.green fullName}{pad}{timeLine}"
 
   -- Throughput line (if present)
   if let some t := m.throughput then
     -- Higher time ⇒ lower throughput, so bounds are inverted
-    IO.println s!"{indent24}thrpt:  [{style.faint (t.formatRate ciUb)} {style.bold (t.formatRate typicalEstimate.pointEstimate)} {style.faint (t.formatRate ciLb)}]"
+    IO.println s!"{indent24}thrpt:  [{Ansi.faint (t.formatRate ciUb)} {Ansi.bold (t.formatRate typicalEstimate.pointEstimate)} {Ansi.faint (t.formatRate ciLb)}]"
 
   -- Change section (gated by verbosity, not shown in quiet)
   if verbosity != .quiet then
@@ -321,13 +318,13 @@ def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
       let comparison := if notSignificant then ComparisonResult.NonSignificant
         else compareToThreshold meanEst comp.noiseThreshold
       let colorPointEst (s : String) : String := match comparison with
-        | .Improved => style.green (style.bold s)
-        | .Regressed => style.red (style.bold s)
+        | .Improved => Ansi.green (Ansi.bold s)
+        | .Regressed => Ansi.red (Ansi.bold s)
         | .NonSignificant => s
 
       let pointEstStr := colorPointEst (fmtSigned meanEst.pointEstimate)
-      let lbStr := style.faint (fmtSigned meanEst.confidenceInterval.lowerBound)
-      let ubStr := style.faint (fmtSigned meanEst.confidenceInterval.upperBound)
+      let lbStr := Ansi.faint (fmtSigned meanEst.confidenceInterval.lowerBound)
+      let ubStr := Ansi.faint (fmtSigned meanEst.confidenceInterval.upperBound)
       let pStr := s!"(p = {comp.pValue.floatPretty 2} {if notSignificant then ">" else "<"} {comp.significanceThreshold.floatPretty 2})"
 
       -- Layout differs depending on whether throughput is present
@@ -335,8 +332,8 @@ def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
         -- Throughput present: separate "change:" header, then time: and thrpt: sub-lines
         let toThrptEst (ratio : Float) : Float := 1.0 / (1.0 + ratio) - 1.0
         let thrptPointStr := colorPointEst (fmtSigned (toThrptEst meanEst.pointEstimate))
-        let thrptLbStr := style.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.upperBound))
-        let thrptUbStr := style.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.lowerBound))
+        let thrptLbStr := Ansi.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.upperBound))
+        let thrptUbStr := Ansi.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.lowerBound))
         IO.println s!"{String.ofList (List.replicate 17 ' ')}change:"
         IO.println s!"{indent24}time:   [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
         IO.println s!"{indent24}thrpt:  [{thrptLbStr}% {thrptPointStr}% {thrptUbStr}%]"
@@ -348,8 +345,8 @@ def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
       let explanation := if notSignificant then
         "No change in performance detected."
       else match comparison with
-        | .Improved => s!"Performance has {style.green "improved"}."
-        | .Regressed => s!"Performance has {style.red "regressed"}."
+        | .Improved => s!"Performance has {Ansi.green "improved"}."
+        | .Regressed => s!"Performance has {Ansi.red "regressed"}."
         | .NonSignificant => "Change within noise threshold."
       IO.println s!"{indent24}{explanation}"
 
@@ -367,7 +364,7 @@ def BenchGroup.printResults (bg : BenchGroup) (benchName : String)
       let showVariance := verbosity == .verbose || (effectAboveSlight && verbosity != .quiet)
       if showVariance then
         if let some outs := m.outliers then
-          Outliers.note outs m.avgTimes.d.size style
+          Outliers.note outs m.avgTimes.d.size
         let pct := (ov.fraction * 100).floatPretty 0
         IO.println s!"variance introduced by outliers: {pct}% ({ov.desc})"
 
@@ -433,14 +430,14 @@ def BenchReport.throughputStr (r : BenchReport) : String :=
   | none => "N/A"
 
 /--
-Computes the weighted-average primary throughput rate across a collection of
-reports, weighted by each bench's primary quantity. Returns `none` if no
-report has throughput set, or if the reports use more than one `Throughput`
-variant (averaging across variants — e.g. bytes/s and elements/s — would be
-meaningless). On success, returns the variant of the first throughput-bearing
-report (used to pick display units) together with the averaged rate.
+Computes weighted-average throughput rate(s) across a collection of reports.
+Returns `none` if no report has throughput set, or if the reports use more
+than one `Throughput` variant. On success, returns the representative variant,
+the primary weighted-average rate, and (for `ElementsAndBytes`) the secondary
+bytes-weighted-average rate.
 -/
-def weightedAverageThroughput (reports : Array BenchReport) : Option (Throughput × Float) := Id.run do
+def weightedAverageThroughput (reports : Array BenchReport) :
+    Option (Throughput × Float × Option Float) := Id.run do
   let mut representative : Option Throughput := none
   let mut sumQty : Float := 0.0
   let mut weightedSum : Float := 0.0
@@ -461,7 +458,21 @@ def weightedAverageThroughput (reports : Array BenchReport) : Option (Throughput
   | none => return none
   | some t =>
     if sumQty == 0 then return none
-    return some (t, weightedSum / sumQty)
+    let primaryAvg := weightedSum / sumQty
+    -- For ElementsAndBytes, compute a separate bytes-weighted average
+    let secondaryAvg ← match t with
+      | .ElementsAndBytes _ _ _ => do
+        let mut sumBytes : Float := 0.0
+        let mut weightedBytesSum : Float := 0.0
+        for r in reports do
+          if let some (.ElementsAndBytes _ b _) := r.throughput then
+            let bytes := b.toNat.toFloat
+            let bytesRate := bytes * 1e9 / r.newBench.getTime
+            sumBytes := sumBytes + bytes
+            weightedBytesSum := weightedBytesSum + bytes * bytesRate
+        pure (if sumBytes > 0 then some (weightedBytesSum / sumBytes) else none)
+      | _ => pure none
+    return some (t, primaryAvg, secondaryAvg)
 
 def percentChangeToString (pc : Float) : String :=
   let rounded := (100 * pc).floatPretty 2
@@ -580,15 +591,15 @@ def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
   let benchTime := finish - start
   style.overwrite
   -- Use the same 24-char column layout as sampled mode
-  let timeStr := s!"time:   {style.bold (benchTime.toFloat.formatNanos)}"
+  let timeStr := s!"time:   {Ansi.bold (benchTime.toFloat.formatNanos)}"
   if benchId.length > 23 then
-    IO.println (style.green benchId)
+    IO.println (Ansi.green benchId)
     IO.println s!"{indent24}{timeStr}"
   else
     let pad := String.ofList (List.replicate (24 - benchId.length) ' ')
-    IO.println s!"{style.green benchId}{pad}{timeStr}"
+    IO.println s!"{Ansi.green benchId}{pad}{timeStr}"
   if let some t := tput then
-    IO.println s!"{indent24}thrpt:  {style.bold (t.formatRate benchTime.toFloat)}"
+    IO.println s!"{indent24}thrpt:  {Ansi.bold (t.formatRate benchTime.toFloat)}"
   let (basePath, newPath) ← mkDirs groupName b.name
   let fileExt := toString config.serde
   let newFile := newPath / s!"one-shot.{fileExt}"
@@ -676,7 +687,8 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
   let config ← getConfigEnv config
   let (_, state) ← action.run { config, benches := #[] }
   let bg : BenchGroup := { name, config }
-  let style : CliStyle := { colorEnabled := config.color, overwriteEnabled := config.overwrite }
+  -- Verbose mode makes all output permanent (no ephemeral line overwriting)
+  let style : CliStyle := { overwriteEnabled := config.verbosity != .verbose }
   let mut reports : Array BenchReport := #[]
   for (b, tput) in state.benches do
     let benchId := s!"{name}/{b.name}"
@@ -735,7 +747,7 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
         outliers := some outliers
       }
       style.overwrite
-      resolvedBg.printResults b.name measurement style
+      resolvedBg.printResults b.name measurement
       saveMeasurement name b.name measurement resolvedConfig
       let benchReport : BenchReport := {
         function := b.name,
@@ -748,8 +760,11 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
     reports := reports.push report
   if config.avgThroughput then
     match weightedAverageThroughput reports with
-    | some (t, avgRate) =>
-      IO.println s!"Average throughput: {t.formatRateValue avgRate}"
+    | some (t, primaryAvg, secondaryAvg) =>
+      IO.println s!"Average throughput: {t.formatRateValue primaryAvg}"
+      -- For ElementsAndBytes, also print the secondary bytes/s average
+      if let some bytesAvg := secondaryAvg then
+        IO.println s!"Average throughput (bytes): {Float.formatBytesRate bytesAvg}"
     | none =>
       IO.eprintln "Average throughput: skipped (no throughput set, or mixed Throughput variants across benches)"
   if config.report then

--- a/Ix/Benchmark/Bench.lean
+++ b/Ix/Benchmark/Bench.lean
@@ -14,6 +14,35 @@ open Batteries (RBMap)
 /-!
 # Benchmarking library modeled after Criterion in Rust and Haskell
 
+## Quick start
+
+Simple benchmark of a pure function:
+
+```
+import Ix.Benchmark.Bench
+open BgroupM
+
+def main : IO Unit := do
+  let _ ← bgroup "sorting" {} do
+    bench "List.mergeSort 1000" List.mergeSort (List.range 1000)
+    bench "List.mergeSort 10000" List.mergeSort (List.range 10000)
+```
+
+With throughput, iterating over input sizes:
+
+```
+import Ix.Benchmark.Bench
+open BgroupM
+
+def sizes := #[1000, 10000, 100000]
+
+def main : IO Unit := do
+  let _ ← bgroup "sorting" { avgThroughput := true, report := true } do
+    for n in sizes do
+      throughput (.Elements n.toUInt64 "items")
+      bench s!"mergeSort n={n}" List.mergeSort (List.range n)
+```
+
 ## Verbosity
 
 Three levels controlled by `Config.verbosity` or the `BENCH_VERBOSITY` env var
@@ -21,8 +50,8 @@ Three levels controlled by `Config.verbosity` or the `BENCH_VERBOSITY` env var
 enum doc comments for details.
 
 - `quiet`   — only per-bench summary lines (time / thrpt / change / perf note)
-- `normal`  — default; adds warmup + running lines, plus the variance-introduced-by-outliers warning and Tukey breakdown *only* when the outlier effect is moderate or severe
-- `verbose` — adds R² alongside the time line, and always prints the variance warning + Tukey breakdown regardless of severity
+- `normal`  — default; adds warmup + running lines, plus the outlier-variance warning when moderate or severe
+- `verbose` — adds R² alongside the time line, always prints outlier-variance + Tukey breakdown
 
 Example: `BENCH_VERBOSITY=v lake exe bench-shardmap`
 

--- a/Ix/Benchmark/Change.lean
+++ b/Ix/Benchmark/Change.lean
@@ -55,7 +55,11 @@ def tBootstrap (newAvgTimes baseAvgTimes : Distribution) (bootstrapSamples : Nat
 
 def tTest (newAvgTimes baseAvgTimes : Distribution) (config : Config) (gen : StdGen) :(Float × Distribution) :=
   let tStatistic := tScore newAvgTimes baseAvgTimes
-  let tDistribution := (tBootstrap newAvgTimes baseAvgTimes config.numSamples gen).run.fst
+  -- Use `bootstrapSamples` (default 100_000), NOT `numSamples` (default 100),
+  -- for the null distribution. With only 100 resamples the p-value resolution
+  -- is ~0.01 and its tails are badly estimated, which produces spurious
+  -- "No change in performance detected" results even for real effects.
+  let tDistribution := (tBootstrap newAvgTimes baseAvgTimes config.bootstrapSamples gen).run.fst
   -- Hack to filter out non-finite numbers from https://github.com/bheisler/criterion.rs/blob/ccccbcc15237233af22af4c76751a7aa184609b3/src/analysis/compare.rs#L86
   let tDistribution : Distribution := { d := tDistribution.d.filter (fun x => x.isFinite && !x.isNaN ) }
   (tStatistic, tDistribution)

--- a/Ix/Benchmark/Change.lean
+++ b/Ix/Benchmark/Change.lean
@@ -36,7 +36,7 @@ def tScore (xs ys : Distribution) : Float :=
   let (nX, nY) := (Float.ofNat xs.d.size, Float.ofNat ys.d.size)
   let num := xBar - yBar
   let den := (s2X / nX + s2Y / nY).sqrt
-  num / den
+  if den == 0 then 0.0 else num / den
 
 def Array.splitAt {α} (a : Array α) (n : Nat) : Array α × Array α :=
   (a.extract 0 n, a.extract n a.size)
@@ -45,20 +45,15 @@ def Array.splitAt {α} (a : Array α) (n : Nat) : Array α × Array α :=
 def tBootstrap (newAvgTimes baseAvgTimes : Distribution) (bootstrapSamples : Nat) : StateM StdGen Distribution := do
   let allTimes : Distribution := { d := newAvgTimes.d ++ baseAvgTimes.d }
   let newLen := newAvgTimes.d.size
-  let mut tDistribution := #[]
-  for _ in Array.range bootstrapSamples do
+  let mut tDistribution := Array.mkEmpty bootstrapSamples
+  for _ in [:bootstrapSamples] do
     let resample ← allTimes.resampleM allTimes.d.size
     let (xs, ys) := resample.d.splitAt newLen
-    let t := tScore { d := xs } { d := ys }
-    tDistribution := tDistribution.push t
+    tDistribution := tDistribution.push (tScore { d := xs } { d := ys })
   return { d := tDistribution }
 
-def tTest (newAvgTimes baseAvgTimes : Distribution) (config : Config) (gen : StdGen) :(Float × Distribution) :=
+def tTest (newAvgTimes baseAvgTimes : Distribution) (config : Config) (gen : StdGen) : (Float × Distribution) :=
   let tStatistic := tScore newAvgTimes baseAvgTimes
-  -- Use `bootstrapSamples` (default 100_000), NOT `numSamples` (default 100),
-  -- for the null distribution. With only 100 resamples the p-value resolution
-  -- is ~0.01 and its tails are badly estimated, which produces spurious
-  -- "No change in performance detected" results even for real effects.
   let tDistribution := (tBootstrap newAvgTimes baseAvgTimes config.bootstrapSamples gen).run.fst
   -- Hack to filter out non-finite numbers from https://github.com/bheisler/criterion.rs/blob/ccccbcc15237233af22af4c76751a7aa184609b3/src/analysis/compare.rs#L86
   let tDistribution : Distribution := { d := tDistribution.d.filter (fun x => x.isFinite && !x.isNaN ) }
@@ -67,17 +62,15 @@ def tTest (newAvgTimes baseAvgTimes : Distribution) (config : Config) (gen : Std
 def changeStats (xs ys : Distribution) : (Float × Float) :=
   (xs.mean / ys.mean - 1, xs.median / ys.median - 1)
 
--- TODO: Genericize bootstrap functions
-/-- Performs a two-sample bootstrap -/
+/-- Performs a two-sample bootstrap for change estimation -/
 def changeBootstrap (xs ys : Distribution) (numSamples bootstrapSamples : Nat) : StateM StdGen ChangeDistributions := do
-  let mut means := #[]
-  let mut medians := #[]
-  for _ in Array.range bootstrapSamples do
+  let mut means := Array.mkEmpty bootstrapSamples
+  let mut medians := Array.mkEmpty bootstrapSamples
+  for _ in [:bootstrapSamples] do
     let resampleX ← xs.resampleM numSamples
     let resampleY ← ys.resampleM numSamples
-    let (mean, median) := changeStats resampleX resampleY
-    means := means.push mean
-    medians := medians.push median
+    means := means.push (resampleX.mean / resampleY.mean - 1)
+    medians := medians.push (resampleX.median / resampleY.median - 1)
   return ⟨ { d := means }, { d := medians } ⟩
 
 def buildChangeEstimates (changeDist : ChangeDistributions) (mean median confidenceLevel : Float) : ChangeEstimates :=

--- a/Ix/Benchmark/Common.lean
+++ b/Ix/Benchmark/Common.lean
@@ -12,8 +12,7 @@ inductive SamplingMode where
       is recovered by regression, which is more robust to single-sample outliers
       but 50× more total work for `N = 100`. -/
   | linear : SamplingMode
-  /-- Pick flat or linear based on warmup timing (matches criterion.rs's
-      `SamplingMode::Auto`): choose linear if its expected total time is at
+  /-- Pick flat or linear based on warmup timing: choose linear if its expected total time is at
       most 2× the target sample time, otherwise flat. -/
   | auto : SamplingMode
   deriving Repr, BEq, Lean.ToJson, Lean.FromJson
@@ -29,8 +28,7 @@ instance : ToString SerdeFormat where
   | .ixon => "ixon"
 
 /--
-Controls how much diagnostic output the benchmark harness prints, matching
-Haskell criterion's `Verbosity`. Can be overridden per-run via the
+Controls how much diagnostic output the benchmark harness prints. Can be overridden per-run via the
 `BENCH_VERBOSITY` env var or via `-q` / `-v` on the `lake exe` command line.
 -/
 inductive Verbosity where
@@ -50,15 +48,13 @@ inductive Verbosity where
 
 /--
 Describes the work performed by one iteration of a benchmark, for rate
-computations in the report. Modeled after criterion.rs's `Throughput` enum.
+computations in the report.
 
 - `Bits`: bits processed per iteration; formatted with decimal (1000-based) units (`b/s`, `Kb/s`, ..).
 - `Bytes`: bytes processed per iteration; formatted with binary (1024-based) units (`B/s`, `KiB/s`, ..).
 - `BytesDecimal`: bytes processed per iteration; formatted with decimal (1000-based) units (`B/s`, `KB/s`, ..).
 - `Elements`: generic elements per iteration; formatted with decimal units using the
-  `label` (defaults to `elem`, so you get `elem/s`, `Kelem/s`, .., but you can pass
-  e.g. `"hashes"` for `hashes/s`, `Khashes/s`, ..). Extension over criterion.rs,
-  which hardcodes the `elem` label.
+  `label` (defaults to `elem`, e.g. `elem/s`, `Kelem/s`, .., or with label "hashes": `hashes/s`, `Khashes/s`, ..).
 - `ElementsAndBytes`: reports both elements/s and bytes/s in the same cell. The
   elements side accepts a custom `elementsLabel` with the same semantics as
   `Elements`; the bytes side always uses the binary `B` scheme.
@@ -78,14 +74,20 @@ structure Config where
   sampleTime : Float := 5.0
   /-- Number of data points to collect per sample -/
   numSamples : Nat := 100
-  /-- Sample in flat, linear, or auto mode. Defaults to `.auto` to match
-      criterion.rs: linear is more robust to per-sample outliers but runs 50×
+  /-- Sample in flat, linear, or auto mode. Defaults to `.auto`.
+      Linear is more robust to per-sample outliers but runs 50×
       more total iterations than flat for `numSamples = 100`, so it's unusable
       for expensive benches. Auto picks linear when it fits in ~2× the target
       sample time and falls back to flat otherwise. -/
   samplingMode : SamplingMode := .auto
-  /-- Number of bootstrap samples (with replacement) to run -/
-  bootstrapSamples : Nat := 100000
+  /-- Number of bootstrap samples (with replacement) to run.
+      Defaults to 10K rather than criterion.rs's 100K because Lean's
+      runtime has ~10x per-operation overhead for many operations vs native Rust,
+      making 100K bootstrap iterations take ~5s per bench. 10K produces
+      statistically indistinguishable confidence intervals for typical Lean benchmarks
+      (µs–s scale) where execution variance already dwarfs bootstrap
+      estimation noise. -/
+  bootstrapSamples : Nat := 10000
   /-- Confidence level for estimates -/
   confidenceLevel : Float := 0.95
   /-- Significance level for hypothesis testing when comparing two benchmark runs for significant difference -/
@@ -117,21 +119,28 @@ structure Config where
   /--
   Throughput for the next benchmark registered in a `bgroup` do-block. Each
   `bench`/`benchIO` call inside a `bgroup` captures a snapshot of this field
-  at registration time, so you can set it once and register several benches,
+  at registration time, so we can set it once and register several benches,
   or mutate it between registrations via the monadic `throughput` helper.
   -/
   throughput : Option Throughput := none
   /--
   If `true`, `bgroup` prints a weighted-average throughput across all benches
   in the group at the end of the run. The average is weighted by the primary
-  quantity of each bench (e.g. bytes processed), following the same formula
-  as criterion.rs. Requires every bench in the group to use the same
+  quantity of each bench (e.g. bytes processed). Requires every bench in the group to use the same
   `Throughput` variant; otherwise the average is skipped with a warning.
   -/
   avgThroughput : Bool := false
   /-- Diagnostic output level. Overridable via `BENCH_VERBOSITY` env var or
-      `-q` / `-v` / `-vv` command-line flags (see `getConfigEnv`). -/
+      `-q` / `-v` command-line flags (see `getConfigEnv`). -/
   verbosity : Verbosity := .normal
+  /-- Enable ANSI color/bold/faint in output. Defaults to `true`; set to
+      `false` or set the `BENCH_NO_COLOR` env var to disable. -/
+  color : Bool := true
+  /-- Enable ephemeral progress lines (warmup/sampling status overwritten
+      in-place on stderr). Defaults to `true`; automatically disabled when
+      `BENCH_NO_COLOR` is set. Forced to `false` in verbose mode so all
+      output is permanent. -/
+  overwrite : Bool := true
   deriving Repr, Lean.ToJson, Lean.FromJson
 
 /--
@@ -144,7 +153,7 @@ initialize benchArgsRef : IO.Ref (List String) ← IO.mkRef []
 
 /-- Populate the global bench-args ref from this program's `main (args : List String)`.
     Call this once at the top of every bench `main` to enable CLI flag parsing
-    in `getConfigEnv`. Safe to skip if you don't need CLI verbosity overrides. -/
+    in `getConfigEnv`. Safe to skip if we don't need CLI verbosity overrides. -/
 def setBenchArgs (args : List String) : IO Unit :=
   benchArgsRef.set args
 
@@ -152,7 +161,7 @@ def setBenchArgs (args : List String) : IO Unit :=
 Overrides config values with the corresponding `BENCH_<SETTING>` env vars and
 `lake exe` command-line flags. Precedence order (lowest to highest):
 
-1. `config` field defaults (the literal values you passed to `bgroup`)
+1. `config` field defaults (the literal values passed to `bgroup`)
 2. `BENCH_*` env vars (`BENCH_SERDE`, `BENCH_REPORT`, `BENCH_VERBOSITY`)
 3. CLI flags (`-q` / `--quiet`, `-v` / `--verbose`) from the args set
    via `setBenchArgs` at the top of `main`
@@ -178,7 +187,12 @@ def getConfigEnv (config : Config) : IO Config := do
     else if has "-q" args || has "--quiet" args then some .quiet
     else none
   let verbosity := cliVerbosity.getD (envVerbosity.getD config.verbosity)
-  return { config with serde, report, verbosity }
+  -- `BENCH_NO_COLOR` disables both ANSI codes and ephemeral overwrites.
+  -- Verbose mode also forces overwrite off so all output is permanent.
+  let noColor := (← IO.getEnv "BENCH_NO_COLOR").isSome
+  let color := if noColor then false else config.color
+  let overwrite := if noColor || verbosity == .verbose then false else config.overwrite
+  return { config with serde, report, verbosity, color, overwrite }
 
 @[inline] def Float.toNanos (f : Float) : Float := f * 10 ^ 9
 
@@ -209,16 +223,18 @@ Rounds a `Float` to the desired number of decimal places, then prints it with tr
 
 E.g. `10.012345.floatPretty 5` => `"10.01235"`
 
-Panics if float is a NaN.
+Returns the raw `.toString` representation for non-finite values (NaN, Inf).
 -/
 def Float.floatPretty (float : Float) (precision : Nat): String :=
-  let precise := float.variablePrecision precision
-  let parts := precise.toString.splitOn "."
-  let integer := parts[0]!
-  let fractional := parts[1]!.take precision
-  if !fractional.isEmpty
-  then integer ++ "." ++ fractional
-  else integer
+  if !float.isFinite then float.toString
+  else
+    let precise := float.variablePrecision precision
+    let parts := precise.toString.splitOn "."
+    let integer := parts[0]!
+    let fractional := parts[1]!.take precision
+    if !fractional.isEmpty
+    then integer ++ "." ++ fractional
+    else integer
 
 /--
 Formats a time in ns as an xx.yy string with time units.
@@ -271,8 +287,7 @@ def Float.formatRateValueDecimal (rate : Float) (baseUnit : String) : String :=
 
 /--
 Extracts the primary quantity of work per iteration from a `Throughput`.
-For `ElementsAndBytes`, the elements count is considered the primary quantity,
-matching criterion.rs's convention.
+For `ElementsAndBytes`, the elements count is considered the primary quantity.
 -/
 def Throughput.quantity (t : Throughput) : UInt64 :=
   match t with
@@ -323,7 +338,7 @@ def Throughput.rate (t : Throughput) (timeNs : Float) : Float :=
 
 /--
 Formats a `Throughput` value and a typical iteration time `timeNs` as a
-human-readable rate string, matching criterion.rs's `DurationFormatter`.
+human-readable rate string.
 -/
 def Throughput.formatRate (t : Throughput) (timeNs : Float) : String :=
   if timeNs ≤ 0 then "—" else

--- a/Ix/Benchmark/Common.lean
+++ b/Ix/Benchmark/Common.lean
@@ -1,21 +1,75 @@
 module
+public import Lean.Data.Json
 
 public section
 
 inductive SamplingMode where
+  /-- Every sample runs the same number of iterations. Best for expensive
+      benches where linear's `[d, 2d, ..., Nd]` schedule would blow past the
+      target sample time. -/
   | flat : SamplingMode
+  /-- Iteration counts grow linearly `[d, 2d, ..., Nd]`; the per-iteration time
+      is recovered by regression, which is more robust to single-sample outliers
+      but 50× more total work for `N = 100`. -/
   | linear : SamplingMode
-  deriving Repr, BEq
+  /-- Pick flat or linear based on warmup timing (matches criterion.rs's
+      `SamplingMode::Auto`): choose linear if its expected total time is at
+      most 2× the target sample time, otherwise flat. -/
+  | auto : SamplingMode
+  deriving Repr, BEq, Lean.ToJson, Lean.FromJson
 
 inductive SerdeFormat where
   | json
   | ixon
-  deriving Repr, BEq
+  deriving Repr, BEq, Lean.ToJson, Lean.FromJson
 
 instance : ToString SerdeFormat where
   toString sf := match sf with
   | .json => "json"
   | .ixon => "ixon"
+
+/--
+Controls how much diagnostic output the benchmark harness prints, matching
+Haskell criterion's `Verbosity`. Can be overridden per-run via the
+`BENCH_VERBOSITY` env var or via `-q` / `-v` on the `lake exe` command line.
+-/
+inductive Verbosity where
+  /-- Only per-bench summary lines (time/thrpt/change/perf note). Suppresses
+      warmup banners, "Running N samples" lines, and the
+      outlier-variance/breakdown output. -/
+  | quiet
+  /-- Default output. Warmup + running lines print. Outlier-variance warning
+      and Tukey breakdown print only when the outliers are moderately or
+      severely inflating the std-dev estimate. -/
+  | normal
+  /-- Everything in `normal` plus R² always printed next to the time line,
+      full Tukey outlier breakdown always printed, and the outlier-variance
+      warning always printed regardless of severity. -/
+  | verbose
+  deriving Repr, BEq, Ord, Lean.ToJson, Lean.FromJson
+
+/--
+Describes the work performed by one iteration of a benchmark, for rate
+computations in the report. Modeled after criterion.rs's `Throughput` enum.
+
+- `Bits`: bits processed per iteration; formatted with decimal (1000-based) units (`b/s`, `Kb/s`, ..).
+- `Bytes`: bytes processed per iteration; formatted with binary (1024-based) units (`B/s`, `KiB/s`, ..).
+- `BytesDecimal`: bytes processed per iteration; formatted with decimal (1000-based) units (`B/s`, `KB/s`, ..).
+- `Elements`: generic elements per iteration; formatted with decimal units using the
+  `label` (defaults to `elem`, so you get `elem/s`, `Kelem/s`, .., but you can pass
+  e.g. `"hashes"` for `hashes/s`, `Khashes/s`, ..). Extension over criterion.rs,
+  which hardcodes the `elem` label.
+- `ElementsAndBytes`: reports both elements/s and bytes/s in the same cell. The
+  elements side accepts a custom `elementsLabel` with the same semantics as
+  `Elements`; the bytes side always uses the binary `B` scheme.
+-/
+inductive Throughput where
+  | Bits (n : UInt64)
+  | Bytes (n : UInt64)
+  | BytesDecimal (n : UInt64)
+  | Elements (n : UInt64) (label : String := "elem")
+  | ElementsAndBytes (elements : UInt64) (bytes : UInt64) (elementsLabel : String := "elem")
+  deriving Repr, Lean.ToJson, Lean.FromJson
 
 structure Config where
   /-- Warmup time in seconds -/
@@ -24,8 +78,12 @@ structure Config where
   sampleTime : Float := 5.0
   /-- Number of data points to collect per sample -/
   numSamples : Nat := 100
-  /-- Sample in flat or linear mode -/
-  samplingMode : SamplingMode := .flat
+  /-- Sample in flat, linear, or auto mode. Defaults to `.auto` to match
+      criterion.rs: linear is more robust to per-sample outliers but runs 50×
+      more total iterations than flat for `numSamples = 100`, so it's unusable
+      for expensive benches. Auto picks linear when it fits in ~2× the target
+      sample time and falls back to flat otherwise. -/
+  samplingMode : SamplingMode := .auto
   /-- Number of bootstrap samples (with replacement) to run -/
   bootstrapSamples : Nat := 100000
   /-- Confidence level for estimates -/
@@ -36,18 +94,91 @@ structure Config where
   noiseThreshold : Float := 0.01
   /-- Serde format for bench report written to disk, defaults to JSON for human readability -/
   serde : SerdeFormat := .json
-  /-- Whether to skip sampling altogether and only collect a single data point. Takes precedence over all sampling settings. Used for expensive benchmarks -/
+  /--
+  Whether to skip sampling altogether and only collect a single data point.
+  Takes precedence over all sampling settings (`samplingMode`, `numSamples`,
+  `sampleTime`, `warmupTime`).
+
+  Rule of thumb (based on the mean per-iteration time `μ` of the bench, as
+  estimated during warmup): enable `oneShot := true` when a single iteration
+  takes longer than ~1s. At that point even flat-mode sampling
+  (`numSamples × μ`) exceeds 100s per bench, and the statistical estimates
+  gained from a full sample run rarely justify the wall-clock cost.
+
+  Concretely:
+  - μ < ~50ms   ⇒ leave `.auto`: linear sampling, full statistics
+  - μ ~ 50ms–1s ⇒ leave `.auto`: falls back to flat sampling automatically
+  - μ > ~1s     ⇒ set `oneShot := true` (total group time stays bounded
+                  by `numBenches × μ`, not `numBenches × numSamples × μ`)
+  -/
   oneShot : Bool := false
   /-- Whether to generate a Markdown report of all timings including comparison to disk if possible-/
   report : Bool := false
-  deriving Repr
+  /--
+  Throughput for the next benchmark registered in a `bgroup` do-block. Each
+  `bench`/`benchIO` call inside a `bgroup` captures a snapshot of this field
+  at registration time, so you can set it once and register several benches,
+  or mutate it between registrations via the monadic `throughput` helper.
+  -/
+  throughput : Option Throughput := none
+  /--
+  If `true`, `bgroup` prints a weighted-average throughput across all benches
+  in the group at the end of the run. The average is weighted by the primary
+  quantity of each bench (e.g. bytes processed), following the same formula
+  as criterion.rs. Requires every bench in the group to use the same
+  `Throughput` variant; otherwise the average is skipped with a warning.
+  -/
+  avgThroughput : Bool := false
+  /-- Diagnostic output level. Overridable via `BENCH_VERBOSITY` env var or
+      `-q` / `-v` / `-vv` command-line flags (see `getConfigEnv`). -/
+  verbosity : Verbosity := .normal
+  deriving Repr, Lean.ToJson, Lean.FromJson
 
--- TODO: Integrate this with a `lake bench` CLI to set config options via flags
-/-- Overrides config values with the corresponding `BENCH_<SETTING>` env vars if they are set -/
+/--
+Global mutable holder for the benchmark harness's command-line args, so that
+`getConfigEnv` can pick up `-q`/`-v`/`-vv` flags passed on `lake exe`
+without every individual bench `main` having to thread args through explicitly.
+Set it once at the top of `main` via `setBenchArgs args`.
+-/
+initialize benchArgsRef : IO.Ref (List String) ← IO.mkRef []
+
+/-- Populate the global bench-args ref from this program's `main (args : List String)`.
+    Call this once at the top of every bench `main` to enable CLI flag parsing
+    in `getConfigEnv`. Safe to skip if you don't need CLI verbosity overrides. -/
+def setBenchArgs (args : List String) : IO Unit :=
+  benchArgsRef.set args
+
+/--
+Overrides config values with the corresponding `BENCH_<SETTING>` env vars and
+`lake exe` command-line flags. Precedence order (lowest to highest):
+
+1. `config` field defaults (the literal values you passed to `bgroup`)
+2. `BENCH_*` env vars (`BENCH_SERDE`, `BENCH_REPORT`, `BENCH_VERBOSITY`)
+3. CLI flags (`-q` / `--quiet`, `-v` / `--verbose`) from the args set
+   via `setBenchArgs` at the top of `main`
+
+`BENCH_VERBOSITY` accepts `quiet` | `normal` | `verbose` or the numeric
+equivalents `0` | `1` | `2`.
+-/
 def getConfigEnv (config : Config) : IO Config := do
   let serde : SerdeFormat := if (← IO.getEnv "BENCH_SERDE") == some "ixon" then .ixon else config.serde
   let report := if let some val := (← IO.getEnv "BENCH_REPORT") then val == "1" else config.report
-  return { config with serde, report }
+  let envVerbosity : Option Verbosity ← do
+    match (← IO.getEnv "BENCH_VERBOSITY") with
+    | some "quiet"   | some "0" => pure (some .quiet)
+    | some "normal"  | some "1" => pure (some .normal)
+    | some "verbose" | some "2" => pure (some .verbose)
+    | _ => pure none
+  let args ← benchArgsRef.get
+  let rec has (flag : String) : List String → Bool
+    | [] => false
+    | a :: rest => a == flag || has flag rest
+  let cliVerbosity : Option Verbosity :=
+    if has "-v" args || has "--verbose" args then some .verbose
+    else if has "-q" args || has "--quiet" args then some .quiet
+    else none
+  let verbosity := cliVerbosity.getD (envVerbosity.getD config.verbosity)
+  return { config with serde, report, verbosity }
 
 @[inline] def Float.toNanos (f : Float) : Float := f * 10 ^ 9
 
@@ -110,5 +241,99 @@ def Float.formatNanos (f : Float) : String :=
     (f / 10 ^ 3).floatPretty 2 ++ "µs"
   else
     f.floatPretty 2  ++ "ns"
+
+/--
+Formats a per-second `rate` with binary (1024-based) unit suffixes:
+`B/s`, `KiB/s`, `MiB/s`, `GiB/s`.
+-/
+def Float.formatRateValueBinary (rate : Float) (baseUnit : String) : String :=
+  if rate ≥ 1024.0 * 1024.0 * 1024.0
+  then (rate / (1024.0 * 1024.0 * 1024.0)).floatPretty 2 ++ " Gi" ++ baseUnit ++ "/s"
+  else if rate ≥ 1024.0 * 1024.0
+  then (rate / (1024.0 * 1024.0)).floatPretty 2 ++ " Mi" ++ baseUnit ++ "/s"
+  else if rate ≥ 1024.0
+  then (rate / 1024.0).floatPretty 2 ++ " Ki" ++ baseUnit ++ "/s"
+  else
+    rate.floatPretty 2 ++ " " ++ baseUnit ++ "/s"
+
+/--
+Formats a per-second `rate` with decimal (1000-based) unit prefixes.
+-/
+def Float.formatRateValueDecimal (rate : Float) (baseUnit : String) : String :=
+  if rate ≥ 1e9
+  then (rate / 1e9).floatPretty 2 ++ " G" ++ baseUnit ++ "/s"
+  else if rate ≥ 1e6
+  then (rate / 1e6).floatPretty 2 ++ " M" ++ baseUnit ++ "/s"
+  else if rate ≥ 1e3
+  then (rate / 1e3).floatPretty 2 ++ " K" ++ baseUnit ++ "/s"
+  else
+    rate.floatPretty 2 ++ " " ++ baseUnit ++ "/s"
+
+/--
+Extracts the primary quantity of work per iteration from a `Throughput`.
+For `ElementsAndBytes`, the elements count is considered the primary quantity,
+matching criterion.rs's convention.
+-/
+def Throughput.quantity (t : Throughput) : UInt64 :=
+  match t with
+  | .Bits n => n
+  | .Bytes n => n
+  | .BytesDecimal n => n
+  | .Elements n _ => n
+  | .ElementsAndBytes e _ _ => e
+
+/--
+True iff two `Throughput` values use the same variant (regardless of numeric
+payload or custom label). Used to decide whether a weighted-average rate
+across a group of benches is meaningful.
+-/
+def Throughput.sameVariant (a b : Throughput) : Bool :=
+  match a, b with
+  | .Bits _,             .Bits _             => true
+  | .Bytes _,            .Bytes _            => true
+  | .BytesDecimal _,     .BytesDecimal _     => true
+  | .Elements _ _,       .Elements _ _       => true
+  | .ElementsAndBytes _ _ _, .ElementsAndBytes _ _ _ => true
+  | _, _ => false
+
+/--
+Formats an already-computed primary per-second `rate` using the unit scheme
+of the given `Throughput` variant (binary vs decimal, bytes vs elements, ..).
+The numeric payload of `t` is ignored — only the variant and (for
+`Elements`/`ElementsAndBytes`) the custom label are consulted.
+-/
+def Throughput.formatRateValue (t : Throughput) (rate : Float) : String :=
+  match t with
+  | .Bits _ => Float.formatRateValueDecimal rate "b"
+  | .Bytes _ => Float.formatRateValueBinary rate "B"
+  | .BytesDecimal _ => Float.formatRateValueDecimal rate "B"
+  | .Elements _ label => Float.formatRateValueDecimal rate label
+  -- For `ElementsAndBytes` we surface only the elements rate as the primary
+  -- aggregate; the secondary bytes rate would require a separate average.
+  | .ElementsAndBytes _ _ label => Float.formatRateValueDecimal rate label
+
+/--
+Computes the per-second rate (primary quantity per iteration divided by
+iteration time) of a `Throughput` given a typical iteration time in
+nanoseconds. Returns `0` if `timeNs ≤ 0`.
+-/
+def Throughput.rate (t : Throughput) (timeNs : Float) : Float :=
+  if timeNs ≤ 0 then 0.0 else
+  t.quantity.toNat.toFloat * 1e9 / timeNs
+
+/--
+Formats a `Throughput` value and a typical iteration time `timeNs` as a
+human-readable rate string, matching criterion.rs's `DurationFormatter`.
+-/
+def Throughput.formatRate (t : Throughput) (timeNs : Float) : String :=
+  if timeNs ≤ 0 then "—" else
+  match t with
+  | .ElementsAndBytes e b label =>
+    let eRate := e.toNat.toFloat * 1e9 / timeNs
+    let bRate := b.toNat.toFloat * 1e9 / timeNs
+    let eStr := Float.formatRateValueDecimal eRate label
+    let bStr := Float.formatRateValueBinary bRate "B"
+    s!"{eStr} / {bStr}"
+  | _ => t.formatRateValue (t.rate timeNs)
 
 end

--- a/Ix/Benchmark/Common.lean
+++ b/Ix/Benchmark/Common.lean
@@ -5,7 +5,7 @@ public section
 
 inductive SamplingMode where
   /-- Every sample runs the same number of iterations. Best for expensive
-      benches where linear's `[d, 2d, ..., Nd]` schedule would blow past the
+      benches where linear's `[d, 2d, ..., Nd]` schedule would exceed the
       target sample time. -/
   | flat : SamplingMode
   /-- Iteration counts grow linearly `[d, 2d, ..., Nd]`; the per-iteration time
@@ -29,7 +29,7 @@ instance : ToString SerdeFormat where
 
 /--
 Controls how much diagnostic output the benchmark harness prints. Can be overridden per-run via the
-`BENCH_VERBOSITY` env var or via `-q` / `-v` on the `lake exe` command line.
+`BENCH_VERBOSITY` env var (see `getConfigEnv`).
 -/
 inductive Verbosity where
   /-- Only per-bench summary lines (time/thrpt/change/perf note). Suppresses
@@ -130,69 +130,30 @@ structure Config where
   `Throughput` variant; otherwise the average is skipped with a warning.
   -/
   avgThroughput : Bool := false
-  /-- Diagnostic output level. Overridable via `BENCH_VERBOSITY` env var or
-      `-q` / `-v` command-line flags (see `getConfigEnv`). -/
+  /-- Diagnostic output level. Overridable via `BENCH_VERBOSITY` env var
+      (see `getConfigEnv`). -/
   verbosity : Verbosity := .normal
-  /-- Enable ANSI color/bold/faint in output. Defaults to `true`; set to
-      `false` or set the `BENCH_NO_COLOR` env var to disable. -/
-  color : Bool := true
-  /-- Enable ephemeral progress lines (warmup/sampling status overwritten
-      in-place on stderr). Defaults to `true`; automatically disabled when
-      `BENCH_NO_COLOR` is set. Forced to `false` in verbose mode so all
-      output is permanent. -/
-  overwrite : Bool := true
   deriving Repr, Lean.ToJson, Lean.FromJson
 
-/--
-Global mutable holder for the benchmark harness's command-line args, so that
-`getConfigEnv` can pick up `-q`/`-v`/`-vv` flags passed on `lake exe`
-without every individual bench `main` having to thread args through explicitly.
-Set it once at the top of `main` via `setBenchArgs args`.
--/
-initialize benchArgsRef : IO.Ref (List String) ← IO.mkRef []
-
-/-- Populate the global bench-args ref from this program's `main (args : List String)`.
-    Call this once at the top of every bench `main` to enable CLI flag parsing
-    in `getConfigEnv`. Safe to skip if we don't need CLI verbosity overrides. -/
-def setBenchArgs (args : List String) : IO Unit :=
-  benchArgsRef.set args
 
 /--
-Overrides config values with the corresponding `BENCH_<SETTING>` env vars and
-`lake exe` command-line flags. Precedence order (lowest to highest):
+Overrides config values with the corresponding `BENCH_*` env vars.
 
-1. `config` field defaults (the literal values passed to `bgroup`)
-2. `BENCH_*` env vars (`BENCH_SERDE`, `BENCH_REPORT`, `BENCH_VERBOSITY`)
-3. CLI flags (`-q` / `--quiet`, `-v` / `--verbose`) from the args set
-   via `setBenchArgs` at the top of `main`
+- `BENCH_SERDE`: `"ixon"` to use Ixon format, otherwise JSON (default)
+- `BENCH_REPORT`: `"1"` to generate a Markdown report
+- `BENCH_VERBOSITY`: `q` (quiet) | `v` (verbose); omit for normal
 
-`BENCH_VERBOSITY` accepts `quiet` | `normal` | `verbose` or the numeric
-equivalents `0` | `1` | `2`.
+Example: `BENCH_VERBOSITY=v lake exe bench-shardmap`
 -/
 def getConfigEnv (config : Config) : IO Config := do
   let serde : SerdeFormat := if (← IO.getEnv "BENCH_SERDE") == some "ixon" then .ixon else config.serde
   let report := if let some val := (← IO.getEnv "BENCH_REPORT") then val == "1" else config.report
-  let envVerbosity : Option Verbosity ← do
+  let verbosity : Verbosity ← do
     match (← IO.getEnv "BENCH_VERBOSITY") with
-    | some "quiet"   | some "0" => pure (some .quiet)
-    | some "normal"  | some "1" => pure (some .normal)
-    | some "verbose" | some "2" => pure (some .verbose)
-    | _ => pure none
-  let args ← benchArgsRef.get
-  let rec has (flag : String) : List String → Bool
-    | [] => false
-    | a :: rest => a == flag || has flag rest
-  let cliVerbosity : Option Verbosity :=
-    if has "-v" args || has "--verbose" args then some .verbose
-    else if has "-q" args || has "--quiet" args then some .quiet
-    else none
-  let verbosity := cliVerbosity.getD (envVerbosity.getD config.verbosity)
-  -- `BENCH_NO_COLOR` disables both ANSI codes and ephemeral overwrites.
-  -- Verbose mode also forces overwrite off so all output is permanent.
-  let noColor := (← IO.getEnv "BENCH_NO_COLOR").isSome
-  let color := if noColor then false else config.color
-  let overwrite := if noColor || verbosity == .verbose then false else config.overwrite
-  return { config with serde, report, verbosity, color, overwrite }
+    | some "q" => pure .quiet
+    | some "v" => pure .verbose
+    | _ => pure config.verbosity
+  return { config with serde, report, verbosity }
 
 @[inline] def Float.toNanos (f : Float) : Float := f * 10 ^ 9
 
@@ -258,32 +219,29 @@ def Float.formatNanos (f : Float) : String :=
   else
     f.floatPretty 2  ++ "ns"
 
-/--
-Formats a per-second `rate` with binary (1024-based) unit suffixes:
-`B/s`, `KiB/s`, `MiB/s`, `GiB/s`.
--/
-def Float.formatRateValueBinary (rate : Float) (baseUnit : String) : String :=
+/-- Formats a bytes-per-second `rate` with binary (1024-based) unit suffixes:
+    `B/s`, `KiB/s`, `MiB/s`, `GiB/s`. -/
+def Float.formatBytesRate (rate : Float) : String :=
   if rate ≥ 1024.0 * 1024.0 * 1024.0
-  then (rate / (1024.0 * 1024.0 * 1024.0)).floatPretty 2 ++ " Gi" ++ baseUnit ++ "/s"
+  then (rate / (1024.0 * 1024.0 * 1024.0)).floatPretty 2 ++ " GiB/s"
   else if rate ≥ 1024.0 * 1024.0
-  then (rate / (1024.0 * 1024.0)).floatPretty 2 ++ " Mi" ++ baseUnit ++ "/s"
+  then (rate / (1024.0 * 1024.0)).floatPretty 2 ++ " MiB/s"
   else if rate ≥ 1024.0
-  then (rate / 1024.0).floatPretty 2 ++ " Ki" ++ baseUnit ++ "/s"
+  then (rate / 1024.0).floatPretty 2 ++ " KiB/s"
   else
-    rate.floatPretty 2 ++ " " ++ baseUnit ++ "/s"
+    rate.floatPretty 2 ++ " B/s"
 
-/--
-Formats a per-second `rate` with decimal (1000-based) unit prefixes.
--/
-def Float.formatRateValueDecimal (rate : Float) (baseUnit : String) : String :=
+/-- Formats a per-second `rate` with decimal (1000-based) unit prefixes
+    and the given `unit` label (e.g. `"elem"`, `"b"`, `"B"`, `"hashes"`). -/
+def Float.formatRate (rate : Float) (unit : String) : String :=
   if rate ≥ 1e9
-  then (rate / 1e9).floatPretty 2 ++ " G" ++ baseUnit ++ "/s"
+  then (rate / 1e9).floatPretty 2 ++ " G" ++ unit ++ "/s"
   else if rate ≥ 1e6
-  then (rate / 1e6).floatPretty 2 ++ " M" ++ baseUnit ++ "/s"
+  then (rate / 1e6).floatPretty 2 ++ " M" ++ unit ++ "/s"
   else if rate ≥ 1e3
-  then (rate / 1e3).floatPretty 2 ++ " K" ++ baseUnit ++ "/s"
+  then (rate / 1e3).floatPretty 2 ++ " K" ++ unit ++ "/s"
   else
-    rate.floatPretty 2 ++ " " ++ baseUnit ++ "/s"
+    rate.floatPretty 2 ++ " " ++ unit ++ "/s"
 
 /--
 Extracts the primary quantity of work per iteration from a `Throughput`.
@@ -319,13 +277,11 @@ The numeric payload of `t` is ignored — only the variant and (for
 -/
 def Throughput.formatRateValue (t : Throughput) (rate : Float) : String :=
   match t with
-  | .Bits _ => Float.formatRateValueDecimal rate "b"
-  | .Bytes _ => Float.formatRateValueBinary rate "B"
-  | .BytesDecimal _ => Float.formatRateValueDecimal rate "B"
-  | .Elements _ label => Float.formatRateValueDecimal rate label
-  -- For `ElementsAndBytes` we surface only the elements rate as the primary
-  -- aggregate; the secondary bytes rate would require a separate average.
-  | .ElementsAndBytes _ _ label => Float.formatRateValueDecimal rate label
+  | .Bits _ => Float.formatRate rate "b"
+  | .Bytes _ => Float.formatBytesRate rate
+  | .BytesDecimal _ => Float.formatRate rate "B"
+  | .Elements _ label => Float.formatRate rate label
+  | .ElementsAndBytes _ _ label => Float.formatRate rate label
 
 /--
 Computes the per-second rate (primary quantity per iteration divided by
@@ -346,8 +302,8 @@ def Throughput.formatRate (t : Throughput) (timeNs : Float) : String :=
   | .ElementsAndBytes e b label =>
     let eRate := e.toNat.toFloat * 1e9 / timeNs
     let bRate := b.toNat.toFloat * 1e9 / timeNs
-    let eStr := Float.formatRateValueDecimal eRate label
-    let bStr := Float.formatRateValueBinary bRate "B"
+    let eStr := Float.formatRate eRate label
+    let bStr := Float.formatBytesRate bRate
     s!"{eStr} / {bStr}"
   | _ => t.formatRateValue (t.rate timeNs)
 

--- a/Ix/Benchmark/Data.lean
+++ b/Ix/Benchmark/Data.lean
@@ -23,7 +23,7 @@ def Data.randDataM (data : Data) : StateM StdGen (Nat × Nat) := do
   set gen'
   return data.d[n]!
 
-/-- Creates a random permutation of the distribution with replacement -/
+/-- Creates a random permutation of the distribution with replacement (i.e. duplicates are permitted) -/
 def Data.resampleM (data : Data) (numSamples : Nat) : StateM StdGen Data := do
   let mut rands := Array.mkEmpty numSamples
   for _ in [:numSamples] do

--- a/Ix/Benchmark/Data.lean
+++ b/Ix/Benchmark/Data.lean
@@ -41,17 +41,46 @@ def Data.bootstrap (data : Data) (numSamples bootstrapSamples : Nat): StateM Std
   return { d := slopes }
 
 /--
-Performs a linear regression on a sample, returning a pair of the bootstrap samples and the estimated slope by fitting the data to a straight line.
+Centered coefficient of determination (R²) for the no-intercept linear model
+`y = slope * x`:
+
+  R² = 1 − SS_res / SS_tot
+  SS_res = Σ (yᵢ − slope·xᵢ)²
+  SS_tot = Σ (yᵢ − ȳ)²         where ȳ = mean(y)
+
+Clamped to `[0, 1]`. If the sample has zero total variance (all y values
+equal), returns `1.0` — the model trivially fits. A high R² (e.g. > 0.98)
+indicates the linear time-per-iteration model is a good fit for the sample;
+a low R² means the bench is doing something nonlinear or is dominated by noise.
+-/
+def Data.rSquared (data : Data) (slope : Float) : Float :=
+  let n := Float.ofNat data.d.size
+  if n == 0 then 1.0 else
+  let ySum := data.d.foldl (fun acc (_, y) => acc + Float.ofNat y) 0.0
+  let yMean := ySum / n
+  let (ssRes, ssTot) := data.d.foldl (fun (r, t) (x, y) =>
+    let yF := Float.ofNat y
+    let residual := yF - slope * Float.ofNat x
+    let centered := yF - yMean
+    (r + residual * residual, t + centered * centered)) (0.0, 0.0)
+  if ssTot == 0 then 1.0
+  else max 0.0 (1.0 - ssRes / ssTot)
+
+/--
+Performs a linear regression on a sample, returning the bootstrap distribution,
+the estimated slope, and the R² goodness-of-fit.
 
 Used only with linear sampling mode.
 -/
-def Data.regression (data : Data) (config : Config) (gen : StdGen) : (Distribution × Estimate) :=
+def Data.regression (data : Data) (config : Config) (gen : StdGen) :
+    (Distribution × Estimate × Float) :=
   let distribution := ((data.bootstrap config.numSamples config.bootstrapSamples).run gen).fst
   let pointEstimate := data.slope
   let confidenceInterval := distribution.confidenceInterval config.confidenceLevel
   let mean := distribution.mean
   let stdErr := distribution.stdDev mean
   let estimate : Estimate := { confidenceInterval, pointEstimate, stdErr }
-  (distribution, estimate)
+  let r2 := data.rSquared pointEstimate
+  (distribution, estimate, r2)
 
 end

--- a/Ix/Benchmark/Data.lean
+++ b/Ix/Benchmark/Data.lean
@@ -23,21 +23,20 @@ def Data.randDataM (data : Data) : StateM StdGen (Nat × Nat) := do
   set gen'
   return data.d[n]!
 
-/-- Creates a random permutation of the distribution with replacement (i.e. duplicates are permitted) -/
+/-- Creates a random permutation of the distribution with replacement -/
 def Data.resampleM (data : Data) (numSamples : Nat) : StateM StdGen Data := do
-  let mut rands := #[]
-  for _ in Array.range numSamples do
+  let mut rands := Array.mkEmpty numSamples
+  for _ in [:numSamples] do
     let res ← data.randDataM
     rands := rands.push res
   return { d := rands }
 
 /-- Performs a one-sample bootstrap of bivariate data -/
-def Data.bootstrap (data : Data) (numSamples bootstrapSamples : Nat): StateM StdGen Distribution := do
-  let mut slopes : Array Float := #[]
-  for _ in Array.range bootstrapSamples do
-    let resample ← Data.resampleM data numSamples
-    let slope := resample.slope
-    slopes := slopes.push slope
+def Data.bootstrap (data : Data) (numSamples bootstrapSamples : Nat) : StateM StdGen Distribution := do
+  let mut slopes := Array.mkEmpty bootstrapSamples
+  for _ in [:bootstrapSamples] do
+    let resample ← data.resampleM numSamples
+    slopes := slopes.push resample.slope
   return { d := slopes }
 
 /--

--- a/Ix/Benchmark/Distribution.lean
+++ b/Ix/Benchmark/Distribution.lean
@@ -89,7 +89,7 @@ def Distribution.resampleM (dist : Distribution) (numSamples : Nat) : StateM Std
 Performs a one-sample bootstrap: resamples the distribution `bootstrapSamples`
 times and computes mean, stdDev, median, and medianAbsDev for each resample.
 
-Assumes `numSamples ≥ 2`.
+Assumes `numSamples ≥ 2`
 -/
 def Distribution.bootstrap (dist : Distribution) (numSamples bootstrapSamples : Nat) : StateM StdGen Distributions := do
   let mut means := Array.mkEmpty bootstrapSamples

--- a/Ix/Benchmark/Distribution.lean
+++ b/Ix/Benchmark/Distribution.lean
@@ -4,7 +4,6 @@ public import Ix.Benchmark.Estimate
 
 public section
 
--- TODO: Ensure all array instances are used linearly for optimal performance
 structure Distribution where
   d : Array Float
   deriving Repr, Inhabited, Lean.ToJson, Lean.FromJson
@@ -18,6 +17,7 @@ as extreme as `t` under the null distribution `dist`. Returns a value in
 `[0, 1]`; smaller means the observed `t` is more extreme (less consistent with
 the null hypothesis). -/
 def Distribution.pValue (dist : Distribution) (t : Float) : Float :=
+  if dist.d.isEmpty then 1.0 else
   let len := Float.ofNat dist.d.size
   let hits := Float.ofNat (dist.d.filter (· < t)).size
   2 * (min hits (len - hits)) / len
@@ -51,12 +51,14 @@ def Distribution.confidenceInterval (dist : Distribution) (confidenceLevel : Flo
   { confidenceLevel, lowerBound, upperBound }
 
 def Distribution.mean (dist : Distribution) : Float :=
+  if dist.d.isEmpty then 0.0 else
   dist.d.sum / Float.ofNat dist.d.size
 
 def Distribution.median (dist : Distribution) : Float :=
   (dist.percentile? 50).get!
 
 def Distribution.variance (dist : Distribution) (mean : Float) : Float :=
+  if dist.d.size ≤ 1 then 0.0 else
   let sum := dist.d.foldl (fun acc x => acc + ((x - mean) ^ 2)) 0.0
   sum / Float.ofNat (dist.d.size - 1)
 
@@ -76,29 +78,33 @@ def Distribution.randDistM (dist : Distribution) : StateM StdGen Float := do
 
 /-- Creates a random permutation of the distribution with replacement (i.e. duplicates are permitted) -/
 def Distribution.resampleM (dist : Distribution) (numSamples : Nat) : StateM StdGen Distribution := do
-  let mut rands := #[]
-  for _ in Array.range numSamples do
+  let mut rands := Array.mkEmpty numSamples
+  for _ in [:numSamples] do
     let res ← dist.randDistM
     rands := rands.push res
   return { d := rands }
 
-/--
-Performs a one-sample bootstrap, gets `bootstrapSamples` resamples of the distribution and computes statistics for each.
 
-Assumes `numSamples ≥ 2`
+/--
+Performs a one-sample bootstrap: resamples the distribution `bootstrapSamples`
+times and computes mean, stdDev, median, and medianAbsDev for each resample.
+
+Assumes `numSamples ≥ 2`.
 -/
 def Distribution.bootstrap (dist : Distribution) (numSamples bootstrapSamples : Nat) : StateM StdGen Distributions := do
-  let mut means : Distribution := default
-  let mut stdDevs : Distribution := default
-  let mut medians : Distribution := default
-  let mut medianAbsDevs : Distribution := default
-  for _ in Array.range bootstrapSamples do
-    let resample ← Distribution.resampleM dist numSamples
-    means := { means with d := means.d.push resample.mean }
-    stdDevs := { stdDevs with d := stdDevs.d.push (resample.stdDev resample.mean) }
-    medians := { medians with d := medians.d.push resample.median }
-    medianAbsDevs := { medianAbsDevs with d := medianAbsDevs.d.push (resample.medianAbsDev resample.median) }
-  return { means, medians, medianAbsDevs, slope := none, stdDevs }
+  let mut means := Array.mkEmpty bootstrapSamples
+  let mut stdDevs := Array.mkEmpty bootstrapSamples
+  let mut medians := Array.mkEmpty bootstrapSamples
+  let mut medianAbsDevs := Array.mkEmpty bootstrapSamples
+  for _ in [:bootstrapSamples] do
+    let resample ← dist.resampleM numSamples
+    let m := resample.mean
+    means := means.push m
+    stdDevs := stdDevs.push (resample.stdDev m)
+    let med := resample.median
+    medians := medians.push med
+    medianAbsDevs := medianAbsDevs.push (resample.medianAbsDev med)
+  return { means := ⟨means⟩, medians := ⟨medians⟩, medianAbsDevs := ⟨medianAbsDevs⟩, slope := none, stdDevs := ⟨stdDevs⟩ }
 
 def Distribution.toEstimate (dist : Distribution) (pointEstimate : Float) (confidenceLevel : Float) : Estimate :=
   let confidenceInterval := dist.confidenceInterval confidenceLevel
@@ -178,7 +184,7 @@ def outlierVariance (meanEst stdDevEst : Estimate) (numSamples : Float) : Outlie
     let ad := numSamples * d
     let k0 := -numSamples * ad
     let k1 := sb2 - numSamples * sg2 + ad
-    let det := k1 * k1 - 4 * sg2 * k0
+    let det := max (k1 * k1 - 4 * sg2 * k0) 0
     (-2 * k0 / (k1 + det.sqrt)).floor
   let minBy (f : Float → Float) (q r : Float) : Float := min (f q) (f r)
   let varOutMin := (minBy varOut 1 (minBy cMax 0 ugMin)) / sb2

--- a/Ix/Benchmark/Distribution.lean
+++ b/Ix/Benchmark/Distribution.lean
@@ -13,11 +13,14 @@ structure Distribution where
 instance : Coe Distribution (Array Float) where
   coe x := x.d
 
-/-- Gets the p value of the distribution, which is the likelihood of seeing the `t` value or a more extreme value in the distribution. Smaller p value => less likely -/
+/-- Two-sided p-value: the probability of observing a test statistic at least
+as extreme as `t` under the null distribution `dist`. Returns a value in
+`[0, 1]`; smaller means the observed `t` is more extreme (less consistent with
+the null hypothesis). -/
 def Distribution.pValue (dist : Distribution) (t : Float) : Float :=
   let len := Float.ofNat dist.d.size
   let hits := Float.ofNat (dist.d.filter (· < t)).size
-  (min len (len - hits)) / len * 2
+  2 * (min hits (len - hits)) / len
 
 def Distribution.percentile? (data : Distribution) (p : Float): Option Float :=
   if data.d.isEmpty || p > 100
@@ -120,5 +123,70 @@ def Distribution.estimates (avgTimes : Distribution) (config : Config) (gen : St
   let dists := ((avgTimes.bootstrap config.numSamples config.bootstrapSamples).run gen).fst
   let est := dists.buildEstimates points config.confidenceLevel
   (dists, est)
+
+/--
+Qualitative classification of how much outliers are inflating the sample's
+std-dev estimate, ported from Haskell criterion's `OutlierEffect`.
+-/
+inductive OutlierEffect where
+  /-- < 1% of the variance can be blamed on outliers — numbers are trustworthy. -/
+  | unaffected
+  /-- 1%–10% — minor but noticeable. -/
+  | slight
+  /-- 10%–50% — take the reported CI with a grain of salt. -/
+  | moderate
+  /-- ≥ 50% — measurements are essentially useless. -/
+  | severe
+  deriving Repr, BEq, Ord, Lean.ToJson, Lean.FromJson
+
+/-- Summary of the outlier-variance analysis for a sample. -/
+structure OutlierVariance where
+  effect : OutlierEffect
+  /-- English description slotted into criterion's `variance introduced by
+      outliers: N% ({desc} inflated)` message — one of `"unaffected"`,
+      `"slightly"`, `"moderately"`, or `"severely"`. -/
+  desc : String
+  /-- Quantitative fraction in `[0, 1]`. -/
+  fraction : Float
+  deriving Repr, Lean.ToJson, Lean.FromJson
+
+/--
+Computes the fraction of the sample std-dev estimate that is attributable to
+outliers, following Haskell criterion's `outlierVariance` (`Analysis.hs:85-112`).
+
+Takes the bootstrap point estimates of the sample mean and std-dev plus the
+original iteration count `numSamples` (e.g. `100` for a default `bgroup`).
+-/
+def outlierVariance (meanEst stdDevEst : Estimate) (numSamples : Float) : OutlierVariance :=
+  -- Names from Haskell criterion's implementation:
+  --   sb  = bootstrap point estimate of std dev          (σ_b)
+  --   ua  = mean point estimate divided by `numSamples`  (µ_a)
+  --   ugMin = ua / 2                                     (µ_{g,min})
+  --   sg  = contributed std dev from the outlier model   (σ_g)
+  let sb  := stdDevEst.pointEstimate
+  let sb2 := sb * sb
+  let ua  := meanEst.pointEstimate / numSamples
+  let ugMin := ua / 2
+  let sg  := min (ugMin / 4) (sb / numSamples.sqrt)
+  let sg2 := sg * sg
+  let varOut (c : Float) : Float :=
+    let ac := numSamples - c
+    (ac / numSamples) * (sb2 - ac * sg2)
+  let cMax (x : Float) : Float :=
+    let k := ua - x
+    let d := k * k
+    let ad := numSamples * d
+    let k0 := -numSamples * ad
+    let k1 := sb2 - numSamples * sg2 + ad
+    let det := k1 * k1 - 4 * sg2 * k0
+    (-2 * k0 / (k1 + det.sqrt)).floor
+  let minBy (f : Float → Float) (q r : Float) : Float := min (f q) (f r)
+  let varOutMin := (minBy varOut 1 (minBy cMax 0 ugMin)) / sb2
+  let (effect, desc) :=
+    if varOutMin < 0.01 then (OutlierEffect.unaffected, "unaffected")
+    else if varOutMin < 0.1 then (OutlierEffect.slight, "slightly inflated")
+    else if varOutMin < 0.5 then (OutlierEffect.moderate, "moderately inflated")
+    else (OutlierEffect.severe, "severely inflated")
+  { effect, desc, fraction := varOutMin }
 
 end

--- a/Ix/Benchmark/OneShot.lean
+++ b/Ix/Benchmark/OneShot.lean
@@ -1,10 +1,15 @@
 module
 public import Lean.Data.Json.FromToJson
+public import Ix.Benchmark.Common
 
 public section
 
 structure OneShot where
   benchTime : Nat
+  /-- Optional throughput metadata captured at registration time. Embedded
+      directly in the one-shot result so one-shot mode doesn't need a separate
+      throughput file on disk. -/
+  throughput : Option Throughput := none
   deriving Lean.ToJson, Lean.FromJson, Repr
 
 end

--- a/Ix/Benchmark/OneShot.lean
+++ b/Ix/Benchmark/OneShot.lean
@@ -6,9 +6,6 @@ public section
 
 structure OneShot where
   benchTime : Nat
-  /-- Optional throughput metadata captured at registration time. Embedded
-      directly in the one-shot result so one-shot mode doesn't need a separate
-      throughput file on disk. -/
   throughput : Option Throughput := none
   deriving Lean.ToJson, Lean.FromJson, Repr
 

--- a/Ix/Benchmark/Report.lean
+++ b/Ix/Benchmark/Report.lean
@@ -1,0 +1,328 @@
+module
+public import Ix.Benchmark.Serde
+public import Ix.Benchmark.Tukey
+public import Ix.Benchmark.Ansi
+
+public section
+
+/-! # Benchmark report output — console (ANSI) and Markdown table
+
+This module contains display logic and the data types that form the interface
+between measurement and display (`MeasurementData`, `BenchResult`,
+`BenchReport`). These types are constructed by `Bench.lean` and consumed by
+the formatting functions here.
+-/
+
+structure MeasurementData where
+  data : Data
+  avgTimes : Distribution
+  absoluteEstimates : Estimates
+  distributions : Distributions
+  comparison : Option ComparisonData
+  throughput : Option Throughput
+  rSquared : Option Float := none
+  outlierVariance : Option OutlierVariance := none
+  outliers : Option Outliers := none
+  deriving Repr
+
+inductive BenchResult where
+| oneShot : OneShot → BenchResult
+| sample : Estimates → BenchResult
+  deriving Repr
+
+def BenchResult.getTime (bench: BenchResult) : Float :=
+  match bench with
+  | oneShot o => o.benchTime.toFloat
+  | sample s => s.mean.pointEstimate
+
+structure BenchReport where
+  function: String
+  newBench : BenchResult
+  baseBench : Option BenchResult
+  percentChange : Option Float
+  throughput : Option Throughput := none
+
+/-- Rendered display string for a report's throughput, or `"N/A"` if `none`. -/
+def BenchReport.throughputStr (r : BenchReport) : String :=
+  match r.throughput with
+  | some t => t.formatRate r.newBench.getTime
+  | none => "N/A"
+
+/--
+Computes weighted-average throughput rate(s) across a collection of reports.
+For `ElementsAndBytes`, also returns the secondary bytes-weighted-average rate.
+-/
+def weightedAverageThroughput (reports : Array BenchReport) :
+    Option (Throughput × Float × Option Float) := Id.run do
+  let mut representative : Option Throughput := none
+  let mut sumQty : Float := 0.0
+  let mut weightedSum : Float := 0.0
+  for r in reports do
+    match r.throughput with
+    | none => pure ()
+    | some t =>
+      match representative with
+      | none => representative := some t
+      | some t0 =>
+        unless t.sameVariant t0 do
+          return none
+      let qty := t.quantity.toNat.toFloat
+      let rate := t.rate r.newBench.getTime
+      sumQty := sumQty + qty
+      weightedSum := weightedSum + qty * rate
+  match representative with
+  | none => return none
+  | some t =>
+    if sumQty == 0 then return none
+    let primaryAvg := weightedSum / sumQty
+    let secondaryAvg ← match t with
+      | .ElementsAndBytes _ _ _ => do
+        let mut sumBytes : Float := 0.0
+        let mut weightedBytesSum : Float := 0.0
+        for r in reports do
+          if let some (.ElementsAndBytes _ b _) := r.throughput then
+            let bytes := b.toNat.toFloat
+            let bytesRate := bytes * 1e9 / r.newBench.getTime
+            sumBytes := sumBytes + bytes
+            weightedBytesSum := weightedBytesSum + bytes * bytesRate
+        pure (if sumBytes > 0 then some (weightedBytesSum / sumBytes) else none)
+      | _ => pure none
+    return some (t, primaryAvg, secondaryAvg)
+
+inductive ComparisonResult where
+| Improved
+| Regressed
+| NonSignificant
+
+def compareToThreshold (estimate : Estimate) (noiseThreshold : Float) : ComparisonResult :=
+  let ci := estimate.confidenceInterval
+  let (lb, ub) := (ci.lowerBound, ci.upperBound)
+  let noiseNeg := noiseThreshold.neg
+
+  if lb < noiseNeg && ub < noiseNeg
+  then
+    ComparisonResult.Improved
+  else if lb > noiseThreshold && ub > noiseThreshold
+  then
+    ComparisonResult.Regressed
+  else
+    ComparisonResult.NonSignificant
+
+/-- Criterion.rs uses a fixed 24-char column for the time/thrpt labels. -/
+def indent24 : String := String.ofList (List.replicate 24 ' ')
+
+def printRunning (config : Config) (style : CliStyle) (benchId : String) (expectedTime : Float) (numIters : Nat) (warningFactor : Nat) : IO Unit := do
+  if warningFactor == 1 then
+    -- Clear the ephemeral line before printing the permanent warning
+    style.overwrite
+    IO.eprintln s!"Warning: Unable to complete {config.numSamples} samples in {config.sampleTime.floatPretty 2}s. You may wish to increase target time to {expectedTime.floatPretty 2}s"
+  style.printEphemeral s!"Benchmarking {benchId}: Collecting {config.numSamples} samples in estimated {expectedTime.floatPretty 2}s ({numIters.natPretty} iterations)"
+
+/-- Prints the results of a single sampled benchmark to stdout, matching
+    criterion.rs's layout with ANSI colors.
+
+    `groupName` and `config` are used for the bench label and verbosity gating
+    (replaces the old `BenchGroup.printResults` method so that Report.lean
+    doesn't need to know about `BenchGroup`). -/
+def printResults (groupName : String) (config : Config) (benchName : String)
+    (m : MeasurementData) : IO Unit := do
+  let estimates := m.absoluteEstimates
+  let typicalEstimate := estimates.slope.getD estimates.mean
+  let fullName := s!"{groupName}/{benchName}"
+  let verbosity := config.verbosity
+  let ciLb := typicalEstimate.confidenceInterval.lowerBound
+  let ciUb := typicalEstimate.confidenceInterval.upperBound
+
+  -- Name line + time, matching criterion.rs's 24-char column layout:
+  -- Short name (≤ 23 chars): name + pad + time on one line
+  -- Long name (> 23 chars): name on its own line, time on the next
+  let r2Suffix := match m.rSquared with
+    | some r2 => s!" R²={r2.floatPretty 3}"
+    | none => ""
+  let timeLine := s!"time:   [{Ansi.faint ciLb.formatNanos} {Ansi.bold typicalEstimate.pointEstimate.formatNanos} {Ansi.faint ciUb.formatNanos}]{r2Suffix}"
+  if fullName.length > 23 then
+    IO.println (Ansi.green fullName)
+    IO.println s!"{indent24}{timeLine}"
+  else
+    let pad := String.ofList (List.replicate (24 - fullName.length) ' ')
+    IO.println s!"{Ansi.green fullName}{pad}{timeLine}"
+
+  -- Throughput line (if present)
+  if let some t := m.throughput then
+    -- Higher time ⇒ lower throughput, so bounds are inverted
+    IO.println s!"{indent24}thrpt:  [{Ansi.faint (t.formatRate ciUb)} {Ansi.bold (t.formatRate typicalEstimate.pointEstimate)} {Ansi.faint (t.formatRate ciLb)}]"
+
+  -- Change section (gated by verbosity, not shown in quiet)
+  if verbosity != .quiet then
+    if let some comp := m.comparison then
+      -- `p > significanceThreshold` means we fail to reject the null hypothesis
+      -- that the two samples come from the same distribution — i.e. no
+      -- statistically significant change.
+      let notSignificant := comp.pValue > comp.significanceThreshold
+      let meanEst := comp.relativeEstimates.mean
+      let fmtSigned (f : Float) : String :=
+        let body := (f * 100).floatPretty 4
+        if f ≥ 0 then s!"+{body}" else body
+
+      -- Determine coloring for point estimate based on comparison result
+      let comparison := if notSignificant then ComparisonResult.NonSignificant
+        else compareToThreshold meanEst comp.noiseThreshold
+      let colorPointEst (s : String) : String := match comparison with
+        | .Improved => Ansi.green (Ansi.bold s)
+        | .Regressed => Ansi.red (Ansi.bold s)
+        | .NonSignificant => s
+
+      let pointEstStr := colorPointEst (fmtSigned meanEst.pointEstimate)
+      let lbStr := Ansi.faint (fmtSigned meanEst.confidenceInterval.lowerBound)
+      let ubStr := Ansi.faint (fmtSigned meanEst.confidenceInterval.upperBound)
+      let pStr := s!"(p = {comp.pValue.floatPretty 2} {if notSignificant then ">" else "<"} {comp.significanceThreshold.floatPretty 2})"
+
+      -- Layout differs depending on whether throughput is present
+      if m.throughput.isSome then
+        -- Throughput present: separate "change:" header, then time: and thrpt: sub-lines
+        let toThrptEst (ratio : Float) : Float := 1.0 / (1.0 + ratio) - 1.0
+        let thrptPointStr := colorPointEst (fmtSigned (toThrptEst meanEst.pointEstimate))
+        let thrptLbStr := Ansi.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.upperBound))
+        let thrptUbStr := Ansi.faint (fmtSigned (toThrptEst meanEst.confidenceInterval.lowerBound))
+        IO.println s!"{String.ofList (List.replicate 17 ' ')}change:"
+        IO.println s!"{indent24}time:   [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
+        IO.println s!"{indent24}thrpt:  [{thrptLbStr}% {thrptPointStr}% {thrptUbStr}%]"
+      else
+        -- No throughput: inline change
+        IO.println s!"{indent24}change: [{lbStr}% {pointEstStr}% {ubStr}%] {pStr}"
+
+      -- Explanation line
+      let explanation := if notSignificant then
+        "No change in performance detected."
+      else match comparison with
+        | .Improved => s!"Performance has {Ansi.green "improved"}."
+        | .Regressed => s!"Performance has {Ansi.red "regressed"}."
+        | .NonSignificant => "Change within noise threshold."
+      IO.println s!"{indent24}{explanation}"
+
+  -- Outlier-variance warning + Tukey breakdown. Verbosity gating matches
+  -- Haskell criterion's `Internal.hs:89-92`:
+  --   • verbose             → always print the variance line AND breakdown
+  --   • normal + > slight   → print the variance line AND breakdown
+  --   • normal + ≤ slight   → silent
+  --   • quiet               → silent regardless
+  if verbosity != .quiet then
+    if let some ov := m.outlierVariance then
+      let effectAboveSlight := match ov.effect with
+        | .moderate | .severe => true
+        | _ => false
+      let showVariance := verbosity == .verbose || (effectAboveSlight && verbosity != .quiet)
+      if showVariance then
+        if let some outs := m.outliers then
+          Outliers.note outs m.avgTimes.d.size
+        let pct := (ov.fraction * 100).floatPretty 0
+        IO.println s!"variance introduced by outliers: {pct}% ({ov.desc})"
+
+/-! ## Markdown table -/
+
+def percentChangeToString (pc : Float) : String :=
+  let rounded := (100 * pc).floatPretty 2
+  if pc < 0 then s!"{rounded.drop 1}% faster"
+  else if pc > 0 then s!"{rounded}% slower"
+  else "No change"
+
+structure ColumnWidths where
+  function : Nat
+  newBench : Nat
+  baseBench : Nat
+  percentChange : Nat
+  /-- `none` ⇒ the Throughput column is not rendered for this group. -/
+  throughput : Option Nat
+
+def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidths :=
+  let fnLen := row.function.length
+  let function := if fnLen > maxWidths.function then fnLen else maxWidths.function
+  let newBenchLen := row.newBench.getTime.formatNanos.length
+  let newBench := if newBenchLen > maxWidths.newBench then newBenchLen else maxWidths.newBench
+  let baseBench := if let some baseBench := row.baseBench then
+    let baseBenchLen := baseBench.getTime.formatNanos.length
+    if baseBenchLen > maxWidths.baseBench then baseBenchLen
+    else maxWidths.baseBench
+  else maxWidths.baseBench
+  let percentChange := if let some percentChange := row.percentChange then
+    let percentChangeStr := percentChangeToString percentChange
+    let percentLen := percentChangeStr.length
+    if percentLen > maxWidths.percentChange then percentLen
+    else maxWidths.percentChange
+  else maxWidths.percentChange
+  let throughput := match maxWidths.throughput with
+    | none => none
+    | some w =>
+      let tStr := row.throughputStr
+      let tLen := tStr.length
+      some (if tLen > w then tLen else w)
+  { function, newBench, baseBench, percentChange, throughput }
+
+def getColumnWidths (report : Array BenchReport) : ColumnWidths :=
+  let hasThroughput := report.any (·.throughput.isSome)
+  let maxWidths : ColumnWidths := {
+    function := "Function".length
+    newBench := "New Benchmark".length
+    baseBench := "Base Benchmark".length
+    percentChange := "% change".length
+    throughput := if hasThroughput then some "Throughput".length else none
+  }
+  report.foldl getColumnWidths' maxWidths
+
+def padWhitespace (input : String) (width : Nat) : String :=
+  let padWidth := width - input.length
+  let leftPad := padWidth / 2
+  let rightPad := padWidth - leftPad
+  String.ofList (List.replicate leftPad ' ') ++ input ++ (String.ofList (List.replicate rightPad ' '))
+
+def padDashes (width : Nat) : String :=
+  String.ofList (List.replicate width '-')
+
+def mkReportPretty' (columnWidths : ColumnWidths) (reportPretty : String) (row : BenchReport) : String :=
+  let functionStr := padWhitespace row.function columnWidths.function
+  let newBenchStr := row.newBench.getTime.formatNanos
+  let newBenchStr := padWhitespace newBenchStr columnWidths.newBench
+  let baseBenchStr := if let some baseBench := row.baseBench then
+    baseBench.getTime.formatNanos
+  else "None"
+  let baseBenchStr := padWhitespace baseBenchStr columnWidths.baseBench
+  let percentChangeStr := if let some percentChange := row.percentChange then
+    percentChangeToString percentChange
+  else "N/A"
+  let percentChangeStr := padWhitespace percentChangeStr columnWidths.percentChange
+  let throughputCell := match columnWidths.throughput with
+    | none => ""
+    | some w => s!" {padWhitespace row.throughputStr w} |"
+  let rowPretty :=
+    s!"| {functionStr} | {newBenchStr} | {baseBenchStr} | {percentChangeStr} |{throughputCell}\n"
+  reportPretty ++ rowPretty
+
+/--
+Generates a Markdown table with comparative benchmark timings.
+Each table row contains the benchmark function name, the new timing, the base
+timing, the percent change between the two, and (optionally) a throughput rate.
+-/
+def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
+  let columnWidths := getColumnWidths report
+  let title := s!"## {groupName}\n\n"
+  let (fn, new, base, percent) := (
+    padWhitespace "Function" columnWidths.function,
+    padWhitespace "New Benchmark" columnWidths.newBench,
+    padWhitespace "Base Benchmark" columnWidths.baseBench,
+    padWhitespace "% change" columnWidths.percentChange
+  )
+  let (d1, d2, d3, d4) := (
+    padDashes columnWidths.function,
+    padDashes columnWidths.newBench,
+    padDashes columnWidths.baseBench,
+    padDashes columnWidths.percentChange
+  )
+  let (throughputHeader, throughputDashes) := match columnWidths.throughput with
+    | none => ("", "")
+    | some w => (s!" {padWhitespace "Throughput" w} |", s!"-{padDashes w}-|")
+  let header := s!"| {fn} | {new} | {base} | {percent} |{throughputHeader}\n"
+  let dashes := s!"|-{d1}-|-{d2}-|-{d3}-|-{d4}-|{throughputDashes}\n"
+  let reportPretty := title ++ header ++ dashes
+  report.foldl (mkReportPretty' columnWidths) reportPretty
+
+end

--- a/Ix/Benchmark/Serde.lean
+++ b/Ix/Benchmark/Serde.lean
@@ -116,11 +116,165 @@ instance : Serialize ChangeEstimates where
   put := putChangeEstimates
   get := getChangeEstimates
 
+def putLabel (s : String) : PutM Unit := do
+  let bytes := s.toUTF8
+  putU64LE bytes.size.toUInt64
+  putBytes bytes
+
+def getLabel : GetM String := do
+  let len ← getU64LE
+  let bytes ← getBytes len.toNat
+  return String.fromUTF8! bytes
+
+def putThroughput (t : Throughput) : PutM Unit := do
+  match t with
+  | .Bits n => putU8 0; putU64LE n
+  | .Bytes n => putU8 1; putU64LE n
+  | .BytesDecimal n => putU8 2; putU64LE n
+  | .Elements n label => putU8 3; putU64LE n; putLabel label
+  | .ElementsAndBytes e b label => putU8 4; putU64LE e; putU64LE b; putLabel label
+
+def getThroughput : GetM Throughput := do
+  let tag ← getU8
+  match tag with
+  | 0 => return .Bits (← getU64LE)
+  | 1 => return .Bytes (← getU64LE)
+  | 2 => return .BytesDecimal (← getU64LE)
+  | 3 =>
+    let n ← getU64LE
+    let label ← getLabel
+    return .Elements n label
+  | 4 =>
+    let e ← getU64LE
+    let b ← getU64LE
+    let label ← getLabel
+    return .ElementsAndBytes e b label
+  | _ => throw s!"invalid Throughput tag {tag}"
+
+instance : Serialize Throughput where
+  put := putThroughput
+  get := getThroughput
+
+def putSamplingMode (m : SamplingMode) : PutM Unit := do
+  match m with
+  | .flat => putU8 0
+  | .linear => putU8 1
+  | .auto => panic! "SamplingMode.auto must be resolved before persisting"
+
+def getSamplingMode : GetM SamplingMode := do
+  let tag ← getU8
+  match tag with
+  | 0 => return .flat
+  | 1 => return .linear
+  | _ => throw s!"invalid SamplingMode tag {tag}"
+
+instance : Serialize SamplingMode where
+  put := putSamplingMode
+  get := getSamplingMode
+
+def putSerdeFormat (f : SerdeFormat) : PutM Unit := do
+  match f with
+  | .json => putU8 0
+  | .ixon => putU8 1
+
+def getSerdeFormat : GetM SerdeFormat := do
+  let tag ← getU8
+  match tag with
+  | 0 => return .json
+  | 1 => return .ixon
+  | _ => throw s!"invalid SerdeFormat tag {tag}"
+
+instance : Serialize SerdeFormat where
+  put := putSerdeFormat
+  get := getSerdeFormat
+
+def putVerbosity (v : Verbosity) : PutM Unit := do
+  match v with
+  | .quiet => putU8 0
+  | .normal => putU8 1
+  | .verbose => putU8 2
+
+def getVerbosity : GetM Verbosity := do
+  let tag ← getU8
+  match tag with
+  | 0 => return .quiet
+  | 1 => return .normal
+  | 2 => return .verbose
+  | _ => throw s!"invalid Verbosity tag {tag}"
+
+instance : Serialize Verbosity where
+  put := putVerbosity
+  get := getVerbosity
+
+instance [Serialize α] : Serialize (Option α) where
+  put
+    | none => putU8 0
+    | some a => do putU8 1; Serialize.put a
+  get := do
+    let tag ← getU8
+    match tag with
+    | 0 => return none
+    | 1 => return some (← Serialize.get)
+    | _ => throw s!"invalid Option tag {tag}"
+
+def putConfig (c : Config) : PutM Unit := do
+  putFloat c.warmupTime
+  putFloat c.sampleTime
+  Serialize.put c.numSamples
+  Serialize.put c.samplingMode
+  Serialize.put c.bootstrapSamples
+  putFloat c.confidenceLevel
+  putFloat c.significanceLevel
+  putFloat c.noiseThreshold
+  Serialize.put c.serde
+  putU8 (if c.oneShot then 1 else 0)
+  putU8 (if c.report then 1 else 0)
+  Serialize.put c.throughput
+  putU8 (if c.avgThroughput then 1 else 0)
+  Serialize.put c.verbosity
+
+def getConfig : GetM Config := do
+  let warmupTime ← getFloat
+  let sampleTime ← getFloat
+  let numSamples : Nat ← Serialize.get
+  let samplingMode ← getSamplingMode
+  let bootstrapSamples : Nat ← Serialize.get
+  let confidenceLevel ← getFloat
+  let significanceLevel ← getFloat
+  let noiseThreshold ← getFloat
+  let serde ← getSerdeFormat
+  let oneShot ← (· != 0) <$> getU8
+  let report ← (· != 0) <$> getU8
+  let throughput : Option Throughput ← Serialize.get
+  let avgThroughput ← (· != 0) <$> getU8
+  let verbosity ← getVerbosity
+  return {
+    warmupTime, sampleTime, numSamples, samplingMode, bootstrapSamples,
+    confidenceLevel, significanceLevel, noiseThreshold, serde,
+    oneShot, report, throughput, avgThroughput, verbosity
+  }
+
+instance : Serialize Config where
+  put := putConfig
+  get := getConfig
+
+def putOneShot (os : OneShot) : PutM Unit := do
+  Serialize.put os.benchTime
+  match os.throughput with
+  | none => putU8 0
+  | some t => putU8 1; putThroughput t
+
 def getOneShot: GetM OneShot := do
-  return { benchTime := (← Serialize.get) }
+  let benchTime : Nat ← Serialize.get
+  let tag ← getU8
+  let throughput ← match tag with
+    | 0 => pure none
+    | 1 => pure (some (← getThroughput))
+    | _ => throw s!"invalid OneShot throughput flag {tag}"
+  return { benchTime, throughput }
 
 instance : Serialize OneShot where
-  put os := Serialize.put os.benchTime
+  put := putOneShot
   get := getOneShot
 
 /-- Writes JSON to disk at `benchPath/fileName` -/

--- a/Ix/Benchmark/Serde.lean
+++ b/Ix/Benchmark/Serde.lean
@@ -228,10 +228,9 @@ def putConfig (c : Config) : PutM Unit := do
   putFloat c.noiseThreshold
   Serialize.put c.serde
   putU8 (if c.oneShot then 1 else 0)
-  putU8 (if c.report then 1 else 0)
   Serialize.put c.throughput
   putU8 (if c.avgThroughput then 1 else 0)
-  -- `verbosity`, `color`, and `overwrite` are runtime display preferences, not persisted.
+  -- `report`, `verbosity`, and `overwrite` are runtime display preferences, not persisted.
 
 def getConfig : GetM Config := do
   let warmupTime ← getFloat
@@ -244,13 +243,12 @@ def getConfig : GetM Config := do
   let noiseThreshold ← getFloat
   let serde ← getSerdeFormat
   let oneShot ← (· != 0) <$> getU8
-  let report ← (· != 0) <$> getU8
   let throughput : Option Throughput ← Serialize.get
   let avgThroughput ← (· != 0) <$> getU8
   return {
     warmupTime, sampleTime, numSamples, samplingMode, bootstrapSamples,
     confidenceLevel, significanceLevel, noiseThreshold, serde,
-    oneShot, report, throughput, avgThroughput
+    oneShot, throughput, avgThroughput
   }
 
 instance : Serialize Config where

--- a/Ix/Benchmark/Serde.lean
+++ b/Ix/Benchmark/Serde.lean
@@ -231,7 +231,7 @@ def putConfig (c : Config) : PutM Unit := do
   putU8 (if c.report then 1 else 0)
   Serialize.put c.throughput
   putU8 (if c.avgThroughput then 1 else 0)
-  Serialize.put c.verbosity
+  -- `verbosity`, `color`, and `overwrite` are runtime display preferences, not persisted.
 
 def getConfig : GetM Config := do
   let warmupTime ← getFloat
@@ -247,11 +247,10 @@ def getConfig : GetM Config := do
   let report ← (· != 0) <$> getU8
   let throughput : Option Throughput ← Serialize.get
   let avgThroughput ← (· != 0) <$> getU8
-  let verbosity ← getVerbosity
   return {
     warmupTime, sampleTime, numSamples, samplingMode, bootstrapSamples,
     confidenceLevel, significanceLevel, noiseThreshold, serde,
-    oneShot, report, throughput, avgThroughput, verbosity
+    oneShot, report, throughput, avgThroughput
   }
 
 instance : Serialize Config where

--- a/Ix/Benchmark/Tukey.lean
+++ b/Ix/Benchmark/Tukey.lean
@@ -17,8 +17,7 @@ def Outliers.getTotal (o : Outliers) : Nat :=
   o.highSevere + o.highMild + o.lowMild + o.lowSevere
 
 /-- Classifies each sample in `data` by the Tukey-fence technique (1.5×IQR / 3×IQR)
-    and returns an `Outliers` record. Pure — does no IO. Matches Haskell
-    criterion's `classifyOutliers`. -/
+    and returns an `Outliers` record. -/
 def Distribution.classifyOutliers (data : Distribution) : Outliers := Id.run do
   let upper := (data.percentile? 75).get!
   let lower := (data.percentile? 25).get!
@@ -39,13 +38,12 @@ def Distribution.classifyOutliers (data : Distribution) : Outliers := Id.run do
         out := { out with outliers := elem :: out.outliers, highMild := out.highMild + 1 }
   return out
 
-/-- Prints the Tukey outlier breakdown to stdout, matching criterion.rs's
-    format (yellow header, uncolored sub-lines). -/
-def Outliers.note (out : Outliers) (totalSamples : Nat) (style : CliStyle) : IO Unit := do
+/-- Prints the Tukey outlier breakdown to stdout -/
+def Outliers.note (out : Outliers) (totalSamples : Nat) : IO Unit := do
   let outLength := out.outliers.length
   if outLength > 0 then
     let pctTotal := Float.ofNat outLength / (Float.ofNat totalSamples) * 100
-    IO.println (style.yellow s!"Found {outLength} outliers among {totalSamples} measurements ({pctTotal.floatPretty 2}%)")
+    IO.println (Ansi.yellow s!"Found {outLength} outliers among {totalSamples} measurements ({pctTotal.floatPretty 2}%)")
     if out.lowSevere > 0 then
       let pct := Float.ofNat out.lowSevere / (Float.ofNat totalSamples) * 100
       IO.println s!"  {out.lowSevere} ({pct.floatPretty 2}%) low severe"

--- a/Ix/Benchmark/Tukey.lean
+++ b/Ix/Benchmark/Tukey.lean
@@ -1,5 +1,6 @@
 module
 public import Ix.Benchmark.Distribution
+public import Ix.Benchmark.Ansi
 
 public section
 
@@ -38,23 +39,24 @@ def Distribution.classifyOutliers (data : Distribution) : Outliers := Id.run do
         out := { out with outliers := elem :: out.outliers, highMild := out.highMild + 1 }
   return out
 
-/-- Prints the Tukey outlier breakdown to stdout. Called conditionally by
-    `bgroup` based on the verbosity level and the outlier-variance severity. -/
-def Outliers.note (out : Outliers) (totalSamples : Nat) (indent : String := "") : IO Unit := do
+/-- Prints the Tukey outlier breakdown to stdout, matching criterion.rs's
+    format (yellow header, uncolored sub-lines). -/
+def Outliers.note (out : Outliers) (totalSamples : Nat) (style : CliStyle) : IO Unit := do
   let outLength := out.outliers.length
   if outLength > 0 then
-    IO.println s!"{indent}Found {outLength} outliers among {totalSamples} measurements"
-    if out.lowMild > 0 then
-      let pct := Float.ofNat out.lowMild / (Float.ofNat totalSamples) * 100
-      IO.println s!"{indent}  {out.lowMild} ({pct.floatPretty 2}%) low mild"
+    let pctTotal := Float.ofNat outLength / (Float.ofNat totalSamples) * 100
+    IO.println (style.yellow s!"Found {outLength} outliers among {totalSamples} measurements ({pctTotal.floatPretty 2}%)")
     if out.lowSevere > 0 then
       let pct := Float.ofNat out.lowSevere / (Float.ofNat totalSamples) * 100
-      IO.println s!"{indent}  {out.lowSevere} ({pct.floatPretty 2}%) low severe"
+      IO.println s!"  {out.lowSevere} ({pct.floatPretty 2}%) low severe"
+    if out.lowMild > 0 then
+      let pct := Float.ofNat out.lowMild / (Float.ofNat totalSamples) * 100
+      IO.println s!"  {out.lowMild} ({pct.floatPretty 2}%) low mild"
     if out.highMild > 0 then
       let pct := Float.ofNat out.highMild / (Float.ofNat totalSamples) * 100
-      IO.println s!"{indent}  {out.highMild} ({pct.floatPretty 2}%) high mild"
+      IO.println s!"  {out.highMild} ({pct.floatPretty 2}%) high mild"
     if out.highSevere > 0 then
       let pct := Float.ofNat out.highSevere / (Float.ofNat totalSamples) * 100
-      IO.println s!"{indent}  {out.highSevere} ({pct.floatPretty 2}%) high severe"
+      IO.println s!"  {out.highSevere} ({pct.floatPretty 2}%) high severe"
 
 end

--- a/Ix/Benchmark/Tukey.lean
+++ b/Ix/Benchmark/Tukey.lean
@@ -10,13 +10,15 @@ structure Outliers where
   highMild : Nat
   lowMild : Nat
   lowSevere : Nat
-  deriving Repr
+  deriving Repr, Lean.ToJson, Lean.FromJson
 
 def Outliers.getTotal (o : Outliers) : Nat :=
   o.highSevere + o.highMild + o.lowMild + o.lowSevere
 
--- TODO: Refactor to cut down verbosity, and return the list for plotting
-def Distribution.tukey (data : Distribution) : IO Unit := do
+/-- Classifies each sample in `data` by the Tukey-fence technique (1.5×IQR / 3×IQR)
+    and returns an `Outliers` record. Pure — does no IO. Matches Haskell
+    criterion's `classifyOutliers`. -/
+def Distribution.classifyOutliers (data : Distribution) : Outliers := Id.run do
   let upper := (data.percentile? 75).get!
   let lower := (data.percentile? 25).get!
   let iqr := upper - lower
@@ -34,21 +36,25 @@ def Distribution.tukey (data : Distribution) : IO Unit := do
         out := { out with outliers := elem :: out.outliers, highSevere := out.highSevere + 1 }
       else
         out := { out with outliers := elem :: out.outliers, highMild := out.highMild + 1 }
+  return out
+
+/-- Prints the Tukey outlier breakdown to stdout. Called conditionally by
+    `bgroup` based on the verbosity level and the outlier-variance severity. -/
+def Outliers.note (out : Outliers) (totalSamples : Nat) (indent : String := "") : IO Unit := do
   let outLength := out.outliers.length
   if outLength > 0 then
-    let samples := data.d.size
-    IO.println s!"Found {outLength} outliers among {samples} measurements"
+    IO.println s!"{indent}Found {outLength} outliers among {totalSamples} measurements"
     if out.lowMild > 0 then
-      let pct := Float.ofNat out.lowMild / (Float.ofNat samples) * 100
-      IO.println s!"  {out.lowMild} ({pct.floatPretty 2}%) low mild"
+      let pct := Float.ofNat out.lowMild / (Float.ofNat totalSamples) * 100
+      IO.println s!"{indent}  {out.lowMild} ({pct.floatPretty 2}%) low mild"
     if out.lowSevere > 0 then
-      let pct := Float.ofNat out.lowSevere / (Float.ofNat samples) * 100
-      IO.println s!"  {out.lowSevere} ({pct.floatPretty 2}%) low severe"
+      let pct := Float.ofNat out.lowSevere / (Float.ofNat totalSamples) * 100
+      IO.println s!"{indent}  {out.lowSevere} ({pct.floatPretty 2}%) low severe"
     if out.highMild > 0 then
-      let pct := Float.ofNat out.highMild / (Float.ofNat samples) * 100
-      IO.println s!"  {out.highMild} ({pct.floatPretty 2}%) high mild"
+      let pct := Float.ofNat out.highMild / (Float.ofNat totalSamples) * 100
+      IO.println s!"{indent}  {out.highMild} ({pct.floatPretty 2}%) high mild"
     if out.highSevere > 0 then
-      let pct := Float.ofNat out.highSevere / (Float.ofNat samples) * 100
-      IO.println s!"  {out.highSevere} ({pct.floatPretty 2}%) high severe"
+      let pct := Float.ofNat out.highSevere / (Float.ofNat totalSamples) * 100
+      IO.println s!"{indent}  {out.highSevere} ({pct.floatPretty 2}%) high severe"
 
 end


### PR DESCRIPTION
This PR makes several improvements to the Benchmark.lean library:

- Adds throughput tracking per benchmark, which required creating a `BgroupM` state monad so we can thread the input sizes through to each benchmark. This also cleans up the UX so you can run any custom logic around/between bench calls in a `do` block instead of pushing each bench to an array.
- Adds R^2 regression analysis and outlier variance detection based on https://github.com/haskell/criterion, which isn't present in https://github.com/criterion-rs/criterion.rs but gives additional metrics for user confidence.
- Decreases the default bootstrap sample count from 100k (used in criterion.rs) to 10k. 10k resamples is sufficient for stable confidence interval estimates at the default sample size of 100 or similar, and the 10x reduction in analysis time (5s->.5s, where criterion.rs is also about .5s) is a meaningful UX improvement.
- Adds an `Ansi.lean` color-printing module, and fully replicates the pretty-printed console output of criterion.rs.
- Factors out display/reporting logic from `Bench.lean` into `Report.lean`.