### PR TITLE
chore: Update lean-ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=600320b1a9f058ebcd07d9e1a50c6d84bdf94e62#600320b1a9f058ebcd07d9e1a50c6d84bdf94e62"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=fc7c979716f7177c1c43da68c3bdce4a698029b3#fc7c979716f7177c1c43da68c3bdce4a698029b3"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=85187ff86de7fe12b274c564d7b2f433fcda4ddf#85187ff86de7fe12b274c564d7b2f433fcda4ddf"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=345b21087878da46a5a7d4c47e4b6e4e86ee27a6#345b21087878da46a5a7d4c47e4b6e4e86ee27a6"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=8da54955beec1c3565c58467b1f98c8d2a91a18c#8da54955beec1c3565c58467b1f98c8d2a91a18c"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=e931b7a9108a02208776d07312ff66a4f56cfdf9#e931b7a9108a02208776d07312ff66a4f56cfdf9"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=ad4629e1c3e42e0b519dbfda70f331b597a3d580#ad4629e1c3e42e0b519dbfda70f331b597a3d580"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=87bbd8d66f03f5d022e440adf04d6e0ed3dbcf1c#87bbd8d66f03f5d022e440adf04d6e0ed3dbcf1c"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=7d00b4529ce34ca7c9d6732c78b98460d2e34116#7d00b4529ce34ca7c9d6732c78b98460d2e34116"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=600320b1a9f058ebcd07d9e1a50c6d84bdf94e62#600320b1a9f058ebcd07d9e1a50c6d84bdf94e62"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=460d7986a603552bca9b24b25e37683dbca04447#460d7986a603552bca9b24b25e37683dbca04447"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=8da54955beec1c3565c58467b1f98c8d2a91a18c#8da54955beec1c3565c58467b1f98c8d2a91a18c"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=87bbd8d66f03f5d022e440adf04d6e0ed3dbcf1c#87bbd8d66f03f5d022e440adf04d6e0ed3dbcf1c"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=85187ff86de7fe12b274c564d7b2f433fcda4ddf#85187ff86de7fe12b274c564d7b2f433fcda4ddf"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=e931b7a9108a02208776d07312ff66a4f56cfdf9#e931b7a9108a02208776d07312ff66a4f56cfdf9"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=7d00b4529ce34ca7c9d6732c78b98460d2e34116#7d00b4529ce34ca7c9d6732c78b98460d2e34116"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=2ee6267354ce460a8dd95ae9f087cc2569a90ad6#2ee6267354ce460a8dd95ae9f087cc2569a90ad6"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=460d7986a603552bca9b24b25e37683dbca04447#460d7986a603552bca9b24b25e37683dbca04447"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "lean-ffi"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/lean-ffi?rev=fc7c979716f7177c1c43da68c3bdce4a698029b3#fc7c979716f7177c1c43da68c3bdce4a698029b3"
+source = "git+https://github.com/argumentcomputer/lean-ffi?rev=ad4629e1c3e42e0b519dbfda70f331b597a3d580#ad4629e1c3e42e0b519dbfda70f331b597a3d580"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "87bbd8d66f03f5d022e440adf04d6e0ed3dbcf1c" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "85187ff86de7fe12b274c564d7b2f433fcda4ddf" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "e931b7a9108a02208776d07312ff66a4f56cfdf9" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "7d00b4529ce34ca7c9d6732c78b98460d2e34116" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "600320b1a9f058ebcd07d9e1a50c6d84bdf94e62" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "fc7c979716f7177c1c43da68c3bdce4a698029b3" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "8da54955beec1c3565c58467b1f98c8d2a91a18c" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "e931b7a9108a02208776d07312ff66a4f56cfdf9" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "ad4629e1c3e42e0b519dbfda70f331b597a3d580" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "87bbd8d66f03f5d022e440adf04d6e0ed3dbcf1c" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "2ee6267354ce460a8dd95ae9f087cc2569a90ad6" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "460d7986a603552bca9b24b25e37683dbca04447" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "7d00b4529ce34ca7c9d6732c78b98460d2e34116" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "600320b1a9f058ebcd07d9e1a50c6d84bdf94e62" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "fc7c979716f7177c1c43da68c3bdce4a698029b3" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "ad4629e1c3e42e0b519dbfda70f331b597a3d580" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "460d7986a603552bca9b24b25e37683dbca04447" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "8da54955beec1c3565c58467b1f98c8d2a91a18c" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 blake3 = "1.8.3"
 itertools = "0.14.0"
 indexmap = { version = "2", features = ["rayon"] }
-lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "85187ff86de7fe12b274c564d7b2f433fcda4ddf" }
+lean-ffi = { git = "https://github.com/argumentcomputer/lean-ffi", rev = "345b21087878da46a5a7d4c47e4b6e4e86ee27a6" }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "a8a15ea6aa2890f9f60f32a6e0e5e66afc1535ff" }
 num-bigint = "0.4.6"
 rayon = "1"

--- a/src/ffi/aiur/protocol.rs
+++ b/src/ffi/aiur/protocol.rs
@@ -7,8 +7,8 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::sync::LazyLock;
 
 use lean_ffi::object::{
-  ExternalClass, LeanArray, LeanBorrowed, LeanByteArray, LeanCtor, LeanExcept,
-  LeanExternal, LeanNat, LeanOwned, LeanRef,
+  ExternalClass, LeanArray, LeanBorrowed, LeanByteArray, LeanExcept,
+  LeanExternal, LeanNat, LeanOwned, LeanProd, LeanRef,
 };
 
 use crate::{
@@ -128,12 +128,8 @@ extern "C" fn rs_aiur_toplevel_execute(
 
   let lean_io = build_lean_io_buffer(&io_buffer);
   // (Array G, (Array G × Array (Array G × IOKeyInfo), Array Nat))
-  let io_counts = LeanCtor::alloc(0, 2, 0);
-  io_counts.set(0, lean_io);
-  io_counts.set(1, lean_query_counts);
-  let result = LeanCtor::alloc(0, 2, 0);
-  result.set(0, build_g_array(&output));
-  result.set(1, io_counts);
+  let io_counts = LeanProd::new(lean_io, lean_query_counts);
+  let result = LeanProd::new(build_g_array(&output), io_counts);
   result.into()
 }
 
@@ -160,13 +156,9 @@ extern "C" fn rs_aiur_system_prove(
     LeanExternal::alloc(&AIUR_PROOF_CLASS, proof).into();
   let lean_io = build_lean_io_buffer(&io_buffer);
   // Proof × Array G × Array (Array G × IOKeyInfo)
-  let proof_io_tuple = LeanCtor::alloc(0, 2, 0);
-  proof_io_tuple.set(0, lean_proof);
-  proof_io_tuple.set(1, lean_io);
+  let proof_io_tuple = LeanProd::new(lean_proof, lean_io);
   // Array G × Proof × Array G × Array (Array G × IOKeyInfo)
-  let result = LeanCtor::alloc(0, 2, 0);
-  result.set(0, build_g_array(&claim));
-  result.set(1, proof_io_tuple);
+  let result = LeanProd::new(build_g_array(&claim), proof_io_tuple);
   result.into()
 }
 
@@ -199,19 +191,16 @@ fn build_lean_io_buffer(io_buffer: &IOBuffer) -> LeanOwned {
     let arr = LeanArray::alloc(io_buffer.map.len());
     for (i, (key, info)) in io_buffer.map.iter().enumerate() {
       let key_arr = build_g_array(key);
-      let key_info = LeanCtor::alloc(0, 2, 0);
-      key_info.set(0, LeanOwned::box_usize(info.idx));
-      key_info.set(1, LeanOwned::box_usize(info.len));
-      let map_elt = LeanCtor::alloc(0, 2, 0);
-      map_elt.set(0, key_arr);
-      map_elt.set(1, key_info);
+      let key_info = LeanProd::new(
+        LeanOwned::box_usize(info.idx),
+        LeanOwned::box_usize(info.len),
+      );
+      let map_elt = LeanProd::new(key_arr, key_info);
       arr.set(i, map_elt);
     }
     arr
   };
-  let io_tuple = LeanCtor::alloc(0, 2, 0);
-  io_tuple.set(0, lean_io_data);
-  io_tuple.set(1, lean_io_map);
+  let io_tuple = LeanProd::new(lean_io_data, lean_io_map);
   io_tuple.into()
 }
 

--- a/src/ffi/aiur/toplevel.rs
+++ b/src/ffi/aiur/toplevel.rs
@@ -1,6 +1,6 @@
 use multi_stark::p3_field::PrimeCharacteristicRing;
 
-use lean_ffi::object::{LeanBorrowed, LeanCtor, LeanCtorScalar, LeanRef};
+use lean_ffi::object::{LeanBorrowed, LeanCtor, LeanRef};
 
 use crate::lean::LeanAiurFunction;
 
@@ -233,12 +233,11 @@ fn decode_function_layout(ctor: LeanCtor<LeanBorrowed<'_>>) -> FunctionLayout {
 }
 
 fn decode_function(ctor: LeanCtor<LeanBorrowed<'_>>) -> Function {
-  let [body_obj, layout_obj] = ctor.objs::<2>();
-  let body = decode_block(body_obj.as_ctor());
-  let layout = decode_function_layout(layout_obj.as_ctor());
-  let func = LeanAiurFunction::from_ctor(ctor);
-  let entry = func.get_num_8(0) != 0;
-  let constrained = func.get_num_8(1) != 0;
+  let ctor = LeanAiurFunction::from_ctor(ctor);
+  let body = decode_block(ctor.get_obj(0).as_ctor());
+  let layout = decode_function_layout(ctor.get_obj(1).as_ctor());
+  let entry = ctor.get_num_8(0) != 0;
+  let constrained = ctor.get_num_8(1) != 0;
   Function { body, layout, entry, constrained }
 }
 

--- a/src/ffi/aiur/toplevel.rs
+++ b/src/ffi/aiur/toplevel.rs
@@ -2,6 +2,8 @@ use multi_stark::p3_field::PrimeCharacteristicRing;
 
 use lean_ffi::object::{LeanBorrowed, LeanCtor, LeanRef};
 
+use lean_ffi::object::scalar_base;
+
 use crate::{
   FxIndexMap,
   aiur::{
@@ -234,7 +236,9 @@ fn decode_function(ctor: LeanCtor<LeanBorrowed<'_>>) -> Function {
   let [body_obj, layout_obj] = ctor.objs::<2>();
   let body = decode_block(body_obj.as_ctor());
   let layout = decode_function_layout(layout_obj.as_ctor());
-  let [entry, constrained] = ctor.get_scalars::<2, bool>(ctor.scalar_base(0));
+  let s = scalar_base(&ctor, 0);
+  let entry = ctor.get_bool(s);
+  let constrained = ctor.get_bool(s + 1);
   Function { body, layout, entry, constrained }
 }
 

--- a/src/ffi/aiur/toplevel.rs
+++ b/src/ffi/aiur/toplevel.rs
@@ -1,8 +1,8 @@
 use multi_stark::p3_field::PrimeCharacteristicRing;
 
-use lean_ffi::object::{LeanBorrowed, LeanCtor, LeanRef};
+use lean_ffi::object::{LeanBorrowed, LeanCtor, LeanCtorScalar, LeanRef};
 
-use lean_ffi::object::scalar_base;
+use crate::lean::LeanAiurFunction;
 
 use crate::{
   FxIndexMap,
@@ -236,9 +236,9 @@ fn decode_function(ctor: LeanCtor<LeanBorrowed<'_>>) -> Function {
   let [body_obj, layout_obj] = ctor.objs::<2>();
   let body = decode_block(body_obj.as_ctor());
   let layout = decode_function_layout(layout_obj.as_ctor());
-  let s = scalar_base(&ctor, 0);
-  let entry = ctor.get_bool(s);
-  let constrained = ctor.get_bool(s + 1);
+  let func = LeanAiurFunction::from_ctor(ctor);
+  let entry = func.get_num_8(0) != 0;
+  let constrained = func.get_num_8(1) != 0;
   Function { body, layout, entry, constrained }
 }
 

--- a/src/ffi/aiur/toplevel.rs
+++ b/src/ffi/aiur/toplevel.rs
@@ -231,11 +231,10 @@ fn decode_function_layout(ctor: LeanCtor<LeanBorrowed<'_>>) -> FunctionLayout {
 }
 
 fn decode_function(ctor: LeanCtor<LeanBorrowed<'_>>) -> Function {
-  let [body_obj, layout_obj, packed_bools] = ctor.objs();
+  let [body_obj, layout_obj] = ctor.objs::<2>();
   let body = decode_block(body_obj.as_ctor());
   let layout = decode_function_layout(layout_obj.as_ctor());
-  let [entry, constrained, ..] =
-    packed_bools.as_enum_tag().to_le_bytes().map(|u| u == 1);
+  let [entry, constrained] = ctor.get_bools::<2>(ctor.scalar_base(0));
   Function { body, layout, entry, constrained }
 }
 

--- a/src/ffi/aiur/toplevel.rs
+++ b/src/ffi/aiur/toplevel.rs
@@ -234,7 +234,7 @@ fn decode_function(ctor: LeanCtor<LeanBorrowed<'_>>) -> Function {
   let [body_obj, layout_obj] = ctor.objs::<2>();
   let body = decode_block(body_obj.as_ctor());
   let layout = decode_function_layout(layout_obj.as_ctor());
-  let [entry, constrained] = ctor.get_bools::<2>(ctor.scalar_base(0));
+  let [entry, constrained] = ctor.get_scalars::<2, bool>(ctor.scalar_base(0));
   Function { body, layout, entry, constrained }
 }
 

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -22,22 +22,10 @@ use crate::ix::ixon::constant::ConstantInfo;
 use crate::ix::ixon::expr::Expr as IxonExpr;
 use crate::ix::ixon::{Comm, ConstantMeta};
 use crate::lean::{
-  LeanIxBlock, LeanIxCompileError, LeanIxCompileErrorInvalidMutualBlock,
-  LeanIxCompileErrorMissingAddress, LeanIxCompileErrorMissingConstant,
-  LeanIxCompileErrorSerialize, LeanIxCompileErrorUnknownUnivParam,
-  LeanIxCompileErrorUnsupportedExpr, LeanIxCompilePhases,
-  LeanIxCondensedBlocks, LeanIxConstantInfo, LeanIxDecompileError,
-  LeanIxDecompileErrorBadBlobFormat, LeanIxDecompileErrorBadConstantFormat,
-  LeanIxDecompileErrorBlobNotFound, LeanIxDecompileErrorMissingAddress,
-  LeanIxDecompileErrorMissingMetadata, LeanIxDecompileErrorRecIndex,
-  LeanIxDecompileErrorRefIndex, LeanIxDecompileErrorSerialize,
-  LeanIxDecompileErrorShareIndex, LeanIxDecompileErrorUnivIndex,
-  LeanIxDecompileErrorUnivVarIndex, LeanIxName, LeanIxRawEnvironment,
-  LeanIxSerializeError, LeanIxSerializeErrorInvalidBool,
-  LeanIxSerializeErrorInvalidFlag, LeanIxSerializeErrorInvalidShareIndex,
-  LeanIxSerializeErrorInvalidTag, LeanIxSerializeErrorInvalidVariant,
-  LeanIxSerializeErrorUnexpectedEof, LeanIxonRawBlob, LeanIxonRawComm,
-  LeanIxonRawConst, LeanIxonRawEnv, LeanIxonRawNameEntry, LeanIxonRawNamed,
+  LeanIxBlock, LeanIxCompileError, LeanIxCompilePhases, LeanIxCondensedBlocks,
+  LeanIxConstantInfo, LeanIxDecompileError, LeanIxName, LeanIxRawEnvironment,
+  LeanIxSerializeError, LeanIxonRawBlob, LeanIxonRawComm, LeanIxonRawConst,
+  LeanIxonRawEnv, LeanIxonRawNameEntry, LeanIxonRawNamed,
 };
 use lean_ffi::nat::Nat;
 use lean_ffi::object::LeanIOResult;
@@ -59,10 +47,7 @@ use crate::ffi::lean_env::{GlobalCache, decode_name};
 #[cfg(feature = "test-ffi")]
 use crate::ix::ixon::serialize::put_expr;
 #[cfg(feature = "test-ffi")]
-use crate::lean::{
-  LeanIxBlockCompareDetail, LeanIxBlockCompareResult,
-  LeanIxBlockCompareResultMismatch,
-};
+use crate::lean::{LeanIxBlockCompareDetail, LeanIxBlockCompareResult};
 #[cfg(feature = "test-ffi")]
 use std::collections::HashMap;
 
@@ -127,11 +112,11 @@ pub extern "C" fn rs_roundtrip_rust_condensed_blocks(
   let blocks = ctor.get(1).to_owned_ref();
   let block_refs = ctor.get(2).to_owned_ref();
 
-  let result = LeanIxCondensedBlocks::alloc();
+  let result = LeanIxCondensedBlocks::alloc(0);
   result.set_obj(0, low_links);
   result.set_obj(1, blocks);
   result.set_obj(2, block_refs);
-  LeanIxCondensedBlocks::new(result.into())
+  result
 }
 
 /// Round-trip a RustCompilePhases structure.
@@ -145,11 +130,11 @@ pub extern "C" fn rs_roundtrip_rust_compile_phases(
   let condensed = ctor.get(1).to_owned_ref();
   let compile_env = ctor.get(2).to_owned_ref();
 
-  let result = LeanIxCompilePhases::alloc();
+  let result = LeanIxCompilePhases::alloc(0);
   result.set_obj(0, raw_env);
   result.set_obj(1, condensed);
   result.set_obj(2, compile_env);
-  LeanIxCompilePhases::new(result.into())
+  result
 }
 
 // =============================================================================
@@ -170,16 +155,15 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
   match ctor.tag() {
     1 => {
       // mismatch: 0 obj, 24 scalar bytes (3 × u64)
-      let ctor = LeanIxBlockCompareResultMismatch::from_ctor(ctor);
-      let lean_size = ctor.get_num_64(0);
-      let rust_size = ctor.get_num_64(1);
-      let first_diff = ctor.get_num_64(2);
+      let lean_size = obj.get_num_64(0);
+      let rust_size = obj.get_num_64(1);
+      let first_diff = obj.get_num_64(2);
 
-      let out = LeanIxBlockCompareResultMismatch::alloc();
+      let out = LeanIxBlockCompareResult::alloc(1);
       out.set_num_64(0, lean_size);
       out.set_num_64(1, rust_size);
       out.set_num_64(2, first_diff);
-      LeanIxBlockCompareResult::new(out.into())
+      out
     },
     _ => unreachable!("Invalid BlockCompareResult tag: {}", ctor.tag()),
   }
@@ -191,19 +175,17 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
 pub extern "C" fn rs_roundtrip_block_compare_detail(
   obj: LeanIxBlockCompareDetail<LeanBorrowed<'_>>,
 ) -> LeanIxBlockCompareDetail<LeanOwned> {
-  let ctor = LeanIxBlockCompareDetail::from_ctor(obj.as_ctor());
-  let lean_sharing_len = ctor.get_num_64(0);
-  let rust_sharing_len = ctor.get_num_64(1);
+  let lean_sharing_len = obj.get_num_64(0);
+  let rust_sharing_len = obj.get_num_64(1);
 
-  let result_obj = rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(
-    ctor.get_obj(0),
-  ));
+  let result_obj =
+    rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(obj.get_obj(0)));
 
-  let out = LeanIxBlockCompareDetail::alloc();
+  let out = LeanIxBlockCompareDetail::alloc(0);
   out.set_obj(0, result_obj);
   out.set_num_64(0, lean_sharing_len);
   out.set_num_64(1, rust_sharing_len);
-  LeanIxBlockCompareDetail::new(out.into())
+  out
 }
 
 // =============================================================================
@@ -270,7 +252,7 @@ pub extern "C" fn rs_compile_env_full(
       let ba = LeanByteArray::from_bytes(bytes);
 
       // Block: { name: Ix.Name, bytes: ByteArray, sharingLen: UInt64 }
-      let block = LeanIxBlock::alloc();
+      let block = LeanIxBlock::alloc(0);
       block.set_obj(0, name_obj);
       block.set_obj(1, ba);
       block.set_num_64(0, *sharing_len as u64);
@@ -296,7 +278,7 @@ pub extern "C" fn rs_compile_env_full(
     let compiled_obj = LeanProd::new(blocks_arr, name_to_addr_arr);
 
     // Build RustCompilationResult
-    let result = LeanIxCompilePhases::alloc();
+    let result = LeanIxCompilePhases::alloc(0);
     result.set_obj(0, raw_env);
     result.set_obj(1, condensed_obj);
     result.set_obj(2, compiled_obj);
@@ -430,14 +412,14 @@ pub extern "C" fn rs_compile_phases(
       names_arr.set(i, LeanIxonRawNameEntry::build(&mut cache, addr, name));
     }
 
-    let raw_ixon_env = LeanIxonRawEnv::alloc();
+    let raw_ixon_env = LeanIxonRawEnv::alloc(0);
     raw_ixon_env.set_obj(0, consts_arr);
     raw_ixon_env.set_obj(1, named_arr);
     raw_ixon_env.set_obj(2, blobs_arr);
     raw_ixon_env.set_obj(3, comms_arr);
     raw_ixon_env.set_obj(4, names_arr);
 
-    let result = LeanIxCompilePhases::alloc();
+    let result = LeanIxCompilePhases::alloc(0);
     result.set_obj(0, raw_env);
     result.set_obj(1, condensed_obj);
     result.set_obj(2, raw_ixon_env);
@@ -522,7 +504,7 @@ pub extern "C" fn rs_compile_env_to_ixon(
       names_arr.set(i, LeanIxonRawNameEntry::build(&mut cache, addr, name));
     }
 
-    let result = LeanIxonRawEnv::alloc();
+    let result = LeanIxonRawEnv::alloc(0);
     result.set_obj(0, consts_arr);
     result.set_obj(1, named_arr);
     result.set_obj(2, blobs_arr);
@@ -1083,44 +1065,43 @@ impl LeanIxSerializeError<LeanOwned> {
   ///   5: addressError → 0 obj + 0 scalar
   ///   6: invalidShareIndex (idx : UInt64) (max : Nat) → 1 obj (Nat) + 8 scalar (UInt64)
   pub fn build(se: &SerializeError) -> Self {
-    let obj = match se {
+    match se {
       SerializeError::UnexpectedEof { expected } => {
-        let ctor = LeanIxSerializeErrorUnexpectedEof::alloc();
+        let ctor = LeanIxSerializeError::alloc(0);
         ctor.set_obj(0, build_lean_string(expected));
-        ctor.into()
+        ctor
       },
       SerializeError::InvalidTag { tag, context } => {
-        let ctor = LeanIxSerializeErrorInvalidTag::alloc();
+        let ctor = LeanIxSerializeError::alloc(1);
         ctor.set_obj(0, build_lean_string(context));
         ctor.set_num_8(0, *tag);
-        ctor.into()
+        ctor
       },
       SerializeError::InvalidFlag { flag, context } => {
-        let ctor = LeanIxSerializeErrorInvalidFlag::alloc();
+        let ctor = LeanIxSerializeError::alloc(2);
         ctor.set_obj(0, build_lean_string(context));
         ctor.set_num_8(0, *flag);
-        ctor.into()
+        ctor
       },
       SerializeError::InvalidVariant { variant, context } => {
-        let ctor = LeanIxSerializeErrorInvalidVariant::alloc();
+        let ctor = LeanIxSerializeError::alloc(3);
         ctor.set_obj(0, build_lean_string(context));
         ctor.set_num_64(0, *variant);
-        ctor.into()
+        ctor
       },
       SerializeError::InvalidBool { value } => {
-        let ctor = LeanIxSerializeErrorInvalidBool::alloc();
+        let ctor = LeanIxSerializeError::alloc(4);
         ctor.set_num_8(0, *value);
-        ctor.into()
+        ctor
       },
-      SerializeError::AddressError => LeanOwned::box_usize(5),
+      SerializeError::AddressError => Self::new(LeanOwned::box_usize(5)),
       SerializeError::InvalidShareIndex { idx, max } => {
-        let ctor = LeanIxSerializeErrorInvalidShareIndex::alloc();
+        let ctor = LeanIxSerializeError::alloc(6);
         ctor.set_obj(0, build_lean_nat_usize(*max));
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -1140,36 +1121,31 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
         SerializeError::UnexpectedEof { expected }
       },
       1 => {
-        let ctor = LeanIxSerializeErrorInvalidTag::from_ctor(ctor);
-        let context = ctor.get_obj(0).as_string().to_string();
-        let tag_val = ctor.get_num_8(0);
+        let context = self.get_obj(0).as_string().to_string();
+        let tag_val = self.get_num_8(0);
         SerializeError::InvalidTag { tag: tag_val, context }
       },
       2 => {
-        let ctor = LeanIxSerializeErrorInvalidFlag::from_ctor(ctor);
-        let context = ctor.get_obj(0).as_string().to_string();
-        let flag = ctor.get_num_8(0);
+        let context = self.get_obj(0).as_string().to_string();
+        let flag = self.get_num_8(0);
         SerializeError::InvalidFlag { flag, context }
       },
       3 => {
-        let ctor = LeanIxSerializeErrorInvalidVariant::from_ctor(ctor);
-        let context = ctor.get_obj(0).as_string().to_string();
-        let variant = ctor.get_num_64(0);
+        let context = self.get_obj(0).as_string().to_string();
+        let variant = self.get_num_64(0);
         SerializeError::InvalidVariant { variant, context }
       },
       4 => {
-        let ctor = LeanIxSerializeErrorInvalidBool::from_ctor(ctor);
-        let value = ctor.get_num_8(0);
+        let value = self.get_num_8(0);
         SerializeError::InvalidBool { value }
       },
       5 => SerializeError::AddressError,
       6 => {
-        let ctor = LeanIxSerializeErrorInvalidShareIndex::from_ctor(ctor);
-        let max = Nat::from_obj(&ctor.get_obj(0))
+        let max = Nat::from_obj(&self.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let idx = ctor.get_num_64(0);
+        let idx = self.get_num_64(0);
         SerializeError::InvalidShareIndex { idx, max }
       },
       _ => unreachable!("Invalid SerializeError tag: {}", ctor.tag()),
@@ -1186,75 +1162,74 @@ impl LeanIxDecompileError<LeanOwned> {
   ///   → `lean_alloc_ctor(tag, 2, 8)`
   ///   → obj[0] = Nat, obj[1] = String, scalar[0] = UInt64
   pub fn build(err: &DecompileError) -> Self {
-    let obj = match err {
+    match err {
       DecompileError::InvalidRefIndex { idx, refs_len, constant } => {
-        let ctor = LeanIxDecompileErrorRefIndex::alloc();
+        let ctor = LeanIxDecompileError::alloc(0);
         ctor.set_obj(0, build_lean_nat_usize(*refs_len));
         ctor.set_obj(1, build_lean_string(constant));
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor
       },
       DecompileError::InvalidUnivIndex { idx, univs_len, constant } => {
-        let ctor = LeanIxDecompileErrorUnivIndex::alloc();
+        let ctor = LeanIxDecompileError::alloc(1);
         ctor.set_obj(0, build_lean_nat_usize(*univs_len));
         ctor.set_obj(1, build_lean_string(constant));
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor
       },
       DecompileError::InvalidShareIndex { idx, max, constant } => {
-        let ctor = LeanIxDecompileErrorShareIndex::alloc();
+        let ctor = LeanIxDecompileError::alloc(2);
         ctor.set_obj(0, build_lean_nat_usize(*max));
         ctor.set_obj(1, build_lean_string(constant));
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor
       },
       DecompileError::InvalidRecIndex { idx, ctx_size, constant } => {
-        let ctor = LeanIxDecompileErrorRecIndex::alloc();
+        let ctor = LeanIxDecompileError::alloc(3);
         ctor.set_obj(0, build_lean_nat_usize(*ctx_size));
         ctor.set_obj(1, build_lean_string(constant));
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor
       },
       DecompileError::InvalidUnivVarIndex { idx, max, constant } => {
-        let ctor = LeanIxDecompileErrorUnivVarIndex::alloc();
+        let ctor = LeanIxDecompileError::alloc(4);
         ctor.set_obj(0, build_lean_nat_usize(*max));
         ctor.set_obj(1, build_lean_string(constant));
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor
       },
       DecompileError::MissingAddress(addr) => {
-        let ctor = LeanIxDecompileErrorMissingAddress::alloc();
+        let ctor = LeanIxDecompileError::alloc(5);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       DecompileError::MissingMetadata(addr) => {
-        let ctor = LeanIxDecompileErrorMissingMetadata::alloc();
+        let ctor = LeanIxDecompileError::alloc(6);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       DecompileError::BlobNotFound(addr) => {
-        let ctor = LeanIxDecompileErrorBlobNotFound::alloc();
+        let ctor = LeanIxDecompileError::alloc(7);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       DecompileError::BadBlobFormat { addr, expected } => {
-        let ctor = LeanIxDecompileErrorBadBlobFormat::alloc();
+        let ctor = LeanIxDecompileError::alloc(8);
         ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.set_obj(1, build_lean_string(expected));
-        ctor.into()
+        ctor
       },
       DecompileError::BadConstantFormat { msg } => {
-        let ctor = LeanIxDecompileErrorBadConstantFormat::alloc();
+        let ctor = LeanIxDecompileError::alloc(9);
         ctor.set_obj(0, build_lean_string(msg));
-        ctor.into()
+        ctor
       },
       DecompileError::Serialize(se) => {
-        let ctor = LeanIxDecompileErrorSerialize::alloc();
+        let ctor = LeanIxDecompileError::alloc(10);
         ctor.set_obj(0, LeanIxSerializeError::build(se));
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -1264,53 +1239,48 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
     let ctor = self.as_ctor();
     match ctor.tag() {
       0 => {
-        let ctor = LeanIxDecompileErrorRefIndex::from_ctor(ctor);
-        let refs_len = Nat::from_obj(&ctor.get_obj(0))
+        let refs_len = Nat::from_obj(&self.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get_obj(1).as_string().to_string();
-        let idx = ctor.get_num_64(0);
+        let constant = self.get_obj(1).as_string().to_string();
+        let idx = self.get_num_64(0);
         DecompileError::InvalidRefIndex { idx, refs_len, constant }
       },
       1 => {
-        let ctor = LeanIxDecompileErrorUnivIndex::from_ctor(ctor);
-        let univs_len = Nat::from_obj(&ctor.get_obj(0))
+        let univs_len = Nat::from_obj(&self.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get_obj(1).as_string().to_string();
-        let idx = ctor.get_num_64(0);
+        let constant = self.get_obj(1).as_string().to_string();
+        let idx = self.get_num_64(0);
         DecompileError::InvalidUnivIndex { idx, univs_len, constant }
       },
       2 => {
-        let ctor = LeanIxDecompileErrorShareIndex::from_ctor(ctor);
-        let max = Nat::from_obj(&ctor.get_obj(0))
+        let max = Nat::from_obj(&self.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get_obj(1).as_string().to_string();
-        let idx = ctor.get_num_64(0);
+        let constant = self.get_obj(1).as_string().to_string();
+        let idx = self.get_num_64(0);
         DecompileError::InvalidShareIndex { idx, max, constant }
       },
       3 => {
-        let ctor = LeanIxDecompileErrorRecIndex::from_ctor(ctor);
-        let ctx_size = Nat::from_obj(&ctor.get_obj(0))
+        let ctx_size = Nat::from_obj(&self.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get_obj(1).as_string().to_string();
-        let idx = ctor.get_num_64(0);
+        let constant = self.get_obj(1).as_string().to_string();
+        let idx = self.get_num_64(0);
         DecompileError::InvalidRecIndex { idx, ctx_size, constant }
       },
       4 => {
-        let ctor = LeanIxDecompileErrorUnivVarIndex::from_ctor(ctor);
-        let max = Nat::from_obj(&ctor.get_obj(0))
+        let max = Nat::from_obj(&self.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get_obj(1).as_string().to_string();
-        let idx = ctor.get_num_64(0);
+        let constant = self.get_obj(1).as_string().to_string();
+        let idx = self.get_num_64(0);
         DecompileError::InvalidUnivVarIndex { idx, max, constant }
       },
       5 => DecompileError::MissingAddress(
@@ -1351,40 +1321,39 @@ impl LeanIxCompileError<LeanOwned> {
   ///   4: unknownUnivParam (curr param : String) → 2 obj
   ///   5: serializeError (msg : String) → 1 obj
   pub fn build(err: &CompileError) -> Self {
-    let obj = match err {
+    match err {
       CompileError::MissingConstant { name } => {
-        let ctor = LeanIxCompileErrorMissingConstant::alloc();
+        let ctor = LeanIxCompileError::alloc(0);
         ctor.set_obj(0, build_lean_string(name));
-        ctor.into()
+        ctor
       },
       CompileError::MissingAddress(addr) => {
-        let ctor = LeanIxCompileErrorMissingAddress::alloc();
+        let ctor = LeanIxCompileError::alloc(1);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       CompileError::InvalidMutualBlock { reason } => {
-        let ctor = LeanIxCompileErrorInvalidMutualBlock::alloc();
+        let ctor = LeanIxCompileError::alloc(2);
         ctor.set_obj(0, build_lean_string(reason));
-        ctor.into()
+        ctor
       },
       CompileError::UnsupportedExpr { desc } => {
-        let ctor = LeanIxCompileErrorUnsupportedExpr::alloc();
+        let ctor = LeanIxCompileError::alloc(3);
         ctor.set_obj(0, build_lean_string(desc));
-        ctor.into()
+        ctor
       },
       CompileError::UnknownUnivParam { curr, param } => {
-        let ctor = LeanIxCompileErrorUnknownUnivParam::alloc();
+        let ctor = LeanIxCompileError::alloc(4);
         ctor.set_obj(0, build_lean_string(curr));
         ctor.set_obj(1, build_lean_string(param));
-        ctor.into()
+        ctor
       },
       CompileError::Serialize(se) => {
-        let ctor = LeanIxCompileErrorSerialize::alloc();
+        let ctor = LeanIxCompileError::alloc(5);
         ctor.set_obj(0, LeanIxSerializeError::build(se));
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -34,6 +34,8 @@ use lean_ffi::object::{
   LeanOwned, LeanRef, LeanString,
 };
 
+use lean_ffi::object::scalar_base;
+
 use dashmap::DashMap;
 use dashmap::DashSet;
 
@@ -157,10 +159,16 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
   match ctor.tag() {
     1 => {
       // mismatch: 0 obj, 24 scalar bytes (3 × u64)
-      let vals = ctor.get_scalars::<3, u64>(ctor.scalar_base(0));
+      let s = scalar_base(&ctor, 0);
+      let v0 = ctor.get_u64(s);
+      let v1 = ctor.get_u64(s + 8);
+      let v2 = ctor.get_u64(s + 16);
 
       let out = LeanCtor::alloc(1, 0, 24);
-      out.set_scalars::<3, u64>(out.scalar_base(0), vals);
+      let s = scalar_base(&out, 0);
+      out.set_u64(s, v0);
+      out.set_u64(s + 8, v1);
+      out.set_u64(s + 16, v2);
       LeanIxBlockCompareResult::new(out.into())
     },
     _ => unreachable!("Invalid BlockCompareResult tag: {}", ctor.tag()),
@@ -169,24 +177,25 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
 
 /// Round-trip a BlockCompareDetail.
 #[cfg(feature = "test-ffi")]
+use lean_ffi::object::LeanCtorScalar;
+#[cfg(feature = "test-ffi")]
 #[unsafe(no_mangle)]
 pub extern "C" fn rs_roundtrip_block_compare_detail(
   obj: LeanIxBlockCompareDetail<LeanBorrowed<'_>>,
 ) -> LeanIxBlockCompareDetail<LeanOwned> {
-  let ctor = obj.as_ctor();
-  let [lean_sharing_len, rust_sharing_len] =
-    ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+  let lean_sharing_len = obj.get_64(0);
+  let rust_sharing_len = obj.get_64(1);
 
-  let result_obj =
-    rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(ctor.get(0)));
+  let result_obj = rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(
+    obj.as_ctor().get(0),
+  ));
 
   let out = LeanCtor::alloc(0, 1, 16);
   out.set(0, result_obj);
-  out.set_scalars::<2, u64>(
-    out.scalar_base(0),
-    [lean_sharing_len, rust_sharing_len],
-  );
-  LeanIxBlockCompareDetail::new(out.into())
+  let result = LeanIxBlockCompareDetail::new(out.into());
+  result.set_64(0, lean_sharing_len);
+  result.set_64(1, rust_sharing_len);
+  result
 }
 
 // =============================================================================
@@ -256,7 +265,7 @@ pub extern "C" fn rs_compile_env_full(
       let block = LeanCtor::alloc(0, 2, 8);
       block.set(0, name_obj);
       block.set(1, ba);
-      block.set_u64(block.scalar_base(0), *sharing_len as u64);
+      block.set_u64(scalar_base(&block, 0), *sharing_len as u64);
 
       blocks_arr.set(i, block);
     }
@@ -1080,31 +1089,31 @@ impl LeanIxSerializeError<LeanOwned> {
       SerializeError::InvalidTag { tag, context } => {
         let ctor = LeanCtor::alloc(1, 1, 1);
         ctor.set(0, build_lean_string(context));
-        ctor.set_u8(ctor.scalar_base(0), *tag);
+        ctor.set_u8(scalar_base(&ctor, 0), *tag);
         ctor.into()
       },
       SerializeError::InvalidFlag { flag, context } => {
         let ctor = LeanCtor::alloc(2, 1, 1);
         ctor.set(0, build_lean_string(context));
-        ctor.set_u8(ctor.scalar_base(0), *flag);
+        ctor.set_u8(scalar_base(&ctor, 0), *flag);
         ctor.into()
       },
       SerializeError::InvalidVariant { variant, context } => {
         let ctor = LeanCtor::alloc(3, 1, 8);
         ctor.set(0, build_lean_string(context));
-        ctor.set_u64(ctor.scalar_base(0), *variant);
+        ctor.set_u64(scalar_base(&ctor, 0), *variant);
         ctor.into()
       },
       SerializeError::InvalidBool { value } => {
         let ctor = LeanCtor::alloc(4, 0, 1);
-        ctor.set_u8(ctor.scalar_base(0), *value);
+        ctor.set_u8(scalar_base(&ctor, 0), *value);
         ctor.into()
       },
       SerializeError::AddressError => LeanOwned::box_usize(5),
       SerializeError::InvalidShareIndex { idx, max } => {
         let ctor = LeanCtor::alloc(6, 1, 8);
         ctor.set(0, build_lean_nat_usize(*max));
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
     };
@@ -1129,21 +1138,21 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
       },
       1 => {
         let context = ctor.get(0).as_string().to_string();
-        let tag_val = ctor.get_u8(ctor.scalar_base(0));
+        let tag_val = ctor.get_u8(scalar_base(&ctor, 0));
         SerializeError::InvalidTag { tag: tag_val, context }
       },
       2 => {
         let context = ctor.get(0).as_string().to_string();
-        let flag = ctor.get_u8(ctor.scalar_base(0));
+        let flag = ctor.get_u8(scalar_base(&ctor, 0));
         SerializeError::InvalidFlag { flag, context }
       },
       3 => {
         let context = ctor.get(0).as_string().to_string();
-        let variant = ctor.get_u64(ctor.scalar_base(0));
+        let variant = ctor.get_u64(scalar_base(&ctor, 0));
         SerializeError::InvalidVariant { variant, context }
       },
       4 => {
-        let value = ctor.get_u8(ctor.scalar_base(0));
+        let value = ctor.get_u8(scalar_base(&ctor, 0));
         SerializeError::InvalidBool { value }
       },
       5 => SerializeError::AddressError,
@@ -1152,7 +1161,7 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         SerializeError::InvalidShareIndex { idx, max }
       },
       _ => unreachable!("Invalid SerializeError tag: {}", ctor.tag()),
@@ -1174,35 +1183,35 @@ impl LeanIxDecompileError<LeanOwned> {
         let ctor = LeanCtor::alloc(0, 2, 8);
         ctor.set(0, build_lean_nat_usize(*refs_len));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       DecompileError::InvalidUnivIndex { idx, univs_len, constant } => {
         let ctor = LeanCtor::alloc(1, 2, 8);
         ctor.set(0, build_lean_nat_usize(*univs_len));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       DecompileError::InvalidShareIndex { idx, max, constant } => {
         let ctor = LeanCtor::alloc(2, 2, 8);
         ctor.set(0, build_lean_nat_usize(*max));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       DecompileError::InvalidRecIndex { idx, ctx_size, constant } => {
         let ctor = LeanCtor::alloc(3, 2, 8);
         ctor.set(0, build_lean_nat_usize(*ctx_size));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       DecompileError::InvalidUnivVarIndex { idx, max, constant } => {
         let ctor = LeanCtor::alloc(4, 2, 8);
         ctor.set(0, build_lean_nat_usize(*max));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       DecompileError::MissingAddress(addr) => {
@@ -1252,7 +1261,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         DecompileError::InvalidRefIndex { idx, refs_len, constant }
       },
       1 => {
@@ -1261,7 +1270,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         DecompileError::InvalidUnivIndex { idx, univs_len, constant }
       },
       2 => {
@@ -1270,7 +1279,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         DecompileError::InvalidShareIndex { idx, max, constant }
       },
       3 => {
@@ -1279,7 +1288,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         DecompileError::InvalidRecIndex { idx, ctx_size, constant }
       },
       4 => {
@@ -1288,7 +1297,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         DecompileError::InvalidUnivVarIndex { idx, max, constant }
       },
       5 => DecompileError::MissingAddress(

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -22,21 +22,28 @@ use crate::ix::ixon::constant::ConstantInfo;
 use crate::ix::ixon::expr::Expr as IxonExpr;
 use crate::ix::ixon::{Comm, ConstantMeta};
 use crate::lean::{
-  LeanIxCompileError, LeanIxCondensedBlocks, LeanIxConstantInfo,
-  LeanIxDecompileError, LeanIxDecompileErrorRecIndex,
-  LeanIxDecompileErrorRefIndex, LeanIxDecompileErrorShareIndex,
-  LeanIxDecompileErrorUnivIndex, LeanIxDecompileErrorUnivVarIndex, LeanIxName,
-  LeanIxRawEnvironment, LeanIxSerializeError, LeanIxSerializeErrorInvalidBool,
+  LeanIxBlock, LeanIxCompileError, LeanIxCompileErrorInvalidMutualBlock,
+  LeanIxCompileErrorMissingAddress, LeanIxCompileErrorMissingConstant,
+  LeanIxCompileErrorSerialize, LeanIxCompileErrorUnknownUnivParam,
+  LeanIxCompileErrorUnsupportedExpr, LeanIxCompilePhases,
+  LeanIxCondensedBlocks, LeanIxConstantInfo, LeanIxDecompileError,
+  LeanIxDecompileErrorBadBlobFormat, LeanIxDecompileErrorBadConstantFormat,
+  LeanIxDecompileErrorBlobNotFound, LeanIxDecompileErrorMissingAddress,
+  LeanIxDecompileErrorMissingMetadata, LeanIxDecompileErrorRecIndex,
+  LeanIxDecompileErrorRefIndex, LeanIxDecompileErrorSerialize,
+  LeanIxDecompileErrorShareIndex, LeanIxDecompileErrorUnivIndex,
+  LeanIxDecompileErrorUnivVarIndex, LeanIxName, LeanIxRawEnvironment,
+  LeanIxSerializeError, LeanIxSerializeErrorInvalidBool,
   LeanIxSerializeErrorInvalidFlag, LeanIxSerializeErrorInvalidShareIndex,
   LeanIxSerializeErrorInvalidTag, LeanIxSerializeErrorInvalidVariant,
-  LeanIxonRawBlob, LeanIxonRawComm, LeanIxonRawConst, LeanIxonRawEnv,
-  LeanIxonRawNameEntry, LeanIxonRawNamed,
+  LeanIxSerializeErrorUnexpectedEof, LeanIxonRawBlob, LeanIxonRawComm,
+  LeanIxonRawConst, LeanIxonRawEnv, LeanIxonRawNameEntry, LeanIxonRawNamed,
 };
 use lean_ffi::nat::Nat;
 use lean_ffi::object::LeanIOResult;
 use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanByteArray, LeanCtor, LeanCtorScalar, LeanExcept,
-  LeanList, LeanOwned, LeanRef, LeanString,
+  LeanArray, LeanBorrowed, LeanByteArray, LeanExcept, LeanList, LeanOwned,
+  LeanProd, LeanRef, LeanString,
 };
 
 use dashmap::DashMap;
@@ -51,11 +58,10 @@ use crate::lean::LeanIxAddress;
 use crate::ffi::lean_env::{GlobalCache, decode_name};
 #[cfg(feature = "test-ffi")]
 use crate::ix::ixon::serialize::put_expr;
-use crate::lean::LeanIxBlock;
 #[cfg(feature = "test-ffi")]
 use crate::lean::{
   LeanIxBlockCompareDetail, LeanIxBlockCompareResult,
-  LeanIxBlockCompareResultMismatch, LeanIxCompilePhases,
+  LeanIxBlockCompareResultMismatch,
 };
 #[cfg(feature = "test-ffi")]
 use std::collections::HashMap;
@@ -121,10 +127,10 @@ pub extern "C" fn rs_roundtrip_rust_condensed_blocks(
   let blocks = ctor.get(1).to_owned_ref();
   let block_refs = ctor.get(2).to_owned_ref();
 
-  let result = LeanCtor::alloc(0, 3, 0);
-  result.set(0, low_links);
-  result.set(1, blocks);
-  result.set(2, block_refs);
+  let result = LeanIxCondensedBlocks::alloc();
+  result.set_obj(0, low_links);
+  result.set_obj(1, blocks);
+  result.set_obj(2, block_refs);
   LeanIxCondensedBlocks::new(result.into())
 }
 
@@ -139,10 +145,10 @@ pub extern "C" fn rs_roundtrip_rust_compile_phases(
   let condensed = ctor.get(1).to_owned_ref();
   let compile_env = ctor.get(2).to_owned_ref();
 
-  let result = LeanCtor::alloc(0, 3, 0);
-  result.set(0, raw_env);
-  result.set(1, condensed);
-  result.set(2, compile_env);
+  let result = LeanIxCompilePhases::alloc();
+  result.set_obj(0, raw_env);
+  result.set_obj(1, condensed);
+  result.set_obj(2, compile_env);
   LeanIxCompilePhases::new(result.into())
 }
 
@@ -164,16 +170,16 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
   match ctor.tag() {
     1 => {
       // mismatch: 0 obj, 24 scalar bytes (3 × u64)
-      let src = LeanIxBlockCompareResultMismatch::from_ctor(ctor);
-      let v0 = src.get_num_64(0);
-      let v1 = src.get_num_64(1);
-      let v2 = src.get_num_64(2);
+      let ctor = LeanIxBlockCompareResultMismatch::from_ctor(ctor);
+      let lean_size = ctor.get_num_64(0);
+      let rust_size = ctor.get_num_64(1);
+      let first_diff = ctor.get_num_64(2);
 
-      let dst = LeanIxBlockCompareResultMismatch::alloc();
-      dst.set_num_64(0, v0);
-      dst.set_num_64(1, v1);
-      dst.set_num_64(2, v2);
-      LeanIxBlockCompareResult::new(dst.into())
+      let out = LeanIxBlockCompareResultMismatch::alloc();
+      out.set_num_64(0, lean_size);
+      out.set_num_64(1, rust_size);
+      out.set_num_64(2, first_diff);
+      LeanIxBlockCompareResult::new(out.into())
     },
     _ => unreachable!("Invalid BlockCompareResult tag: {}", ctor.tag()),
   }
@@ -185,18 +191,19 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
 pub extern "C" fn rs_roundtrip_block_compare_detail(
   obj: LeanIxBlockCompareDetail<LeanBorrowed<'_>>,
 ) -> LeanIxBlockCompareDetail<LeanOwned> {
-  let lean_sharing_len = obj.get_num_64(0);
-  let rust_sharing_len = obj.get_num_64(1);
+  let ctor = LeanIxBlockCompareDetail::from_ctor(obj.as_ctor());
+  let lean_sharing_len = ctor.get_num_64(0);
+  let rust_sharing_len = ctor.get_num_64(1);
 
   let result_obj = rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(
-    obj.as_ctor().get(0),
+    ctor.get_obj(0),
   ));
 
-  let ctor = LeanIxBlockCompareDetail::alloc();
-  ctor.set_obj(0, result_obj);
-  ctor.set_num_64(0, lean_sharing_len);
-  ctor.set_num_64(1, rust_sharing_len);
-  ctor
+  let out = LeanIxBlockCompareDetail::alloc();
+  out.set_obj(0, result_obj);
+  out.set_num_64(0, lean_sharing_len);
+  out.set_num_64(1, rust_sharing_len);
+  LeanIxBlockCompareDetail::new(out.into())
 }
 
 // =============================================================================
@@ -281,23 +288,18 @@ pub extern "C" fn rs_compile_env_full(
       let name_obj = LeanIxName::build(&mut cache, name);
       let addr_ba = LeanByteArray::from_bytes(addr.as_bytes());
 
-      let entry_obj = LeanCtor::alloc(0, 2, 0);
-      entry_obj.set(0, name_obj);
-      entry_obj.set(1, addr_ba);
-
+      let entry_obj = LeanProd::new(name_obj, addr_ba);
       name_to_addr_arr.set(i, entry_obj);
     }
 
     // Build RawCompiledEnv
-    let compiled_obj = LeanCtor::alloc(0, 2, 0);
-    compiled_obj.set(0, blocks_arr);
-    compiled_obj.set(1, name_to_addr_arr);
+    let compiled_obj = LeanProd::new(blocks_arr, name_to_addr_arr);
 
     // Build RustCompilationResult
-    let result = LeanCtor::alloc(0, 3, 0);
-    result.set(0, raw_env);
-    result.set(1, condensed_obj);
-    result.set(2, compiled_obj);
+    let result = LeanIxCompilePhases::alloc();
+    result.set_obj(0, raw_env);
+    result.set_obj(1, condensed_obj);
+    result.set_obj(2, compiled_obj);
 
     LeanIOResult::ok(result)
   }
@@ -428,17 +430,17 @@ pub extern "C" fn rs_compile_phases(
       names_arr.set(i, LeanIxonRawNameEntry::build(&mut cache, addr, name));
     }
 
-    let raw_ixon_env = LeanCtor::alloc(0, 5, 0);
-    raw_ixon_env.set(0, consts_arr);
-    raw_ixon_env.set(1, named_arr);
-    raw_ixon_env.set(2, blobs_arr);
-    raw_ixon_env.set(3, comms_arr);
-    raw_ixon_env.set(4, names_arr);
+    let raw_ixon_env = LeanIxonRawEnv::alloc();
+    raw_ixon_env.set_obj(0, consts_arr);
+    raw_ixon_env.set_obj(1, named_arr);
+    raw_ixon_env.set_obj(2, blobs_arr);
+    raw_ixon_env.set_obj(3, comms_arr);
+    raw_ixon_env.set_obj(4, names_arr);
 
-    let result = LeanCtor::alloc(0, 3, 0);
-    result.set(0, raw_env);
-    result.set(1, condensed_obj);
-    result.set(2, raw_ixon_env);
+    let result = LeanIxCompilePhases::alloc();
+    result.set_obj(0, raw_env);
+    result.set_obj(1, condensed_obj);
+    result.set_obj(2, raw_ixon_env);
 
     LeanIOResult::ok(result)
   }
@@ -520,12 +522,12 @@ pub extern "C" fn rs_compile_env_to_ixon(
       names_arr.set(i, LeanIxonRawNameEntry::build(&mut cache, addr, name));
     }
 
-    let result = LeanCtor::alloc(0, 5, 0);
-    result.set(0, consts_arr);
-    result.set(1, named_arr);
-    result.set(2, blobs_arr);
-    result.set(3, comms_arr);
-    result.set(4, names_arr);
+    let result = LeanIxonRawEnv::alloc();
+    result.set_obj(0, consts_arr);
+    result.set_obj(1, named_arr);
+    result.set_obj(2, blobs_arr);
+    result.set_obj(3, comms_arr);
+    result.set_obj(4, names_arr);
     LeanIOResult::ok(result)
   }
 }
@@ -1083,8 +1085,8 @@ impl LeanIxSerializeError<LeanOwned> {
   pub fn build(se: &SerializeError) -> Self {
     let obj = match se {
       SerializeError::UnexpectedEof { expected } => {
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, build_lean_string(expected));
+        let ctor = LeanIxSerializeErrorUnexpectedEof::alloc();
+        ctor.set_obj(0, build_lean_string(expected));
         ctor.into()
       },
       SerializeError::InvalidTag { tag, context } => {
@@ -1139,31 +1141,36 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
       },
       1 => {
         let ctor = LeanIxSerializeErrorInvalidTag::from_ctor(ctor);
-        let context = ctor.as_ctor().get(0).as_string().to_string();
-        SerializeError::InvalidTag { tag: ctor.get_num_8(0), context }
+        let context = ctor.get_obj(0).as_string().to_string();
+        let tag_val = ctor.get_num_8(0);
+        SerializeError::InvalidTag { tag: tag_val, context }
       },
       2 => {
         let ctor = LeanIxSerializeErrorInvalidFlag::from_ctor(ctor);
-        let context = ctor.as_ctor().get(0).as_string().to_string();
-        SerializeError::InvalidFlag { flag: ctor.get_num_8(0), context }
+        let context = ctor.get_obj(0).as_string().to_string();
+        let flag = ctor.get_num_8(0);
+        SerializeError::InvalidFlag { flag, context }
       },
       3 => {
         let ctor = LeanIxSerializeErrorInvalidVariant::from_ctor(ctor);
-        let context = ctor.as_ctor().get(0).as_string().to_string();
-        SerializeError::InvalidVariant { variant: ctor.get_num_64(0), context }
+        let context = ctor.get_obj(0).as_string().to_string();
+        let variant = ctor.get_num_64(0);
+        SerializeError::InvalidVariant { variant, context }
       },
       4 => {
         let ctor = LeanIxSerializeErrorInvalidBool::from_ctor(ctor);
-        SerializeError::InvalidBool { value: ctor.get_num_8(0) }
+        let value = ctor.get_num_8(0);
+        SerializeError::InvalidBool { value }
       },
       5 => SerializeError::AddressError,
       6 => {
         let ctor = LeanIxSerializeErrorInvalidShareIndex::from_ctor(ctor);
-        let max = Nat::from_obj(&ctor.as_ctor().get(0))
+        let max = Nat::from_obj(&ctor.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        SerializeError::InvalidShareIndex { idx: ctor.get_num_64(0), max }
+        let idx = ctor.get_num_64(0);
+        SerializeError::InvalidShareIndex { idx, max }
       },
       _ => unreachable!("Invalid SerializeError tag: {}", ctor.tag()),
     }
@@ -1216,34 +1223,34 @@ impl LeanIxDecompileError<LeanOwned> {
         ctor.into()
       },
       DecompileError::MissingAddress(addr) => {
-        let ctor = LeanCtor::alloc(5, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxDecompileErrorMissingAddress::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       DecompileError::MissingMetadata(addr) => {
-        let ctor = LeanCtor::alloc(6, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxDecompileErrorMissingMetadata::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       DecompileError::BlobNotFound(addr) => {
-        let ctor = LeanCtor::alloc(7, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxDecompileErrorBlobNotFound::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       DecompileError::BadBlobFormat { addr, expected } => {
-        let ctor = LeanCtor::alloc(8, 2, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
-        ctor.set(1, build_lean_string(expected));
+        let ctor = LeanIxDecompileErrorBadBlobFormat::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
+        ctor.set_obj(1, build_lean_string(expected));
         ctor.into()
       },
       DecompileError::BadConstantFormat { msg } => {
-        let ctor = LeanCtor::alloc(9, 1, 0);
-        ctor.set(0, build_lean_string(msg));
+        let ctor = LeanIxDecompileErrorBadConstantFormat::alloc();
+        ctor.set_obj(0, build_lean_string(msg));
         ctor.into()
       },
       DecompileError::Serialize(se) => {
-        let ctor = LeanCtor::alloc(10, 1, 0);
-        ctor.set(0, LeanIxSerializeError::build(se));
+        let ctor = LeanIxDecompileErrorSerialize::alloc();
+        ctor.set_obj(0, LeanIxSerializeError::build(se));
         ctor.into()
       },
     };
@@ -1258,68 +1265,53 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
     match ctor.tag() {
       0 => {
         let ctor = LeanIxDecompileErrorRefIndex::from_ctor(ctor);
-        let refs_len = Nat::from_obj(&ctor.as_ctor().get(0))
+        let refs_len = Nat::from_obj(&ctor.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.as_ctor().get(1).as_string().to_string();
-        DecompileError::InvalidRefIndex {
-          idx: ctor.get_num_64(0),
-          refs_len,
-          constant,
-        }
+        let constant = ctor.get_obj(1).as_string().to_string();
+        let idx = ctor.get_num_64(0);
+        DecompileError::InvalidRefIndex { idx, refs_len, constant }
       },
       1 => {
         let ctor = LeanIxDecompileErrorUnivIndex::from_ctor(ctor);
-        let univs_len = Nat::from_obj(&ctor.as_ctor().get(0))
+        let univs_len = Nat::from_obj(&ctor.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.as_ctor().get(1).as_string().to_string();
-        DecompileError::InvalidUnivIndex {
-          idx: ctor.get_num_64(0),
-          univs_len,
-          constant,
-        }
+        let constant = ctor.get_obj(1).as_string().to_string();
+        let idx = ctor.get_num_64(0);
+        DecompileError::InvalidUnivIndex { idx, univs_len, constant }
       },
       2 => {
         let ctor = LeanIxDecompileErrorShareIndex::from_ctor(ctor);
-        let max = Nat::from_obj(&ctor.as_ctor().get(0))
+        let max = Nat::from_obj(&ctor.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.as_ctor().get(1).as_string().to_string();
-        DecompileError::InvalidShareIndex {
-          idx: ctor.get_num_64(0),
-          max,
-          constant,
-        }
+        let constant = ctor.get_obj(1).as_string().to_string();
+        let idx = ctor.get_num_64(0);
+        DecompileError::InvalidShareIndex { idx, max, constant }
       },
       3 => {
         let ctor = LeanIxDecompileErrorRecIndex::from_ctor(ctor);
-        let ctx_size = Nat::from_obj(&ctor.as_ctor().get(0))
+        let ctx_size = Nat::from_obj(&ctor.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.as_ctor().get(1).as_string().to_string();
-        DecompileError::InvalidRecIndex {
-          idx: ctor.get_num_64(0),
-          ctx_size,
-          constant,
-        }
+        let constant = ctor.get_obj(1).as_string().to_string();
+        let idx = ctor.get_num_64(0);
+        DecompileError::InvalidRecIndex { idx, ctx_size, constant }
       },
       4 => {
         let ctor = LeanIxDecompileErrorUnivVarIndex::from_ctor(ctor);
-        let max = Nat::from_obj(&ctor.as_ctor().get(0))
+        let max = Nat::from_obj(&ctor.get_obj(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.as_ctor().get(1).as_string().to_string();
-        DecompileError::InvalidUnivVarIndex {
-          idx: ctor.get_num_64(0),
-          max,
-          constant,
-        }
+        let constant = ctor.get_obj(1).as_string().to_string();
+        let idx = ctor.get_num_64(0);
+        DecompileError::InvalidUnivVarIndex { idx, max, constant }
       },
       5 => DecompileError::MissingAddress(
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
@@ -1361,34 +1353,34 @@ impl LeanIxCompileError<LeanOwned> {
   pub fn build(err: &CompileError) -> Self {
     let obj = match err {
       CompileError::MissingConstant { name } => {
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, build_lean_string(name));
+        let ctor = LeanIxCompileErrorMissingConstant::alloc();
+        ctor.set_obj(0, build_lean_string(name));
         ctor.into()
       },
       CompileError::MissingAddress(addr) => {
-        let ctor = LeanCtor::alloc(1, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxCompileErrorMissingAddress::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       CompileError::InvalidMutualBlock { reason } => {
-        let ctor = LeanCtor::alloc(2, 1, 0);
-        ctor.set(0, build_lean_string(reason));
+        let ctor = LeanIxCompileErrorInvalidMutualBlock::alloc();
+        ctor.set_obj(0, build_lean_string(reason));
         ctor.into()
       },
       CompileError::UnsupportedExpr { desc } => {
-        let ctor = LeanCtor::alloc(3, 1, 0);
-        ctor.set(0, build_lean_string(desc));
+        let ctor = LeanIxCompileErrorUnsupportedExpr::alloc();
+        ctor.set_obj(0, build_lean_string(desc));
         ctor.into()
       },
       CompileError::UnknownUnivParam { curr, param } => {
-        let ctor = LeanCtor::alloc(4, 2, 0);
-        ctor.set(0, build_lean_string(curr));
-        ctor.set(1, build_lean_string(param));
+        let ctor = LeanIxCompileErrorUnknownUnivParam::alloc();
+        ctor.set_obj(0, build_lean_string(curr));
+        ctor.set_obj(1, build_lean_string(param));
         ctor.into()
       },
       CompileError::Serialize(se) => {
-        let ctor = LeanCtor::alloc(5, 1, 0);
-        ctor.set(0, LeanIxSerializeError::build(se));
+        let ctor = LeanIxCompileErrorSerialize::alloc();
+        ctor.set_obj(0, LeanIxSerializeError::build(se));
         ctor.into()
       },
     };
@@ -1486,9 +1478,7 @@ pub extern "C" fn rs_decompile_env(
       for (i, (name, info)) in entries.iter().enumerate() {
         let name_obj = LeanIxName::build(&mut cache, name);
         let info_obj = LeanIxConstantInfo::build(&mut cache, info);
-        let pair = LeanCtor::alloc(0, 2, 0);
-        pair.set(0, name_obj);
-        pair.set(1, info_obj);
+        let pair = LeanProd::new(name_obj, info_obj);
         arr.set(i, pair);
       }
 

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -157,14 +157,10 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
   match ctor.tag() {
     1 => {
       // mismatch: 0 obj, 24 scalar bytes (3 × u64)
-      let lean_size = ctor.get_u64(0, 0);
-      let rust_size = ctor.get_u64(0, 8);
-      let first_diff = ctor.get_u64(0, 16);
+      let vals = ctor.get_scalars::<3, u64>(ctor.scalar_base(0));
 
       let out = LeanCtor::alloc(1, 0, 24);
-      out.set_u64(0, 0, lean_size);
-      out.set_u64(0, 8, rust_size);
-      out.set_u64(0, 16, first_diff);
+      out.set_scalars::<3, u64>(out.scalar_base(0), vals);
       LeanIxBlockCompareResult::new(out.into())
     },
     _ => unreachable!("Invalid BlockCompareResult tag: {}", ctor.tag()),
@@ -178,16 +174,14 @@ pub extern "C" fn rs_roundtrip_block_compare_detail(
   obj: LeanIxBlockCompareDetail<LeanBorrowed<'_>>,
 ) -> LeanIxBlockCompareDetail<LeanOwned> {
   let ctor = obj.as_ctor();
-  let lean_sharing_len = ctor.get_u64(1, 0);
-  let rust_sharing_len = ctor.get_u64(1, 8);
+  let [lean_sharing_len, rust_sharing_len] = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
 
   let result_obj =
     rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(ctor.get(0)));
 
   let out = LeanCtor::alloc(0, 1, 16);
   out.set(0, result_obj);
-  out.set_u64(1, 0, lean_sharing_len);
-  out.set_u64(1, 8, rust_sharing_len);
+  out.set_scalars::<2, u64>(out.scalar_base(0), [lean_sharing_len, rust_sharing_len]);
   LeanIxBlockCompareDetail::new(out.into())
 }
 
@@ -258,7 +252,7 @@ pub extern "C" fn rs_compile_env_full(
       let block = LeanCtor::alloc(0, 2, 8);
       block.set(0, name_obj);
       block.set(1, ba);
-      block.set_u64(2, 0, *sharing_len as u64);
+      block.set_u64(block.scalar_base(0), *sharing_len as u64);
 
       blocks_arr.set(i, block);
     }
@@ -1082,31 +1076,31 @@ impl LeanIxSerializeError<LeanOwned> {
       SerializeError::InvalidTag { tag, context } => {
         let ctor = LeanCtor::alloc(1, 1, 1);
         ctor.set(0, build_lean_string(context));
-        ctor.set_u8(1, 0, *tag);
+        ctor.set_u8(ctor.scalar_base(0), *tag);
         ctor.into()
       },
       SerializeError::InvalidFlag { flag, context } => {
         let ctor = LeanCtor::alloc(2, 1, 1);
         ctor.set(0, build_lean_string(context));
-        ctor.set_u8(1, 0, *flag);
+        ctor.set_u8(ctor.scalar_base(0), *flag);
         ctor.into()
       },
       SerializeError::InvalidVariant { variant, context } => {
         let ctor = LeanCtor::alloc(3, 1, 8);
         ctor.set(0, build_lean_string(context));
-        ctor.set_u64(1, 0, *variant);
+        ctor.set_u64(ctor.scalar_base(0), *variant);
         ctor.into()
       },
       SerializeError::InvalidBool { value } => {
         let ctor = LeanCtor::alloc(4, 0, 1);
-        ctor.set_u8(0, 0, *value);
+        ctor.set_u8(ctor.scalar_base(0), *value);
         ctor.into()
       },
       SerializeError::AddressError => LeanOwned::box_usize(5),
       SerializeError::InvalidShareIndex { idx, max } => {
         let ctor = LeanCtor::alloc(6, 1, 8);
         ctor.set(0, build_lean_nat_usize(*max));
-        ctor.set_u64(1, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
     };
@@ -1131,21 +1125,21 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
       },
       1 => {
         let context = ctor.get(0).as_string().to_string();
-        let tag_val = ctor.get_u8(1, 0);
+        let tag_val = ctor.get_u8(ctor.scalar_base(0));
         SerializeError::InvalidTag { tag: tag_val, context }
       },
       2 => {
         let context = ctor.get(0).as_string().to_string();
-        let flag = ctor.get_u8(1, 0);
+        let flag = ctor.get_u8(ctor.scalar_base(0));
         SerializeError::InvalidFlag { flag, context }
       },
       3 => {
         let context = ctor.get(0).as_string().to_string();
-        let variant = ctor.get_u64(1, 0);
+        let variant = ctor.get_u64(ctor.scalar_base(0));
         SerializeError::InvalidVariant { variant, context }
       },
       4 => {
-        let value = ctor.get_u8(0, 0);
+        let value = ctor.get_u8(ctor.scalar_base(0));
         SerializeError::InvalidBool { value }
       },
       5 => SerializeError::AddressError,
@@ -1154,7 +1148,7 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let idx = ctor.get_u64(1, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         SerializeError::InvalidShareIndex { idx, max }
       },
       _ => unreachable!("Invalid SerializeError tag: {}", ctor.tag()),
@@ -1176,35 +1170,35 @@ impl LeanIxDecompileError<LeanOwned> {
         let ctor = LeanCtor::alloc(0, 2, 8);
         ctor.set(0, build_lean_nat_usize(*refs_len));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(2, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       DecompileError::InvalidUnivIndex { idx, univs_len, constant } => {
         let ctor = LeanCtor::alloc(1, 2, 8);
         ctor.set(0, build_lean_nat_usize(*univs_len));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(2, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       DecompileError::InvalidShareIndex { idx, max, constant } => {
         let ctor = LeanCtor::alloc(2, 2, 8);
         ctor.set(0, build_lean_nat_usize(*max));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(2, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       DecompileError::InvalidRecIndex { idx, ctx_size, constant } => {
         let ctor = LeanCtor::alloc(3, 2, 8);
         ctor.set(0, build_lean_nat_usize(*ctx_size));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(2, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       DecompileError::InvalidUnivVarIndex { idx, max, constant } => {
         let ctor = LeanCtor::alloc(4, 2, 8);
         ctor.set(0, build_lean_nat_usize(*max));
         ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(2, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       DecompileError::MissingAddress(addr) => {
@@ -1254,7 +1248,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(2, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         DecompileError::InvalidRefIndex { idx, refs_len, constant }
       },
       1 => {
@@ -1263,7 +1257,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(2, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         DecompileError::InvalidUnivIndex { idx, univs_len, constant }
       },
       2 => {
@@ -1272,7 +1266,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(2, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         DecompileError::InvalidShareIndex { idx, max, constant }
       },
       3 => {
@@ -1281,7 +1275,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(2, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         DecompileError::InvalidRecIndex { idx, ctx_size, constant }
       },
       4 => {
@@ -1290,7 +1284,7 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
         let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(2, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         DecompileError::InvalidUnivVarIndex { idx, max, constant }
       },
       5 => DecompileError::MissingAddress(

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -23,18 +23,21 @@ use crate::ix::ixon::expr::Expr as IxonExpr;
 use crate::ix::ixon::{Comm, ConstantMeta};
 use crate::lean::{
   LeanIxCompileError, LeanIxCondensedBlocks, LeanIxConstantInfo,
-  LeanIxDecompileError, LeanIxName, LeanIxRawEnvironment, LeanIxSerializeError,
+  LeanIxDecompileError, LeanIxDecompileErrorRecIndex,
+  LeanIxDecompileErrorRefIndex, LeanIxDecompileErrorShareIndex,
+  LeanIxDecompileErrorUnivIndex, LeanIxDecompileErrorUnivVarIndex, LeanIxName,
+  LeanIxRawEnvironment, LeanIxSerializeError, LeanIxSerializeErrorInvalidBool,
+  LeanIxSerializeErrorInvalidFlag, LeanIxSerializeErrorInvalidShareIndex,
+  LeanIxSerializeErrorInvalidTag, LeanIxSerializeErrorInvalidVariant,
   LeanIxonRawBlob, LeanIxonRawComm, LeanIxonRawConst, LeanIxonRawEnv,
   LeanIxonRawNameEntry, LeanIxonRawNamed,
 };
 use lean_ffi::nat::Nat;
 use lean_ffi::object::LeanIOResult;
 use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanByteArray, LeanCtor, LeanExcept, LeanList,
-  LeanOwned, LeanRef, LeanString,
+  LeanArray, LeanBorrowed, LeanByteArray, LeanCtor, LeanCtorScalar, LeanExcept,
+  LeanList, LeanOwned, LeanRef, LeanString,
 };
-
-use lean_ffi::object::scalar_base;
 
 use dashmap::DashMap;
 use dashmap::DashSet;
@@ -48,9 +51,11 @@ use crate::lean::LeanIxAddress;
 use crate::ffi::lean_env::{GlobalCache, decode_name};
 #[cfg(feature = "test-ffi")]
 use crate::ix::ixon::serialize::put_expr;
+use crate::lean::LeanIxBlock;
 #[cfg(feature = "test-ffi")]
 use crate::lean::{
-  LeanIxBlockCompareDetail, LeanIxBlockCompareResult, LeanIxCompilePhases,
+  LeanIxBlockCompareDetail, LeanIxBlockCompareResult,
+  LeanIxBlockCompareResultMismatch, LeanIxCompilePhases,
 };
 #[cfg(feature = "test-ffi")]
 use std::collections::HashMap;
@@ -159,17 +164,16 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
   match ctor.tag() {
     1 => {
       // mismatch: 0 obj, 24 scalar bytes (3 × u64)
-      let s = scalar_base(&ctor, 0);
-      let v0 = ctor.get_u64(s);
-      let v1 = ctor.get_u64(s + 8);
-      let v2 = ctor.get_u64(s + 16);
+      let src = LeanIxBlockCompareResultMismatch::from_ctor(ctor);
+      let v0 = src.get_num_64(0);
+      let v1 = src.get_num_64(1);
+      let v2 = src.get_num_64(2);
 
-      let out = LeanCtor::alloc(1, 0, 24);
-      let s = scalar_base(&out, 0);
-      out.set_u64(s, v0);
-      out.set_u64(s + 8, v1);
-      out.set_u64(s + 16, v2);
-      LeanIxBlockCompareResult::new(out.into())
+      let dst = LeanIxBlockCompareResultMismatch::alloc();
+      dst.set_num_64(0, v0);
+      dst.set_num_64(1, v1);
+      dst.set_num_64(2, v2);
+      LeanIxBlockCompareResult::new(dst.into())
     },
     _ => unreachable!("Invalid BlockCompareResult tag: {}", ctor.tag()),
   }
@@ -177,25 +181,22 @@ pub extern "C" fn rs_roundtrip_block_compare_result(
 
 /// Round-trip a BlockCompareDetail.
 #[cfg(feature = "test-ffi")]
-use lean_ffi::object::LeanCtorScalar;
-#[cfg(feature = "test-ffi")]
 #[unsafe(no_mangle)]
 pub extern "C" fn rs_roundtrip_block_compare_detail(
   obj: LeanIxBlockCompareDetail<LeanBorrowed<'_>>,
 ) -> LeanIxBlockCompareDetail<LeanOwned> {
-  let lean_sharing_len = obj.get_64(0);
-  let rust_sharing_len = obj.get_64(1);
+  let lean_sharing_len = obj.get_num_64(0);
+  let rust_sharing_len = obj.get_num_64(1);
 
   let result_obj = rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(
     obj.as_ctor().get(0),
   ));
 
-  let out = LeanCtor::alloc(0, 1, 16);
-  out.set(0, result_obj);
-  let result = LeanIxBlockCompareDetail::new(out.into());
-  result.set_64(0, lean_sharing_len);
-  result.set_64(1, rust_sharing_len);
-  result
+  let ctor = LeanIxBlockCompareDetail::alloc();
+  ctor.set_obj(0, result_obj);
+  ctor.set_num_64(0, lean_sharing_len);
+  ctor.set_num_64(1, rust_sharing_len);
+  ctor
 }
 
 // =============================================================================
@@ -262,10 +263,10 @@ pub extern "C" fn rs_compile_env_full(
       let ba = LeanByteArray::from_bytes(bytes);
 
       // Block: { name: Ix.Name, bytes: ByteArray, sharingLen: UInt64 }
-      let block = LeanCtor::alloc(0, 2, 8);
-      block.set(0, name_obj);
-      block.set(1, ba);
-      block.set_u64(scalar_base(&block, 0), *sharing_len as u64);
+      let block = LeanIxBlock::alloc();
+      block.set_obj(0, name_obj);
+      block.set_obj(1, ba);
+      block.set_num_64(0, *sharing_len as u64);
 
       blocks_arr.set(i, block);
     }
@@ -1087,33 +1088,33 @@ impl LeanIxSerializeError<LeanOwned> {
         ctor.into()
       },
       SerializeError::InvalidTag { tag, context } => {
-        let ctor = LeanCtor::alloc(1, 1, 1);
-        ctor.set(0, build_lean_string(context));
-        ctor.set_u8(scalar_base(&ctor, 0), *tag);
+        let ctor = LeanIxSerializeErrorInvalidTag::alloc();
+        ctor.set_obj(0, build_lean_string(context));
+        ctor.set_num_8(0, *tag);
         ctor.into()
       },
       SerializeError::InvalidFlag { flag, context } => {
-        let ctor = LeanCtor::alloc(2, 1, 1);
-        ctor.set(0, build_lean_string(context));
-        ctor.set_u8(scalar_base(&ctor, 0), *flag);
+        let ctor = LeanIxSerializeErrorInvalidFlag::alloc();
+        ctor.set_obj(0, build_lean_string(context));
+        ctor.set_num_8(0, *flag);
         ctor.into()
       },
       SerializeError::InvalidVariant { variant, context } => {
-        let ctor = LeanCtor::alloc(3, 1, 8);
-        ctor.set(0, build_lean_string(context));
-        ctor.set_u64(scalar_base(&ctor, 0), *variant);
+        let ctor = LeanIxSerializeErrorInvalidVariant::alloc();
+        ctor.set_obj(0, build_lean_string(context));
+        ctor.set_num_64(0, *variant);
         ctor.into()
       },
       SerializeError::InvalidBool { value } => {
-        let ctor = LeanCtor::alloc(4, 0, 1);
-        ctor.set_u8(scalar_base(&ctor, 0), *value);
+        let ctor = LeanIxSerializeErrorInvalidBool::alloc();
+        ctor.set_num_8(0, *value);
         ctor.into()
       },
       SerializeError::AddressError => LeanOwned::box_usize(5),
       SerializeError::InvalidShareIndex { idx, max } => {
-        let ctor = LeanCtor::alloc(6, 1, 8);
-        ctor.set(0, build_lean_nat_usize(*max));
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxSerializeErrorInvalidShareIndex::alloc();
+        ctor.set_obj(0, build_lean_nat_usize(*max));
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
     };
@@ -1137,32 +1138,32 @@ impl<R: LeanRef> LeanIxSerializeError<R> {
         SerializeError::UnexpectedEof { expected }
       },
       1 => {
-        let context = ctor.get(0).as_string().to_string();
-        let tag_val = ctor.get_u8(scalar_base(&ctor, 0));
-        SerializeError::InvalidTag { tag: tag_val, context }
+        let ctor = LeanIxSerializeErrorInvalidTag::from_ctor(ctor);
+        let context = ctor.as_ctor().get(0).as_string().to_string();
+        SerializeError::InvalidTag { tag: ctor.get_num_8(0), context }
       },
       2 => {
-        let context = ctor.get(0).as_string().to_string();
-        let flag = ctor.get_u8(scalar_base(&ctor, 0));
-        SerializeError::InvalidFlag { flag, context }
+        let ctor = LeanIxSerializeErrorInvalidFlag::from_ctor(ctor);
+        let context = ctor.as_ctor().get(0).as_string().to_string();
+        SerializeError::InvalidFlag { flag: ctor.get_num_8(0), context }
       },
       3 => {
-        let context = ctor.get(0).as_string().to_string();
-        let variant = ctor.get_u64(scalar_base(&ctor, 0));
-        SerializeError::InvalidVariant { variant, context }
+        let ctor = LeanIxSerializeErrorInvalidVariant::from_ctor(ctor);
+        let context = ctor.as_ctor().get(0).as_string().to_string();
+        SerializeError::InvalidVariant { variant: ctor.get_num_64(0), context }
       },
       4 => {
-        let value = ctor.get_u8(scalar_base(&ctor, 0));
-        SerializeError::InvalidBool { value }
+        let ctor = LeanIxSerializeErrorInvalidBool::from_ctor(ctor);
+        SerializeError::InvalidBool { value: ctor.get_num_8(0) }
       },
       5 => SerializeError::AddressError,
       6 => {
-        let max = Nat::from_obj(&ctor.get(0))
+        let ctor = LeanIxSerializeErrorInvalidShareIndex::from_ctor(ctor);
+        let max = Nat::from_obj(&ctor.as_ctor().get(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        SerializeError::InvalidShareIndex { idx, max }
+        SerializeError::InvalidShareIndex { idx: ctor.get_num_64(0), max }
       },
       _ => unreachable!("Invalid SerializeError tag: {}", ctor.tag()),
     }
@@ -1180,38 +1181,38 @@ impl LeanIxDecompileError<LeanOwned> {
   pub fn build(err: &DecompileError) -> Self {
     let obj = match err {
       DecompileError::InvalidRefIndex { idx, refs_len, constant } => {
-        let ctor = LeanCtor::alloc(0, 2, 8);
-        ctor.set(0, build_lean_nat_usize(*refs_len));
-        ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxDecompileErrorRefIndex::alloc();
+        ctor.set_obj(0, build_lean_nat_usize(*refs_len));
+        ctor.set_obj(1, build_lean_string(constant));
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       DecompileError::InvalidUnivIndex { idx, univs_len, constant } => {
-        let ctor = LeanCtor::alloc(1, 2, 8);
-        ctor.set(0, build_lean_nat_usize(*univs_len));
-        ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxDecompileErrorUnivIndex::alloc();
+        ctor.set_obj(0, build_lean_nat_usize(*univs_len));
+        ctor.set_obj(1, build_lean_string(constant));
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       DecompileError::InvalidShareIndex { idx, max, constant } => {
-        let ctor = LeanCtor::alloc(2, 2, 8);
-        ctor.set(0, build_lean_nat_usize(*max));
-        ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxDecompileErrorShareIndex::alloc();
+        ctor.set_obj(0, build_lean_nat_usize(*max));
+        ctor.set_obj(1, build_lean_string(constant));
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       DecompileError::InvalidRecIndex { idx, ctx_size, constant } => {
-        let ctor = LeanCtor::alloc(3, 2, 8);
-        ctor.set(0, build_lean_nat_usize(*ctx_size));
-        ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxDecompileErrorRecIndex::alloc();
+        ctor.set_obj(0, build_lean_nat_usize(*ctx_size));
+        ctor.set_obj(1, build_lean_string(constant));
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       DecompileError::InvalidUnivVarIndex { idx, max, constant } => {
-        let ctor = LeanCtor::alloc(4, 2, 8);
-        ctor.set(0, build_lean_nat_usize(*max));
-        ctor.set(1, build_lean_string(constant));
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxDecompileErrorUnivVarIndex::alloc();
+        ctor.set_obj(0, build_lean_nat_usize(*max));
+        ctor.set_obj(1, build_lean_string(constant));
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       DecompileError::MissingAddress(addr) => {
@@ -1256,49 +1257,69 @@ impl<R: LeanRef> LeanIxDecompileError<R> {
     let ctor = self.as_ctor();
     match ctor.tag() {
       0 => {
-        let refs_len = Nat::from_obj(&ctor.get(0))
+        let ctor = LeanIxDecompileErrorRefIndex::from_ctor(ctor);
+        let refs_len = Nat::from_obj(&ctor.as_ctor().get(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        DecompileError::InvalidRefIndex { idx, refs_len, constant }
+        let constant = ctor.as_ctor().get(1).as_string().to_string();
+        DecompileError::InvalidRefIndex {
+          idx: ctor.get_num_64(0),
+          refs_len,
+          constant,
+        }
       },
       1 => {
-        let univs_len = Nat::from_obj(&ctor.get(0))
+        let ctor = LeanIxDecompileErrorUnivIndex::from_ctor(ctor);
+        let univs_len = Nat::from_obj(&ctor.as_ctor().get(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        DecompileError::InvalidUnivIndex { idx, univs_len, constant }
+        let constant = ctor.as_ctor().get(1).as_string().to_string();
+        DecompileError::InvalidUnivIndex {
+          idx: ctor.get_num_64(0),
+          univs_len,
+          constant,
+        }
       },
       2 => {
-        let max = Nat::from_obj(&ctor.get(0))
+        let ctor = LeanIxDecompileErrorShareIndex::from_ctor(ctor);
+        let max = Nat::from_obj(&ctor.as_ctor().get(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        DecompileError::InvalidShareIndex { idx, max, constant }
+        let constant = ctor.as_ctor().get(1).as_string().to_string();
+        DecompileError::InvalidShareIndex {
+          idx: ctor.get_num_64(0),
+          max,
+          constant,
+        }
       },
       3 => {
-        let ctx_size = Nat::from_obj(&ctor.get(0))
+        let ctor = LeanIxDecompileErrorRecIndex::from_ctor(ctor);
+        let ctx_size = Nat::from_obj(&ctor.as_ctor().get(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        DecompileError::InvalidRecIndex { idx, ctx_size, constant }
+        let constant = ctor.as_ctor().get(1).as_string().to_string();
+        DecompileError::InvalidRecIndex {
+          idx: ctor.get_num_64(0),
+          ctx_size,
+          constant,
+        }
       },
       4 => {
-        let max = Nat::from_obj(&ctor.get(0))
+        let ctor = LeanIxDecompileErrorUnivVarIndex::from_ctor(ctor);
+        let max = Nat::from_obj(&ctor.as_ctor().get(0))
           .to_u64()
           .and_then(|x| usize::try_from(x).ok())
           .unwrap_or(0);
-        let constant = ctor.get(1).as_string().to_string();
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        DecompileError::InvalidUnivVarIndex { idx, max, constant }
+        let constant = ctor.as_ctor().get(1).as_string().to_string();
+        DecompileError::InvalidUnivVarIndex {
+          idx: ctor.get_num_64(0),
+          max,
+          constant,
+        }
       },
       5 => DecompileError::MissingAddress(
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -174,14 +174,18 @@ pub extern "C" fn rs_roundtrip_block_compare_detail(
   obj: LeanIxBlockCompareDetail<LeanBorrowed<'_>>,
 ) -> LeanIxBlockCompareDetail<LeanOwned> {
   let ctor = obj.as_ctor();
-  let [lean_sharing_len, rust_sharing_len] = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+  let [lean_sharing_len, rust_sharing_len] =
+    ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
 
   let result_obj =
     rs_roundtrip_block_compare_result(LeanIxBlockCompareResult(ctor.get(0)));
 
   let out = LeanCtor::alloc(0, 1, 16);
   out.set(0, result_obj);
-  out.set_scalars::<2, u64>(out.scalar_base(0), [lean_sharing_len, rust_sharing_len]);
+  out.set_scalars::<2, u64>(
+    out.scalar_base(0),
+    [lean_sharing_len, rust_sharing_len],
+  );
   LeanIxBlockCompareDetail::new(out.into())
 }
 

--- a/src/ffi/graph.rs
+++ b/src/ffi/graph.rs
@@ -76,11 +76,11 @@ impl LeanIxCondensedBlocks<LeanOwned> {
     }
 
     // Build RustCondensedBlocks structure (3 fields)
-    let result = LeanIxCondensedBlocks::alloc();
+    let result = LeanIxCondensedBlocks::alloc(0);
     result.set_obj(0, low_links_arr);
     result.set_obj(1, blocks_arr);
     result.set_obj(2, block_refs_arr);
-    Self::new(result.into())
+    result
   }
 }
 

--- a/src/ffi/graph.rs
+++ b/src/ffi/graph.rs
@@ -6,7 +6,7 @@ use crate::ix::condense::compute_sccs;
 use crate::ix::graph::build_ref_graph;
 use crate::lean::LeanIxCondensedBlocks;
 use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanCtor, LeanIOResult, LeanList, LeanOwned,
+  LeanArray, LeanBorrowed, LeanIOResult, LeanList, LeanOwned, LeanProd,
 };
 
 use crate::ffi::builder::LeanBuildCache;
@@ -28,9 +28,7 @@ pub fn build_ref_graph_array(
       refs_arr.set(j, ref_name_obj);
     }
 
-    let pair = LeanCtor::alloc(0, 2, 0);
-    pair.set(0, name_obj);
-    pair.set(1, refs_arr);
+    let pair = LeanProd::new(name_obj, refs_arr);
     arr.set(i, pair);
   }
   arr
@@ -47,9 +45,7 @@ impl LeanIxCondensedBlocks<LeanOwned> {
     for (i, (name, low_link)) in condensed.low_links.iter().enumerate() {
       let name_obj = LeanIxName::build(cache, name);
       let low_link_obj = LeanIxName::build(cache, low_link);
-      let pair = LeanCtor::alloc(0, 2, 0);
-      pair.set(0, name_obj);
-      pair.set(1, low_link_obj);
+      let pair = LeanProd::new(name_obj, low_link_obj);
       low_links_arr.set(i, pair);
     }
 
@@ -62,9 +58,7 @@ impl LeanIxCondensedBlocks<LeanOwned> {
         let block_name_obj = LeanIxName::build(cache, block_name);
         block_names_arr.set(j, block_name_obj);
       }
-      let pair = LeanCtor::alloc(0, 2, 0);
-      pair.set(0, name_obj);
-      pair.set(1, block_names_arr);
+      let pair = LeanProd::new(name_obj, block_names_arr);
       blocks_arr.set(i, pair);
     }
 
@@ -77,17 +71,15 @@ impl LeanIxCondensedBlocks<LeanOwned> {
         let ref_name_obj = LeanIxName::build(cache, ref_name);
         refs_arr.set(j, ref_name_obj);
       }
-      let pair = LeanCtor::alloc(0, 2, 0);
-      pair.set(0, name_obj);
-      pair.set(1, refs_arr);
+      let pair = LeanProd::new(name_obj, refs_arr);
       block_refs_arr.set(i, pair);
     }
 
     // Build RustCondensedBlocks structure (3 fields)
-    let result = LeanCtor::alloc(0, 3, 0);
-    result.set(0, low_links_arr);
-    result.set(1, blocks_arr);
-    result.set(2, block_refs_arr);
+    let result = LeanIxCondensedBlocks::alloc();
+    result.set_obj(0, low_links_arr);
+    result.set_obj(1, blocks_arr);
+    result.set_obj(2, block_refs_arr);
     Self::new(result.into())
   }
 }

--- a/src/ffi/iroh.rs
+++ b/src/ffi/iroh.rs
@@ -1,17 +1,11 @@
 use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanByteArray, LeanCtor, LeanExcept, LeanOwned,
-  LeanRef, LeanString,
+  LeanArray, LeanBorrowed, LeanByteArray, LeanExcept, LeanOwned, LeanString,
 };
 
 use crate::iroh::common::{GetRequest, PutRequest, Request, Response};
 use crate::iroh::{client, server};
 
-lean_ffi::lean_domain_type! {
-  /// Lean `Iroh.Connect.PutResponse` object.
-  LeanPutResponse;
-  /// Lean `Iroh.Connect.GetResponse` object.
-  LeanGetResponse;
-}
+use crate::lean::{LeanGetResponse, LeanPutResponse};
 
 impl LeanPutResponse<LeanOwned> {
   /// Build from `message` and `hash` strings.
@@ -22,9 +16,9 @@ impl LeanPutResponse<LeanOwned> {
   ///   hash : String
   /// ```
   pub fn mk(message: &str, hash: &str) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanString::new(message));
-    ctor.set(1, LeanString::new(hash));
+    let ctor = LeanPutResponse::alloc();
+    ctor.set_obj(0, LeanString::new(message));
+    ctor.set_obj(1, LeanString::new(hash));
     Self::new(ctor.into())
   }
 }
@@ -39,10 +33,10 @@ impl LeanGetResponse<LeanOwned> {
   ///   bytes : ByteArray
   /// ```
   pub fn mk(message: &str, hash: &str, bytes: &[u8]) -> Self {
-    let ctor = LeanCtor::alloc(0, 3, 0);
-    ctor.set(0, LeanString::new(message));
-    ctor.set(1, LeanString::new(hash));
-    ctor.set(2, LeanByteArray::from_bytes(bytes));
+    let ctor = LeanGetResponse::alloc();
+    ctor.set_obj(0, LeanString::new(message));
+    ctor.set_obj(1, LeanString::new(hash));
+    ctor.set_obj(2, LeanByteArray::from_bytes(bytes));
     Self::new(ctor.into())
   }
 }

--- a/src/ffi/iroh.rs
+++ b/src/ffi/iroh.rs
@@ -16,10 +16,10 @@ impl LeanPutResponse<LeanOwned> {
   ///   hash : String
   /// ```
   pub fn mk(message: &str, hash: &str) -> Self {
-    let ctor = LeanPutResponse::alloc();
+    let ctor = LeanPutResponse::alloc(0);
     ctor.set_obj(0, LeanString::new(message));
     ctor.set_obj(1, LeanString::new(hash));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -33,11 +33,11 @@ impl LeanGetResponse<LeanOwned> {
   ///   bytes : ByteArray
   /// ```
   pub fn mk(message: &str, hash: &str, bytes: &[u8]) -> Self {
-    let ctor = LeanGetResponse::alloc();
+    let ctor = LeanGetResponse::alloc(0);
     ctor.set_obj(0, LeanString::new(message));
     ctor.set_obj(1, LeanString::new(hash));
     ctor.set_obj(2, LeanByteArray::from_bytes(bytes));
-    Self::new(ctor.into())
+    ctor
   }
 }
 

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -267,7 +267,10 @@ impl LeanIxConstantInfo<LeanOwned> {
         induct_val.set(3, all_obj);
         induct_val.set(4, ctors_obj);
         induct_val.set(5, num_nested_obj);
-        induct_val.set_bools::<3>(induct_val.scalar_base(0), [v.is_rec, v.is_unsafe, v.is_reflexive]);
+        induct_val.set_bools::<3>(
+          induct_val.scalar_base(0),
+          [v.is_rec, v.is_unsafe, v.is_reflexive],
+        );
 
         let obj = LeanCtor::alloc(5, 1, 0);
         obj.set(0, induct_val);
@@ -391,7 +394,8 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       5 => {
-        let [is_rec, is_unsafe, is_reflexive] = inner.get_bools::<3>(inner.scalar_base(0));
+        let [is_rec, is_unsafe, is_reflexive] =
+          inner.get_bools::<3>(inner.scalar_base(0));
 
         ConstantInfo::InductInfo(InductiveVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -16,13 +16,10 @@ use crate::ix::env::{
   RecursorRule, RecursorVal, ReducibilityHints, TheoremVal,
 };
 use crate::lean::{
-  LeanIxAxiomVal, LeanIxConstantInfo, LeanIxConstantInfoAxiom,
-  LeanIxConstantInfoCtor, LeanIxConstantInfoDefn, LeanIxConstantInfoInduct,
-  LeanIxConstantInfoOpaque, LeanIxConstantInfoQuot, LeanIxConstantInfoRec,
-  LeanIxConstantInfoThm, LeanIxConstantVal, LeanIxConstructorVal,
+  LeanIxAxiomVal, LeanIxConstantInfo, LeanIxConstantVal, LeanIxConstructorVal,
   LeanIxDefinitionVal, LeanIxExpr, LeanIxInductiveVal, LeanIxName,
   LeanIxOpaqueVal, LeanIxQuotVal, LeanIxRecursorRule, LeanIxRecursorVal,
-  LeanIxReducibilityHints, LeanIxReducibilityHintsRegular, LeanIxTheoremVal,
+  LeanIxReducibilityHints, LeanIxTheoremVal,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
@@ -43,11 +40,11 @@ impl LeanIxConstantVal<LeanOwned> {
     let level_params_obj = LeanIxName::build_array(cache, &cv.level_params);
     let type_obj = LeanIxExpr::build(cache, &cv.typ);
 
-    let ctor = LeanIxConstantVal::alloc();
+    let ctor = LeanIxConstantVal::alloc(0);
     ctor.set_obj(0, name_obj);
     ctor.set_obj(1, level_params_obj);
     ctor.set_obj(2, type_obj);
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -74,19 +71,18 @@ impl LeanIxReducibilityHints<LeanOwned> {
   /// NOTE: In Lean 4, 0-field constructors are boxed scalars when the inductive has
   /// other constructors with fields. So opaque and abbrev use box_usize.
   pub fn build(hints: &ReducibilityHints) -> Self {
-    let obj = match hints {
+    match hints {
       // | opaque -- tag 0, boxed as scalar
-      ReducibilityHints::Opaque => LeanOwned::box_usize(0),
+      ReducibilityHints::Opaque => Self::new(LeanOwned::box_usize(0)),
       // | abbrev -- tag 1, boxed as scalar
-      ReducibilityHints::Abbrev => LeanOwned::box_usize(1),
+      ReducibilityHints::Abbrev => Self::new(LeanOwned::box_usize(1)),
       // | regular (h : UInt32) -- tag 2, object constructor
       ReducibilityHints::Regular(h) => {
-        let ctor = LeanIxReducibilityHintsRegular::alloc();
+        let ctor = LeanIxReducibilityHints::alloc(2);
         ctor.set_num_32(0, *h);
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -108,8 +104,7 @@ impl<R: LeanRef> LeanIxReducibilityHints<R> {
       1 => ReducibilityHints::Abbrev,
       2 => {
         // regular: 0 obj fields, 4 scalar bytes (UInt32)
-        let ctor = LeanIxReducibilityHintsRegular::from_ctor(ctor);
-        ReducibilityHints::Regular(ctor.get_num_32(0))
+        ReducibilityHints::Regular(self.get_num_32(0))
       },
       _ => panic!("Invalid ReducibilityHints tag: {}", ctor.tag()),
     }
@@ -149,7 +144,7 @@ impl LeanIxRecursorRule<LeanOwned> {
       let n_fields_obj = Nat::to_lean(&rule.n_fields);
       let rhs_obj = LeanIxExpr::build(cache, &rule.rhs);
 
-      let rule_obj = LeanIxRecursorRule::alloc();
+      let rule_obj = LeanIxRecursorRule::alloc(0);
       rule_obj.set_obj(0, ctor_obj);
       rule_obj.set_obj(1, n_fields_obj);
       rule_obj.set_obj(2, rhs_obj);
@@ -163,18 +158,18 @@ impl LeanIxRecursorRule<LeanOwned> {
 impl LeanIxConstantInfo<LeanOwned> {
   /// Build a Ix.ConstantInfo from a Rust ConstantInfo.
   pub fn build(cache: &mut LeanBuildCache, info: &ConstantInfo) -> Self {
-    let result: LeanOwned = match info {
+    match info {
       // | axiomInfo (v : AxiomVal) -- tag 0
       ConstantInfo::AxiomInfo(v) => {
         // AxiomVal = { cnst : ConstantVal, isUnsafe : Bool }
         let cnst_obj = LeanIxConstantVal::build(cache, &v.cnst);
-        let axiom_val = LeanIxAxiomVal::alloc();
+        let axiom_val = LeanIxAxiomVal::alloc(0);
         axiom_val.set_obj(0, cnst_obj);
         axiom_val.set_num_8(0, v.is_unsafe as u8);
 
-        let obj = LeanIxConstantInfoAxiom::alloc();
+        let obj = LeanIxConstantInfo::alloc(0);
         obj.set_obj(0, axiom_val);
-        obj.into()
+        obj
       },
       // | defnInfo (v : DefinitionVal) -- tag 1
       ConstantInfo::DefnInfo(v) => {
@@ -190,16 +185,16 @@ impl LeanIxConstantInfo<LeanOwned> {
           DefinitionSafety::Partial => 2u8,
         };
 
-        let defn_val = LeanIxDefinitionVal::alloc();
+        let defn_val = LeanIxDefinitionVal::alloc(0);
         defn_val.set_obj(0, cnst_obj);
         defn_val.set_obj(1, value_obj);
         defn_val.set_obj(2, hints_obj);
         defn_val.set_obj(3, all_obj);
         defn_val.set_num_8(0, safety_byte);
 
-        let obj = LeanIxConstantInfoDefn::alloc();
+        let obj = LeanIxConstantInfo::alloc(1);
         obj.set_obj(0, defn_val);
-        obj.into()
+        obj
       },
       // | thmInfo (v : TheoremVal) -- tag 2
       ConstantInfo::ThmInfo(v) => {
@@ -208,14 +203,14 @@ impl LeanIxConstantInfo<LeanOwned> {
         let value_obj = LeanIxExpr::build(cache, &v.value);
         let all_obj = LeanIxName::build_array(cache, &v.all);
 
-        let thm_val = LeanIxTheoremVal::alloc();
+        let thm_val = LeanIxTheoremVal::alloc(0);
         thm_val.set_obj(0, cnst_obj);
         thm_val.set_obj(1, value_obj);
         thm_val.set_obj(2, all_obj);
 
-        let obj = LeanIxConstantInfoThm::alloc();
+        let obj = LeanIxConstantInfo::alloc(2);
         obj.set_obj(0, thm_val);
-        obj.into()
+        obj
       },
       // | opaqueInfo (v : OpaqueVal) -- tag 3
       ConstantInfo::OpaqueInfo(v) => {
@@ -224,15 +219,15 @@ impl LeanIxConstantInfo<LeanOwned> {
         let value_obj = LeanIxExpr::build(cache, &v.value);
         let all_obj = LeanIxName::build_array(cache, &v.all);
 
-        let opaque_val = LeanIxOpaqueVal::alloc();
+        let opaque_val = LeanIxOpaqueVal::alloc(0);
         opaque_val.set_obj(0, cnst_obj);
         opaque_val.set_obj(1, value_obj);
         opaque_val.set_obj(2, all_obj);
         opaque_val.set_num_8(0, v.is_unsafe as u8);
 
-        let obj = LeanIxConstantInfoOpaque::alloc();
+        let obj = LeanIxConstantInfo::alloc(3);
         obj.set_obj(0, opaque_val);
-        obj.into()
+        obj
       },
       // | quotInfo (v : QuotVal) -- tag 4
       ConstantInfo::QuotInfo(v) => {
@@ -246,13 +241,13 @@ impl LeanIxConstantInfo<LeanOwned> {
           QuotKind::Ind => 3u8,
         };
 
-        let quot_val = LeanIxQuotVal::alloc();
+        let quot_val = LeanIxQuotVal::alloc(0);
         quot_val.set_obj(0, cnst_obj);
         quot_val.set_num_8(0, kind_byte);
 
-        let obj = LeanIxConstantInfoQuot::alloc();
+        let obj = LeanIxConstantInfo::alloc(4);
         obj.set_obj(0, quot_val);
-        obj.into()
+        obj
       },
       // | inductInfo (v : InductiveVal) -- tag 5
       ConstantInfo::InductInfo(v) => {
@@ -265,7 +260,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         let num_nested_obj = Nat::to_lean(&v.num_nested);
 
         // 6 object fields, 3 scalar bytes for bools
-        let induct_val = LeanIxInductiveVal::alloc();
+        let induct_val = LeanIxInductiveVal::alloc(0);
         induct_val.set_obj(0, cnst_obj);
         induct_val.set_obj(1, num_params_obj);
         induct_val.set_obj(2, num_indices_obj);
@@ -276,9 +271,9 @@ impl LeanIxConstantInfo<LeanOwned> {
         induct_val.set_num_8(1, v.is_unsafe as u8);
         induct_val.set_num_8(2, v.is_reflexive as u8);
 
-        let obj = LeanIxConstantInfoInduct::alloc();
+        let obj = LeanIxConstantInfo::alloc(5);
         obj.set_obj(0, induct_val);
-        obj.into()
+        obj
       },
       // | ctorInfo (v : ConstructorVal) -- tag 6
       ConstantInfo::CtorInfo(v) => {
@@ -290,7 +285,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         let num_fields_obj = Nat::to_lean(&v.num_fields);
 
         // 5 object fields, 1 scalar byte for bool
-        let ctor_val = LeanIxConstructorVal::alloc();
+        let ctor_val = LeanIxConstructorVal::alloc(0);
         ctor_val.set_obj(0, cnst_obj);
         ctor_val.set_obj(1, induct_obj);
         ctor_val.set_obj(2, cidx_obj);
@@ -298,9 +293,9 @@ impl LeanIxConstantInfo<LeanOwned> {
         ctor_val.set_obj(4, num_fields_obj);
         ctor_val.set_num_8(0, v.is_unsafe as u8);
 
-        let obj = LeanIxConstantInfoCtor::alloc();
+        let obj = LeanIxConstantInfo::alloc(6);
         obj.set_obj(0, ctor_val);
-        obj.into()
+        obj
       },
       // | recInfo (v : RecursorVal) -- tag 7
       ConstantInfo::RecInfo(v) => {
@@ -314,7 +309,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         let rules_obj = LeanIxRecursorRule::build_array(cache, &v.rules);
 
         // 7 object fields, 2 scalar bytes for bools
-        let rec_val = LeanIxRecursorVal::alloc();
+        let rec_val = LeanIxRecursorVal::alloc(0);
         rec_val.set_obj(0, cnst_obj);
         rec_val.set_obj(1, all_obj);
         rec_val.set_obj(2, num_params_obj);
@@ -325,13 +320,11 @@ impl LeanIxConstantInfo<LeanOwned> {
         rec_val.set_num_8(0, v.k as u8);
         rec_val.set_num_8(1, v.is_unsafe as u8);
 
-        let obj = LeanIxConstantInfoRec::alloc();
+        let obj = LeanIxConstantInfo::alloc(7);
         obj.set_obj(0, rec_val);
-        obj.into()
+        obj
       },
-    };
-
-    Self::new(result)
+    }
   }
 }
 
@@ -344,17 +337,18 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
 
     match outer.tag() {
       0 => {
-        let inner = LeanIxAxiomVal::from_ctor(inner);
-        let is_unsafe = inner.get_num_8(0) != 0;
+        // AxiomVal inner
+        let inner_val = LeanIxAxiomVal(inner_obj);
+        let is_unsafe = inner_val.get_num_8(0) != 0;
 
         ConstantInfo::AxiomInfo(AxiomVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
           is_unsafe,
         })
       },
       1 => {
-        let inner = LeanIxDefinitionVal::from_ctor(inner);
-        let safety_byte = inner.get_num_8(0);
+        let inner_val = LeanIxDefinitionVal(inner_obj);
+        let safety_byte = inner_val.get_num_8(0);
         let safety = match safety_byte {
           0 => DefinitionSafety::Unsafe,
           1 => DefinitionSafety::Safe,
@@ -363,11 +357,11 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         };
 
         ConstantInfo::DefnInfo(DefinitionVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
-          value: LeanIxExpr(inner.get_obj(1)).decode(),
-          hints: LeanIxReducibilityHints(inner.get_obj(2)).decode(),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
+          value: LeanIxExpr(inner_val.get_obj(1)).decode(),
+          hints: LeanIxReducibilityHints(inner_val.get_obj(2)).decode(),
           safety,
-          all: LeanIxName::decode_array(inner.get_obj(3).as_array()),
+          all: LeanIxName::decode_array(inner_val.get_obj(3).as_array()),
         })
       },
       2 => ConstantInfo::ThmInfo(TheoremVal {
@@ -376,19 +370,19 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         all: LeanIxName::decode_array(inner.get(2).as_array()),
       }),
       3 => {
-        let inner = LeanIxOpaqueVal::from_ctor(inner);
-        let is_unsafe = inner.get_num_8(0) != 0;
+        let inner_val = LeanIxOpaqueVal(inner_obj);
+        let is_unsafe = inner_val.get_num_8(0) != 0;
 
         ConstantInfo::OpaqueInfo(OpaqueVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
-          value: LeanIxExpr(inner.get_obj(1)).decode(),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
+          value: LeanIxExpr(inner_val.get_obj(1)).decode(),
           is_unsafe,
-          all: LeanIxName::decode_array(inner.get_obj(2).as_array()),
+          all: LeanIxName::decode_array(inner_val.get_obj(2).as_array()),
         })
       },
       4 => {
-        let inner = LeanIxQuotVal::from_ctor(inner);
-        let kind_byte = inner.get_num_8(0);
+        let inner_val = LeanIxQuotVal(inner_obj);
+        let kind_byte = inner_val.get_num_8(0);
         let kind = match kind_byte {
           0 => QuotKind::Type,
           1 => QuotKind::Ctor,
@@ -398,56 +392,58 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         };
 
         ConstantInfo::QuotInfo(QuotVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
           kind,
         })
       },
       5 => {
-        let inner = LeanIxInductiveVal::from_ctor(inner);
-        let is_rec = inner.get_num_8(0) != 0;
-        let is_unsafe = inner.get_num_8(1) != 0;
-        let is_reflexive = inner.get_num_8(2) != 0;
+        let inner_val = LeanIxInductiveVal(inner_obj);
+        let is_rec = inner_val.get_num_8(0) != 0;
+        let is_unsafe = inner_val.get_num_8(1) != 0;
+        let is_reflexive = inner_val.get_num_8(2) != 0;
 
         ConstantInfo::InductInfo(InductiveVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
-          num_params: Nat::from_obj(&inner.get_obj(1)),
-          num_indices: Nat::from_obj(&inner.get_obj(2)),
-          all: LeanIxName::decode_array(inner.get_obj(3).as_array()),
-          ctors: LeanIxName::decode_array(inner.get_obj(4).as_array()),
-          num_nested: Nat::from_obj(&inner.get_obj(5)),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
+          num_params: Nat::from_obj(&inner_val.get_obj(1)),
+          num_indices: Nat::from_obj(&inner_val.get_obj(2)),
+          all: LeanIxName::decode_array(inner_val.get_obj(3).as_array()),
+          ctors: LeanIxName::decode_array(inner_val.get_obj(4).as_array()),
+          num_nested: Nat::from_obj(&inner_val.get_obj(5)),
           is_rec,
           is_unsafe,
           is_reflexive,
         })
       },
       6 => {
-        let inner = LeanIxConstructorVal::from_ctor(inner);
-        let is_unsafe = inner.get_num_8(0) != 0;
+        let inner_val = LeanIxConstructorVal(inner_obj);
+        let is_unsafe = inner_val.get_num_8(0) != 0;
 
         ConstantInfo::CtorInfo(ConstructorVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
-          induct: LeanIxName(inner.get_obj(1)).decode(),
-          cidx: Nat::from_obj(&inner.get_obj(2)),
-          num_params: Nat::from_obj(&inner.get_obj(3)),
-          num_fields: Nat::from_obj(&inner.get_obj(4)),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
+          induct: LeanIxName(inner_val.get_obj(1)).decode(),
+          cidx: Nat::from_obj(&inner_val.get_obj(2)),
+          num_params: Nat::from_obj(&inner_val.get_obj(3)),
+          num_fields: Nat::from_obj(&inner_val.get_obj(4)),
           is_unsafe,
         })
       },
       7 => {
-        let inner = LeanIxRecursorVal::from_ctor(inner);
-        let k = inner.get_num_8(0) != 0;
-        let is_unsafe = inner.get_num_8(1) != 0;
+        let inner_val = LeanIxRecursorVal(inner_obj);
+        let k = inner_val.get_num_8(0) != 0;
+        let is_unsafe = inner_val.get_num_8(1) != 0;
 
-        let rules: Vec<RecursorRule> =
-          inner.get_obj(6).as_array().map(|x| LeanIxRecursorRule(x).decode());
+        let rules: Vec<RecursorRule> = inner_val
+          .get_obj(6)
+          .as_array()
+          .map(|x| LeanIxRecursorRule(x).decode());
 
         ConstantInfo::RecInfo(RecursorVal {
-          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
-          all: LeanIxName::decode_array(inner.get_obj(1).as_array()),
-          num_params: Nat::from_obj(&inner.get_obj(2)),
-          num_indices: Nat::from_obj(&inner.get_obj(3)),
-          num_motives: Nat::from_obj(&inner.get_obj(4)),
-          num_minors: Nat::from_obj(&inner.get_obj(5)),
+          cnst: LeanIxConstantVal(inner_val.get_obj(0)).decode(),
+          all: LeanIxName::decode_array(inner_val.get_obj(1).as_array()),
+          num_params: Nat::from_obj(&inner_val.get_obj(2)),
+          num_indices: Nat::from_obj(&inner_val.get_obj(3)),
+          num_motives: Nat::from_obj(&inner_val.get_obj(4)),
+          num_minors: Nat::from_obj(&inner_val.get_obj(5)),
           rules,
           k,
           is_unsafe,

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -24,6 +24,8 @@ use lean_ffi::nat::Nat;
 use lean_ffi::object::LeanBorrowed;
 use lean_ffi::object::{LeanArray, LeanCtor, LeanOwned, LeanRef};
 
+use lean_ffi::object::scalar_base;
+
 use crate::ffi::builder::LeanBuildCache;
 
 // =============================================================================
@@ -78,7 +80,7 @@ impl LeanIxReducibilityHints<LeanOwned> {
       ReducibilityHints::Regular(h) => {
         // UInt32 is a scalar, stored inline
         let ctor = LeanCtor::alloc(2, 0, 4);
-        ctor.set_u32(ctor.scalar_base(0), *h);
+        ctor.set_u32(scalar_base(&ctor, 0), *h);
         ctor.into()
       },
     };
@@ -104,7 +106,7 @@ impl<R: LeanRef> LeanIxReducibilityHints<R> {
       1 => ReducibilityHints::Abbrev,
       2 => {
         // regular: 0 obj fields, 4 scalar bytes (UInt32)
-        ReducibilityHints::Regular(ctor.get_u32(ctor.scalar_base(0)))
+        ReducibilityHints::Regular(ctor.get_u32(scalar_base(&ctor, 0)))
       },
       _ => panic!("Invalid ReducibilityHints tag: {}", ctor.tag()),
     }
@@ -165,7 +167,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         let cnst_obj = LeanIxConstantVal::build(cache, &v.cnst);
         let axiom_val = LeanCtor::alloc(0, 1, 1);
         axiom_val.set(0, cnst_obj);
-        axiom_val.set_bool(axiom_val.scalar_base(0), v.is_unsafe);
+        axiom_val.set_bool(scalar_base(&axiom_val, 0), v.is_unsafe);
 
         let obj = LeanCtor::alloc(0, 1, 0);
         obj.set(0, axiom_val);
@@ -190,7 +192,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         defn_val.set(1, value_obj);
         defn_val.set(2, hints_obj);
         defn_val.set(3, all_obj);
-        defn_val.set_u8(defn_val.scalar_base(0), safety_byte);
+        defn_val.set_u8(scalar_base(&defn_val, 0), safety_byte);
 
         let obj = LeanCtor::alloc(1, 1, 0);
         obj.set(0, defn_val);
@@ -223,7 +225,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         opaque_val.set(0, cnst_obj);
         opaque_val.set(1, value_obj);
         opaque_val.set(2, all_obj);
-        opaque_val.set_bool(opaque_val.scalar_base(0), v.is_unsafe);
+        opaque_val.set_bool(scalar_base(&opaque_val, 0), v.is_unsafe);
 
         let obj = LeanCtor::alloc(3, 1, 0);
         obj.set(0, opaque_val);
@@ -243,7 +245,7 @@ impl LeanIxConstantInfo<LeanOwned> {
 
         let quot_val = LeanCtor::alloc(0, 1, 1);
         quot_val.set(0, cnst_obj);
-        quot_val.set_u8(quot_val.scalar_base(0), kind_byte);
+        quot_val.set_u8(scalar_base(&quot_val, 0), kind_byte);
 
         let obj = LeanCtor::alloc(4, 1, 0);
         obj.set(0, quot_val);
@@ -267,10 +269,10 @@ impl LeanIxConstantInfo<LeanOwned> {
         induct_val.set(3, all_obj);
         induct_val.set(4, ctors_obj);
         induct_val.set(5, num_nested_obj);
-        induct_val.set_scalars::<3, bool>(
-          induct_val.scalar_base(0),
-          [v.is_rec, v.is_unsafe, v.is_reflexive],
-        );
+        let s = scalar_base(&induct_val, 0);
+        induct_val.set_bool(s, v.is_rec);
+        induct_val.set_bool(s + 1, v.is_unsafe);
+        induct_val.set_bool(s + 2, v.is_reflexive);
 
         let obj = LeanCtor::alloc(5, 1, 0);
         obj.set(0, induct_val);
@@ -292,7 +294,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         ctor_val.set(2, cidx_obj);
         ctor_val.set(3, num_params_obj);
         ctor_val.set(4, num_fields_obj);
-        ctor_val.set_bool(ctor_val.scalar_base(0), v.is_unsafe);
+        ctor_val.set_bool(scalar_base(&ctor_val, 0), v.is_unsafe);
 
         let obj = LeanCtor::alloc(6, 1, 0);
         obj.set(0, ctor_val);
@@ -318,8 +320,9 @@ impl LeanIxConstantInfo<LeanOwned> {
         rec_val.set(4, num_motives_obj);
         rec_val.set(5, num_minors_obj);
         rec_val.set(6, rules_obj);
-        rec_val
-          .set_scalars::<2, bool>(rec_val.scalar_base(0), [v.k, v.is_unsafe]);
+        let s = scalar_base(&rec_val, 0);
+        rec_val.set_bool(s, v.k);
+        rec_val.set_bool(s + 1, v.is_unsafe);
 
         let obj = LeanCtor::alloc(7, 1, 0);
         obj.set(0, rec_val);
@@ -340,7 +343,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
 
     match outer.tag() {
       0 => {
-        let is_unsafe = inner.get_bool(inner.scalar_base(0));
+        let is_unsafe = inner.get_bool(scalar_base(&inner, 0));
 
         ConstantInfo::AxiomInfo(AxiomVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -348,7 +351,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       1 => {
-        let safety_byte = inner.get_u8(inner.scalar_base(0));
+        let safety_byte = inner.get_u8(scalar_base(&inner, 0));
         let safety = match safety_byte {
           0 => DefinitionSafety::Unsafe,
           1 => DefinitionSafety::Safe,
@@ -370,7 +373,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         all: LeanIxName::decode_array(inner.get(2).as_array()),
       }),
       3 => {
-        let is_unsafe = inner.get_bool(inner.scalar_base(0));
+        let is_unsafe = inner.get_bool(scalar_base(&inner, 0));
 
         ConstantInfo::OpaqueInfo(OpaqueVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -380,7 +383,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       4 => {
-        let kind_byte = inner.get_u8(inner.scalar_base(0));
+        let kind_byte = inner.get_u8(scalar_base(&inner, 0));
         let kind = match kind_byte {
           0 => QuotKind::Type,
           1 => QuotKind::Ctor,
@@ -395,8 +398,10 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       5 => {
-        let [is_rec, is_unsafe, is_reflexive] =
-          inner.get_scalars::<3, bool>(inner.scalar_base(0));
+        let s = scalar_base(&inner, 0);
+        let is_rec = inner.get_bool(s);
+        let is_unsafe = inner.get_bool(s + 1);
+        let is_reflexive = inner.get_bool(s + 2);
 
         ConstantInfo::InductInfo(InductiveVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -411,7 +416,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       6 => {
-        let is_unsafe = inner.get_bool(inner.scalar_base(0));
+        let is_unsafe = inner.get_bool(scalar_base(&inner, 0));
 
         ConstantInfo::CtorInfo(ConstructorVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -423,7 +428,9 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       7 => {
-        let [k, is_unsafe] = inner.get_scalars::<2, bool>(inner.scalar_base(0));
+        let s = scalar_base(&inner, 0);
+        let k = inner.get_bool(s);
+        let is_unsafe = inner.get_bool(s + 1);
 
         let rules: Vec<RecursorRule> =
           inner.get(6).as_array().map(|x| LeanIxRecursorRule(x).decode());

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -16,15 +16,17 @@ use crate::ix::env::{
   RecursorRule, RecursorVal, ReducibilityHints, TheoremVal,
 };
 use crate::lean::{
-  LeanIxConstantInfo, LeanIxConstantVal, LeanIxExpr, LeanIxName,
-  LeanIxRecursorRule, LeanIxReducibilityHints,
+  LeanIxAxiomVal, LeanIxConstantInfo, LeanIxConstantVal, LeanIxConstructorVal,
+  LeanIxDefinitionVal, LeanIxExpr, LeanIxInductiveVal, LeanIxName,
+  LeanIxOpaqueVal, LeanIxQuotVal, LeanIxRecursorRule, LeanIxRecursorVal,
+  LeanIxReducibilityHints, LeanIxReducibilityHintsRegular,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{LeanArray, LeanCtor, LeanOwned, LeanRef};
-
-use lean_ffi::object::scalar_base;
+use lean_ffi::object::{
+  LeanArray, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
+};
 
 use crate::ffi::builder::LeanBuildCache;
 
@@ -79,8 +81,8 @@ impl LeanIxReducibilityHints<LeanOwned> {
       // | regular (h : UInt32) -- tag 2, object constructor
       ReducibilityHints::Regular(h) => {
         // UInt32 is a scalar, stored inline
-        let ctor = LeanCtor::alloc(2, 0, 4);
-        ctor.set_u32(scalar_base(&ctor, 0), *h);
+        let ctor = LeanIxReducibilityHintsRegular::alloc();
+        ctor.set_num_32(0, *h);
         ctor.into()
       },
     };
@@ -106,7 +108,8 @@ impl<R: LeanRef> LeanIxReducibilityHints<R> {
       1 => ReducibilityHints::Abbrev,
       2 => {
         // regular: 0 obj fields, 4 scalar bytes (UInt32)
-        ReducibilityHints::Regular(ctor.get_u32(scalar_base(&ctor, 0)))
+        let ctor = LeanIxReducibilityHintsRegular::from_ctor(ctor);
+        ReducibilityHints::Regular(ctor.get_num_32(0))
       },
       _ => panic!("Invalid ReducibilityHints tag: {}", ctor.tag()),
     }
@@ -165,12 +168,12 @@ impl LeanIxConstantInfo<LeanOwned> {
       ConstantInfo::AxiomInfo(v) => {
         // AxiomVal = { cnst : ConstantVal, isUnsafe : Bool }
         let cnst_obj = LeanIxConstantVal::build(cache, &v.cnst);
-        let axiom_val = LeanCtor::alloc(0, 1, 1);
-        axiom_val.set(0, cnst_obj);
-        axiom_val.set_bool(scalar_base(&axiom_val, 0), v.is_unsafe);
+        let ctor = LeanIxAxiomVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_num_8(0, v.is_unsafe as u8);
 
         let obj = LeanCtor::alloc(0, 1, 0);
-        obj.set(0, axiom_val);
+        obj.set(0, ctor);
         obj.into()
       },
       // | defnInfo (v : DefinitionVal) -- tag 1
@@ -187,15 +190,15 @@ impl LeanIxConstantInfo<LeanOwned> {
           DefinitionSafety::Partial => 2u8,
         };
 
-        let defn_val = LeanCtor::alloc(0, 4, 1);
-        defn_val.set(0, cnst_obj);
-        defn_val.set(1, value_obj);
-        defn_val.set(2, hints_obj);
-        defn_val.set(3, all_obj);
-        defn_val.set_u8(scalar_base(&defn_val, 0), safety_byte);
+        let ctor = LeanIxDefinitionVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_obj(1, value_obj);
+        ctor.set_obj(2, hints_obj);
+        ctor.set_obj(3, all_obj);
+        ctor.set_num_8(0, safety_byte);
 
         let obj = LeanCtor::alloc(1, 1, 0);
-        obj.set(0, defn_val);
+        obj.set(0, ctor);
         obj.into()
       },
       // | thmInfo (v : TheoremVal) -- tag 2
@@ -221,14 +224,14 @@ impl LeanIxConstantInfo<LeanOwned> {
         let value_obj = LeanIxExpr::build(cache, &v.value);
         let all_obj = LeanIxName::build_array(cache, &v.all);
 
-        let opaque_val = LeanCtor::alloc(0, 3, 1);
-        opaque_val.set(0, cnst_obj);
-        opaque_val.set(1, value_obj);
-        opaque_val.set(2, all_obj);
-        opaque_val.set_bool(scalar_base(&opaque_val, 0), v.is_unsafe);
+        let ctor = LeanIxOpaqueVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_obj(1, value_obj);
+        ctor.set_obj(2, all_obj);
+        ctor.set_num_8(0, v.is_unsafe as u8);
 
         let obj = LeanCtor::alloc(3, 1, 0);
-        obj.set(0, opaque_val);
+        obj.set(0, ctor);
         obj.into()
       },
       // | quotInfo (v : QuotVal) -- tag 4
@@ -243,12 +246,12 @@ impl LeanIxConstantInfo<LeanOwned> {
           QuotKind::Ind => 3u8,
         };
 
-        let quot_val = LeanCtor::alloc(0, 1, 1);
-        quot_val.set(0, cnst_obj);
-        quot_val.set_u8(scalar_base(&quot_val, 0), kind_byte);
+        let ctor = LeanIxQuotVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_num_8(0, kind_byte);
 
         let obj = LeanCtor::alloc(4, 1, 0);
-        obj.set(0, quot_val);
+        obj.set(0, ctor);
         obj.into()
       },
       // | inductInfo (v : InductiveVal) -- tag 5
@@ -262,20 +265,19 @@ impl LeanIxConstantInfo<LeanOwned> {
         let num_nested_obj = Nat::to_lean(&v.num_nested);
 
         // 6 object fields, 3 scalar bytes for bools
-        let induct_val = LeanCtor::alloc(0, 6, 3);
-        induct_val.set(0, cnst_obj);
-        induct_val.set(1, num_params_obj);
-        induct_val.set(2, num_indices_obj);
-        induct_val.set(3, all_obj);
-        induct_val.set(4, ctors_obj);
-        induct_val.set(5, num_nested_obj);
-        let s = scalar_base(&induct_val, 0);
-        induct_val.set_bool(s, v.is_rec);
-        induct_val.set_bool(s + 1, v.is_unsafe);
-        induct_val.set_bool(s + 2, v.is_reflexive);
+        let ctor = LeanIxInductiveVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_obj(1, num_params_obj);
+        ctor.set_obj(2, num_indices_obj);
+        ctor.set_obj(3, all_obj);
+        ctor.set_obj(4, ctors_obj);
+        ctor.set_obj(5, num_nested_obj);
+        ctor.set_num_8(0, v.is_rec as u8);
+        ctor.set_num_8(1, v.is_unsafe as u8);
+        ctor.set_num_8(2, v.is_reflexive as u8);
 
         let obj = LeanCtor::alloc(5, 1, 0);
-        obj.set(0, induct_val);
+        obj.set(0, ctor);
         obj.into()
       },
       // | ctorInfo (v : ConstructorVal) -- tag 6
@@ -288,16 +290,16 @@ impl LeanIxConstantInfo<LeanOwned> {
         let num_fields_obj = Nat::to_lean(&v.num_fields);
 
         // 5 object fields, 1 scalar byte for bool
-        let ctor_val = LeanCtor::alloc(0, 5, 1);
-        ctor_val.set(0, cnst_obj);
-        ctor_val.set(1, induct_obj);
-        ctor_val.set(2, cidx_obj);
-        ctor_val.set(3, num_params_obj);
-        ctor_val.set(4, num_fields_obj);
-        ctor_val.set_bool(scalar_base(&ctor_val, 0), v.is_unsafe);
+        let ctor = LeanIxConstructorVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_obj(1, induct_obj);
+        ctor.set_obj(2, cidx_obj);
+        ctor.set_obj(3, num_params_obj);
+        ctor.set_obj(4, num_fields_obj);
+        ctor.set_num_8(0, v.is_unsafe as u8);
 
         let obj = LeanCtor::alloc(6, 1, 0);
-        obj.set(0, ctor_val);
+        obj.set(0, ctor);
         obj.into()
       },
       // | recInfo (v : RecursorVal) -- tag 7
@@ -312,20 +314,19 @@ impl LeanIxConstantInfo<LeanOwned> {
         let rules_obj = LeanIxRecursorRule::build_array(cache, &v.rules);
 
         // 7 object fields, 2 scalar bytes for bools
-        let rec_val = LeanCtor::alloc(0, 7, 2);
-        rec_val.set(0, cnst_obj);
-        rec_val.set(1, all_obj);
-        rec_val.set(2, num_params_obj);
-        rec_val.set(3, num_indices_obj);
-        rec_val.set(4, num_motives_obj);
-        rec_val.set(5, num_minors_obj);
-        rec_val.set(6, rules_obj);
-        let s = scalar_base(&rec_val, 0);
-        rec_val.set_bool(s, v.k);
-        rec_val.set_bool(s + 1, v.is_unsafe);
+        let ctor = LeanIxRecursorVal::alloc();
+        ctor.set_obj(0, cnst_obj);
+        ctor.set_obj(1, all_obj);
+        ctor.set_obj(2, num_params_obj);
+        ctor.set_obj(3, num_indices_obj);
+        ctor.set_obj(4, num_motives_obj);
+        ctor.set_obj(5, num_minors_obj);
+        ctor.set_obj(6, rules_obj);
+        ctor.set_num_8(0, v.k as u8);
+        ctor.set_num_8(1, v.is_unsafe as u8);
 
         let obj = LeanCtor::alloc(7, 1, 0);
-        obj.set(0, rec_val);
+        obj.set(0, ctor);
         obj.into()
       },
     };
@@ -343,7 +344,8 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
 
     match outer.tag() {
       0 => {
-        let is_unsafe = inner.get_bool(scalar_base(&inner, 0));
+        let ctor = LeanIxAxiomVal::from_ctor(inner);
+        let is_unsafe = ctor.get_num_8(0) != 0;
 
         ConstantInfo::AxiomInfo(AxiomVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -351,7 +353,8 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       1 => {
-        let safety_byte = inner.get_u8(scalar_base(&inner, 0));
+        let ctor = LeanIxDefinitionVal::from_ctor(inner);
+        let safety_byte = ctor.get_num_8(0);
         let safety = match safety_byte {
           0 => DefinitionSafety::Unsafe,
           1 => DefinitionSafety::Safe,
@@ -373,7 +376,8 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         all: LeanIxName::decode_array(inner.get(2).as_array()),
       }),
       3 => {
-        let is_unsafe = inner.get_bool(scalar_base(&inner, 0));
+        let ctor = LeanIxOpaqueVal::from_ctor(inner);
+        let is_unsafe = ctor.get_num_8(0) != 0;
 
         ConstantInfo::OpaqueInfo(OpaqueVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -383,7 +387,8 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       4 => {
-        let kind_byte = inner.get_u8(scalar_base(&inner, 0));
+        let ctor = LeanIxQuotVal::from_ctor(inner);
+        let kind_byte = ctor.get_num_8(0);
         let kind = match kind_byte {
           0 => QuotKind::Type,
           1 => QuotKind::Ctor,
@@ -398,10 +403,10 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       5 => {
-        let s = scalar_base(&inner, 0);
-        let is_rec = inner.get_bool(s);
-        let is_unsafe = inner.get_bool(s + 1);
-        let is_reflexive = inner.get_bool(s + 2);
+        let ctor = LeanIxInductiveVal::from_ctor(inner);
+        let is_rec = ctor.get_num_8(0) != 0;
+        let is_unsafe = ctor.get_num_8(1) != 0;
+        let is_reflexive = ctor.get_num_8(2) != 0;
 
         ConstantInfo::InductInfo(InductiveVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -416,7 +421,8 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       6 => {
-        let is_unsafe = inner.get_bool(scalar_base(&inner, 0));
+        let ctor = LeanIxConstructorVal::from_ctor(inner);
+        let is_unsafe = ctor.get_num_8(0) != 0;
 
         ConstantInfo::CtorInfo(ConstructorVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -428,9 +434,9 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       7 => {
-        let s = scalar_base(&inner, 0);
-        let k = inner.get_bool(s);
-        let is_unsafe = inner.get_bool(s + 1);
+        let ctor = LeanIxRecursorVal::from_ctor(inner);
+        let k = ctor.get_num_8(0) != 0;
+        let is_unsafe = ctor.get_num_8(1) != 0;
 
         let rules: Vec<RecursorRule> =
           inner.get(6).as_array().map(|x| LeanIxRecursorRule(x).decode());

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -267,7 +267,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         induct_val.set(3, all_obj);
         induct_val.set(4, ctors_obj);
         induct_val.set(5, num_nested_obj);
-        induct_val.set_bools::<3>(
+        induct_val.set_scalars::<3, bool>(
           induct_val.scalar_base(0),
           [v.is_rec, v.is_unsafe, v.is_reflexive],
         );
@@ -318,7 +318,8 @@ impl LeanIxConstantInfo<LeanOwned> {
         rec_val.set(4, num_motives_obj);
         rec_val.set(5, num_minors_obj);
         rec_val.set(6, rules_obj);
-        rec_val.set_bools::<2>(rec_val.scalar_base(0), [v.k, v.is_unsafe]);
+        rec_val
+          .set_scalars::<2, bool>(rec_val.scalar_base(0), [v.k, v.is_unsafe]);
 
         let obj = LeanCtor::alloc(7, 1, 0);
         obj.set(0, rec_val);
@@ -395,7 +396,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
       },
       5 => {
         let [is_rec, is_unsafe, is_reflexive] =
-          inner.get_bools::<3>(inner.scalar_base(0));
+          inner.get_scalars::<3, bool>(inner.scalar_base(0));
 
         ConstantInfo::InductInfo(InductiveVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -422,7 +423,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       7 => {
-        let [k, is_unsafe] = inner.get_bools::<2>(inner.scalar_base(0));
+        let [k, is_unsafe] = inner.get_scalars::<2, bool>(inner.scalar_base(0));
 
         let rules: Vec<RecursorRule> =
           inner.get(6).as_array().map(|x| LeanIxRecursorRule(x).decode());

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -16,17 +16,18 @@ use crate::ix::env::{
   RecursorRule, RecursorVal, ReducibilityHints, TheoremVal,
 };
 use crate::lean::{
-  LeanIxAxiomVal, LeanIxConstantInfo, LeanIxConstantVal, LeanIxConstructorVal,
+  LeanIxAxiomVal, LeanIxConstantInfo, LeanIxConstantInfoAxiom,
+  LeanIxConstantInfoCtor, LeanIxConstantInfoDefn, LeanIxConstantInfoInduct,
+  LeanIxConstantInfoOpaque, LeanIxConstantInfoQuot, LeanIxConstantInfoRec,
+  LeanIxConstantInfoThm, LeanIxConstantVal, LeanIxConstructorVal,
   LeanIxDefinitionVal, LeanIxExpr, LeanIxInductiveVal, LeanIxName,
   LeanIxOpaqueVal, LeanIxQuotVal, LeanIxRecursorRule, LeanIxRecursorVal,
-  LeanIxReducibilityHints, LeanIxReducibilityHintsRegular,
+  LeanIxReducibilityHints, LeanIxReducibilityHintsRegular, LeanIxTheoremVal,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{
-  LeanArray, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
-};
+use lean_ffi::object::{LeanArray, LeanOwned, LeanRef};
 
 use crate::ffi::builder::LeanBuildCache;
 
@@ -42,11 +43,11 @@ impl LeanIxConstantVal<LeanOwned> {
     let level_params_obj = LeanIxName::build_array(cache, &cv.level_params);
     let type_obj = LeanIxExpr::build(cache, &cv.typ);
 
-    let obj = LeanCtor::alloc(0, 3, 0);
-    obj.set(0, name_obj);
-    obj.set(1, level_params_obj);
-    obj.set(2, type_obj);
-    Self::new(obj.into())
+    let ctor = LeanIxConstantVal::alloc();
+    ctor.set_obj(0, name_obj);
+    ctor.set_obj(1, level_params_obj);
+    ctor.set_obj(2, type_obj);
+    Self::new(ctor.into())
   }
 }
 
@@ -80,7 +81,6 @@ impl LeanIxReducibilityHints<LeanOwned> {
       ReducibilityHints::Abbrev => LeanOwned::box_usize(1),
       // | regular (h : UInt32) -- tag 2, object constructor
       ReducibilityHints::Regular(h) => {
-        // UInt32 is a scalar, stored inline
         let ctor = LeanIxReducibilityHintsRegular::alloc();
         ctor.set_num_32(0, *h);
         ctor.into()
@@ -149,10 +149,10 @@ impl LeanIxRecursorRule<LeanOwned> {
       let n_fields_obj = Nat::to_lean(&rule.n_fields);
       let rhs_obj = LeanIxExpr::build(cache, &rule.rhs);
 
-      let rule_obj = LeanCtor::alloc(0, 3, 0);
-      rule_obj.set(0, ctor_obj);
-      rule_obj.set(1, n_fields_obj);
-      rule_obj.set(2, rhs_obj);
+      let rule_obj = LeanIxRecursorRule::alloc();
+      rule_obj.set_obj(0, ctor_obj);
+      rule_obj.set_obj(1, n_fields_obj);
+      rule_obj.set_obj(2, rhs_obj);
 
       arr.set(i, rule_obj);
     }
@@ -168,12 +168,12 @@ impl LeanIxConstantInfo<LeanOwned> {
       ConstantInfo::AxiomInfo(v) => {
         // AxiomVal = { cnst : ConstantVal, isUnsafe : Bool }
         let cnst_obj = LeanIxConstantVal::build(cache, &v.cnst);
-        let ctor = LeanIxAxiomVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_num_8(0, v.is_unsafe as u8);
+        let axiom_val = LeanIxAxiomVal::alloc();
+        axiom_val.set_obj(0, cnst_obj);
+        axiom_val.set_num_8(0, v.is_unsafe as u8);
 
-        let obj = LeanCtor::alloc(0, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoAxiom::alloc();
+        obj.set_obj(0, axiom_val);
         obj.into()
       },
       // | defnInfo (v : DefinitionVal) -- tag 1
@@ -190,15 +190,15 @@ impl LeanIxConstantInfo<LeanOwned> {
           DefinitionSafety::Partial => 2u8,
         };
 
-        let ctor = LeanIxDefinitionVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_obj(1, value_obj);
-        ctor.set_obj(2, hints_obj);
-        ctor.set_obj(3, all_obj);
-        ctor.set_num_8(0, safety_byte);
+        let defn_val = LeanIxDefinitionVal::alloc();
+        defn_val.set_obj(0, cnst_obj);
+        defn_val.set_obj(1, value_obj);
+        defn_val.set_obj(2, hints_obj);
+        defn_val.set_obj(3, all_obj);
+        defn_val.set_num_8(0, safety_byte);
 
-        let obj = LeanCtor::alloc(1, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoDefn::alloc();
+        obj.set_obj(0, defn_val);
         obj.into()
       },
       // | thmInfo (v : TheoremVal) -- tag 2
@@ -208,13 +208,13 @@ impl LeanIxConstantInfo<LeanOwned> {
         let value_obj = LeanIxExpr::build(cache, &v.value);
         let all_obj = LeanIxName::build_array(cache, &v.all);
 
-        let thm_val = LeanCtor::alloc(0, 3, 0);
-        thm_val.set(0, cnst_obj);
-        thm_val.set(1, value_obj);
-        thm_val.set(2, all_obj);
+        let thm_val = LeanIxTheoremVal::alloc();
+        thm_val.set_obj(0, cnst_obj);
+        thm_val.set_obj(1, value_obj);
+        thm_val.set_obj(2, all_obj);
 
-        let obj = LeanCtor::alloc(2, 1, 0);
-        obj.set(0, thm_val);
+        let obj = LeanIxConstantInfoThm::alloc();
+        obj.set_obj(0, thm_val);
         obj.into()
       },
       // | opaqueInfo (v : OpaqueVal) -- tag 3
@@ -224,14 +224,14 @@ impl LeanIxConstantInfo<LeanOwned> {
         let value_obj = LeanIxExpr::build(cache, &v.value);
         let all_obj = LeanIxName::build_array(cache, &v.all);
 
-        let ctor = LeanIxOpaqueVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_obj(1, value_obj);
-        ctor.set_obj(2, all_obj);
-        ctor.set_num_8(0, v.is_unsafe as u8);
+        let opaque_val = LeanIxOpaqueVal::alloc();
+        opaque_val.set_obj(0, cnst_obj);
+        opaque_val.set_obj(1, value_obj);
+        opaque_val.set_obj(2, all_obj);
+        opaque_val.set_num_8(0, v.is_unsafe as u8);
 
-        let obj = LeanCtor::alloc(3, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoOpaque::alloc();
+        obj.set_obj(0, opaque_val);
         obj.into()
       },
       // | quotInfo (v : QuotVal) -- tag 4
@@ -246,12 +246,12 @@ impl LeanIxConstantInfo<LeanOwned> {
           QuotKind::Ind => 3u8,
         };
 
-        let ctor = LeanIxQuotVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_num_8(0, kind_byte);
+        let quot_val = LeanIxQuotVal::alloc();
+        quot_val.set_obj(0, cnst_obj);
+        quot_val.set_num_8(0, kind_byte);
 
-        let obj = LeanCtor::alloc(4, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoQuot::alloc();
+        obj.set_obj(0, quot_val);
         obj.into()
       },
       // | inductInfo (v : InductiveVal) -- tag 5
@@ -265,19 +265,19 @@ impl LeanIxConstantInfo<LeanOwned> {
         let num_nested_obj = Nat::to_lean(&v.num_nested);
 
         // 6 object fields, 3 scalar bytes for bools
-        let ctor = LeanIxInductiveVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_obj(1, num_params_obj);
-        ctor.set_obj(2, num_indices_obj);
-        ctor.set_obj(3, all_obj);
-        ctor.set_obj(4, ctors_obj);
-        ctor.set_obj(5, num_nested_obj);
-        ctor.set_num_8(0, v.is_rec as u8);
-        ctor.set_num_8(1, v.is_unsafe as u8);
-        ctor.set_num_8(2, v.is_reflexive as u8);
+        let induct_val = LeanIxInductiveVal::alloc();
+        induct_val.set_obj(0, cnst_obj);
+        induct_val.set_obj(1, num_params_obj);
+        induct_val.set_obj(2, num_indices_obj);
+        induct_val.set_obj(3, all_obj);
+        induct_val.set_obj(4, ctors_obj);
+        induct_val.set_obj(5, num_nested_obj);
+        induct_val.set_num_8(0, v.is_rec as u8);
+        induct_val.set_num_8(1, v.is_unsafe as u8);
+        induct_val.set_num_8(2, v.is_reflexive as u8);
 
-        let obj = LeanCtor::alloc(5, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoInduct::alloc();
+        obj.set_obj(0, induct_val);
         obj.into()
       },
       // | ctorInfo (v : ConstructorVal) -- tag 6
@@ -290,16 +290,16 @@ impl LeanIxConstantInfo<LeanOwned> {
         let num_fields_obj = Nat::to_lean(&v.num_fields);
 
         // 5 object fields, 1 scalar byte for bool
-        let ctor = LeanIxConstructorVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_obj(1, induct_obj);
-        ctor.set_obj(2, cidx_obj);
-        ctor.set_obj(3, num_params_obj);
-        ctor.set_obj(4, num_fields_obj);
-        ctor.set_num_8(0, v.is_unsafe as u8);
+        let ctor_val = LeanIxConstructorVal::alloc();
+        ctor_val.set_obj(0, cnst_obj);
+        ctor_val.set_obj(1, induct_obj);
+        ctor_val.set_obj(2, cidx_obj);
+        ctor_val.set_obj(3, num_params_obj);
+        ctor_val.set_obj(4, num_fields_obj);
+        ctor_val.set_num_8(0, v.is_unsafe as u8);
 
-        let obj = LeanCtor::alloc(6, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoCtor::alloc();
+        obj.set_obj(0, ctor_val);
         obj.into()
       },
       // | recInfo (v : RecursorVal) -- tag 7
@@ -314,19 +314,19 @@ impl LeanIxConstantInfo<LeanOwned> {
         let rules_obj = LeanIxRecursorRule::build_array(cache, &v.rules);
 
         // 7 object fields, 2 scalar bytes for bools
-        let ctor = LeanIxRecursorVal::alloc();
-        ctor.set_obj(0, cnst_obj);
-        ctor.set_obj(1, all_obj);
-        ctor.set_obj(2, num_params_obj);
-        ctor.set_obj(3, num_indices_obj);
-        ctor.set_obj(4, num_motives_obj);
-        ctor.set_obj(5, num_minors_obj);
-        ctor.set_obj(6, rules_obj);
-        ctor.set_num_8(0, v.k as u8);
-        ctor.set_num_8(1, v.is_unsafe as u8);
+        let rec_val = LeanIxRecursorVal::alloc();
+        rec_val.set_obj(0, cnst_obj);
+        rec_val.set_obj(1, all_obj);
+        rec_val.set_obj(2, num_params_obj);
+        rec_val.set_obj(3, num_indices_obj);
+        rec_val.set_obj(4, num_motives_obj);
+        rec_val.set_obj(5, num_minors_obj);
+        rec_val.set_obj(6, rules_obj);
+        rec_val.set_num_8(0, v.k as u8);
+        rec_val.set_num_8(1, v.is_unsafe as u8);
 
-        let obj = LeanCtor::alloc(7, 1, 0);
-        obj.set(0, ctor);
+        let obj = LeanIxConstantInfoRec::alloc();
+        obj.set_obj(0, rec_val);
         obj.into()
       },
     };
@@ -344,17 +344,17 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
 
     match outer.tag() {
       0 => {
-        let ctor = LeanIxAxiomVal::from_ctor(inner);
-        let is_unsafe = ctor.get_num_8(0) != 0;
+        let inner = LeanIxAxiomVal::from_ctor(inner);
+        let is_unsafe = inner.get_num_8(0) != 0;
 
         ConstantInfo::AxiomInfo(AxiomVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
           is_unsafe,
         })
       },
       1 => {
-        let ctor = LeanIxDefinitionVal::from_ctor(inner);
-        let safety_byte = ctor.get_num_8(0);
+        let inner = LeanIxDefinitionVal::from_ctor(inner);
+        let safety_byte = inner.get_num_8(0);
         let safety = match safety_byte {
           0 => DefinitionSafety::Unsafe,
           1 => DefinitionSafety::Safe,
@@ -363,11 +363,11 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         };
 
         ConstantInfo::DefnInfo(DefinitionVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
-          value: LeanIxExpr(inner.get(1)).decode(),
-          hints: LeanIxReducibilityHints(inner.get(2)).decode(),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          value: LeanIxExpr(inner.get_obj(1)).decode(),
+          hints: LeanIxReducibilityHints(inner.get_obj(2)).decode(),
           safety,
-          all: LeanIxName::decode_array(inner.get(3).as_array()),
+          all: LeanIxName::decode_array(inner.get_obj(3).as_array()),
         })
       },
       2 => ConstantInfo::ThmInfo(TheoremVal {
@@ -376,19 +376,19 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         all: LeanIxName::decode_array(inner.get(2).as_array()),
       }),
       3 => {
-        let ctor = LeanIxOpaqueVal::from_ctor(inner);
-        let is_unsafe = ctor.get_num_8(0) != 0;
+        let inner = LeanIxOpaqueVal::from_ctor(inner);
+        let is_unsafe = inner.get_num_8(0) != 0;
 
         ConstantInfo::OpaqueInfo(OpaqueVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
-          value: LeanIxExpr(inner.get(1)).decode(),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          value: LeanIxExpr(inner.get_obj(1)).decode(),
           is_unsafe,
-          all: LeanIxName::decode_array(inner.get(2).as_array()),
+          all: LeanIxName::decode_array(inner.get_obj(2).as_array()),
         })
       },
       4 => {
-        let ctor = LeanIxQuotVal::from_ctor(inner);
-        let kind_byte = ctor.get_num_8(0);
+        let inner = LeanIxQuotVal::from_ctor(inner);
+        let kind_byte = inner.get_num_8(0);
         let kind = match kind_byte {
           0 => QuotKind::Type,
           1 => QuotKind::Ctor,
@@ -398,56 +398,56 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         };
 
         ConstantInfo::QuotInfo(QuotVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
           kind,
         })
       },
       5 => {
-        let ctor = LeanIxInductiveVal::from_ctor(inner);
-        let is_rec = ctor.get_num_8(0) != 0;
-        let is_unsafe = ctor.get_num_8(1) != 0;
-        let is_reflexive = ctor.get_num_8(2) != 0;
+        let inner = LeanIxInductiveVal::from_ctor(inner);
+        let is_rec = inner.get_num_8(0) != 0;
+        let is_unsafe = inner.get_num_8(1) != 0;
+        let is_reflexive = inner.get_num_8(2) != 0;
 
         ConstantInfo::InductInfo(InductiveVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
-          num_params: Nat::from_obj(&inner.get(1)),
-          num_indices: Nat::from_obj(&inner.get(2)),
-          all: LeanIxName::decode_array(inner.get(3).as_array()),
-          ctors: LeanIxName::decode_array(inner.get(4).as_array()),
-          num_nested: Nat::from_obj(&inner.get(5)),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          num_params: Nat::from_obj(&inner.get_obj(1)),
+          num_indices: Nat::from_obj(&inner.get_obj(2)),
+          all: LeanIxName::decode_array(inner.get_obj(3).as_array()),
+          ctors: LeanIxName::decode_array(inner.get_obj(4).as_array()),
+          num_nested: Nat::from_obj(&inner.get_obj(5)),
           is_rec,
           is_unsafe,
           is_reflexive,
         })
       },
       6 => {
-        let ctor = LeanIxConstructorVal::from_ctor(inner);
-        let is_unsafe = ctor.get_num_8(0) != 0;
+        let inner = LeanIxConstructorVal::from_ctor(inner);
+        let is_unsafe = inner.get_num_8(0) != 0;
 
         ConstantInfo::CtorInfo(ConstructorVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
-          induct: LeanIxName(inner.get(1)).decode(),
-          cidx: Nat::from_obj(&inner.get(2)),
-          num_params: Nat::from_obj(&inner.get(3)),
-          num_fields: Nat::from_obj(&inner.get(4)),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          induct: LeanIxName(inner.get_obj(1)).decode(),
+          cidx: Nat::from_obj(&inner.get_obj(2)),
+          num_params: Nat::from_obj(&inner.get_obj(3)),
+          num_fields: Nat::from_obj(&inner.get_obj(4)),
           is_unsafe,
         })
       },
       7 => {
-        let ctor = LeanIxRecursorVal::from_ctor(inner);
-        let k = ctor.get_num_8(0) != 0;
-        let is_unsafe = ctor.get_num_8(1) != 0;
+        let inner = LeanIxRecursorVal::from_ctor(inner);
+        let k = inner.get_num_8(0) != 0;
+        let is_unsafe = inner.get_num_8(1) != 0;
 
         let rules: Vec<RecursorRule> =
-          inner.get(6).as_array().map(|x| LeanIxRecursorRule(x).decode());
+          inner.get_obj(6).as_array().map(|x| LeanIxRecursorRule(x).decode());
 
         ConstantInfo::RecInfo(RecursorVal {
-          cnst: LeanIxConstantVal(inner.get(0)).decode(),
-          all: LeanIxName::decode_array(inner.get(1).as_array()),
-          num_params: Nat::from_obj(&inner.get(2)),
-          num_indices: Nat::from_obj(&inner.get(3)),
-          num_motives: Nat::from_obj(&inner.get(4)),
-          num_minors: Nat::from_obj(&inner.get(5)),
+          cnst: LeanIxConstantVal(inner.get_obj(0)).decode(),
+          all: LeanIxName::decode_array(inner.get_obj(1).as_array()),
+          num_params: Nat::from_obj(&inner.get_obj(2)),
+          num_indices: Nat::from_obj(&inner.get_obj(3)),
+          num_motives: Nat::from_obj(&inner.get_obj(4)),
+          num_minors: Nat::from_obj(&inner.get_obj(5)),
           rules,
           k,
           is_unsafe,

--- a/src/ffi/ix/constant.rs
+++ b/src/ffi/ix/constant.rs
@@ -78,7 +78,7 @@ impl LeanIxReducibilityHints<LeanOwned> {
       ReducibilityHints::Regular(h) => {
         // UInt32 is a scalar, stored inline
         let ctor = LeanCtor::alloc(2, 0, 4);
-        ctor.set_u32(0, 0, *h);
+        ctor.set_u32(ctor.scalar_base(0), *h);
         ctor.into()
       },
     };
@@ -104,7 +104,7 @@ impl<R: LeanRef> LeanIxReducibilityHints<R> {
       1 => ReducibilityHints::Abbrev,
       2 => {
         // regular: 0 obj fields, 4 scalar bytes (UInt32)
-        ReducibilityHints::Regular(ctor.get_u32(0, 0))
+        ReducibilityHints::Regular(ctor.get_u32(ctor.scalar_base(0)))
       },
       _ => panic!("Invalid ReducibilityHints tag: {}", ctor.tag()),
     }
@@ -165,7 +165,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         let cnst_obj = LeanIxConstantVal::build(cache, &v.cnst);
         let axiom_val = LeanCtor::alloc(0, 1, 1);
         axiom_val.set(0, cnst_obj);
-        axiom_val.set_bool(1, 0, v.is_unsafe);
+        axiom_val.set_bool(axiom_val.scalar_base(0), v.is_unsafe);
 
         let obj = LeanCtor::alloc(0, 1, 0);
         obj.set(0, axiom_val);
@@ -190,7 +190,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         defn_val.set(1, value_obj);
         defn_val.set(2, hints_obj);
         defn_val.set(3, all_obj);
-        defn_val.set_u8(4, 0, safety_byte);
+        defn_val.set_u8(defn_val.scalar_base(0), safety_byte);
 
         let obj = LeanCtor::alloc(1, 1, 0);
         obj.set(0, defn_val);
@@ -223,7 +223,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         opaque_val.set(0, cnst_obj);
         opaque_val.set(1, value_obj);
         opaque_val.set(2, all_obj);
-        opaque_val.set_bool(3, 0, v.is_unsafe);
+        opaque_val.set_bool(opaque_val.scalar_base(0), v.is_unsafe);
 
         let obj = LeanCtor::alloc(3, 1, 0);
         obj.set(0, opaque_val);
@@ -243,7 +243,7 @@ impl LeanIxConstantInfo<LeanOwned> {
 
         let quot_val = LeanCtor::alloc(0, 1, 1);
         quot_val.set(0, cnst_obj);
-        quot_val.set_u8(1, 0, kind_byte);
+        quot_val.set_u8(quot_val.scalar_base(0), kind_byte);
 
         let obj = LeanCtor::alloc(4, 1, 0);
         obj.set(0, quot_val);
@@ -267,9 +267,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         induct_val.set(3, all_obj);
         induct_val.set(4, ctors_obj);
         induct_val.set(5, num_nested_obj);
-        induct_val.set_bool(6, 0, v.is_rec);
-        induct_val.set_bool(6, 1, v.is_unsafe);
-        induct_val.set_bool(6, 2, v.is_reflexive);
+        induct_val.set_bools::<3>(induct_val.scalar_base(0), [v.is_rec, v.is_unsafe, v.is_reflexive]);
 
         let obj = LeanCtor::alloc(5, 1, 0);
         obj.set(0, induct_val);
@@ -291,7 +289,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         ctor_val.set(2, cidx_obj);
         ctor_val.set(3, num_params_obj);
         ctor_val.set(4, num_fields_obj);
-        ctor_val.set_bool(5, 0, v.is_unsafe);
+        ctor_val.set_bool(ctor_val.scalar_base(0), v.is_unsafe);
 
         let obj = LeanCtor::alloc(6, 1, 0);
         obj.set(0, ctor_val);
@@ -317,8 +315,7 @@ impl LeanIxConstantInfo<LeanOwned> {
         rec_val.set(4, num_motives_obj);
         rec_val.set(5, num_minors_obj);
         rec_val.set(6, rules_obj);
-        rec_val.set_bool(7, 0, v.k);
-        rec_val.set_bool(7, 1, v.is_unsafe);
+        rec_val.set_bools::<2>(rec_val.scalar_base(0), [v.k, v.is_unsafe]);
 
         let obj = LeanCtor::alloc(7, 1, 0);
         obj.set(0, rec_val);
@@ -339,7 +336,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
 
     match outer.tag() {
       0 => {
-        let is_unsafe = inner.get_u8(1, 0) != 0;
+        let is_unsafe = inner.get_bool(inner.scalar_base(0));
 
         ConstantInfo::AxiomInfo(AxiomVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -347,7 +344,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       1 => {
-        let safety_byte = inner.get_u8(4, 0);
+        let safety_byte = inner.get_u8(inner.scalar_base(0));
         let safety = match safety_byte {
           0 => DefinitionSafety::Unsafe,
           1 => DefinitionSafety::Safe,
@@ -369,7 +366,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         all: LeanIxName::decode_array(inner.get(2).as_array()),
       }),
       3 => {
-        let is_unsafe = inner.get_u8(3, 0) != 0;
+        let is_unsafe = inner.get_bool(inner.scalar_base(0));
 
         ConstantInfo::OpaqueInfo(OpaqueVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -379,7 +376,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       4 => {
-        let kind_byte = inner.get_u8(1, 0);
+        let kind_byte = inner.get_u8(inner.scalar_base(0));
         let kind = match kind_byte {
           0 => QuotKind::Type,
           1 => QuotKind::Ctor,
@@ -394,9 +391,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       5 => {
-        let is_rec = inner.get_u8(6, 0) != 0;
-        let is_unsafe = inner.get_u8(6, 1) != 0;
-        let is_reflexive = inner.get_u8(6, 2) != 0;
+        let [is_rec, is_unsafe, is_reflexive] = inner.get_bools::<3>(inner.scalar_base(0));
 
         ConstantInfo::InductInfo(InductiveVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -411,7 +406,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       6 => {
-        let is_unsafe = inner.get_u8(5, 0) != 0;
+        let is_unsafe = inner.get_bool(inner.scalar_base(0));
 
         ConstantInfo::CtorInfo(ConstructorVal {
           cnst: LeanIxConstantVal(inner.get(0)).decode(),
@@ -423,8 +418,7 @@ impl<R: LeanRef> LeanIxConstantInfo<R> {
         })
       },
       7 => {
-        let k = inner.get_u8(7, 0) != 0;
-        let is_unsafe = inner.get_u8(7, 1) != 0;
+        let [k, is_unsafe] = inner.get_bools::<2>(inner.scalar_base(0));
 
         let rules: Vec<RecursorRule> =
           inner.get(6).as_array().map(|x| LeanIxRecursorRule(x).decode());

--- a/src/ffi/ix/data.rs
+++ b/src/ffi/ix/data.rs
@@ -4,17 +4,18 @@ use crate::ix::env::{
   DataValue, Int, Name, SourceInfo, Substring, Syntax, SyntaxPreresolved,
 };
 use crate::lean::{
-  LeanIxDataValue, LeanIxInt, LeanIxName, LeanIxSourceInfo, LeanIxSubstring,
-  LeanIxSyntax, LeanIxSyntaxPreresolved,
+  LeanIxDataValue, LeanIxDataValueBool, LeanIxDataValueInt,
+  LeanIxDataValueName, LeanIxDataValueNat, LeanIxDataValueString,
+  LeanIxDataValueSyntax, LeanIxInt, LeanIxIntNegSucc, LeanIxIntOfNat,
+  LeanIxName, LeanIxSourceInfo, LeanIxSourceInfoNone, LeanIxSourceInfoOriginal,
+  LeanIxSourceInfoSynthetic, LeanIxSubstring, LeanIxSyntax, LeanIxSyntaxAtom,
+  LeanIxSyntaxIdent, LeanIxSyntaxMissing, LeanIxSyntaxNode,
+  LeanIxSyntaxPreresolved, LeanIxSyntaxPreresolvedA, LeanIxSyntaxPreresolvedB,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{
-  LeanArray, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef, LeanString,
-};
-
-use crate::lean::{LeanIxDataValueBool, LeanIxSourceInfoSynthetic};
+use lean_ffi::object::{LeanArray, LeanOwned, LeanProd, LeanRef, LeanString};
 
 use crate::ffi::builder::LeanBuildCache;
 
@@ -23,14 +24,14 @@ impl LeanIxInt<LeanOwned> {
   pub fn build(int: &Int) -> Self {
     match int {
       Int::OfNat(n) => {
-        let obj = LeanCtor::alloc(0, 1, 0);
-        obj.set(0, Nat::to_lean(n));
-        Self::new(obj.into())
+        let ctor = LeanIxIntOfNat::alloc();
+        ctor.set_obj(0, Nat::to_lean(n));
+        Self::new(ctor.into())
       },
       Int::NegSucc(n) => {
-        let obj = LeanCtor::alloc(1, 1, 0);
-        obj.set(0, Nat::to_lean(n));
-        Self::new(obj.into())
+        let ctor = LeanIxIntNegSucc::alloc();
+        ctor.set_obj(0, Nat::to_lean(n));
+        Self::new(ctor.into())
       },
     }
   }
@@ -53,11 +54,11 @@ impl<R: LeanRef> LeanIxInt<R> {
 impl LeanIxSubstring<LeanOwned> {
   /// Build a Ix.Substring.
   pub fn build(ss: &Substring) -> Self {
-    let obj = LeanCtor::alloc(0, 3, 0);
-    obj.set(0, LeanString::new(ss.str.as_str()));
-    obj.set(1, Nat::to_lean(&ss.start_pos));
-    obj.set(2, Nat::to_lean(&ss.stop_pos));
-    Self::new(obj.into())
+    let ctor = LeanIxSubstring::alloc();
+    ctor.set_obj(0, LeanString::new(ss.str.as_str()));
+    ctor.set_obj(1, Nat::to_lean(&ss.start_pos));
+    ctor.set_obj(2, Nat::to_lean(&ss.stop_pos));
+    Self::new(ctor.into())
   }
 }
 
@@ -79,12 +80,12 @@ impl LeanIxSourceInfo<LeanOwned> {
     match si {
       // | original (leading : Substring) (pos : Nat) (trailing : Substring) (endPos : Nat) -- tag 0
       SourceInfo::Original(leading, pos, trailing, end_pos) => {
-        let obj = LeanCtor::alloc(0, 4, 0);
-        obj.set(0, LeanIxSubstring::build(leading));
-        obj.set(1, Nat::to_lean(pos));
-        obj.set(2, LeanIxSubstring::build(trailing));
-        obj.set(3, Nat::to_lean(end_pos));
-        Self::new(obj.into())
+        let ctor = LeanIxSourceInfoOriginal::alloc();
+        ctor.set_obj(0, LeanIxSubstring::build(leading));
+        ctor.set_obj(1, Nat::to_lean(pos));
+        ctor.set_obj(2, LeanIxSubstring::build(trailing));
+        ctor.set_obj(3, Nat::to_lean(end_pos));
+        Self::new(ctor.into())
       },
       // | synthetic (pos : Nat) (endPos : Nat) (canonical : Bool) -- tag 1
       SourceInfo::Synthetic(pos, end_pos, canonical) => {
@@ -95,7 +96,7 @@ impl LeanIxSourceInfo<LeanOwned> {
         Self::new(ctor.into())
       },
       // | none -- tag 2
-      SourceInfo::None => Self::new(LeanCtor::alloc(2, 0, 0).into()),
+      SourceInfo::None => Self::new(LeanIxSourceInfoNone::alloc().into()),
     }
   }
 }
@@ -123,8 +124,8 @@ impl<R: LeanRef> LeanIxSourceInfo<R> {
         let canonical = ctor.get_num_8(0) != 0;
 
         SourceInfo::Synthetic(
-          Nat::from_obj(&ctor.as_ctor().get(0)),
-          Nat::from_obj(&ctor.as_ctor().get(1)),
+          Nat::from_obj(&ctor.get_obj(0)),
+          Nat::from_obj(&ctor.get_obj(1)),
           canonical,
         )
       },
@@ -140,18 +141,16 @@ impl LeanIxSyntaxPreresolved<LeanOwned> {
     match sp {
       // | namespace (name : Name) -- tag 0
       SyntaxPreresolved::Namespace(name) => {
-        let obj = LeanCtor::alloc(0, 1, 0);
-        obj.set(0, LeanIxName::build(cache, name));
-        Self::new(obj.into())
+        let ctor = LeanIxSyntaxPreresolvedA::alloc();
+        ctor.set_obj(0, LeanIxName::build(cache, name));
+        Self::new(ctor.into())
       },
       // | decl (name : Name) (aliases : Array String) -- tag 1
       SyntaxPreresolved::Decl(name, aliases) => {
-        let name_obj = LeanIxName::build(cache, name);
-        let aliases_obj = build_string_array(aliases);
-        let obj = LeanCtor::alloc(1, 2, 0);
-        obj.set(0, name_obj);
-        obj.set(1, aliases_obj);
-        Self::new(obj.into())
+        let ctor = LeanIxSyntaxPreresolvedB::alloc();
+        ctor.set_obj(0, LeanIxName::build(cache, name));
+        ctor.set_obj(1, build_string_array(aliases));
+        Self::new(ctor.into())
       },
     }
   }
@@ -193,38 +192,30 @@ impl LeanIxSyntax<LeanOwned> {
   pub fn build(cache: &mut LeanBuildCache, syn: &Syntax) -> Self {
     match syn {
       // | missing -- tag 0
-      Syntax::Missing => Self::new(LeanCtor::alloc(0, 0, 0).into()),
+      Syntax::Missing => Self::new(LeanIxSyntaxMissing::alloc().into()),
       // | node (info : SourceInfo) (kind : Name) (args : Array Syntax) -- tag 1
       Syntax::Node(info, kind, args) => {
-        let info_obj = LeanIxSourceInfo::build(info);
-        let kind_obj = LeanIxName::build(cache, kind);
-        let args_obj = Self::build_array(cache, args);
-        let obj = LeanCtor::alloc(1, 3, 0);
-        obj.set(0, info_obj);
-        obj.set(1, kind_obj);
-        obj.set(2, args_obj);
-        Self::new(obj.into())
+        let ctor = LeanIxSyntaxNode::alloc();
+        ctor.set_obj(0, LeanIxSourceInfo::build(info));
+        ctor.set_obj(1, LeanIxName::build(cache, kind));
+        ctor.set_obj(2, Self::build_array(cache, args));
+        Self::new(ctor.into())
       },
       // | atom (info : SourceInfo) (val : String) -- tag 2
       Syntax::Atom(info, val) => {
-        let info_obj = LeanIxSourceInfo::build(info);
-        let obj = LeanCtor::alloc(2, 2, 0);
-        obj.set(0, info_obj);
-        obj.set(1, LeanString::new(val.as_str()));
-        Self::new(obj.into())
+        let ctor = LeanIxSyntaxAtom::alloc();
+        ctor.set_obj(0, LeanIxSourceInfo::build(info));
+        ctor.set_obj(1, LeanString::new(val.as_str()));
+        Self::new(ctor.into())
       },
       // | ident (info : SourceInfo) (rawVal : Substring) (val : Name) (preresolved : Array SyntaxPreresolved) -- tag 3
       Syntax::Ident(info, raw_val, val, preresolved) => {
-        let info_obj = LeanIxSourceInfo::build(info);
-        let raw_val_obj = LeanIxSubstring::build(raw_val);
-        let val_obj = LeanIxName::build(cache, val);
-        let preresolved_obj = Self::build_preresolved_array(cache, preresolved);
-        let obj = LeanCtor::alloc(3, 4, 0);
-        obj.set(0, info_obj);
-        obj.set(1, raw_val_obj);
-        obj.set(2, val_obj);
-        obj.set(3, preresolved_obj);
-        Self::new(obj.into())
+        let ctor = LeanIxSyntaxIdent::alloc();
+        ctor.set_obj(0, LeanIxSourceInfo::build(info));
+        ctor.set_obj(1, LeanIxSubstring::build(raw_val));
+        ctor.set_obj(2, LeanIxName::build(cache, val));
+        ctor.set_obj(3, Self::build_preresolved_array(cache, preresolved));
+        Self::new(ctor.into())
       },
     }
   }
@@ -297,9 +288,9 @@ impl LeanIxDataValue<LeanOwned> {
   pub fn build(cache: &mut LeanBuildCache, dv: &DataValue) -> Self {
     match dv {
       DataValue::OfString(s) => {
-        let obj = LeanCtor::alloc(0, 1, 0);
-        obj.set(0, LeanString::new(s.as_str()));
-        Self::new(obj.into())
+        let ctor = LeanIxDataValueString::alloc();
+        ctor.set_obj(0, LeanString::new(s.as_str()));
+        Self::new(ctor.into())
       },
       DataValue::OfBool(b) => {
         let ctor = LeanIxDataValueBool::alloc();
@@ -307,24 +298,24 @@ impl LeanIxDataValue<LeanOwned> {
         Self::new(ctor.into())
       },
       DataValue::OfName(n) => {
-        let obj = LeanCtor::alloc(2, 1, 0);
-        obj.set(0, LeanIxName::build(cache, n));
-        Self::new(obj.into())
+        let ctor = LeanIxDataValueName::alloc();
+        ctor.set_obj(0, LeanIxName::build(cache, n));
+        Self::new(ctor.into())
       },
       DataValue::OfNat(n) => {
-        let obj = LeanCtor::alloc(3, 1, 0);
-        obj.set(0, Nat::to_lean(n));
-        Self::new(obj.into())
+        let ctor = LeanIxDataValueNat::alloc();
+        ctor.set_obj(0, Nat::to_lean(n));
+        Self::new(ctor.into())
       },
       DataValue::OfInt(i) => {
-        let obj = LeanCtor::alloc(4, 1, 0);
-        obj.set(0, LeanIxInt::build(i));
-        Self::new(obj.into())
+        let ctor = LeanIxDataValueInt::alloc();
+        ctor.set_obj(0, LeanIxInt::build(i));
+        Self::new(ctor.into())
       },
       DataValue::OfSyntax(syn) => {
-        let obj = LeanCtor::alloc(5, 1, 0);
-        obj.set(0, LeanIxSyntax::build(cache, syn));
-        Self::new(obj.into())
+        let ctor = LeanIxDataValueSyntax::alloc();
+        ctor.set_obj(0, LeanIxSyntax::build(cache, syn));
+        Self::new(ctor.into())
       },
     }
   }
@@ -339,9 +330,7 @@ impl LeanIxDataValue<LeanOwned> {
       let name_obj = LeanIxName::build(cache, name);
       let dv_obj = Self::build(cache, dv);
       // Prod (Name x DataValue)
-      let pair = LeanCtor::alloc(0, 2, 0);
-      pair.set(0, name_obj);
-      pair.set(1, dv_obj);
+      let pair = LeanProd::new(name_obj, dv_obj);
       arr.set(i, pair);
     }
     arr
@@ -360,7 +349,8 @@ impl<R: LeanRef> LeanIxDataValue<R> {
       1 => {
         // ofBool: 0 object fields, 1 scalar byte
         let ctor = LeanIxDataValueBool::from_ctor(ctor);
-        DataValue::OfBool(ctor.get_num_8(0) != 0)
+        let b = ctor.get_num_8(0) != 0;
+        DataValue::OfBool(b)
       },
       2 => {
         // ofName: 1 object field

--- a/src/ffi/ix/data.rs
+++ b/src/ffi/ix/data.rs
@@ -10,9 +10,11 @@ use crate::lean::{
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{LeanArray, LeanCtor, LeanOwned, LeanRef, LeanString};
+use lean_ffi::object::{
+  LeanArray, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef, LeanString,
+};
 
-use lean_ffi::object::scalar_base;
+use crate::lean::{LeanIxDataValueBool, LeanIxSourceInfoSynthetic};
 
 use crate::ffi::builder::LeanBuildCache;
 
@@ -86,11 +88,11 @@ impl LeanIxSourceInfo<LeanOwned> {
       },
       // | synthetic (pos : Nat) (endPos : Nat) (canonical : Bool) -- tag 1
       SourceInfo::Synthetic(pos, end_pos, canonical) => {
-        let obj = LeanCtor::alloc(1, 2, 1);
-        obj.set(0, Nat::to_lean(pos));
-        obj.set(1, Nat::to_lean(end_pos));
-        obj.set_bool(scalar_base(&obj, 0), *canonical);
-        Self::new(obj.into())
+        let ctor = LeanIxSourceInfoSynthetic::alloc();
+        ctor.set_obj(0, Nat::to_lean(pos));
+        ctor.set_obj(1, Nat::to_lean(end_pos));
+        ctor.set_num_8(0, *canonical as u8);
+        Self::new(ctor.into())
       },
       // | none -- tag 2
       SourceInfo::None => Self::new(LeanCtor::alloc(2, 0, 0).into()),
@@ -117,11 +119,12 @@ impl<R: LeanRef> LeanIxSourceInfo<R> {
       },
       1 => {
         // synthetic: 2 obj fields (pos, end_pos), 1 scalar byte (canonical)
-        let canonical = ctor.get_bool(scalar_base(&ctor, 0));
+        let ctor = LeanIxSourceInfoSynthetic::from_ctor(ctor);
+        let canonical = ctor.get_num_8(0) != 0;
 
         SourceInfo::Synthetic(
-          Nat::from_obj(&ctor.get(0)),
-          Nat::from_obj(&ctor.get(1)),
+          Nat::from_obj(&ctor.as_ctor().get(0)),
+          Nat::from_obj(&ctor.as_ctor().get(1)),
           canonical,
         )
       },
@@ -299,10 +302,9 @@ impl LeanIxDataValue<LeanOwned> {
         Self::new(obj.into())
       },
       DataValue::OfBool(b) => {
-        // 0 object fields, 1 scalar byte
-        let obj = LeanCtor::alloc(1, 0, 1);
-        obj.set_bool(scalar_base(&obj, 0), *b);
-        Self::new(obj.into())
+        let ctor = LeanIxDataValueBool::alloc();
+        ctor.set_num_8(0, *b as u8);
+        Self::new(ctor.into())
       },
       DataValue::OfName(n) => {
         let obj = LeanCtor::alloc(2, 1, 0);
@@ -357,8 +359,8 @@ impl<R: LeanRef> LeanIxDataValue<R> {
       },
       1 => {
         // ofBool: 0 object fields, 1 scalar byte
-        let b = ctor.get_bool(scalar_base(&ctor, 0));
-        DataValue::OfBool(b)
+        let ctor = LeanIxDataValueBool::from_ctor(ctor);
+        DataValue::OfBool(ctor.get_num_8(0) != 0)
       },
       2 => {
         // ofName: 1 object field

--- a/src/ffi/ix/data.rs
+++ b/src/ffi/ix/data.rs
@@ -12,6 +12,8 @@ use lean_ffi::nat::Nat;
 use lean_ffi::object::LeanBorrowed;
 use lean_ffi::object::{LeanArray, LeanCtor, LeanOwned, LeanRef, LeanString};
 
+use lean_ffi::object::scalar_base;
+
 use crate::ffi::builder::LeanBuildCache;
 
 impl LeanIxInt<LeanOwned> {
@@ -87,7 +89,7 @@ impl LeanIxSourceInfo<LeanOwned> {
         let obj = LeanCtor::alloc(1, 2, 1);
         obj.set(0, Nat::to_lean(pos));
         obj.set(1, Nat::to_lean(end_pos));
-        obj.set_bool(obj.scalar_base(0), *canonical);
+        obj.set_bool(scalar_base(&obj, 0), *canonical);
         Self::new(obj.into())
       },
       // | none -- tag 2
@@ -115,7 +117,7 @@ impl<R: LeanRef> LeanIxSourceInfo<R> {
       },
       1 => {
         // synthetic: 2 obj fields (pos, end_pos), 1 scalar byte (canonical)
-        let canonical = ctor.get_bool(ctor.scalar_base(0));
+        let canonical = ctor.get_bool(scalar_base(&ctor, 0));
 
         SourceInfo::Synthetic(
           Nat::from_obj(&ctor.get(0)),
@@ -299,7 +301,7 @@ impl LeanIxDataValue<LeanOwned> {
       DataValue::OfBool(b) => {
         // 0 object fields, 1 scalar byte
         let obj = LeanCtor::alloc(1, 0, 1);
-        obj.set_bool(obj.scalar_base(0), *b);
+        obj.set_bool(scalar_base(&obj, 0), *b);
         Self::new(obj.into())
       },
       DataValue::OfName(n) => {
@@ -355,7 +357,7 @@ impl<R: LeanRef> LeanIxDataValue<R> {
       },
       1 => {
         // ofBool: 0 object fields, 1 scalar byte
-        let b = ctor.get_bool(ctor.scalar_base(0));
+        let b = ctor.get_bool(scalar_base(&ctor, 0));
         DataValue::OfBool(b)
       },
       2 => {

--- a/src/ffi/ix/data.rs
+++ b/src/ffi/ix/data.rs
@@ -87,7 +87,7 @@ impl LeanIxSourceInfo<LeanOwned> {
         let obj = LeanCtor::alloc(1, 2, 1);
         obj.set(0, Nat::to_lean(pos));
         obj.set(1, Nat::to_lean(end_pos));
-        obj.set_bool(2, 0, *canonical);
+        obj.set_bool(obj.scalar_base(0), *canonical);
         Self::new(obj.into())
       },
       // | none -- tag 2
@@ -115,7 +115,7 @@ impl<R: LeanRef> LeanIxSourceInfo<R> {
       },
       1 => {
         // synthetic: 2 obj fields (pos, end_pos), 1 scalar byte (canonical)
-        let canonical = ctor.get_u8(2, 0) != 0;
+        let canonical = ctor.get_bool(ctor.scalar_base(0));
 
         SourceInfo::Synthetic(
           Nat::from_obj(&ctor.get(0)),
@@ -299,7 +299,7 @@ impl LeanIxDataValue<LeanOwned> {
       DataValue::OfBool(b) => {
         // 0 object fields, 1 scalar byte
         let obj = LeanCtor::alloc(1, 0, 1);
-        obj.set_bool(0, 0, *b);
+        obj.set_bool(obj.scalar_base(0), *b);
         Self::new(obj.into())
       },
       DataValue::OfName(n) => {
@@ -355,7 +355,7 @@ impl<R: LeanRef> LeanIxDataValue<R> {
       },
       1 => {
         // ofBool: 0 object fields, 1 scalar byte
-        let b = ctor.get_u8(0, 0) != 0;
+        let b = ctor.get_bool(ctor.scalar_base(0));
         DataValue::OfBool(b)
       },
       2 => {

--- a/src/ffi/ix/data.rs
+++ b/src/ffi/ix/data.rs
@@ -4,13 +4,8 @@ use crate::ix::env::{
   DataValue, Int, Name, SourceInfo, Substring, Syntax, SyntaxPreresolved,
 };
 use crate::lean::{
-  LeanIxDataValue, LeanIxDataValueBool, LeanIxDataValueInt,
-  LeanIxDataValueName, LeanIxDataValueNat, LeanIxDataValueString,
-  LeanIxDataValueSyntax, LeanIxInt, LeanIxIntNegSucc, LeanIxIntOfNat,
-  LeanIxName, LeanIxSourceInfo, LeanIxSourceInfoNone, LeanIxSourceInfoOriginal,
-  LeanIxSourceInfoSynthetic, LeanIxSubstring, LeanIxSyntax, LeanIxSyntaxAtom,
-  LeanIxSyntaxIdent, LeanIxSyntaxMissing, LeanIxSyntaxNode,
-  LeanIxSyntaxPreresolved, LeanIxSyntaxPreresolvedA, LeanIxSyntaxPreresolvedB,
+  LeanIxDataValue, LeanIxInt, LeanIxName, LeanIxSourceInfo, LeanIxSubstring,
+  LeanIxSyntax, LeanIxSyntaxPreresolved,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
@@ -24,14 +19,14 @@ impl LeanIxInt<LeanOwned> {
   pub fn build(int: &Int) -> Self {
     match int {
       Int::OfNat(n) => {
-        let ctor = LeanIxIntOfNat::alloc();
+        let ctor = LeanIxInt::alloc(0);
         ctor.set_obj(0, Nat::to_lean(n));
-        Self::new(ctor.into())
+        ctor
       },
       Int::NegSucc(n) => {
-        let ctor = LeanIxIntNegSucc::alloc();
+        let ctor = LeanIxInt::alloc(1);
         ctor.set_obj(0, Nat::to_lean(n));
-        Self::new(ctor.into())
+        ctor
       },
     }
   }
@@ -54,11 +49,11 @@ impl<R: LeanRef> LeanIxInt<R> {
 impl LeanIxSubstring<LeanOwned> {
   /// Build a Ix.Substring.
   pub fn build(ss: &Substring) -> Self {
-    let ctor = LeanIxSubstring::alloc();
+    let ctor = LeanIxSubstring::alloc(0);
     ctor.set_obj(0, LeanString::new(ss.str.as_str()));
     ctor.set_obj(1, Nat::to_lean(&ss.start_pos));
     ctor.set_obj(2, Nat::to_lean(&ss.stop_pos));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -80,23 +75,23 @@ impl LeanIxSourceInfo<LeanOwned> {
     match si {
       // | original (leading : Substring) (pos : Nat) (trailing : Substring) (endPos : Nat) -- tag 0
       SourceInfo::Original(leading, pos, trailing, end_pos) => {
-        let ctor = LeanIxSourceInfoOriginal::alloc();
+        let ctor = LeanIxSourceInfo::alloc(0);
         ctor.set_obj(0, LeanIxSubstring::build(leading));
         ctor.set_obj(1, Nat::to_lean(pos));
         ctor.set_obj(2, LeanIxSubstring::build(trailing));
         ctor.set_obj(3, Nat::to_lean(end_pos));
-        Self::new(ctor.into())
+        ctor
       },
       // | synthetic (pos : Nat) (endPos : Nat) (canonical : Bool) -- tag 1
       SourceInfo::Synthetic(pos, end_pos, canonical) => {
-        let ctor = LeanIxSourceInfoSynthetic::alloc();
+        let ctor = LeanIxSourceInfo::alloc(1);
         ctor.set_obj(0, Nat::to_lean(pos));
         ctor.set_obj(1, Nat::to_lean(end_pos));
         ctor.set_num_8(0, *canonical as u8);
-        Self::new(ctor.into())
+        ctor
       },
-      // | none -- tag 2
-      SourceInfo::None => Self::new(LeanIxSourceInfoNone::alloc().into()),
+      // | none -- tag 2 (no fields — scalar)
+      SourceInfo::None => Self::new(LeanOwned::box_usize(2)),
     }
   }
 }
@@ -120,12 +115,11 @@ impl<R: LeanRef> LeanIxSourceInfo<R> {
       },
       1 => {
         // synthetic: 2 obj fields (pos, end_pos), 1 scalar byte (canonical)
-        let ctor = LeanIxSourceInfoSynthetic::from_ctor(ctor);
-        let canonical = ctor.get_num_8(0) != 0;
+        let canonical = self.get_num_8(0) != 0;
 
         SourceInfo::Synthetic(
-          Nat::from_obj(&ctor.get_obj(0)),
-          Nat::from_obj(&ctor.get_obj(1)),
+          Nat::from_obj(&self.get_obj(0)),
+          Nat::from_obj(&self.get_obj(1)),
           canonical,
         )
       },
@@ -141,16 +135,16 @@ impl LeanIxSyntaxPreresolved<LeanOwned> {
     match sp {
       // | namespace (name : Name) -- tag 0
       SyntaxPreresolved::Namespace(name) => {
-        let ctor = LeanIxSyntaxPreresolvedA::alloc();
+        let ctor = LeanIxSyntaxPreresolved::alloc(0);
         ctor.set_obj(0, LeanIxName::build(cache, name));
-        Self::new(ctor.into())
+        ctor
       },
       // | decl (name : Name) (aliases : Array String) -- tag 1
       SyntaxPreresolved::Decl(name, aliases) => {
-        let ctor = LeanIxSyntaxPreresolvedB::alloc();
+        let ctor = LeanIxSyntaxPreresolved::alloc(1);
         ctor.set_obj(0, LeanIxName::build(cache, name));
         ctor.set_obj(1, build_string_array(aliases));
-        Self::new(ctor.into())
+        ctor
       },
     }
   }
@@ -191,31 +185,31 @@ impl LeanIxSyntax<LeanOwned> {
   /// Build a Ix.Syntax.
   pub fn build(cache: &mut LeanBuildCache, syn: &Syntax) -> Self {
     match syn {
-      // | missing -- tag 0
-      Syntax::Missing => Self::new(LeanIxSyntaxMissing::alloc().into()),
+      // | missing -- tag 0 (no fields — scalar)
+      Syntax::Missing => Self::new(LeanOwned::box_usize(0)),
       // | node (info : SourceInfo) (kind : Name) (args : Array Syntax) -- tag 1
       Syntax::Node(info, kind, args) => {
-        let ctor = LeanIxSyntaxNode::alloc();
+        let ctor = LeanIxSyntax::alloc(1);
         ctor.set_obj(0, LeanIxSourceInfo::build(info));
         ctor.set_obj(1, LeanIxName::build(cache, kind));
         ctor.set_obj(2, Self::build_array(cache, args));
-        Self::new(ctor.into())
+        ctor
       },
       // | atom (info : SourceInfo) (val : String) -- tag 2
       Syntax::Atom(info, val) => {
-        let ctor = LeanIxSyntaxAtom::alloc();
+        let ctor = LeanIxSyntax::alloc(2);
         ctor.set_obj(0, LeanIxSourceInfo::build(info));
         ctor.set_obj(1, LeanString::new(val.as_str()));
-        Self::new(ctor.into())
+        ctor
       },
       // | ident (info : SourceInfo) (rawVal : Substring) (val : Name) (preresolved : Array SyntaxPreresolved) -- tag 3
       Syntax::Ident(info, raw_val, val, preresolved) => {
-        let ctor = LeanIxSyntaxIdent::alloc();
+        let ctor = LeanIxSyntax::alloc(3);
         ctor.set_obj(0, LeanIxSourceInfo::build(info));
         ctor.set_obj(1, LeanIxSubstring::build(raw_val));
         ctor.set_obj(2, LeanIxName::build(cache, val));
         ctor.set_obj(3, Self::build_preresolved_array(cache, preresolved));
-        Self::new(ctor.into())
+        ctor
       },
     }
   }
@@ -288,34 +282,34 @@ impl LeanIxDataValue<LeanOwned> {
   pub fn build(cache: &mut LeanBuildCache, dv: &DataValue) -> Self {
     match dv {
       DataValue::OfString(s) => {
-        let ctor = LeanIxDataValueString::alloc();
+        let ctor = LeanIxDataValue::alloc(0);
         ctor.set_obj(0, LeanString::new(s.as_str()));
-        Self::new(ctor.into())
+        ctor
       },
       DataValue::OfBool(b) => {
-        let ctor = LeanIxDataValueBool::alloc();
+        let ctor = LeanIxDataValue::alloc(1);
         ctor.set_num_8(0, *b as u8);
-        Self::new(ctor.into())
+        ctor
       },
       DataValue::OfName(n) => {
-        let ctor = LeanIxDataValueName::alloc();
+        let ctor = LeanIxDataValue::alloc(2);
         ctor.set_obj(0, LeanIxName::build(cache, n));
-        Self::new(ctor.into())
+        ctor
       },
       DataValue::OfNat(n) => {
-        let ctor = LeanIxDataValueNat::alloc();
+        let ctor = LeanIxDataValue::alloc(3);
         ctor.set_obj(0, Nat::to_lean(n));
-        Self::new(ctor.into())
+        ctor
       },
       DataValue::OfInt(i) => {
-        let ctor = LeanIxDataValueInt::alloc();
+        let ctor = LeanIxDataValue::alloc(4);
         ctor.set_obj(0, LeanIxInt::build(i));
-        Self::new(ctor.into())
+        ctor
       },
       DataValue::OfSyntax(syn) => {
-        let ctor = LeanIxDataValueSyntax::alloc();
+        let ctor = LeanIxDataValue::alloc(5);
         ctor.set_obj(0, LeanIxSyntax::build(cache, syn));
-        Self::new(ctor.into())
+        ctor
       },
     }
   }
@@ -348,8 +342,7 @@ impl<R: LeanRef> LeanIxDataValue<R> {
       },
       1 => {
         // ofBool: 0 object fields, 1 scalar byte
-        let ctor = LeanIxDataValueBool::from_ctor(ctor);
-        let b = ctor.get_num_8(0) != 0;
+        let b = self.get_num_8(0) != 0;
         DataValue::OfBool(b)
       },
       2 => {

--- a/src/ffi/ix/env.rs
+++ b/src/ffi/ix/env.rs
@@ -6,7 +6,9 @@ use crate::ix::env::{ConstantInfo, Name};
 use crate::lean::{
   LeanIxConstantInfo, LeanIxEnvironment, LeanIxName, LeanIxRawEnvironment,
 };
-use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
+use lean_ffi::object::{
+  LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanProd, LeanRef,
+};
 
 use crate::ffi::builder::LeanBuildCache;
 
@@ -146,9 +148,7 @@ impl LeanIxRawEnvironment<LeanOwned> {
       let key_obj = LeanIxName::build(cache, name);
       let val_obj = LeanIxConstantInfo::build(cache, info);
       // Build pair (Name × ConstantInfo)
-      let pair = LeanCtor::alloc(0, 2, 0);
-      pair.set(0, key_obj);
-      pair.set(1, val_obj);
+      let pair = LeanProd::new(key_obj, val_obj);
       consts_arr.set(i, pair);
     }
 
@@ -164,9 +164,7 @@ impl LeanIxRawEnvironment<LeanOwned> {
     for (i, (name, info)) in consts.iter().enumerate() {
       let key_obj = LeanIxName::build(cache, name);
       let val_obj = LeanIxConstantInfo::build(cache, info);
-      let pair = LeanCtor::alloc(0, 2, 0);
-      pair.set(0, key_obj);
-      pair.set(1, val_obj);
+      let pair = LeanProd::new(key_obj, val_obj);
       consts_arr.set(i, pair);
     }
     Self::new(consts_arr.into())

--- a/src/ffi/ix/expr.rs
+++ b/src/ffi/ix/expr.rs
@@ -91,7 +91,10 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(1, ty_obj);
         ctor.set(2, body_obj);
         ctor.set(3, hash_obj);
-        ctor.set_u8(ctor.scalar_base(0), LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
+        ctor.set_u8(
+          ctor.scalar_base(0),
+          LeanIxBinderInfo::<LeanOwned>::to_u8(bi),
+        );
         Self::new(ctor.into())
       },
       ExprData::ForallE(name, ty, body, bi, h) => {
@@ -104,7 +107,10 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(1, ty_obj);
         ctor.set(2, body_obj);
         ctor.set(3, hash_obj);
-        ctor.set_u8(ctor.scalar_base(0), LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
+        ctor.set_u8(
+          ctor.scalar_base(0),
+          LeanIxBinderInfo::<LeanOwned>::to_u8(bi),
+        );
         Self::new(ctor.into())
       },
       ExprData::LetE(name, ty, val, body, non_dep, h) => {

--- a/src/ffi/ix/expr.rs
+++ b/src/ffi/ix/expr.rs
@@ -20,11 +20,8 @@ use crate::ix::env::{
 };
 use crate::lean::LeanIxAddress;
 use crate::lean::{
-  LeanIxBinderInfo, LeanIxDataValue, LeanIxExpr, LeanIxExprApp, LeanIxExprBvar,
-  LeanIxExprConst, LeanIxExprForallE, LeanIxExprFvar, LeanIxExprLam,
-  LeanIxExprLetE, LeanIxExprLit, LeanIxExprMdata, LeanIxExprMvar,
-  LeanIxExprProj, LeanIxExprSort, LeanIxLevel, LeanIxLiteral, LeanIxLiteralNat,
-  LeanIxLiteralStr, LeanIxName,
+  LeanIxBinderInfo, LeanIxDataValue, LeanIxExpr, LeanIxLevel, LeanIxLiteral,
+  LeanIxName,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
@@ -42,72 +39,72 @@ impl LeanIxExpr<LeanOwned> {
 
     let result = match expr.as_data() {
       ExprData::Bvar(idx, h) => {
-        let ctor = LeanIxExprBvar::alloc();
+        let ctor = LeanIxExpr::alloc(0);
         ctor.set_obj(0, Nat::to_lean(idx));
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Fvar(name, h) => {
-        let ctor = LeanIxExprFvar::alloc();
+        let ctor = LeanIxExpr::alloc(1);
         ctor.set_obj(0, LeanIxName::build(cache, name));
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Mvar(name, h) => {
-        let ctor = LeanIxExprMvar::alloc();
+        let ctor = LeanIxExpr::alloc(2);
         ctor.set_obj(0, LeanIxName::build(cache, name));
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Sort(level, h) => {
-        let ctor = LeanIxExprSort::alloc();
+        let ctor = LeanIxExpr::alloc(3);
         ctor.set_obj(0, LeanIxLevel::build(cache, level));
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Const(name, levels, h) => {
         let name_obj = LeanIxName::build(cache, name);
         let levels_obj = LeanIxLevel::build_array(cache, levels);
-        let ctor = LeanIxExprConst::alloc();
+        let ctor = LeanIxExpr::alloc(4);
         ctor.set_obj(0, name_obj);
         ctor.set_obj(1, levels_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::App(fn_expr, arg_expr, h) => {
         let fn_obj = Self::build(cache, fn_expr);
         let arg_obj = Self::build(cache, arg_expr);
-        let ctor = LeanIxExprApp::alloc();
+        let ctor = LeanIxExpr::alloc(5);
         ctor.set_obj(0, fn_obj);
         ctor.set_obj(1, arg_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Lam(name, ty, body, bi, h) => {
         let name_obj = LeanIxName::build(cache, name);
         let ty_obj = Self::build(cache, ty);
         let body_obj = Self::build(cache, body);
         let hash_obj = LeanIxAddress::build_from_hash(h);
-        let ctor = LeanIxExprLam::alloc();
+        let ctor = LeanIxExpr::alloc(6);
         ctor.set_obj(0, name_obj);
         ctor.set_obj(1, ty_obj);
         ctor.set_obj(2, body_obj);
         ctor.set_obj(3, hash_obj);
         ctor.set_num_8(0, LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::ForallE(name, ty, body, bi, h) => {
         let name_obj = LeanIxName::build(cache, name);
         let ty_obj = Self::build(cache, ty);
         let body_obj = Self::build(cache, body);
         let hash_obj = LeanIxAddress::build_from_hash(h);
-        let ctor = LeanIxExprForallE::alloc();
+        let ctor = LeanIxExpr::alloc(7);
         ctor.set_obj(0, name_obj);
         ctor.set_obj(1, ty_obj);
         ctor.set_obj(2, body_obj);
         ctor.set_obj(3, hash_obj);
         ctor.set_num_8(0, LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::LetE(name, ty, val, body, non_dep, h) => {
         let name_obj = LeanIxName::build(cache, name);
@@ -115,41 +112,41 @@ impl LeanIxExpr<LeanOwned> {
         let val_obj = Self::build(cache, val);
         let body_obj = Self::build(cache, body);
         let hash_obj = LeanIxAddress::build_from_hash(h);
-        let ctor = LeanIxExprLetE::alloc();
+        let ctor = LeanIxExpr::alloc(8);
         ctor.set_obj(0, name_obj);
         ctor.set_obj(1, ty_obj);
         ctor.set_obj(2, val_obj);
         ctor.set_obj(3, body_obj);
         ctor.set_obj(4, hash_obj);
         ctor.set_num_8(0, *non_dep as u8);
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Lit(lit, h) => {
         let lit_obj = LeanIxLiteral::build(lit);
-        let ctor = LeanIxExprLit::alloc();
+        let ctor = LeanIxExpr::alloc(9);
         ctor.set_obj(0, lit_obj);
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Mdata(md, inner, h) => {
         let md_obj = LeanIxDataValue::build_kvmap(cache, md);
         let inner_obj = Self::build(cache, inner);
-        let ctor = LeanIxExprMdata::alloc();
+        let ctor = LeanIxExpr::alloc(10);
         ctor.set_obj(0, md_obj);
         ctor.set_obj(1, inner_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       ExprData::Proj(type_name, idx, struct_expr, h) => {
         let name_obj = LeanIxName::build(cache, type_name);
         let idx_obj = Nat::to_lean(idx);
         let struct_obj = Self::build(cache, struct_expr);
-        let ctor = LeanIxExprProj::alloc();
+        let ctor = LeanIxExpr::alloc(11);
         ctor.set_obj(0, name_obj);
         ctor.set_obj(1, idx_obj);
         ctor.set_obj(2, struct_obj);
         ctor.set_obj(3, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
     };
 
@@ -199,37 +196,34 @@ impl<R: LeanRef> LeanIxExpr<R> {
       },
       6 => {
         // lam: name, ty, body, hash, bi (scalar)
-        let ctor = LeanIxExprLam::from_ctor(ctor);
-        let name = LeanIxName(ctor.get_obj(0)).decode();
-        let ty = LeanIxExpr(ctor.get_obj(1)).decode();
-        let body = LeanIxExpr(ctor.get_obj(2)).decode();
+        let name = LeanIxName(self.get_obj(0)).decode();
+        let ty = LeanIxExpr(self.get_obj(1)).decode();
+        let body = LeanIxExpr(self.get_obj(2)).decode();
 
-        let bi_byte = ctor.get_num_8(0);
+        let bi_byte = self.get_num_8(0);
         let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::lam(name, ty, body, bi)
       },
       7 => {
         // forallE: same layout as lam
-        let ctor = LeanIxExprForallE::from_ctor(ctor);
-        let name = LeanIxName(ctor.get_obj(0)).decode();
-        let ty = LeanIxExpr(ctor.get_obj(1)).decode();
-        let body = LeanIxExpr(ctor.get_obj(2)).decode();
+        let name = LeanIxName(self.get_obj(0)).decode();
+        let ty = LeanIxExpr(self.get_obj(1)).decode();
+        let body = LeanIxExpr(self.get_obj(2)).decode();
 
-        let bi_byte = ctor.get_num_8(0);
+        let bi_byte = self.get_num_8(0);
         let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::all(name, ty, body, bi)
       },
       8 => {
         // letE: name, ty, val, body, hash, nonDep (scalar)
-        let ctor = LeanIxExprLetE::from_ctor(ctor);
-        let name = LeanIxName(ctor.get_obj(0)).decode();
-        let ty = LeanIxExpr(ctor.get_obj(1)).decode();
-        let val = LeanIxExpr(ctor.get_obj(2)).decode();
-        let body = LeanIxExpr(ctor.get_obj(3)).decode();
+        let name = LeanIxName(self.get_obj(0)).decode();
+        let ty = LeanIxExpr(self.get_obj(1)).decode();
+        let val = LeanIxExpr(self.get_obj(2)).decode();
+        let body = LeanIxExpr(self.get_obj(3)).decode();
 
-        let non_dep = ctor.get_num_8(0) != 0;
+        let non_dep = self.get_num_8(0) != 0;
 
         Expr::letE(name, ty, val, body, non_dep)
       },
@@ -268,14 +262,14 @@ impl LeanIxLiteral<LeanOwned> {
   pub fn build(lit: &Literal) -> Self {
     match lit {
       Literal::NatVal(n) => {
-        let ctor = LeanIxLiteralNat::alloc();
+        let ctor = LeanIxLiteral::alloc(0);
         ctor.set_obj(0, Nat::to_lean(n));
-        Self::new(ctor.into())
+        ctor
       },
       Literal::StrVal(s) => {
-        let ctor = LeanIxLiteralStr::alloc();
+        let ctor = LeanIxLiteral::alloc(1);
         ctor.set_obj(0, LeanString::new(s.as_str()));
-        Self::new(ctor.into())
+        ctor
       },
     }
   }

--- a/src/ffi/ix/expr.rs
+++ b/src/ffi/ix/expr.rs
@@ -91,7 +91,7 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(1, ty_obj);
         ctor.set(2, body_obj);
         ctor.set(3, hash_obj);
-        ctor.set_u8(4, 0, LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
+        ctor.set_u8(ctor.scalar_base(0), LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
         Self::new(ctor.into())
       },
       ExprData::ForallE(name, ty, body, bi, h) => {
@@ -104,7 +104,7 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(1, ty_obj);
         ctor.set(2, body_obj);
         ctor.set(3, hash_obj);
-        ctor.set_u8(4, 0, LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
+        ctor.set_u8(ctor.scalar_base(0), LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
         Self::new(ctor.into())
       },
       ExprData::LetE(name, ty, val, body, non_dep, h) => {
@@ -120,7 +120,7 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(2, val_obj);
         ctor.set(3, body_obj);
         ctor.set(4, hash_obj);
-        ctor.set_bool(5, 0, *non_dep);
+        ctor.set_bool(ctor.scalar_base(0), *non_dep);
         Self::new(ctor.into())
       },
       ExprData::Lit(lit, h) => {
@@ -203,7 +203,7 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let body = LeanIxExpr(ctor.get(2)).decode();
 
         // Read BinderInfo scalar (4 obj fields: name, ty, body, hash)
-        let bi_byte = ctor.get_u8(4, 0);
+        let bi_byte = ctor.get_u8(ctor.scalar_base(0));
         let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::lam(name, ty, body, bi)
@@ -215,7 +215,7 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let body = LeanIxExpr(ctor.get(2)).decode();
 
         // 4 obj fields: name, ty, body, hash
-        let bi_byte = ctor.get_u8(4, 0);
+        let bi_byte = ctor.get_u8(ctor.scalar_base(0));
         let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::all(name, ty, body, bi)
@@ -228,7 +228,7 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let body = LeanIxExpr(ctor.get(3)).decode();
 
         // 5 obj fields: name, ty, val, body, hash
-        let non_dep = ctor.get_u8(5, 0) != 0;
+        let non_dep = ctor.get_bool(ctor.scalar_base(0));
 
         Expr::letE(name, ty, val, body, non_dep)
       },

--- a/src/ffi/ix/expr.rs
+++ b/src/ffi/ix/expr.rs
@@ -26,9 +26,11 @@ use crate::lean::{
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{LeanCtor, LeanOwned, LeanRef, LeanString};
+use lean_ffi::object::{
+  LeanCtor, LeanCtorScalar, LeanOwned, LeanRef, LeanString,
+};
 
-use lean_ffi::object::scalar_base;
+use crate::lean::{LeanIxExprForallE, LeanIxExprLam, LeanIxExprLetE};
 
 impl LeanIxExpr<LeanOwned> {
   /// Build a Lean Ix.Expr with embedded hash.
@@ -87,16 +89,12 @@ impl LeanIxExpr<LeanOwned> {
         let ty_obj = Self::build(cache, ty);
         let body_obj = Self::build(cache, body);
         let hash_obj = LeanIxAddress::build_from_hash(h);
-        // 4 object fields, 1 scalar byte for BinderInfo
-        let ctor = LeanCtor::alloc(6, 4, 1);
-        ctor.set(0, name_obj);
-        ctor.set(1, ty_obj);
-        ctor.set(2, body_obj);
-        ctor.set(3, hash_obj);
-        ctor.set_u8(
-          scalar_base(&ctor, 0),
-          LeanIxBinderInfo::<LeanOwned>::to_u8(bi),
-        );
+        let ctor = LeanIxExprLam::alloc();
+        ctor.set_obj(0, name_obj);
+        ctor.set_obj(1, ty_obj);
+        ctor.set_obj(2, body_obj);
+        ctor.set_obj(3, hash_obj);
+        ctor.set_num_8(0, LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
         Self::new(ctor.into())
       },
       ExprData::ForallE(name, ty, body, bi, h) => {
@@ -104,15 +102,12 @@ impl LeanIxExpr<LeanOwned> {
         let ty_obj = Self::build(cache, ty);
         let body_obj = Self::build(cache, body);
         let hash_obj = LeanIxAddress::build_from_hash(h);
-        let ctor = LeanCtor::alloc(7, 4, 1);
-        ctor.set(0, name_obj);
-        ctor.set(1, ty_obj);
-        ctor.set(2, body_obj);
-        ctor.set(3, hash_obj);
-        ctor.set_u8(
-          scalar_base(&ctor, 0),
-          LeanIxBinderInfo::<LeanOwned>::to_u8(bi),
-        );
+        let ctor = LeanIxExprForallE::alloc();
+        ctor.set_obj(0, name_obj);
+        ctor.set_obj(1, ty_obj);
+        ctor.set_obj(2, body_obj);
+        ctor.set_obj(3, hash_obj);
+        ctor.set_num_8(0, LeanIxBinderInfo::<LeanOwned>::to_u8(bi));
         Self::new(ctor.into())
       },
       ExprData::LetE(name, ty, val, body, non_dep, h) => {
@@ -121,14 +116,13 @@ impl LeanIxExpr<LeanOwned> {
         let val_obj = Self::build(cache, val);
         let body_obj = Self::build(cache, body);
         let hash_obj = LeanIxAddress::build_from_hash(h);
-        // 5 object fields, 1 scalar byte for Bool
-        let ctor = LeanCtor::alloc(8, 5, 1);
-        ctor.set(0, name_obj);
-        ctor.set(1, ty_obj);
-        ctor.set(2, val_obj);
-        ctor.set(3, body_obj);
-        ctor.set(4, hash_obj);
-        ctor.set_bool(scalar_base(&ctor, 0), *non_dep);
+        let ctor = LeanIxExprLetE::alloc();
+        ctor.set_obj(0, name_obj);
+        ctor.set_obj(1, ty_obj);
+        ctor.set_obj(2, val_obj);
+        ctor.set_obj(3, body_obj);
+        ctor.set_obj(4, hash_obj);
+        ctor.set_num_8(0, *non_dep as u8);
         Self::new(ctor.into())
       },
       ExprData::Lit(lit, h) => {
@@ -210,9 +204,8 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let ty = LeanIxExpr(ctor.get(1)).decode();
         let body = LeanIxExpr(ctor.get(2)).decode();
 
-        // Read BinderInfo scalar (4 obj fields: name, ty, body, hash)
-        let bi_byte = ctor.get_u8(scalar_base(&ctor, 0));
-        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
+        let ctor = LeanIxExprLam::from_ctor(ctor);
+        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(ctor.get_num_8(0));
 
         Expr::lam(name, ty, body, bi)
       },
@@ -222,9 +215,8 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let ty = LeanIxExpr(ctor.get(1)).decode();
         let body = LeanIxExpr(ctor.get(2)).decode();
 
-        // 4 obj fields: name, ty, body, hash
-        let bi_byte = ctor.get_u8(scalar_base(&ctor, 0));
-        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
+        let ctor = LeanIxExprForallE::from_ctor(ctor);
+        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(ctor.get_num_8(0));
 
         Expr::all(name, ty, body, bi)
       },
@@ -235,8 +227,8 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let val = LeanIxExpr(ctor.get(2)).decode();
         let body = LeanIxExpr(ctor.get(3)).decode();
 
-        // 5 obj fields: name, ty, val, body, hash
-        let non_dep = ctor.get_bool(scalar_base(&ctor, 0));
+        let ctor = LeanIxExprLetE::from_ctor(ctor);
+        let non_dep = ctor.get_num_8(0) != 0;
 
         Expr::letE(name, ty, val, body, non_dep)
       },

--- a/src/ffi/ix/expr.rs
+++ b/src/ffi/ix/expr.rs
@@ -20,17 +20,16 @@ use crate::ix::env::{
 };
 use crate::lean::LeanIxAddress;
 use crate::lean::{
-  LeanIxBinderInfo, LeanIxDataValue, LeanIxExpr, LeanIxLevel, LeanIxLiteral,
-  LeanIxName,
+  LeanIxBinderInfo, LeanIxDataValue, LeanIxExpr, LeanIxExprApp, LeanIxExprBvar,
+  LeanIxExprConst, LeanIxExprForallE, LeanIxExprFvar, LeanIxExprLam,
+  LeanIxExprLetE, LeanIxExprLit, LeanIxExprMdata, LeanIxExprMvar,
+  LeanIxExprProj, LeanIxExprSort, LeanIxLevel, LeanIxLiteral, LeanIxLiteralNat,
+  LeanIxLiteralStr, LeanIxName,
 };
 use lean_ffi::nat::Nat;
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{
-  LeanCtor, LeanCtorScalar, LeanOwned, LeanRef, LeanString,
-};
-
-use crate::lean::{LeanIxExprForallE, LeanIxExprLam, LeanIxExprLetE};
+use lean_ffi::object::{LeanOwned, LeanRef, LeanString};
 
 impl LeanIxExpr<LeanOwned> {
   /// Build a Lean Ix.Expr with embedded hash.
@@ -43,45 +42,45 @@ impl LeanIxExpr<LeanOwned> {
 
     let result = match expr.as_data() {
       ExprData::Bvar(idx, h) => {
-        let ctor = LeanCtor::alloc(0, 2, 0);
-        ctor.set(0, Nat::to_lean(idx));
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprBvar::alloc();
+        ctor.set_obj(0, Nat::to_lean(idx));
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Fvar(name, h) => {
-        let ctor = LeanCtor::alloc(1, 2, 0);
-        ctor.set(0, LeanIxName::build(cache, name));
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprFvar::alloc();
+        ctor.set_obj(0, LeanIxName::build(cache, name));
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Mvar(name, h) => {
-        let ctor = LeanCtor::alloc(2, 2, 0);
-        ctor.set(0, LeanIxName::build(cache, name));
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprMvar::alloc();
+        ctor.set_obj(0, LeanIxName::build(cache, name));
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Sort(level, h) => {
-        let ctor = LeanCtor::alloc(3, 2, 0);
-        ctor.set(0, LeanIxLevel::build(cache, level));
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprSort::alloc();
+        ctor.set_obj(0, LeanIxLevel::build(cache, level));
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Const(name, levels, h) => {
         let name_obj = LeanIxName::build(cache, name);
         let levels_obj = LeanIxLevel::build_array(cache, levels);
-        let ctor = LeanCtor::alloc(4, 3, 0);
-        ctor.set(0, name_obj);
-        ctor.set(1, levels_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprConst::alloc();
+        ctor.set_obj(0, name_obj);
+        ctor.set_obj(1, levels_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::App(fn_expr, arg_expr, h) => {
         let fn_obj = Self::build(cache, fn_expr);
         let arg_obj = Self::build(cache, arg_expr);
-        let ctor = LeanCtor::alloc(5, 3, 0);
-        ctor.set(0, fn_obj);
-        ctor.set(1, arg_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprApp::alloc();
+        ctor.set_obj(0, fn_obj);
+        ctor.set_obj(1, arg_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Lam(name, ty, body, bi, h) => {
@@ -127,29 +126,29 @@ impl LeanIxExpr<LeanOwned> {
       },
       ExprData::Lit(lit, h) => {
         let lit_obj = LeanIxLiteral::build(lit);
-        let ctor = LeanCtor::alloc(9, 2, 0);
-        ctor.set(0, lit_obj);
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprLit::alloc();
+        ctor.set_obj(0, lit_obj);
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Mdata(md, inner, h) => {
         let md_obj = LeanIxDataValue::build_kvmap(cache, md);
         let inner_obj = Self::build(cache, inner);
-        let ctor = LeanCtor::alloc(10, 3, 0);
-        ctor.set(0, md_obj);
-        ctor.set(1, inner_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprMdata::alloc();
+        ctor.set_obj(0, md_obj);
+        ctor.set_obj(1, inner_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       ExprData::Proj(type_name, idx, struct_expr, h) => {
         let name_obj = LeanIxName::build(cache, type_name);
         let idx_obj = Nat::to_lean(idx);
         let struct_obj = Self::build(cache, struct_expr);
-        let ctor = LeanCtor::alloc(11, 4, 0);
-        ctor.set(0, name_obj);
-        ctor.set(1, idx_obj);
-        ctor.set(2, struct_obj);
-        ctor.set(3, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxExprProj::alloc();
+        ctor.set_obj(0, name_obj);
+        ctor.set_obj(1, idx_obj);
+        ctor.set_obj(2, struct_obj);
+        ctor.set_obj(3, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
     };
@@ -200,34 +199,36 @@ impl<R: LeanRef> LeanIxExpr<R> {
       },
       6 => {
         // lam: name, ty, body, hash, bi (scalar)
-        let name = LeanIxName(ctor.get(0)).decode();
-        let ty = LeanIxExpr(ctor.get(1)).decode();
-        let body = LeanIxExpr(ctor.get(2)).decode();
-
         let ctor = LeanIxExprLam::from_ctor(ctor);
-        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(ctor.get_num_8(0));
+        let name = LeanIxName(ctor.get_obj(0)).decode();
+        let ty = LeanIxExpr(ctor.get_obj(1)).decode();
+        let body = LeanIxExpr(ctor.get_obj(2)).decode();
+
+        let bi_byte = ctor.get_num_8(0);
+        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::lam(name, ty, body, bi)
       },
       7 => {
         // forallE: same layout as lam
-        let name = LeanIxName(ctor.get(0)).decode();
-        let ty = LeanIxExpr(ctor.get(1)).decode();
-        let body = LeanIxExpr(ctor.get(2)).decode();
-
         let ctor = LeanIxExprForallE::from_ctor(ctor);
-        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(ctor.get_num_8(0));
+        let name = LeanIxName(ctor.get_obj(0)).decode();
+        let ty = LeanIxExpr(ctor.get_obj(1)).decode();
+        let body = LeanIxExpr(ctor.get_obj(2)).decode();
+
+        let bi_byte = ctor.get_num_8(0);
+        let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::all(name, ty, body, bi)
       },
       8 => {
         // letE: name, ty, val, body, hash, nonDep (scalar)
-        let name = LeanIxName(ctor.get(0)).decode();
-        let ty = LeanIxExpr(ctor.get(1)).decode();
-        let val = LeanIxExpr(ctor.get(2)).decode();
-        let body = LeanIxExpr(ctor.get(3)).decode();
-
         let ctor = LeanIxExprLetE::from_ctor(ctor);
+        let name = LeanIxName(ctor.get_obj(0)).decode();
+        let ty = LeanIxExpr(ctor.get_obj(1)).decode();
+        let val = LeanIxExpr(ctor.get_obj(2)).decode();
+        let body = LeanIxExpr(ctor.get_obj(3)).decode();
+
         let non_dep = ctor.get_num_8(0) != 0;
 
         Expr::letE(name, ty, val, body, non_dep)
@@ -267,13 +268,13 @@ impl LeanIxLiteral<LeanOwned> {
   pub fn build(lit: &Literal) -> Self {
     match lit {
       Literal::NatVal(n) => {
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, Nat::to_lean(n));
+        let ctor = LeanIxLiteralNat::alloc();
+        ctor.set_obj(0, Nat::to_lean(n));
         Self::new(ctor.into())
       },
       Literal::StrVal(s) => {
-        let ctor = LeanCtor::alloc(1, 1, 0);
-        ctor.set(0, LeanString::new(s.as_str()));
+        let ctor = LeanIxLiteralStr::alloc();
+        ctor.set_obj(0, LeanString::new(s.as_str()));
         Self::new(ctor.into())
       },
     }

--- a/src/ffi/ix/expr.rs
+++ b/src/ffi/ix/expr.rs
@@ -28,6 +28,8 @@ use lean_ffi::nat::Nat;
 use lean_ffi::object::LeanBorrowed;
 use lean_ffi::object::{LeanCtor, LeanOwned, LeanRef, LeanString};
 
+use lean_ffi::object::scalar_base;
+
 impl LeanIxExpr<LeanOwned> {
   /// Build a Lean Ix.Expr with embedded hash.
   /// Uses caching to avoid rebuilding the same expression.
@@ -92,7 +94,7 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(2, body_obj);
         ctor.set(3, hash_obj);
         ctor.set_u8(
-          ctor.scalar_base(0),
+          scalar_base(&ctor, 0),
           LeanIxBinderInfo::<LeanOwned>::to_u8(bi),
         );
         Self::new(ctor.into())
@@ -108,7 +110,7 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(2, body_obj);
         ctor.set(3, hash_obj);
         ctor.set_u8(
-          ctor.scalar_base(0),
+          scalar_base(&ctor, 0),
           LeanIxBinderInfo::<LeanOwned>::to_u8(bi),
         );
         Self::new(ctor.into())
@@ -126,7 +128,7 @@ impl LeanIxExpr<LeanOwned> {
         ctor.set(2, val_obj);
         ctor.set(3, body_obj);
         ctor.set(4, hash_obj);
-        ctor.set_bool(ctor.scalar_base(0), *non_dep);
+        ctor.set_bool(scalar_base(&ctor, 0), *non_dep);
         Self::new(ctor.into())
       },
       ExprData::Lit(lit, h) => {
@@ -209,7 +211,7 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let body = LeanIxExpr(ctor.get(2)).decode();
 
         // Read BinderInfo scalar (4 obj fields: name, ty, body, hash)
-        let bi_byte = ctor.get_u8(ctor.scalar_base(0));
+        let bi_byte = ctor.get_u8(scalar_base(&ctor, 0));
         let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::lam(name, ty, body, bi)
@@ -221,7 +223,7 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let body = LeanIxExpr(ctor.get(2)).decode();
 
         // 4 obj fields: name, ty, body, hash
-        let bi_byte = ctor.get_u8(ctor.scalar_base(0));
+        let bi_byte = ctor.get_u8(scalar_base(&ctor, 0));
         let bi = LeanIxBinderInfo::<LeanOwned>::from_u8(bi_byte);
 
         Expr::all(name, ty, body, bi)
@@ -234,7 +236,7 @@ impl<R: LeanRef> LeanIxExpr<R> {
         let body = LeanIxExpr(ctor.get(3)).decode();
 
         // 5 obj fields: name, ty, val, body, hash
-        let non_dep = ctor.get_bool(ctor.scalar_base(0));
+        let non_dep = ctor.get_bool(scalar_base(&ctor, 0));
 
         Expr::letE(name, ty, val, body, non_dep)
       },

--- a/src/ffi/ix/level.rs
+++ b/src/ffi/ix/level.rs
@@ -9,10 +9,7 @@
 //! - Tag 5: mvar (n : Name) (hash : Address)
 
 use crate::ix::env::{Level, LevelData};
-use crate::lean::{
-  LeanIxLevel, LeanIxLevelImax, LeanIxLevelMax, LeanIxLevelMvar,
-  LeanIxLevelParam, LeanIxLevelSucc, LeanIxLevelZero, LeanIxName,
-};
+use crate::lean::{LeanIxLevel, LeanIxName};
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanRef};
 
 use crate::ffi::builder::LeanBuildCache;
@@ -29,48 +26,48 @@ impl LeanIxLevel<LeanOwned> {
 
     let result = match level.as_data() {
       LevelData::Zero(h) => {
-        let ctor = LeanIxLevelZero::alloc();
+        let ctor = LeanIxLevel::alloc(0);
         ctor.set_obj(0, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       LevelData::Succ(x, h) => {
         let x_obj = Self::build(cache, x);
-        let ctor = LeanIxLevelSucc::alloc();
+        let ctor = LeanIxLevel::alloc(1);
         ctor.set_obj(0, x_obj);
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       LevelData::Max(x, y, h) => {
         let x_obj = Self::build(cache, x);
         let y_obj = Self::build(cache, y);
-        let ctor = LeanIxLevelMax::alloc();
+        let ctor = LeanIxLevel::alloc(2);
         ctor.set_obj(0, x_obj);
         ctor.set_obj(1, y_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       LevelData::Imax(x, y, h) => {
         let x_obj = Self::build(cache, x);
         let y_obj = Self::build(cache, y);
-        let ctor = LeanIxLevelImax::alloc();
+        let ctor = LeanIxLevel::alloc(3);
         ctor.set_obj(0, x_obj);
         ctor.set_obj(1, y_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       LevelData::Param(n, h) => {
         let n_obj = LeanIxName::build(cache, n);
-        let ctor = LeanIxLevelParam::alloc();
+        let ctor = LeanIxLevel::alloc(4);
         ctor.set_obj(0, n_obj);
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       LevelData::Mvar(n, h) => {
         let n_obj = LeanIxName::build(cache, n);
-        let ctor = LeanIxLevelMvar::alloc();
+        let ctor = LeanIxLevel::alloc(5);
         ctor.set_obj(0, n_obj);
         ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
     };
 

--- a/src/ffi/ix/level.rs
+++ b/src/ffi/ix/level.rs
@@ -9,8 +9,11 @@
 //! - Tag 5: mvar (n : Name) (hash : Address)
 
 use crate::ix::env::{Level, LevelData};
-use crate::lean::{LeanIxLevel, LeanIxName};
-use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
+use crate::lean::{
+  LeanIxLevel, LeanIxLevelImax, LeanIxLevelMax, LeanIxLevelMvar,
+  LeanIxLevelParam, LeanIxLevelSucc, LeanIxLevelZero, LeanIxName,
+};
+use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanRef};
 
 use crate::ffi::builder::LeanBuildCache;
 use crate::lean::LeanIxAddress;
@@ -26,47 +29,47 @@ impl LeanIxLevel<LeanOwned> {
 
     let result = match level.as_data() {
       LevelData::Zero(h) => {
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxLevelZero::alloc();
+        ctor.set_obj(0, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       LevelData::Succ(x, h) => {
         let x_obj = Self::build(cache, x);
-        let ctor = LeanCtor::alloc(1, 2, 0);
-        ctor.set(0, x_obj);
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxLevelSucc::alloc();
+        ctor.set_obj(0, x_obj);
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       LevelData::Max(x, y, h) => {
         let x_obj = Self::build(cache, x);
         let y_obj = Self::build(cache, y);
-        let ctor = LeanCtor::alloc(2, 3, 0);
-        ctor.set(0, x_obj);
-        ctor.set(1, y_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxLevelMax::alloc();
+        ctor.set_obj(0, x_obj);
+        ctor.set_obj(1, y_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       LevelData::Imax(x, y, h) => {
         let x_obj = Self::build(cache, x);
         let y_obj = Self::build(cache, y);
-        let ctor = LeanCtor::alloc(3, 3, 0);
-        ctor.set(0, x_obj);
-        ctor.set(1, y_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxLevelImax::alloc();
+        ctor.set_obj(0, x_obj);
+        ctor.set_obj(1, y_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       LevelData::Param(n, h) => {
         let n_obj = LeanIxName::build(cache, n);
-        let ctor = LeanCtor::alloc(4, 2, 0);
-        ctor.set(0, n_obj);
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxLevelParam::alloc();
+        ctor.set_obj(0, n_obj);
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       LevelData::Mvar(n, h) => {
         let n_obj = LeanIxName::build(cache, n);
-        let ctor = LeanCtor::alloc(5, 2, 0);
-        ctor.set(0, n_obj);
-        ctor.set(1, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxLevelMvar::alloc();
+        ctor.set_obj(0, n_obj);
+        ctor.set_obj(1, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
     };

--- a/src/ffi/ix/name.rs
+++ b/src/ffi/ix/name.rs
@@ -6,10 +6,12 @@
 //! - Tag 2: num (parent : Name) (i : Nat) (hash : Address)
 
 use crate::ix::env::{Name, NameData};
-use crate::lean::LeanIxName;
+use crate::lean::{
+  LeanIxName, LeanIxNameAnonymous, LeanIxNameNum, LeanIxNameStr,
+};
 use lean_ffi::nat::Nat;
 use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef, LeanString,
+  LeanArray, LeanBorrowed, LeanOwned, LeanRef, LeanString,
 };
 
 use crate::ffi::builder::LeanBuildCache;
@@ -26,26 +28,26 @@ impl LeanIxName<LeanOwned> {
 
     let result = match name.as_data() {
       NameData::Anonymous(h) => {
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxNameAnonymous::alloc();
+        ctor.set_obj(0, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       NameData::Str(parent, s, h) => {
         let parent_obj = Self::build(cache, parent);
         let s_obj = LeanString::new(s.as_str());
-        let ctor = LeanCtor::alloc(1, 3, 0);
-        ctor.set(0, parent_obj);
-        ctor.set(1, s_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxNameStr::alloc();
+        ctor.set_obj(0, parent_obj);
+        ctor.set_obj(1, s_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
       NameData::Num(parent, n, h) => {
         let parent_obj = Self::build(cache, parent);
         let n_obj = Nat::to_lean(n);
-        let ctor = LeanCtor::alloc(2, 3, 0);
-        ctor.set(0, parent_obj);
-        ctor.set(1, n_obj);
-        ctor.set(2, LeanIxAddress::build_from_hash(h));
+        let ctor = LeanIxNameNum::alloc();
+        ctor.set_obj(0, parent_obj);
+        ctor.set_obj(1, n_obj);
+        ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
         Self::new(ctor.into())
       },
     };

--- a/src/ffi/ix/name.rs
+++ b/src/ffi/ix/name.rs
@@ -6,9 +6,7 @@
 //! - Tag 2: num (parent : Name) (i : Nat) (hash : Address)
 
 use crate::ix::env::{Name, NameData};
-use crate::lean::{
-  LeanIxName, LeanIxNameAnonymous, LeanIxNameNum, LeanIxNameStr,
-};
+use crate::lean::LeanIxName;
 use lean_ffi::nat::Nat;
 use lean_ffi::object::{
   LeanArray, LeanBorrowed, LeanOwned, LeanRef, LeanString,
@@ -28,27 +26,27 @@ impl LeanIxName<LeanOwned> {
 
     let result = match name.as_data() {
       NameData::Anonymous(h) => {
-        let ctor = LeanIxNameAnonymous::alloc();
+        let ctor = LeanIxName::alloc(0);
         ctor.set_obj(0, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       NameData::Str(parent, s, h) => {
         let parent_obj = Self::build(cache, parent);
         let s_obj = LeanString::new(s.as_str());
-        let ctor = LeanIxNameStr::alloc();
+        let ctor = LeanIxName::alloc(1);
         ctor.set_obj(0, parent_obj);
         ctor.set_obj(1, s_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
       NameData::Num(parent, n, h) => {
         let parent_obj = Self::build(cache, parent);
         let n_obj = Nat::to_lean(n);
-        let ctor = LeanIxNameNum::alloc();
+        let ctor = LeanIxName::alloc(2);
         ctor.set_obj(0, parent_obj);
         ctor.set_obj(1, n_obj);
         ctor.set_obj(2, LeanIxAddress::build_from_hash(h));
-        Self::new(ctor.into())
+        ctor
       },
     };
 

--- a/src/ffi/ixon/compare.rs
+++ b/src/ffi/ixon/compare.rs
@@ -8,11 +8,10 @@ use crate::ix::ixon::serialize::put_expr;
 use crate::ix::mutual::MutCtx;
 use crate::lean::{
   LeanIxBlockCompareDetail, LeanIxBlockCompareResult,
-  LeanIxBlockCompareResultMismatch,
+  LeanIxBlockCompareResultMatch, LeanIxBlockCompareResultMismatch,
+  LeanIxBlockCompareResultNotFound,
 };
-use lean_ffi::object::{
-  LeanBorrowed, LeanByteArray, LeanCtorScalar, LeanList, LeanOwned,
-};
+use lean_ffi::object::{LeanBorrowed, LeanByteArray, LeanList, LeanOwned};
 
 use crate::ffi::lean_env::{
   Cache as LeanCache, GlobalCache, decode_expr, decode_name,
@@ -76,16 +75,16 @@ impl LeanIxBlockCompareResult<LeanOwned> {
     first_diff_offset: u64,
   ) -> Self {
     let obj = if matched {
-      LeanOwned::box_usize(0) // match (tag 0, no fields)
+      LeanIxBlockCompareResultMatch::alloc().into() // match
     } else if not_found {
-      LeanOwned::box_usize(2) // notFound (tag 2, no fields)
+      LeanIxBlockCompareResultNotFound::alloc().into() // notFound
     } else {
       // mismatch
       let ctor = LeanIxBlockCompareResultMismatch::alloc();
       ctor.set_num_64(0, lean_size);
       ctor.set_num_64(1, rust_size);
       ctor.set_num_64(2, first_diff_offset);
-      ctor.into()
+      ctor.0
     };
     Self::new(obj)
   }

--- a/src/ffi/ixon/compare.rs
+++ b/src/ffi/ixon/compare.rs
@@ -79,7 +79,10 @@ impl LeanIxBlockCompareResult<LeanOwned> {
     } else {
       // mismatch
       let ctor = LeanCtor::alloc(1, 0, 24);
-      ctor.set_scalars::<3, u64>(ctor.scalar_base(0), [lean_size, rust_size, first_diff_offset]);
+      ctor.set_scalars::<3, u64>(
+        ctor.scalar_base(0),
+        [lean_size, rust_size, first_diff_offset],
+      );
       ctor.into()
     };
     Self::new(obj)
@@ -95,7 +98,10 @@ impl LeanIxBlockCompareDetail<LeanOwned> {
   ) -> Self {
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, result);
-    ctor.set_scalars::<2, u64>(ctor.scalar_base(0), [lean_sharing_len, rust_sharing_len]);
+    ctor.set_scalars::<2, u64>(
+      ctor.scalar_base(0),
+      [lean_sharing_len, rust_sharing_len],
+    );
     Self::new(ctor.into())
   }
 }

--- a/src/ffi/ixon/compare.rs
+++ b/src/ffi/ixon/compare.rs
@@ -6,11 +6,7 @@ use crate::ix::compile::{BlockCache, CompileState, compile_env, compile_expr};
 use crate::ix::env::Name;
 use crate::ix::ixon::serialize::put_expr;
 use crate::ix::mutual::MutCtx;
-use crate::lean::{
-  LeanIxBlockCompareDetail, LeanIxBlockCompareResult,
-  LeanIxBlockCompareResultMatch, LeanIxBlockCompareResultMismatch,
-  LeanIxBlockCompareResultNotFound,
-};
+use crate::lean::{LeanIxBlockCompareDetail, LeanIxBlockCompareResult};
 use lean_ffi::object::{LeanBorrowed, LeanByteArray, LeanList, LeanOwned};
 
 use crate::ffi::lean_env::{
@@ -74,19 +70,20 @@ impl LeanIxBlockCompareResult<LeanOwned> {
     rust_size: u64,
     first_diff_offset: u64,
   ) -> Self {
-    let obj = if matched {
-      LeanIxBlockCompareResultMatch::alloc().into() // match
+    if matched {
+      // match (tag 0, no fields) — scalar
+      Self::new(LeanOwned::box_usize(0))
     } else if not_found {
-      LeanIxBlockCompareResultNotFound::alloc().into() // notFound
+      // notFound (tag 2, no fields) — scalar
+      Self::new(LeanOwned::box_usize(2))
     } else {
-      // mismatch
-      let ctor = LeanIxBlockCompareResultMismatch::alloc();
+      // mismatch (tag 1)
+      let ctor = LeanIxBlockCompareResult::alloc(1);
       ctor.set_num_64(0, lean_size);
       ctor.set_num_64(1, rust_size);
       ctor.set_num_64(2, first_diff_offset);
-      ctor.0
-    };
-    Self::new(obj)
+      ctor
+    }
   }
 }
 
@@ -97,7 +94,7 @@ impl LeanIxBlockCompareDetail<LeanOwned> {
     lean_sharing_len: u64,
     rust_sharing_len: u64,
   ) -> Self {
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, result);
     ctor.set_num_64(0, lean_sharing_len);
     ctor.set_num_64(1, rust_sharing_len);

--- a/src/ffi/ixon/compare.rs
+++ b/src/ffi/ixon/compare.rs
@@ -79,9 +79,7 @@ impl LeanIxBlockCompareResult<LeanOwned> {
     } else {
       // mismatch
       let ctor = LeanCtor::alloc(1, 0, 24);
-      ctor.set_u64(0, 0, lean_size);
-      ctor.set_u64(0, 8, rust_size);
-      ctor.set_u64(0, 16, first_diff_offset);
+      ctor.set_scalars::<3, u64>(ctor.scalar_base(0), [lean_size, rust_size, first_diff_offset]);
       ctor.into()
     };
     Self::new(obj)
@@ -97,8 +95,7 @@ impl LeanIxBlockCompareDetail<LeanOwned> {
   ) -> Self {
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, result);
-    ctor.set_u64(1, 0, lean_sharing_len);
-    ctor.set_u64(1, 8, rust_sharing_len);
+    ctor.set_scalars::<2, u64>(ctor.scalar_base(0), [lean_sharing_len, rust_sharing_len]);
     Self::new(ctor.into())
   }
 }

--- a/src/ffi/ixon/compare.rs
+++ b/src/ffi/ixon/compare.rs
@@ -6,12 +6,13 @@ use crate::ix::compile::{BlockCache, CompileState, compile_env, compile_expr};
 use crate::ix::env::Name;
 use crate::ix::ixon::serialize::put_expr;
 use crate::ix::mutual::MutCtx;
-use crate::lean::{LeanIxBlockCompareDetail, LeanIxBlockCompareResult};
-use lean_ffi::object::{
-  LeanBorrowed, LeanByteArray, LeanCtor, LeanCtorScalar, LeanList, LeanOwned,
+use crate::lean::{
+  LeanIxBlockCompareDetail, LeanIxBlockCompareResult,
+  LeanIxBlockCompareResultMismatch,
 };
-
-use lean_ffi::object::scalar_base;
+use lean_ffi::object::{
+  LeanBorrowed, LeanByteArray, LeanCtorScalar, LeanList, LeanOwned,
+};
 
 use crate::ffi::lean_env::{
   Cache as LeanCache, GlobalCache, decode_expr, decode_name,
@@ -75,16 +76,15 @@ impl LeanIxBlockCompareResult<LeanOwned> {
     first_diff_offset: u64,
   ) -> Self {
     let obj = if matched {
-      LeanCtor::alloc(0, 0, 0).into() // match
+      LeanOwned::box_usize(0) // match (tag 0, no fields)
     } else if not_found {
-      LeanCtor::alloc(2, 0, 0).into() // notFound
+      LeanOwned::box_usize(2) // notFound (tag 2, no fields)
     } else {
       // mismatch
-      let ctor = LeanCtor::alloc(1, 0, 24);
-      let s = scalar_base(&ctor, 0);
-      ctor.set_u64(s, lean_size);
-      ctor.set_u64(s + 8, rust_size);
-      ctor.set_u64(s + 16, first_diff_offset);
+      let ctor = LeanIxBlockCompareResultMismatch::alloc();
+      ctor.set_num_64(0, lean_size);
+      ctor.set_num_64(1, rust_size);
+      ctor.set_num_64(2, first_diff_offset);
       ctor.into()
     };
     Self::new(obj)
@@ -98,12 +98,11 @@ impl LeanIxBlockCompareDetail<LeanOwned> {
     lean_sharing_len: u64,
     rust_sharing_len: u64,
   ) -> Self {
-    let ctor = LeanCtor::alloc(0, 1, 16);
-    ctor.set(0, result);
-    let out = Self::new(ctor.into());
-    out.set_64(0, lean_sharing_len);
-    out.set_64(1, rust_sharing_len);
-    out
+    let ctor = Self::alloc();
+    ctor.set_obj(0, result);
+    ctor.set_num_64(0, lean_sharing_len);
+    ctor.set_num_64(1, rust_sharing_len);
+    ctor
   }
 }
 

--- a/src/ffi/ixon/compare.rs
+++ b/src/ffi/ixon/compare.rs
@@ -8,8 +8,10 @@ use crate::ix::ixon::serialize::put_expr;
 use crate::ix::mutual::MutCtx;
 use crate::lean::{LeanIxBlockCompareDetail, LeanIxBlockCompareResult};
 use lean_ffi::object::{
-  LeanBorrowed, LeanByteArray, LeanCtor, LeanList, LeanOwned,
+  LeanBorrowed, LeanByteArray, LeanCtor, LeanCtorScalar, LeanList, LeanOwned,
 };
+
+use lean_ffi::object::scalar_base;
 
 use crate::ffi::lean_env::{
   Cache as LeanCache, GlobalCache, decode_expr, decode_name,
@@ -79,10 +81,10 @@ impl LeanIxBlockCompareResult<LeanOwned> {
     } else {
       // mismatch
       let ctor = LeanCtor::alloc(1, 0, 24);
-      ctor.set_scalars::<3, u64>(
-        ctor.scalar_base(0),
-        [lean_size, rust_size, first_diff_offset],
-      );
+      let s = scalar_base(&ctor, 0);
+      ctor.set_u64(s, lean_size);
+      ctor.set_u64(s + 8, rust_size);
+      ctor.set_u64(s + 16, first_diff_offset);
       ctor.into()
     };
     Self::new(obj)
@@ -98,11 +100,10 @@ impl LeanIxBlockCompareDetail<LeanOwned> {
   ) -> Self {
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, result);
-    ctor.set_scalars::<2, u64>(
-      ctor.scalar_base(0),
-      [lean_sharing_len, rust_sharing_len],
-    );
-    Self::new(ctor.into())
+    let out = Self::new(ctor.into());
+    out.set_64(0, lean_sharing_len);
+    out.set_64(1, rust_sharing_len);
+    out
   }
 }
 

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -39,24 +39,23 @@ impl LeanIxonDefinition<LeanOwned> {
     let typ_obj = LeanIxonExpr::build(&def.typ);
     let value_obj = LeanIxonExpr::build(&def.value);
     // 2 obj fields, 16 scalar bytes (lvls(8) + kind(1) + safety(1) + padding(6))
-    let ctor = LeanCtor::alloc(0, 2, 16);
-    ctor.set(0, typ_obj);
-    ctor.set(1, value_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, def.lvls);
+    let ctor = Self::alloc();
+    ctor.set_obj(0, typ_obj);
+    ctor.set_obj(1, value_obj);
+    ctor.set_num_64(0, def.lvls);
     let kind_val: u8 = match def.kind {
       DefKind::Definition => 0,
       DefKind::Opaque => 1,
       DefKind::Theorem => 2,
     };
-    result.set_8(0, kind_val);
+    ctor.set_num_8(0, kind_val);
     let safety_val: u8 = match def.safety {
       crate::ix::env::DefinitionSafety::Unsafe => 0,
       crate::ix::env::DefinitionSafety::Safe => 1,
       crate::ix::env::DefinitionSafety::Partial => 2,
     };
-    result.set_8(1, safety_val);
-    result
+    ctor.set_num_8(1, safety_val);
+    ctor
   }
 }
 
@@ -69,15 +68,15 @@ impl<R: LeanRef> LeanIxonDefinition<R> {
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
     let value =
       Arc::new(LeanIxonExpr::new(ctor.get(1).to_owned_ref()).decode());
-    let lvls = self.get_64(0);
-    let kind_val = self.get_8(0);
+    let lvls = self.get_num_64(0);
+    let kind_val = self.get_num_8(0);
     let kind = match kind_val {
       0 => DefKind::Definition,
       1 => DefKind::Opaque,
       2 => DefKind::Theorem,
       _ => panic!("Invalid DefKind: {}", kind_val),
     };
-    let safety_val = self.get_8(1);
+    let safety_val = self.get_num_8(1);
     let safety = match safety_val {
       0 => crate::ix::env::DefinitionSafety::Unsafe,
       1 => crate::ix::env::DefinitionSafety::Safe,
@@ -97,11 +96,10 @@ impl LeanIxonRecursorRule<LeanOwned> {
   pub fn build(rule: &IxonRecursorRule) -> Self {
     let rhs_obj = LeanIxonExpr::build(&rule.rhs);
     // 1 obj field, 8 scalar bytes
-    let ctor = LeanCtor::alloc(0, 1, 8);
-    ctor.set(0, rhs_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, rule.fields);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, rhs_obj);
+    ctor.set_num_64(0, rule.fields);
+    ctor
   }
 }
 
@@ -110,7 +108,7 @@ impl<R: LeanRef> LeanIxonRecursorRule<R> {
   pub fn decode(&self) -> IxonRecursorRule {
     let ctor = self.as_ctor();
     let rhs = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let fields = self.get_64(0);
+    let fields = self.get_num_64(0);
     IxonRecursorRule { fields, rhs }
   }
 }
@@ -130,18 +128,17 @@ impl LeanIxonRecursor<LeanOwned> {
       rules_arr.set(i, LeanIxonRecursorRule::build(rule));
     }
     // 2 obj fields (typ, rules), 48 scalar bytes (5×8 + 1 + 1 + 6 padding)
-    let ctor = LeanCtor::alloc(0, 2, 48);
-    ctor.set(0, typ_obj);
-    ctor.set(1, rules_arr);
-    let result = Self::new(ctor.into());
-    result.set_64(0, rec.lvls);
-    result.set_64(1, rec.params);
-    result.set_64(2, rec.indices);
-    result.set_64(3, rec.motives);
-    result.set_64(4, rec.minors);
-    result.set_8(0, rec.k as u8);
-    result.set_8(1, rec.is_unsafe as u8);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, typ_obj);
+    ctor.set_obj(1, rules_arr);
+    ctor.set_num_64(0, rec.lvls);
+    ctor.set_num_64(1, rec.params);
+    ctor.set_num_64(2, rec.indices);
+    ctor.set_num_64(3, rec.motives);
+    ctor.set_num_64(4, rec.minors);
+    ctor.set_num_8(0, rec.k as u8);
+    ctor.set_num_8(1, rec.is_unsafe as u8);
+    ctor
   }
 }
 
@@ -154,13 +151,13 @@ impl<R: LeanRef> LeanIxonRecursor<R> {
     let rules_arr = ctor.get(1).as_array();
     let rules =
       rules_arr.map(|x| LeanIxonRecursorRule::new(x.to_owned_ref()).decode());
-    let lvls = self.get_64(0);
-    let params = self.get_64(1);
-    let indices = self.get_64(2);
-    let motives = self.get_64(3);
-    let minors = self.get_64(4);
-    let k = self.get_8(0) != 0;
-    let is_unsafe = self.get_8(1) != 0;
+    let lvls = self.get_num_64(0);
+    let params = self.get_num_64(1);
+    let indices = self.get_num_64(2);
+    let motives = self.get_num_64(3);
+    let minors = self.get_num_64(4);
+    let k = self.get_num_8(0) != 0;
+    let is_unsafe = self.get_num_8(1) != 0;
     IxonRecursor {
       k,
       is_unsafe,
@@ -185,12 +182,11 @@ impl LeanIxonAxiom<LeanOwned> {
   pub fn build(ax: &IxonAxiom) -> Self {
     let typ_obj = LeanIxonExpr::build(&ax.typ);
     // 1 obj field, 16 scalar bytes (lvls(8) + isUnsafe(1) + padding(7))
-    let ctor = LeanCtor::alloc(0, 1, 16);
-    ctor.set(0, typ_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, ax.lvls);
-    result.set_8(0, ax.is_unsafe as u8);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, typ_obj);
+    ctor.set_num_64(0, ax.lvls);
+    ctor.set_num_8(0, ax.is_unsafe as u8);
+    ctor
   }
 }
 
@@ -200,8 +196,8 @@ impl<R: LeanRef> LeanIxonAxiom<R> {
   pub fn decode(&self) -> IxonAxiom {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let lvls = self.get_64(0);
-    let is_unsafe = self.get_8(0) != 0;
+    let lvls = self.get_num_64(0);
+    let is_unsafe = self.get_num_8(0) != 0;
     IxonAxiom { is_unsafe, lvls, typ }
   }
 }
@@ -217,18 +213,17 @@ impl LeanIxonQuotient<LeanOwned> {
   pub fn build(quot: &IxonQuotient) -> Self {
     let typ_obj = LeanIxonExpr::build(&quot.typ);
     // 1 obj field (typ), 16 scalar bytes (lvls(8) + kind(1) + padding(7))
-    let ctor = LeanCtor::alloc(0, 1, 16);
-    ctor.set(0, typ_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, quot.lvls);
+    let ctor = Self::alloc();
+    ctor.set_obj(0, typ_obj);
+    ctor.set_num_64(0, quot.lvls);
     let kind_val: u8 = match quot.kind {
       crate::ix::env::QuotKind::Type => 0,
       crate::ix::env::QuotKind::Ctor => 1,
       crate::ix::env::QuotKind::Lift => 2,
       crate::ix::env::QuotKind::Ind => 3,
     };
-    result.set_8(0, kind_val);
-    result
+    ctor.set_num_8(0, kind_val);
+    ctor
   }
 }
 
@@ -238,8 +233,8 @@ impl<R: LeanRef> LeanIxonQuotient<R> {
   pub fn decode(&self) -> IxonQuotient {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let lvls = self.get_64(0);
-    let kind_val = self.get_8(0);
+    let lvls = self.get_num_64(0);
+    let kind_val = self.get_num_8(0);
     let kind = match kind_val {
       0 => crate::ix::env::QuotKind::Type,
       1 => crate::ix::env::QuotKind::Ctor,
@@ -261,15 +256,14 @@ impl LeanIxonConstructor<LeanOwned> {
   pub fn build(c: &IxonConstructor) -> Self {
     let typ_obj = LeanIxonExpr::build(&c.typ);
     // 1 obj field, 40 scalar bytes (4×8 + 1 + 7 padding)
-    let ctor = LeanCtor::alloc(0, 1, 40);
-    ctor.set(0, typ_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, c.lvls);
-    result.set_64(1, c.cidx);
-    result.set_64(2, c.params);
-    result.set_64(3, c.fields);
-    result.set_8(0, c.is_unsafe as u8);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, typ_obj);
+    ctor.set_num_64(0, c.lvls);
+    ctor.set_num_64(1, c.cidx);
+    ctor.set_num_64(2, c.params);
+    ctor.set_num_64(3, c.fields);
+    ctor.set_num_8(0, c.is_unsafe as u8);
+    ctor
   }
 }
 
@@ -279,11 +273,11 @@ impl<R: LeanRef> LeanIxonConstructor<R> {
   pub fn decode(&self) -> IxonConstructor {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let lvls = self.get_64(0);
-    let cidx = self.get_64(1);
-    let params = self.get_64(2);
-    let fields = self.get_64(3);
-    let is_unsafe = self.get_8(0) != 0;
+    let lvls = self.get_num_64(0);
+    let cidx = self.get_num_64(1);
+    let params = self.get_num_64(2);
+    let fields = self.get_num_64(3);
+    let is_unsafe = self.get_num_8(0) != 0;
     IxonConstructor { is_unsafe, lvls, cidx, params, fields, typ }
   }
 }
@@ -303,18 +297,17 @@ impl LeanIxonInductive<LeanOwned> {
       ctors_arr.set(i, LeanIxonConstructor::build(c));
     }
     // 2 obj fields, 40 scalar bytes (4×8 + 3 + 5 padding)
-    let ctor = LeanCtor::alloc(0, 2, 40);
-    ctor.set(0, typ_obj);
-    ctor.set(1, ctors_arr);
-    let result = Self::new(ctor.into());
-    result.set_64(0, ind.lvls);
-    result.set_64(1, ind.params);
-    result.set_64(2, ind.indices);
-    result.set_64(3, ind.nested);
-    result.set_8(0, ind.recr as u8);
-    result.set_8(1, ind.refl as u8);
-    result.set_8(2, ind.is_unsafe as u8);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, typ_obj);
+    ctor.set_obj(1, ctors_arr);
+    ctor.set_num_64(0, ind.lvls);
+    ctor.set_num_64(1, ind.params);
+    ctor.set_num_64(2, ind.indices);
+    ctor.set_num_64(3, ind.nested);
+    ctor.set_num_8(0, ind.recr as u8);
+    ctor.set_num_8(1, ind.refl as u8);
+    ctor.set_num_8(2, ind.is_unsafe as u8);
+    ctor
   }
 }
 
@@ -327,13 +320,13 @@ impl<R: LeanRef> LeanIxonInductive<R> {
     let ctors_arr = ctor.get(1).as_array();
     let ctors =
       ctors_arr.map(|x| LeanIxonConstructor::new(x.to_owned_ref()).decode());
-    let lvls = self.get_64(0);
-    let params = self.get_64(1);
-    let indices = self.get_64(2);
-    let nested = self.get_64(3);
-    let recr = self.get_8(0) != 0;
-    let refl = self.get_8(1) != 0;
-    let is_unsafe = self.get_8(2) != 0;
+    let lvls = self.get_num_64(0);
+    let params = self.get_num_64(1);
+    let indices = self.get_num_64(2);
+    let nested = self.get_num_64(3);
+    let recr = self.get_num_8(0) != 0;
+    let refl = self.get_num_8(1) != 0;
+    let is_unsafe = self.get_num_8(2) != 0;
     IxonInductive {
       recr,
       refl,
@@ -355,11 +348,10 @@ impl<R: LeanRef> LeanIxonInductive<R> {
 impl LeanIxonInductiveProj<LeanOwned> {
   pub fn build(proj: &InductiveProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = LeanCtor::alloc(0, 1, 8);
-    ctor.set(0, block_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, proj.idx);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, block_obj);
+    ctor.set_num_64(0, proj.idx);
+    ctor
   }
 }
 
@@ -368,7 +360,7 @@ impl<R: LeanRef> LeanIxonInductiveProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = self.get_64(0);
+    let idx = self.get_num_64(0);
     InductiveProj { idx, block }
   }
 }
@@ -376,12 +368,11 @@ impl<R: LeanRef> LeanIxonInductiveProj<R> {
 impl LeanIxonConstructorProj<LeanOwned> {
   pub fn build(proj: &ConstructorProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = LeanCtor::alloc(0, 1, 16);
-    ctor.set(0, block_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, proj.idx);
-    result.set_64(1, proj.cidx);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, block_obj);
+    ctor.set_num_64(0, proj.idx);
+    ctor.set_num_64(1, proj.cidx);
+    ctor
   }
 }
 
@@ -390,8 +381,8 @@ impl<R: LeanRef> LeanIxonConstructorProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = self.get_64(0);
-    let cidx = self.get_64(1);
+    let idx = self.get_num_64(0);
+    let cidx = self.get_num_64(1);
     ConstructorProj { idx, cidx, block }
   }
 }
@@ -399,11 +390,10 @@ impl<R: LeanRef> LeanIxonConstructorProj<R> {
 impl LeanIxonRecursorProj<LeanOwned> {
   pub fn build(proj: &RecursorProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = LeanCtor::alloc(0, 1, 8);
-    ctor.set(0, block_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, proj.idx);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, block_obj);
+    ctor.set_num_64(0, proj.idx);
+    ctor
   }
 }
 
@@ -412,7 +402,7 @@ impl<R: LeanRef> LeanIxonRecursorProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = self.get_64(0);
+    let idx = self.get_num_64(0);
     RecursorProj { idx, block }
   }
 }
@@ -420,11 +410,10 @@ impl<R: LeanRef> LeanIxonRecursorProj<R> {
 impl LeanIxonDefinitionProj<LeanOwned> {
   pub fn build(proj: &DefinitionProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = LeanCtor::alloc(0, 1, 8);
-    ctor.set(0, block_obj);
-    let result = Self::new(ctor.into());
-    result.set_64(0, proj.idx);
-    result
+    let ctor = Self::alloc();
+    ctor.set_obj(0, block_obj);
+    ctor.set_num_64(0, proj.idx);
+    ctor
   }
 }
 
@@ -433,7 +422,7 @@ impl<R: LeanRef> LeanIxonDefinitionProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = self.get_64(0);
+    let idx = self.get_num_64(0);
     DefinitionProj { idx, block }
   }
 }

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -16,14 +16,10 @@ use crate::ix::ixon::constant::{
 };
 use crate::lean::{
   LeanIxAddress, LeanIxonAxiom, LeanIxonConstant, LeanIxonConstantInfo,
-  LeanIxonConstantInfoAxio, LeanIxonConstantInfoCPrj, LeanIxonConstantInfoDPrj,
-  LeanIxonConstantInfoDefn, LeanIxonConstantInfoIPrj, LeanIxonConstantInfoMuts,
-  LeanIxonConstantInfoQuot, LeanIxonConstantInfoRPrj, LeanIxonConstantInfoRecr,
   LeanIxonConstructor, LeanIxonConstructorProj, LeanIxonDefinition,
   LeanIxonDefinitionProj, LeanIxonExpr, LeanIxonInductive,
-  LeanIxonInductiveProj, LeanIxonMutConst, LeanIxonMutConstDefn,
-  LeanIxonMutConstIndc, LeanIxonMutConstRecr, LeanIxonQuotient,
-  LeanIxonRecursor, LeanIxonRecursorProj, LeanIxonRecursorRule, LeanIxonUniv,
+  LeanIxonInductiveProj, LeanIxonMutConst, LeanIxonQuotient, LeanIxonRecursor,
+  LeanIxonRecursorProj, LeanIxonRecursorRule, LeanIxonUniv,
 };
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
@@ -40,7 +36,7 @@ impl LeanIxonDefinition<LeanOwned> {
   pub fn build(def: &IxonDefinition) -> Self {
     let typ_obj = LeanIxonExpr::build(&def.typ);
     let value_obj = LeanIxonExpr::build(&def.value);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, typ_obj);
     ctor.set_obj(1, value_obj);
     ctor.set_num_64(0, def.lvls);
@@ -96,7 +92,7 @@ impl LeanIxonRecursorRule<LeanOwned> {
   /// Build Ixon.RecursorRule
   pub fn build(rule: &IxonRecursorRule) -> Self {
     let rhs_obj = LeanIxonExpr::build(&rule.rhs);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, rhs_obj);
     ctor.set_num_64(0, rule.fields);
     ctor
@@ -127,7 +123,7 @@ impl LeanIxonRecursor<LeanOwned> {
     for (i, rule) in rec.rules.iter().enumerate() {
       rules_arr.set(i, LeanIxonRecursorRule::build(rule));
     }
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, typ_obj);
     ctor.set_obj(1, rules_arr);
     ctor.set_num_64(0, rec.lvls);
@@ -180,7 +176,7 @@ impl LeanIxonAxiom<LeanOwned> {
   /// Scalars ordered by size: lvls(8) + isUnsafe(1) + padding(7)
   pub fn build(ax: &IxonAxiom) -> Self {
     let typ_obj = LeanIxonExpr::build(&ax.typ);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, typ_obj);
     ctor.set_num_64(0, ax.lvls);
     ctor.set_num_8(0, ax.is_unsafe as u8);
@@ -210,7 +206,7 @@ impl LeanIxonQuotient<LeanOwned> {
   /// Scalars ordered by size: lvls(8) + kind(1) + padding(7)
   pub fn build(quot: &IxonQuotient) -> Self {
     let typ_obj = LeanIxonExpr::build(&quot.typ);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, typ_obj);
     ctor.set_num_64(0, quot.lvls);
     let kind_val: u8 = match quot.kind {
@@ -252,7 +248,7 @@ impl LeanIxonConstructor<LeanOwned> {
   /// Scalars ordered by size: lvls(8) + cidx(8) + params(8) + fields(8) + isUnsafe(1) + padding(7)
   pub fn build(c: &IxonConstructor) -> Self {
     let typ_obj = LeanIxonExpr::build(&c.typ);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, typ_obj);
     ctor.set_num_64(0, c.lvls);
     ctor.set_num_64(1, c.cidx);
@@ -292,7 +288,7 @@ impl LeanIxonInductive<LeanOwned> {
     for (i, c) in ind.ctors.iter().enumerate() {
       ctors_arr.set(i, LeanIxonConstructor::build(c));
     }
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, typ_obj);
     ctor.set_obj(1, ctors_arr);
     ctor.set_num_64(0, ind.lvls);
@@ -343,7 +339,7 @@ impl<R: LeanRef> LeanIxonInductive<R> {
 impl LeanIxonInductiveProj<LeanOwned> {
   pub fn build(proj: &InductiveProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, block_obj);
     ctor.set_num_64(0, proj.idx);
     ctor
@@ -363,7 +359,7 @@ impl<R: LeanRef> LeanIxonInductiveProj<R> {
 impl LeanIxonConstructorProj<LeanOwned> {
   pub fn build(proj: &ConstructorProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, block_obj);
     ctor.set_num_64(0, proj.idx);
     ctor.set_num_64(1, proj.cidx);
@@ -385,7 +381,7 @@ impl<R: LeanRef> LeanIxonConstructorProj<R> {
 impl LeanIxonRecursorProj<LeanOwned> {
   pub fn build(proj: &RecursorProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, block_obj);
     ctor.set_num_64(0, proj.idx);
     ctor
@@ -405,7 +401,7 @@ impl<R: LeanRef> LeanIxonRecursorProj<R> {
 impl LeanIxonDefinitionProj<LeanOwned> {
   pub fn build(proj: &DefinitionProj) -> Self {
     let block_obj = LeanIxAddress::build(&proj.block);
-    let ctor = Self::alloc();
+    let ctor = Self::alloc(0);
     ctor.set_obj(0, block_obj);
     ctor.set_num_64(0, proj.idx);
     ctor
@@ -428,24 +424,23 @@ impl<R: LeanRef> LeanIxonDefinitionProj<R> {
 
 impl LeanIxonMutConst<LeanOwned> {
   pub fn build(mc: &MutConst) -> Self {
-    let obj = match mc {
+    match mc {
       MutConst::Defn(def) => {
-        let ctor = LeanIxonMutConstDefn::alloc();
+        let ctor = LeanIxonMutConst::alloc(0);
         ctor.set_obj(0, LeanIxonDefinition::build(def));
-        ctor.into()
+        ctor
       },
       MutConst::Indc(ind) => {
-        let ctor = LeanIxonMutConstIndc::alloc();
+        let ctor = LeanIxonMutConst::alloc(1);
         ctor.set_obj(0, LeanIxonInductive::build(ind));
-        ctor.into()
+        ctor
       },
       MutConst::Recr(rec) => {
-        let ctor = LeanIxonMutConstRecr::alloc();
+        let ctor = LeanIxonMutConst::alloc(2);
         ctor.set_obj(0, LeanIxonRecursor::build(rec));
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -473,58 +468,57 @@ impl<R: LeanRef> LeanIxonMutConst<R> {
 impl LeanIxonConstantInfo<LeanOwned> {
   /// Build Ixon.ConstantInfo (9 constructors)
   pub fn build(info: &IxonConstantInfo) -> Self {
-    let obj = match info {
+    match info {
       IxonConstantInfo::Defn(def) => {
-        let ctor = LeanIxonConstantInfoDefn::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(0);
         ctor.set_obj(0, LeanIxonDefinition::build(def));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::Recr(rec) => {
-        let ctor = LeanIxonConstantInfoRecr::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(1);
         ctor.set_obj(0, LeanIxonRecursor::build(rec));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::Axio(ax) => {
-        let ctor = LeanIxonConstantInfoAxio::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(2);
         ctor.set_obj(0, LeanIxonAxiom::build(ax));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::Quot(quot) => {
-        let ctor = LeanIxonConstantInfoQuot::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(3);
         ctor.set_obj(0, LeanIxonQuotient::build(quot));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::CPrj(proj) => {
-        let ctor = LeanIxonConstantInfoCPrj::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(4);
         ctor.set_obj(0, LeanIxonConstructorProj::build(proj));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::RPrj(proj) => {
-        let ctor = LeanIxonConstantInfoRPrj::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(5);
         ctor.set_obj(0, LeanIxonRecursorProj::build(proj));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::IPrj(proj) => {
-        let ctor = LeanIxonConstantInfoIPrj::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(6);
         ctor.set_obj(0, LeanIxonInductiveProj::build(proj));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::DPrj(proj) => {
-        let ctor = LeanIxonConstantInfoDPrj::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(7);
         ctor.set_obj(0, LeanIxonDefinitionProj::build(proj));
-        ctor.into()
+        ctor
       },
       IxonConstantInfo::Muts(muts) => {
         let arr = LeanArray::alloc(muts.len());
         for (i, mc) in muts.iter().enumerate() {
           arr.set(i, LeanIxonMutConst::build(mc));
         }
-        let ctor = LeanIxonConstantInfoMuts::alloc();
+        let ctor = LeanIxonConstantInfo::alloc(8);
         ctor.set_obj(0, arr);
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -580,12 +574,12 @@ impl LeanIxonConstant<LeanOwned> {
     let sharing_obj = LeanIxonExpr::build_array(&constant.sharing);
     let refs_obj = LeanIxAddress::build_array(&constant.refs);
     let univs_obj = LeanIxonUniv::build_array(&constant.univs);
-    let ctor = LeanIxonConstant::alloc();
+    let ctor = LeanIxonConstant::alloc(0);
     ctor.set_obj(0, info_obj);
     ctor.set_obj(1, sharing_obj);
     ctor.set_obj(2, refs_obj);
     ctor.set_obj(3, univs_obj);
-    Self::new(ctor.into())
+    ctor
   }
 }
 

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -16,16 +16,18 @@ use crate::ix::ixon::constant::{
 };
 use crate::lean::{
   LeanIxAddress, LeanIxonAxiom, LeanIxonConstant, LeanIxonConstantInfo,
+  LeanIxonConstantInfoAxio, LeanIxonConstantInfoCPrj, LeanIxonConstantInfoDPrj,
+  LeanIxonConstantInfoDefn, LeanIxonConstantInfoIPrj, LeanIxonConstantInfoMuts,
+  LeanIxonConstantInfoQuot, LeanIxonConstantInfoRPrj, LeanIxonConstantInfoRecr,
   LeanIxonConstructor, LeanIxonConstructorProj, LeanIxonDefinition,
   LeanIxonDefinitionProj, LeanIxonExpr, LeanIxonInductive,
-  LeanIxonInductiveProj, LeanIxonMutConst, LeanIxonQuotient, LeanIxonRecursor,
-  LeanIxonRecursorProj, LeanIxonRecursorRule, LeanIxonUniv,
+  LeanIxonInductiveProj, LeanIxonMutConst, LeanIxonMutConstDefn,
+  LeanIxonMutConstIndc, LeanIxonMutConstRecr, LeanIxonQuotient,
+  LeanIxonRecursor, LeanIxonRecursorProj, LeanIxonRecursorRule, LeanIxonUniv,
 };
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{
-  LeanArray, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
-};
+use lean_ffi::object::{LeanArray, LeanOwned, LeanRef};
 
 // =============================================================================
 // Definition
@@ -38,7 +40,6 @@ impl LeanIxonDefinition<LeanOwned> {
   pub fn build(def: &IxonDefinition) -> Self {
     let typ_obj = LeanIxonExpr::build(&def.typ);
     let value_obj = LeanIxonExpr::build(&def.value);
-    // 2 obj fields, 16 scalar bytes (lvls(8) + kind(1) + safety(1) + padding(6))
     let ctor = Self::alloc();
     ctor.set_obj(0, typ_obj);
     ctor.set_obj(1, value_obj);
@@ -95,7 +96,6 @@ impl LeanIxonRecursorRule<LeanOwned> {
   /// Build Ixon.RecursorRule
   pub fn build(rule: &IxonRecursorRule) -> Self {
     let rhs_obj = LeanIxonExpr::build(&rule.rhs);
-    // 1 obj field, 8 scalar bytes
     let ctor = Self::alloc();
     ctor.set_obj(0, rhs_obj);
     ctor.set_num_64(0, rule.fields);
@@ -127,7 +127,6 @@ impl LeanIxonRecursor<LeanOwned> {
     for (i, rule) in rec.rules.iter().enumerate() {
       rules_arr.set(i, LeanIxonRecursorRule::build(rule));
     }
-    // 2 obj fields (typ, rules), 48 scalar bytes (5×8 + 1 + 1 + 6 padding)
     let ctor = Self::alloc();
     ctor.set_obj(0, typ_obj);
     ctor.set_obj(1, rules_arr);
@@ -181,7 +180,6 @@ impl LeanIxonAxiom<LeanOwned> {
   /// Scalars ordered by size: lvls(8) + isUnsafe(1) + padding(7)
   pub fn build(ax: &IxonAxiom) -> Self {
     let typ_obj = LeanIxonExpr::build(&ax.typ);
-    // 1 obj field, 16 scalar bytes (lvls(8) + isUnsafe(1) + padding(7))
     let ctor = Self::alloc();
     ctor.set_obj(0, typ_obj);
     ctor.set_num_64(0, ax.lvls);
@@ -212,7 +210,6 @@ impl LeanIxonQuotient<LeanOwned> {
   /// Scalars ordered by size: lvls(8) + kind(1) + padding(7)
   pub fn build(quot: &IxonQuotient) -> Self {
     let typ_obj = LeanIxonExpr::build(&quot.typ);
-    // 1 obj field (typ), 16 scalar bytes (lvls(8) + kind(1) + padding(7))
     let ctor = Self::alloc();
     ctor.set_obj(0, typ_obj);
     ctor.set_num_64(0, quot.lvls);
@@ -255,7 +252,6 @@ impl LeanIxonConstructor<LeanOwned> {
   /// Scalars ordered by size: lvls(8) + cidx(8) + params(8) + fields(8) + isUnsafe(1) + padding(7)
   pub fn build(c: &IxonConstructor) -> Self {
     let typ_obj = LeanIxonExpr::build(&c.typ);
-    // 1 obj field, 40 scalar bytes (4×8 + 1 + 7 padding)
     let ctor = Self::alloc();
     ctor.set_obj(0, typ_obj);
     ctor.set_num_64(0, c.lvls);
@@ -296,7 +292,6 @@ impl LeanIxonInductive<LeanOwned> {
     for (i, c) in ind.ctors.iter().enumerate() {
       ctors_arr.set(i, LeanIxonConstructor::build(c));
     }
-    // 2 obj fields, 40 scalar bytes (4×8 + 3 + 5 padding)
     let ctor = Self::alloc();
     ctor.set_obj(0, typ_obj);
     ctor.set_obj(1, ctors_arr);
@@ -435,21 +430,18 @@ impl LeanIxonMutConst<LeanOwned> {
   pub fn build(mc: &MutConst) -> Self {
     let obj = match mc {
       MutConst::Defn(def) => {
-        let def_obj = LeanIxonDefinition::build(def);
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, def_obj);
+        let ctor = LeanIxonMutConstDefn::alloc();
+        ctor.set_obj(0, LeanIxonDefinition::build(def));
         ctor.into()
       },
       MutConst::Indc(ind) => {
-        let ind_obj = LeanIxonInductive::build(ind);
-        let ctor = LeanCtor::alloc(1, 1, 0);
-        ctor.set(0, ind_obj);
+        let ctor = LeanIxonMutConstIndc::alloc();
+        ctor.set_obj(0, LeanIxonInductive::build(ind));
         ctor.into()
       },
       MutConst::Recr(rec) => {
-        let rec_obj = LeanIxonRecursor::build(rec);
-        let ctor = LeanCtor::alloc(2, 1, 0);
-        ctor.set(0, rec_obj);
+        let ctor = LeanIxonMutConstRecr::alloc();
+        ctor.set_obj(0, LeanIxonRecursor::build(rec));
         ctor.into()
       },
     };
@@ -483,51 +475,43 @@ impl LeanIxonConstantInfo<LeanOwned> {
   pub fn build(info: &IxonConstantInfo) -> Self {
     let obj = match info {
       IxonConstantInfo::Defn(def) => {
-        let def_obj = LeanIxonDefinition::build(def);
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, def_obj);
+        let ctor = LeanIxonConstantInfoDefn::alloc();
+        ctor.set_obj(0, LeanIxonDefinition::build(def));
         ctor.into()
       },
       IxonConstantInfo::Recr(rec) => {
-        let rec_obj = LeanIxonRecursor::build(rec);
-        let ctor = LeanCtor::alloc(1, 1, 0);
-        ctor.set(0, rec_obj);
+        let ctor = LeanIxonConstantInfoRecr::alloc();
+        ctor.set_obj(0, LeanIxonRecursor::build(rec));
         ctor.into()
       },
       IxonConstantInfo::Axio(ax) => {
-        let ax_obj = LeanIxonAxiom::build(ax);
-        let ctor = LeanCtor::alloc(2, 1, 0);
-        ctor.set(0, ax_obj);
+        let ctor = LeanIxonConstantInfoAxio::alloc();
+        ctor.set_obj(0, LeanIxonAxiom::build(ax));
         ctor.into()
       },
       IxonConstantInfo::Quot(quot) => {
-        let quot_obj = LeanIxonQuotient::build(quot);
-        let ctor = LeanCtor::alloc(3, 1, 0);
-        ctor.set(0, quot_obj);
+        let ctor = LeanIxonConstantInfoQuot::alloc();
+        ctor.set_obj(0, LeanIxonQuotient::build(quot));
         ctor.into()
       },
       IxonConstantInfo::CPrj(proj) => {
-        let proj_obj = LeanIxonConstructorProj::build(proj);
-        let ctor = LeanCtor::alloc(4, 1, 0);
-        ctor.set(0, proj_obj);
+        let ctor = LeanIxonConstantInfoCPrj::alloc();
+        ctor.set_obj(0, LeanIxonConstructorProj::build(proj));
         ctor.into()
       },
       IxonConstantInfo::RPrj(proj) => {
-        let proj_obj = LeanIxonRecursorProj::build(proj);
-        let ctor = LeanCtor::alloc(5, 1, 0);
-        ctor.set(0, proj_obj);
+        let ctor = LeanIxonConstantInfoRPrj::alloc();
+        ctor.set_obj(0, LeanIxonRecursorProj::build(proj));
         ctor.into()
       },
       IxonConstantInfo::IPrj(proj) => {
-        let proj_obj = LeanIxonInductiveProj::build(proj);
-        let ctor = LeanCtor::alloc(6, 1, 0);
-        ctor.set(0, proj_obj);
+        let ctor = LeanIxonConstantInfoIPrj::alloc();
+        ctor.set_obj(0, LeanIxonInductiveProj::build(proj));
         ctor.into()
       },
       IxonConstantInfo::DPrj(proj) => {
-        let proj_obj = LeanIxonDefinitionProj::build(proj);
-        let ctor = LeanCtor::alloc(7, 1, 0);
-        ctor.set(0, proj_obj);
+        let ctor = LeanIxonConstantInfoDPrj::alloc();
+        ctor.set_obj(0, LeanIxonDefinitionProj::build(proj));
         ctor.into()
       },
       IxonConstantInfo::Muts(muts) => {
@@ -535,8 +519,8 @@ impl LeanIxonConstantInfo<LeanOwned> {
         for (i, mc) in muts.iter().enumerate() {
           arr.set(i, LeanIxonMutConst::build(mc));
         }
-        let ctor = LeanCtor::alloc(8, 1, 0);
-        ctor.set(0, arr);
+        let ctor = LeanIxonConstantInfoMuts::alloc();
+        ctor.set_obj(0, arr);
         ctor.into()
       },
     };
@@ -596,11 +580,11 @@ impl LeanIxonConstant<LeanOwned> {
     let sharing_obj = LeanIxonExpr::build_array(&constant.sharing);
     let refs_obj = LeanIxAddress::build_array(&constant.refs);
     let univs_obj = LeanIxonUniv::build_array(&constant.univs);
-    let ctor = LeanCtor::alloc(0, 4, 0);
-    ctor.set(0, info_obj);
-    ctor.set(1, sharing_obj);
-    ctor.set(2, refs_obj);
-    ctor.set(3, univs_obj);
+    let ctor = LeanIxonConstant::alloc();
+    ctor.set_obj(0, info_obj);
+    ctor.set_obj(1, sharing_obj);
+    ctor.set_obj(2, refs_obj);
+    ctor.set_obj(3, univs_obj);
     Self::new(ctor.into())
   }
 }

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -137,7 +137,7 @@ impl LeanIxonRecursor<LeanOwned> {
       s,
       [rec.lvls, rec.params, rec.indices, rec.motives, rec.minors],
     );
-    ctor.set_bools::<2>(s + 40, [rec.k, rec.is_unsafe]);
+    ctor.set_scalars::<2, bool>(s + 40, [rec.k, rec.is_unsafe]);
     Self::new(ctor.into())
   }
 }
@@ -154,7 +154,7 @@ impl<R: LeanRef> LeanIxonRecursor<R> {
     let s = ctor.scalar_base(0);
     let [lvls, params, indices, motives, minors] =
       ctor.get_scalars::<5, u64>(s);
-    let [k, is_unsafe] = ctor.get_bools::<2>(s + 40);
+    let [k, is_unsafe] = ctor.get_scalars::<2, bool>(s + 40);
     IxonRecursor {
       k,
       is_unsafe,
@@ -302,7 +302,7 @@ impl LeanIxonInductive<LeanOwned> {
       s,
       [ind.lvls, ind.params, ind.indices, ind.nested],
     );
-    ctor.set_bools::<3>(s + 32, [ind.recr, ind.refl, ind.is_unsafe]);
+    ctor.set_scalars::<3, bool>(s + 32, [ind.recr, ind.refl, ind.is_unsafe]);
     Self::new(ctor.into())
   }
 }
@@ -318,7 +318,7 @@ impl<R: LeanRef> LeanIxonInductive<R> {
       ctors_arr.map(|x| LeanIxonConstructor::new(x.to_owned_ref()).decode());
     let s = ctor.scalar_base(0);
     let [lvls, params, indices, nested] = ctor.get_scalars::<4, u64>(s);
-    let [recr, refl, is_unsafe] = ctor.get_bools::<3>(s + 32);
+    let [recr, refl, is_unsafe] = ctor.get_scalars::<3, bool>(s + 32);
     IxonInductive {
       recr,
       refl,

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -23,7 +23,9 @@ use crate::lean::{
 };
 #[cfg(feature = "test-ffi")]
 use lean_ffi::object::LeanBorrowed;
-use lean_ffi::object::{LeanArray, LeanCtor, LeanOwned, LeanRef};
+use lean_ffi::object::{
+  LeanArray, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
+};
 
 // =============================================================================
 // Definition
@@ -40,21 +42,21 @@ impl LeanIxonDefinition<LeanOwned> {
     let ctor = LeanCtor::alloc(0, 2, 16);
     ctor.set(0, typ_obj);
     ctor.set(1, value_obj);
-    let s = ctor.scalar_base(0);
-    ctor.set_u64(s, def.lvls);
+    let result = Self::new(ctor.into());
+    result.set_64(0, def.lvls);
     let kind_val: u8 = match def.kind {
       DefKind::Definition => 0,
       DefKind::Opaque => 1,
       DefKind::Theorem => 2,
     };
-    ctor.set_u8(s + 8, kind_val);
+    result.set_8(0, kind_val);
     let safety_val: u8 = match def.safety {
       crate::ix::env::DefinitionSafety::Unsafe => 0,
       crate::ix::env::DefinitionSafety::Safe => 1,
       crate::ix::env::DefinitionSafety::Partial => 2,
     };
-    ctor.set_u8(s + 9, safety_val);
-    Self::new(ctor.into())
+    result.set_8(1, safety_val);
+    result
   }
 }
 
@@ -67,16 +69,15 @@ impl<R: LeanRef> LeanIxonDefinition<R> {
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
     let value =
       Arc::new(LeanIxonExpr::new(ctor.get(1).to_owned_ref()).decode());
-    let s = ctor.scalar_base(0);
-    let lvls = ctor.get_u64(s);
-    let kind_val = ctor.get_u8(s + 8);
+    let lvls = self.get_64(0);
+    let kind_val = self.get_8(0);
     let kind = match kind_val {
       0 => DefKind::Definition,
       1 => DefKind::Opaque,
       2 => DefKind::Theorem,
       _ => panic!("Invalid DefKind: {}", kind_val),
     };
-    let safety_val = ctor.get_u8(s + 9);
+    let safety_val = self.get_8(1);
     let safety = match safety_val {
       0 => crate::ix::env::DefinitionSafety::Unsafe,
       1 => crate::ix::env::DefinitionSafety::Safe,
@@ -98,9 +99,9 @@ impl LeanIxonRecursorRule<LeanOwned> {
     // 1 obj field, 8 scalar bytes
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, rhs_obj);
-    let s = ctor.scalar_base(0);
-    ctor.set_u64(s, rule.fields);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, rule.fields);
+    result
   }
 }
 
@@ -109,7 +110,7 @@ impl<R: LeanRef> LeanIxonRecursorRule<R> {
   pub fn decode(&self) -> IxonRecursorRule {
     let ctor = self.as_ctor();
     let rhs = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let fields = ctor.get_u64(ctor.scalar_base(0));
+    let fields = self.get_64(0);
     IxonRecursorRule { fields, rhs }
   }
 }
@@ -132,13 +133,15 @@ impl LeanIxonRecursor<LeanOwned> {
     let ctor = LeanCtor::alloc(0, 2, 48);
     ctor.set(0, typ_obj);
     ctor.set(1, rules_arr);
-    let s = ctor.scalar_base(0);
-    ctor.set_scalars::<5, u64>(
-      s,
-      [rec.lvls, rec.params, rec.indices, rec.motives, rec.minors],
-    );
-    ctor.set_scalars::<2, bool>(s + 40, [rec.k, rec.is_unsafe]);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, rec.lvls);
+    result.set_64(1, rec.params);
+    result.set_64(2, rec.indices);
+    result.set_64(3, rec.motives);
+    result.set_64(4, rec.minors);
+    result.set_8(0, rec.k as u8);
+    result.set_8(1, rec.is_unsafe as u8);
+    result
   }
 }
 
@@ -151,10 +154,13 @@ impl<R: LeanRef> LeanIxonRecursor<R> {
     let rules_arr = ctor.get(1).as_array();
     let rules =
       rules_arr.map(|x| LeanIxonRecursorRule::new(x.to_owned_ref()).decode());
-    let s = ctor.scalar_base(0);
-    let [lvls, params, indices, motives, minors] =
-      ctor.get_scalars::<5, u64>(s);
-    let [k, is_unsafe] = ctor.get_scalars::<2, bool>(s + 40);
+    let lvls = self.get_64(0);
+    let params = self.get_64(1);
+    let indices = self.get_64(2);
+    let motives = self.get_64(3);
+    let minors = self.get_64(4);
+    let k = self.get_8(0) != 0;
+    let is_unsafe = self.get_8(1) != 0;
     IxonRecursor {
       k,
       is_unsafe,
@@ -181,10 +187,10 @@ impl LeanIxonAxiom<LeanOwned> {
     // 1 obj field, 16 scalar bytes (lvls(8) + isUnsafe(1) + padding(7))
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, typ_obj);
-    let s = ctor.scalar_base(0);
-    ctor.set_u64(s, ax.lvls);
-    ctor.set_bool(s + 8, ax.is_unsafe);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, ax.lvls);
+    result.set_8(0, ax.is_unsafe as u8);
+    result
   }
 }
 
@@ -194,9 +200,8 @@ impl<R: LeanRef> LeanIxonAxiom<R> {
   pub fn decode(&self) -> IxonAxiom {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let s = ctor.scalar_base(0);
-    let lvls = ctor.get_u64(s);
-    let is_unsafe = ctor.get_bool(s + 8);
+    let lvls = self.get_64(0);
+    let is_unsafe = self.get_8(0) != 0;
     IxonAxiom { is_unsafe, lvls, typ }
   }
 }
@@ -214,16 +219,16 @@ impl LeanIxonQuotient<LeanOwned> {
     // 1 obj field (typ), 16 scalar bytes (lvls(8) + kind(1) + padding(7))
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, typ_obj);
-    let s = ctor.scalar_base(0);
-    ctor.set_u64(s, quot.lvls);
+    let result = Self::new(ctor.into());
+    result.set_64(0, quot.lvls);
     let kind_val: u8 = match quot.kind {
       crate::ix::env::QuotKind::Type => 0,
       crate::ix::env::QuotKind::Ctor => 1,
       crate::ix::env::QuotKind::Lift => 2,
       crate::ix::env::QuotKind::Ind => 3,
     };
-    ctor.set_u8(s + 8, kind_val);
-    Self::new(ctor.into())
+    result.set_8(0, kind_val);
+    result
   }
 }
 
@@ -233,9 +238,8 @@ impl<R: LeanRef> LeanIxonQuotient<R> {
   pub fn decode(&self) -> IxonQuotient {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let s = ctor.scalar_base(0);
-    let lvls = ctor.get_u64(s);
-    let kind_val = ctor.get_u8(s + 8);
+    let lvls = self.get_64(0);
+    let kind_val = self.get_8(0);
     let kind = match kind_val {
       0 => crate::ix::env::QuotKind::Type,
       1 => crate::ix::env::QuotKind::Ctor,
@@ -259,10 +263,13 @@ impl LeanIxonConstructor<LeanOwned> {
     // 1 obj field, 40 scalar bytes (4×8 + 1 + 7 padding)
     let ctor = LeanCtor::alloc(0, 1, 40);
     ctor.set(0, typ_obj);
-    let s = ctor.scalar_base(0);
-    ctor.set_scalars::<4, u64>(s, [c.lvls, c.cidx, c.params, c.fields]);
-    ctor.set_bool(s + 32, c.is_unsafe);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, c.lvls);
+    result.set_64(1, c.cidx);
+    result.set_64(2, c.params);
+    result.set_64(3, c.fields);
+    result.set_8(0, c.is_unsafe as u8);
+    result
   }
 }
 
@@ -272,9 +279,11 @@ impl<R: LeanRef> LeanIxonConstructor<R> {
   pub fn decode(&self) -> IxonConstructor {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let s = ctor.scalar_base(0);
-    let [lvls, cidx, params, fields] = ctor.get_scalars::<4, u64>(s);
-    let is_unsafe = ctor.get_bool(s + 32);
+    let lvls = self.get_64(0);
+    let cidx = self.get_64(1);
+    let params = self.get_64(2);
+    let fields = self.get_64(3);
+    let is_unsafe = self.get_8(0) != 0;
     IxonConstructor { is_unsafe, lvls, cidx, params, fields, typ }
   }
 }
@@ -297,13 +306,15 @@ impl LeanIxonInductive<LeanOwned> {
     let ctor = LeanCtor::alloc(0, 2, 40);
     ctor.set(0, typ_obj);
     ctor.set(1, ctors_arr);
-    let s = ctor.scalar_base(0);
-    ctor.set_scalars::<4, u64>(
-      s,
-      [ind.lvls, ind.params, ind.indices, ind.nested],
-    );
-    ctor.set_scalars::<3, bool>(s + 32, [ind.recr, ind.refl, ind.is_unsafe]);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, ind.lvls);
+    result.set_64(1, ind.params);
+    result.set_64(2, ind.indices);
+    result.set_64(3, ind.nested);
+    result.set_8(0, ind.recr as u8);
+    result.set_8(1, ind.refl as u8);
+    result.set_8(2, ind.is_unsafe as u8);
+    result
   }
 }
 
@@ -316,9 +327,13 @@ impl<R: LeanRef> LeanIxonInductive<R> {
     let ctors_arr = ctor.get(1).as_array();
     let ctors =
       ctors_arr.map(|x| LeanIxonConstructor::new(x.to_owned_ref()).decode());
-    let s = ctor.scalar_base(0);
-    let [lvls, params, indices, nested] = ctor.get_scalars::<4, u64>(s);
-    let [recr, refl, is_unsafe] = ctor.get_scalars::<3, bool>(s + 32);
+    let lvls = self.get_64(0);
+    let params = self.get_64(1);
+    let indices = self.get_64(2);
+    let nested = self.get_64(3);
+    let recr = self.get_8(0) != 0;
+    let refl = self.get_8(1) != 0;
+    let is_unsafe = self.get_8(2) != 0;
     IxonInductive {
       recr,
       refl,
@@ -342,8 +357,9 @@ impl LeanIxonInductiveProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, block_obj);
-    ctor.set_u64(ctor.scalar_base(0), proj.idx);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, proj.idx);
+    result
   }
 }
 
@@ -352,7 +368,7 @@ impl<R: LeanRef> LeanIxonInductiveProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(ctor.scalar_base(0));
+    let idx = self.get_64(0);
     InductiveProj { idx, block }
   }
 }
@@ -362,8 +378,10 @@ impl LeanIxonConstructorProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, block_obj);
-    ctor.set_scalars::<2, u64>(ctor.scalar_base(0), [proj.idx, proj.cidx]);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, proj.idx);
+    result.set_64(1, proj.cidx);
+    result
   }
 }
 
@@ -372,7 +390,8 @@ impl<R: LeanRef> LeanIxonConstructorProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let [idx, cidx] = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+    let idx = self.get_64(0);
+    let cidx = self.get_64(1);
     ConstructorProj { idx, cidx, block }
   }
 }
@@ -382,8 +401,9 @@ impl LeanIxonRecursorProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, block_obj);
-    ctor.set_u64(ctor.scalar_base(0), proj.idx);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, proj.idx);
+    result
   }
 }
 
@@ -392,7 +412,7 @@ impl<R: LeanRef> LeanIxonRecursorProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(ctor.scalar_base(0));
+    let idx = self.get_64(0);
     RecursorProj { idx, block }
   }
 }
@@ -402,8 +422,9 @@ impl LeanIxonDefinitionProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, block_obj);
-    ctor.set_u64(ctor.scalar_base(0), proj.idx);
-    Self::new(ctor.into())
+    let result = Self::new(ctor.into());
+    result.set_64(0, proj.idx);
+    result
   }
 }
 
@@ -412,7 +433,7 @@ impl<R: LeanRef> LeanIxonDefinitionProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(ctor.scalar_base(0));
+    let idx = self.get_64(0);
     DefinitionProj { idx, block }
   }
 }

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -133,7 +133,10 @@ impl LeanIxonRecursor<LeanOwned> {
     ctor.set(0, typ_obj);
     ctor.set(1, rules_arr);
     let s = ctor.scalar_base(0);
-    ctor.set_scalars::<5, u64>(s, [rec.lvls, rec.params, rec.indices, rec.motives, rec.minors]);
+    ctor.set_scalars::<5, u64>(
+      s,
+      [rec.lvls, rec.params, rec.indices, rec.motives, rec.minors],
+    );
     ctor.set_bools::<2>(s + 40, [rec.k, rec.is_unsafe]);
     Self::new(ctor.into())
   }
@@ -149,7 +152,8 @@ impl<R: LeanRef> LeanIxonRecursor<R> {
     let rules =
       rules_arr.map(|x| LeanIxonRecursorRule::new(x.to_owned_ref()).decode());
     let s = ctor.scalar_base(0);
-    let [lvls, params, indices, motives, minors] = ctor.get_scalars::<5, u64>(s);
+    let [lvls, params, indices, motives, minors] =
+      ctor.get_scalars::<5, u64>(s);
     let [k, is_unsafe] = ctor.get_bools::<2>(s + 40);
     IxonRecursor {
       k,
@@ -294,7 +298,10 @@ impl LeanIxonInductive<LeanOwned> {
     ctor.set(0, typ_obj);
     ctor.set(1, ctors_arr);
     let s = ctor.scalar_base(0);
-    ctor.set_scalars::<4, u64>(s, [ind.lvls, ind.params, ind.indices, ind.nested]);
+    ctor.set_scalars::<4, u64>(
+      s,
+      [ind.lvls, ind.params, ind.indices, ind.nested],
+    );
     ctor.set_bools::<3>(s + 32, [ind.recr, ind.refl, ind.is_unsafe]);
     Self::new(ctor.into())
   }

--- a/src/ffi/ixon/constant.rs
+++ b/src/ffi/ixon/constant.rs
@@ -40,20 +40,20 @@ impl LeanIxonDefinition<LeanOwned> {
     let ctor = LeanCtor::alloc(0, 2, 16);
     ctor.set(0, typ_obj);
     ctor.set(1, value_obj);
-    // Scalar offsets from obj_cptr: 2*8=16 for lvls, 2*8+8=24 for kind, 2*8+9=25 for safety
-    ctor.set_u64(2, 0, def.lvls);
+    let s = ctor.scalar_base(0);
+    ctor.set_u64(s, def.lvls);
     let kind_val: u8 = match def.kind {
       DefKind::Definition => 0,
       DefKind::Opaque => 1,
       DefKind::Theorem => 2,
     };
-    ctor.set_u8(2, 8, kind_val);
+    ctor.set_u8(s + 8, kind_val);
     let safety_val: u8 = match def.safety {
       crate::ix::env::DefinitionSafety::Unsafe => 0,
       crate::ix::env::DefinitionSafety::Safe => 1,
       crate::ix::env::DefinitionSafety::Partial => 2,
     };
-    ctor.set_u8(2, 9, safety_val);
+    ctor.set_u8(s + 9, safety_val);
     Self::new(ctor.into())
   }
 }
@@ -67,15 +67,16 @@ impl<R: LeanRef> LeanIxonDefinition<R> {
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
     let value =
       Arc::new(LeanIxonExpr::new(ctor.get(1).to_owned_ref()).decode());
-    let lvls = ctor.get_u64(2, 0);
-    let kind_val = ctor.get_u8(2, 8);
+    let s = ctor.scalar_base(0);
+    let lvls = ctor.get_u64(s);
+    let kind_val = ctor.get_u8(s + 8);
     let kind = match kind_val {
       0 => DefKind::Definition,
       1 => DefKind::Opaque,
       2 => DefKind::Theorem,
       _ => panic!("Invalid DefKind: {}", kind_val),
     };
-    let safety_val = ctor.get_u8(2, 9);
+    let safety_val = ctor.get_u8(s + 9);
     let safety = match safety_val {
       0 => crate::ix::env::DefinitionSafety::Unsafe,
       1 => crate::ix::env::DefinitionSafety::Safe,
@@ -97,7 +98,8 @@ impl LeanIxonRecursorRule<LeanOwned> {
     // 1 obj field, 8 scalar bytes
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, rhs_obj);
-    ctor.set_u64(1, 0, rule.fields);
+    let s = ctor.scalar_base(0);
+    ctor.set_u64(s, rule.fields);
     Self::new(ctor.into())
   }
 }
@@ -107,7 +109,7 @@ impl<R: LeanRef> LeanIxonRecursorRule<R> {
   pub fn decode(&self) -> IxonRecursorRule {
     let ctor = self.as_ctor();
     let rhs = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let fields = ctor.get_u64(1, 0);
+    let fields = ctor.get_u64(ctor.scalar_base(0));
     IxonRecursorRule { fields, rhs }
   }
 }
@@ -130,14 +132,9 @@ impl LeanIxonRecursor<LeanOwned> {
     let ctor = LeanCtor::alloc(0, 2, 48);
     ctor.set(0, typ_obj);
     ctor.set(1, rules_arr);
-    // Scalar offsets from obj_cptr: 2*8=16 base
-    ctor.set_u64(2, 0, rec.lvls);
-    ctor.set_u64(2, 8, rec.params);
-    ctor.set_u64(2, 16, rec.indices);
-    ctor.set_u64(2, 24, rec.motives);
-    ctor.set_u64(2, 32, rec.minors);
-    ctor.set_bool(2, 40, rec.k);
-    ctor.set_bool(2, 41, rec.is_unsafe);
+    let s = ctor.scalar_base(0);
+    ctor.set_scalars::<5, u64>(s, [rec.lvls, rec.params, rec.indices, rec.motives, rec.minors]);
+    ctor.set_bools::<2>(s + 40, [rec.k, rec.is_unsafe]);
     Self::new(ctor.into())
   }
 }
@@ -151,13 +148,9 @@ impl<R: LeanRef> LeanIxonRecursor<R> {
     let rules_arr = ctor.get(1).as_array();
     let rules =
       rules_arr.map(|x| LeanIxonRecursorRule::new(x.to_owned_ref()).decode());
-    let lvls = ctor.get_u64(2, 0);
-    let params = ctor.get_u64(2, 8);
-    let indices = ctor.get_u64(2, 16);
-    let motives = ctor.get_u64(2, 24);
-    let minors = ctor.get_u64(2, 32);
-    let k = ctor.get_u8(2, 40) != 0;
-    let is_unsafe = ctor.get_u8(2, 41) != 0;
+    let s = ctor.scalar_base(0);
+    let [lvls, params, indices, motives, minors] = ctor.get_scalars::<5, u64>(s);
+    let [k, is_unsafe] = ctor.get_bools::<2>(s + 40);
     IxonRecursor {
       k,
       is_unsafe,
@@ -184,9 +177,9 @@ impl LeanIxonAxiom<LeanOwned> {
     // 1 obj field, 16 scalar bytes (lvls(8) + isUnsafe(1) + padding(7))
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, typ_obj);
-    // Scalar offsets from obj_cptr: 1*8=8 base
-    ctor.set_u64(1, 0, ax.lvls);
-    ctor.set_bool(1, 8, ax.is_unsafe);
+    let s = ctor.scalar_base(0);
+    ctor.set_u64(s, ax.lvls);
+    ctor.set_bool(s + 8, ax.is_unsafe);
     Self::new(ctor.into())
   }
 }
@@ -197,8 +190,9 @@ impl<R: LeanRef> LeanIxonAxiom<R> {
   pub fn decode(&self) -> IxonAxiom {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let lvls = ctor.get_u64(1, 0);
-    let is_unsafe = ctor.get_u8(1, 8) != 0;
+    let s = ctor.scalar_base(0);
+    let lvls = ctor.get_u64(s);
+    let is_unsafe = ctor.get_bool(s + 8);
     IxonAxiom { is_unsafe, lvls, typ }
   }
 }
@@ -216,15 +210,15 @@ impl LeanIxonQuotient<LeanOwned> {
     // 1 obj field (typ), 16 scalar bytes (lvls(8) + kind(1) + padding(7))
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, typ_obj);
-    // Scalar offsets from obj_cptr: 1*8=8 base
-    ctor.set_u64(1, 0, quot.lvls);
+    let s = ctor.scalar_base(0);
+    ctor.set_u64(s, quot.lvls);
     let kind_val: u8 = match quot.kind {
       crate::ix::env::QuotKind::Type => 0,
       crate::ix::env::QuotKind::Ctor => 1,
       crate::ix::env::QuotKind::Lift => 2,
       crate::ix::env::QuotKind::Ind => 3,
     };
-    ctor.set_u8(1, 8, kind_val);
+    ctor.set_u8(s + 8, kind_val);
     Self::new(ctor.into())
   }
 }
@@ -235,8 +229,9 @@ impl<R: LeanRef> LeanIxonQuotient<R> {
   pub fn decode(&self) -> IxonQuotient {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let lvls = ctor.get_u64(1, 0);
-    let kind_val = ctor.get_u8(1, 8);
+    let s = ctor.scalar_base(0);
+    let lvls = ctor.get_u64(s);
+    let kind_val = ctor.get_u8(s + 8);
     let kind = match kind_val {
       0 => crate::ix::env::QuotKind::Type,
       1 => crate::ix::env::QuotKind::Ctor,
@@ -260,12 +255,9 @@ impl LeanIxonConstructor<LeanOwned> {
     // 1 obj field, 40 scalar bytes (4×8 + 1 + 7 padding)
     let ctor = LeanCtor::alloc(0, 1, 40);
     ctor.set(0, typ_obj);
-    // Scalar offsets from obj_cptr: 1*8=8 base
-    ctor.set_u64(1, 0, c.lvls);
-    ctor.set_u64(1, 8, c.cidx);
-    ctor.set_u64(1, 16, c.params);
-    ctor.set_u64(1, 24, c.fields);
-    ctor.set_bool(1, 32, c.is_unsafe);
+    let s = ctor.scalar_base(0);
+    ctor.set_scalars::<4, u64>(s, [c.lvls, c.cidx, c.params, c.fields]);
+    ctor.set_bool(s + 32, c.is_unsafe);
     Self::new(ctor.into())
   }
 }
@@ -276,11 +268,9 @@ impl<R: LeanRef> LeanIxonConstructor<R> {
   pub fn decode(&self) -> IxonConstructor {
     let ctor = self.as_ctor();
     let typ = Arc::new(LeanIxonExpr::new(ctor.get(0).to_owned_ref()).decode());
-    let lvls = ctor.get_u64(1, 0);
-    let cidx = ctor.get_u64(1, 8);
-    let params = ctor.get_u64(1, 16);
-    let fields = ctor.get_u64(1, 24);
-    let is_unsafe = ctor.get_u8(1, 32) != 0;
+    let s = ctor.scalar_base(0);
+    let [lvls, cidx, params, fields] = ctor.get_scalars::<4, u64>(s);
+    let is_unsafe = ctor.get_bool(s + 32);
     IxonConstructor { is_unsafe, lvls, cidx, params, fields, typ }
   }
 }
@@ -303,14 +293,9 @@ impl LeanIxonInductive<LeanOwned> {
     let ctor = LeanCtor::alloc(0, 2, 40);
     ctor.set(0, typ_obj);
     ctor.set(1, ctors_arr);
-    // Scalar offsets from obj_cptr: 2*8=16 base
-    ctor.set_u64(2, 0, ind.lvls);
-    ctor.set_u64(2, 8, ind.params);
-    ctor.set_u64(2, 16, ind.indices);
-    ctor.set_u64(2, 24, ind.nested);
-    ctor.set_bool(2, 32, ind.recr);
-    ctor.set_bool(2, 33, ind.refl);
-    ctor.set_bool(2, 34, ind.is_unsafe);
+    let s = ctor.scalar_base(0);
+    ctor.set_scalars::<4, u64>(s, [ind.lvls, ind.params, ind.indices, ind.nested]);
+    ctor.set_bools::<3>(s + 32, [ind.recr, ind.refl, ind.is_unsafe]);
     Self::new(ctor.into())
   }
 }
@@ -324,13 +309,9 @@ impl<R: LeanRef> LeanIxonInductive<R> {
     let ctors_arr = ctor.get(1).as_array();
     let ctors =
       ctors_arr.map(|x| LeanIxonConstructor::new(x.to_owned_ref()).decode());
-    let lvls = ctor.get_u64(2, 0);
-    let params = ctor.get_u64(2, 8);
-    let indices = ctor.get_u64(2, 16);
-    let nested = ctor.get_u64(2, 24);
-    let recr = ctor.get_u8(2, 32) != 0;
-    let refl = ctor.get_u8(2, 33) != 0;
-    let is_unsafe = ctor.get_u8(2, 34) != 0;
+    let s = ctor.scalar_base(0);
+    let [lvls, params, indices, nested] = ctor.get_scalars::<4, u64>(s);
+    let [recr, refl, is_unsafe] = ctor.get_bools::<3>(s + 32);
     IxonInductive {
       recr,
       refl,
@@ -354,7 +335,7 @@ impl LeanIxonInductiveProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, block_obj);
-    ctor.set_u64(1, 0, proj.idx);
+    ctor.set_u64(ctor.scalar_base(0), proj.idx);
     Self::new(ctor.into())
   }
 }
@@ -364,7 +345,7 @@ impl<R: LeanRef> LeanIxonInductiveProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(1, 0);
+    let idx = ctor.get_u64(ctor.scalar_base(0));
     InductiveProj { idx, block }
   }
 }
@@ -374,8 +355,7 @@ impl LeanIxonConstructorProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 16);
     ctor.set(0, block_obj);
-    ctor.set_u64(1, 0, proj.idx);
-    ctor.set_u64(1, 8, proj.cidx);
+    ctor.set_scalars::<2, u64>(ctor.scalar_base(0), [proj.idx, proj.cidx]);
     Self::new(ctor.into())
   }
 }
@@ -385,8 +365,7 @@ impl<R: LeanRef> LeanIxonConstructorProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(1, 0);
-    let cidx = ctor.get_u64(1, 8);
+    let [idx, cidx] = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
     ConstructorProj { idx, cidx, block }
   }
 }
@@ -396,7 +375,7 @@ impl LeanIxonRecursorProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, block_obj);
-    ctor.set_u64(1, 0, proj.idx);
+    ctor.set_u64(ctor.scalar_base(0), proj.idx);
     Self::new(ctor.into())
   }
 }
@@ -406,7 +385,7 @@ impl<R: LeanRef> LeanIxonRecursorProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(1, 0);
+    let idx = ctor.get_u64(ctor.scalar_base(0));
     RecursorProj { idx, block }
   }
 }
@@ -416,7 +395,7 @@ impl LeanIxonDefinitionProj<LeanOwned> {
     let block_obj = LeanIxAddress::build(&proj.block);
     let ctor = LeanCtor::alloc(0, 1, 8);
     ctor.set(0, block_obj);
-    ctor.set_u64(1, 0, proj.idx);
+    ctor.set_u64(ctor.scalar_base(0), proj.idx);
     Self::new(ctor.into())
   }
 }
@@ -426,7 +405,7 @@ impl<R: LeanRef> LeanIxonDefinitionProj<R> {
     let ctor = self.as_ctor();
     let block =
       LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-    let idx = ctor.get_u64(1, 0);
+    let idx = ctor.get_u64(ctor.scalar_base(0));
     DefinitionProj { idx, block }
   }
 }

--- a/src/ffi/ixon/env.rs
+++ b/src/ffi/ixon/env.rs
@@ -15,8 +15,7 @@ use crate::lean::{
   LeanIxonRawNameEntry, LeanIxonRawNamed,
 };
 use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanByteArray, LeanCtor, LeanExcept, LeanOwned,
-  LeanRef,
+  LeanArray, LeanBorrowed, LeanByteArray, LeanExcept, LeanOwned, LeanRef,
 };
 
 use crate::ffi::builder::LeanBuildCache;
@@ -35,17 +34,17 @@ pub struct DecodedRawConst {
 impl LeanIxonRawConst<LeanOwned> {
   /// Build Ixon.RawConst Lean object.
   pub fn build(rc: &DecodedRawConst) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(&rc.addr));
-    ctor.set(1, LeanIxonConstant::build(&rc.constant));
+    let ctor = LeanIxonRawConst::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(&rc.addr));
+    ctor.set_obj(1, LeanIxonConstant::build(&rc.constant));
     Self::new(ctor.into())
   }
 
   /// Build from individual parts (used by compile.rs).
   pub fn build_from_parts(addr: &Address, constant: &IxonConstant) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(addr));
-    ctor.set(1, LeanIxonConstant::build(constant));
+    let ctor = LeanIxonRawConst::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(addr));
+    ctor.set_obj(1, LeanIxonConstant::build(constant));
     Self::new(ctor.into())
   }
 }
@@ -75,10 +74,10 @@ pub struct DecodedRawNamed {
 impl LeanIxonRawNamed<LeanOwned> {
   /// Build Ixon.RawNamed Lean object.
   pub fn build(cache: &mut LeanBuildCache, rn: &DecodedRawNamed) -> Self {
-    let ctor = LeanCtor::alloc(0, 3, 0);
-    ctor.set(0, LeanIxName::build(cache, &rn.name));
-    ctor.set(1, LeanIxAddress::build(&rn.addr));
-    ctor.set(2, LeanIxonConstantMeta::build(&rn.const_meta));
+    let ctor = LeanIxonRawNamed::alloc();
+    ctor.set_obj(0, LeanIxName::build(cache, &rn.name));
+    ctor.set_obj(1, LeanIxAddress::build(&rn.addr));
+    ctor.set_obj(2, LeanIxonConstantMeta::build(&rn.const_meta));
     Self::new(ctor.into())
   }
 
@@ -89,10 +88,10 @@ impl LeanIxonRawNamed<LeanOwned> {
     addr: &Address,
     meta: &ConstantMeta,
   ) -> Self {
-    let ctor = LeanCtor::alloc(0, 3, 0);
-    ctor.set(0, LeanIxName::build(cache, name));
-    ctor.set(1, LeanIxAddress::build(addr));
-    ctor.set(2, LeanIxonConstantMeta::build(meta));
+    let ctor = LeanIxonRawNamed::alloc();
+    ctor.set_obj(0, LeanIxName::build(cache, name));
+    ctor.set_obj(1, LeanIxAddress::build(addr));
+    ctor.set_obj(2, LeanIxonConstantMeta::build(meta));
     Self::new(ctor.into())
   }
 }
@@ -123,17 +122,17 @@ pub struct DecodedRawBlob {
 impl LeanIxonRawBlob<LeanOwned> {
   /// Build Ixon.RawBlob Lean object.
   pub fn build(rb: &DecodedRawBlob) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(&rb.addr));
-    ctor.set(1, LeanByteArray::from_bytes(&rb.bytes));
+    let ctor = LeanIxonRawBlob::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(&rb.addr));
+    ctor.set_obj(1, LeanByteArray::from_bytes(&rb.bytes));
     Self::new(ctor.into())
   }
 
   /// Build from individual parts (used by compile.rs).
   pub fn build_from_parts(addr: &Address, bytes: &[u8]) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(addr));
-    ctor.set(1, LeanByteArray::from_bytes(bytes));
+    let ctor = LeanIxonRawBlob::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(addr));
+    ctor.set_obj(1, LeanByteArray::from_bytes(bytes));
     Self::new(ctor.into())
   }
 }
@@ -163,17 +162,17 @@ pub struct DecodedRawComm {
 impl LeanIxonRawComm<LeanOwned> {
   /// Build Ixon.RawComm Lean object.
   pub fn build(rc: &DecodedRawComm) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(&rc.addr));
-    ctor.set(1, LeanIxonComm::build(&rc.comm));
+    let ctor = LeanIxonRawComm::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(&rc.addr));
+    ctor.set_obj(1, LeanIxonComm::build(&rc.comm));
     Self::new(ctor.into())
   }
 
   /// Build from individual parts (used by compile.rs).
   pub fn build_from_parts(addr: &Address, comm: &Comm) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(addr));
-    ctor.set(1, LeanIxonComm::build(comm));
+    let ctor = LeanIxonRawComm::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(addr));
+    ctor.set_obj(1, LeanIxonComm::build(comm));
     Self::new(ctor.into())
   }
 }
@@ -206,9 +205,9 @@ impl LeanIxonRawNameEntry<LeanOwned> {
     addr: &Address,
     name: &Name,
   ) -> Self {
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, LeanIxAddress::build(addr));
-    ctor.set(1, LeanIxName::build(cache, name));
+    let ctor = LeanIxonRawNameEntry::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(addr));
+    ctor.set_obj(1, LeanIxName::build(cache, name));
     Self::new(ctor.into())
   }
 }
@@ -274,12 +273,12 @@ impl LeanIxonRawEnv<LeanOwned> {
     }
 
     // Build RawEnv structure
-    let ctor = LeanCtor::alloc(0, 5, 0);
-    ctor.set(0, consts_arr);
-    ctor.set(1, named_arr);
-    ctor.set(2, blobs_arr);
-    ctor.set(3, comms_arr);
-    ctor.set(4, names_arr);
+    let ctor = LeanIxonRawEnv::alloc();
+    ctor.set_obj(0, consts_arr);
+    ctor.set_obj(1, named_arr);
+    ctor.set_obj(2, blobs_arr);
+    ctor.set_obj(3, comms_arr);
+    ctor.set_obj(4, names_arr);
     Self::new(ctor.into())
   }
 }

--- a/src/ffi/ixon/env.rs
+++ b/src/ffi/ixon/env.rs
@@ -34,18 +34,18 @@ pub struct DecodedRawConst {
 impl LeanIxonRawConst<LeanOwned> {
   /// Build Ixon.RawConst Lean object.
   pub fn build(rc: &DecodedRawConst) -> Self {
-    let ctor = LeanIxonRawConst::alloc();
+    let ctor = LeanIxonRawConst::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(&rc.addr));
     ctor.set_obj(1, LeanIxonConstant::build(&rc.constant));
-    Self::new(ctor.into())
+    ctor
   }
 
   /// Build from individual parts (used by compile.rs).
   pub fn build_from_parts(addr: &Address, constant: &IxonConstant) -> Self {
-    let ctor = LeanIxonRawConst::alloc();
+    let ctor = LeanIxonRawConst::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(addr));
     ctor.set_obj(1, LeanIxonConstant::build(constant));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -74,11 +74,11 @@ pub struct DecodedRawNamed {
 impl LeanIxonRawNamed<LeanOwned> {
   /// Build Ixon.RawNamed Lean object.
   pub fn build(cache: &mut LeanBuildCache, rn: &DecodedRawNamed) -> Self {
-    let ctor = LeanIxonRawNamed::alloc();
+    let ctor = LeanIxonRawNamed::alloc(0);
     ctor.set_obj(0, LeanIxName::build(cache, &rn.name));
     ctor.set_obj(1, LeanIxAddress::build(&rn.addr));
     ctor.set_obj(2, LeanIxonConstantMeta::build(&rn.const_meta));
-    Self::new(ctor.into())
+    ctor
   }
 
   /// Build from individual parts (used by compile.rs).
@@ -88,11 +88,11 @@ impl LeanIxonRawNamed<LeanOwned> {
     addr: &Address,
     meta: &ConstantMeta,
   ) -> Self {
-    let ctor = LeanIxonRawNamed::alloc();
+    let ctor = LeanIxonRawNamed::alloc(0);
     ctor.set_obj(0, LeanIxName::build(cache, name));
     ctor.set_obj(1, LeanIxAddress::build(addr));
     ctor.set_obj(2, LeanIxonConstantMeta::build(meta));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -122,18 +122,18 @@ pub struct DecodedRawBlob {
 impl LeanIxonRawBlob<LeanOwned> {
   /// Build Ixon.RawBlob Lean object.
   pub fn build(rb: &DecodedRawBlob) -> Self {
-    let ctor = LeanIxonRawBlob::alloc();
+    let ctor = LeanIxonRawBlob::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(&rb.addr));
     ctor.set_obj(1, LeanByteArray::from_bytes(&rb.bytes));
-    Self::new(ctor.into())
+    ctor
   }
 
   /// Build from individual parts (used by compile.rs).
   pub fn build_from_parts(addr: &Address, bytes: &[u8]) -> Self {
-    let ctor = LeanIxonRawBlob::alloc();
+    let ctor = LeanIxonRawBlob::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(addr));
     ctor.set_obj(1, LeanByteArray::from_bytes(bytes));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -162,18 +162,18 @@ pub struct DecodedRawComm {
 impl LeanIxonRawComm<LeanOwned> {
   /// Build Ixon.RawComm Lean object.
   pub fn build(rc: &DecodedRawComm) -> Self {
-    let ctor = LeanIxonRawComm::alloc();
+    let ctor = LeanIxonRawComm::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(&rc.addr));
     ctor.set_obj(1, LeanIxonComm::build(&rc.comm));
-    Self::new(ctor.into())
+    ctor
   }
 
   /// Build from individual parts (used by compile.rs).
   pub fn build_from_parts(addr: &Address, comm: &Comm) -> Self {
-    let ctor = LeanIxonRawComm::alloc();
+    let ctor = LeanIxonRawComm::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(addr));
     ctor.set_obj(1, LeanIxonComm::build(comm));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -205,10 +205,10 @@ impl LeanIxonRawNameEntry<LeanOwned> {
     addr: &Address,
     name: &Name,
   ) -> Self {
-    let ctor = LeanIxonRawNameEntry::alloc();
+    let ctor = LeanIxonRawNameEntry::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(addr));
     ctor.set_obj(1, LeanIxName::build(cache, name));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -273,13 +273,13 @@ impl LeanIxonRawEnv<LeanOwned> {
     }
 
     // Build RawEnv structure
-    let ctor = LeanIxonRawEnv::alloc();
+    let ctor = LeanIxonRawEnv::alloc(0);
     ctor.set_obj(0, consts_arr);
     ctor.set_obj(1, named_arr);
     ctor.set_obj(2, blobs_arr);
     ctor.set_obj(3, comms_arr);
     ctor.set_obj(4, names_arr);
-    Self::new(ctor.into())
+    ctor
   }
 }
 

--- a/src/ffi/ixon/expr.rs
+++ b/src/ffi/ixon/expr.rs
@@ -4,9 +4,15 @@ use std::sync::Arc;
 
 use crate::ix::ixon::expr::Expr as IxonExpr;
 use crate::lean::LeanIxonExpr;
-use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
-
-use lean_ffi::object::scalar_base;
+use crate::lean::{
+  LeanIxonExprLet, LeanIxonExprNat, LeanIxonExprPrj, LeanIxonExprRec,
+  LeanIxonExprRef, LeanIxonExprShare, LeanIxonExprSort, LeanIxonExprStr,
+  LeanIxonExprVar,
+};
+use lean_ffi::object::{
+  LeanArray, LeanBorrowed, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
+  scalar_base,
+};
 
 /// Decode Array UInt64 from Lean.
 fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
@@ -28,13 +34,13 @@ impl LeanIxonExpr<LeanOwned> {
   pub fn build(expr: &IxonExpr) -> Self {
     let obj = match expr {
       IxonExpr::Sort(idx) => {
-        let ctor = LeanCtor::alloc(0, 0, 8);
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxonExprSort::alloc();
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       IxonExpr::Var(idx) => {
-        let ctor = LeanCtor::alloc(1, 0, 8);
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxonExprVar::alloc();
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
       IxonExpr::Ref(ref_idx, univ_idxs) => {
@@ -44,9 +50,9 @@ impl LeanIxonExpr<LeanOwned> {
           uint64_obj.set_u64(scalar_base(&uint64_obj, 0), *idx);
           arr.set(i, uint64_obj);
         }
-        let ctor = LeanCtor::alloc(2, 1, 8);
-        ctor.set(0, arr);
-        ctor.set_u64(scalar_base(&ctor, 0), *ref_idx);
+        let ctor = LeanIxonExprRef::alloc();
+        ctor.set_obj(0, arr);
+        ctor.set_num_64(0, *ref_idx);
         ctor.into()
       },
       IxonExpr::Rec(rec_idx, univ_idxs) => {
@@ -56,28 +62,27 @@ impl LeanIxonExpr<LeanOwned> {
           uint64_obj.set_u64(scalar_base(&uint64_obj, 0), *idx);
           arr.set(i, uint64_obj);
         }
-        let ctor = LeanCtor::alloc(3, 1, 8);
-        ctor.set(0, arr);
-        ctor.set_u64(scalar_base(&ctor, 0), *rec_idx);
+        let ctor = LeanIxonExprRec::alloc();
+        ctor.set_obj(0, arr);
+        ctor.set_num_64(0, *rec_idx);
         ctor.into()
       },
       IxonExpr::Prj(type_ref_idx, field_idx, val) => {
         let val_obj = Self::build(val);
-        let ctor = LeanCtor::alloc(4, 1, 16);
-        ctor.set(0, val_obj);
-        let s = scalar_base(&ctor, 0);
-        ctor.set_u64(s, *type_ref_idx);
-        ctor.set_u64(s + 8, *field_idx);
+        let ctor = LeanIxonExprPrj::alloc();
+        ctor.set_obj(0, val_obj);
+        ctor.set_num_64(0, *type_ref_idx);
+        ctor.set_num_64(1, *field_idx);
         ctor.into()
       },
       IxonExpr::Str(ref_idx) => {
-        let ctor = LeanCtor::alloc(5, 0, 8);
-        ctor.set_u64(scalar_base(&ctor, 0), *ref_idx);
+        let ctor = LeanIxonExprStr::alloc();
+        ctor.set_num_64(0, *ref_idx);
         ctor.into()
       },
       IxonExpr::Nat(ref_idx) => {
-        let ctor = LeanCtor::alloc(6, 0, 8);
-        ctor.set_u64(scalar_base(&ctor, 0), *ref_idx);
+        let ctor = LeanIxonExprNat::alloc();
+        ctor.set_num_64(0, *ref_idx);
         ctor.into()
       },
       IxonExpr::App(fun, arg) => {
@@ -108,16 +113,16 @@ impl LeanIxonExpr<LeanOwned> {
         let ty_obj = Self::build(ty);
         let val_obj = Self::build(val);
         let body_obj = Self::build(body);
-        let ctor = LeanCtor::alloc(10, 3, 1);
-        ctor.set(0, ty_obj);
-        ctor.set(1, val_obj);
-        ctor.set(2, body_obj);
-        ctor.set_bool(scalar_base(&ctor, 0), *non_dep);
+        let ctor = LeanIxonExprLet::alloc();
+        ctor.set_obj(0, ty_obj);
+        ctor.set_obj(1, val_obj);
+        ctor.set_obj(2, body_obj);
+        ctor.set_num_8(0, *non_dep as u8);
         ctor.into()
       },
       IxonExpr::Share(idx) => {
-        let ctor = LeanCtor::alloc(11, 0, 8);
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxonExprShare::alloc();
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
     };
@@ -141,40 +146,42 @@ impl<R: LeanRef> LeanIxonExpr<R> {
     let tag = ctor.tag();
     match tag {
       0 => {
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        IxonExpr::Sort(idx)
+        let ctor = LeanIxonExprSort::from_ctor(ctor);
+        IxonExpr::Sort(ctor.get_num_64(0))
       },
       1 => {
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        IxonExpr::Var(idx)
+        let ctor = LeanIxonExprVar::from_ctor(ctor);
+        IxonExpr::Var(ctor.get_num_64(0))
       },
       2 => {
-        let ref_idx = ctor.get_u64(scalar_base(&ctor, 0));
-        let univ_idxs = decode_u64_array(ctor.get(0).as_array());
+        let ctor = LeanIxonExprRef::from_ctor(ctor);
+        let ref_idx = ctor.get_num_64(0);
+        let univ_idxs = decode_u64_array(ctor.as_ctor().get(0).as_array());
         IxonExpr::Ref(ref_idx, univ_idxs)
       },
       3 => {
-        let rec_idx = ctor.get_u64(scalar_base(&ctor, 0));
-        let univ_idxs = decode_u64_array(ctor.get(0).as_array());
+        let ctor = LeanIxonExprRec::from_ctor(ctor);
+        let rec_idx = ctor.get_num_64(0);
+        let univ_idxs = decode_u64_array(ctor.as_ctor().get(0).as_array());
         IxonExpr::Rec(rec_idx, univ_idxs)
       },
       4 => {
-        let s = scalar_base(&ctor, 0);
-        let type_ref_idx = ctor.get_u64(s);
-        let field_idx = ctor.get_u64(s + 8);
+        let ctor = LeanIxonExprPrj::from_ctor(ctor);
+        let type_ref_idx = ctor.get_num_64(0);
+        let field_idx = ctor.get_num_64(1);
         IxonExpr::Prj(
           type_ref_idx,
           field_idx,
-          Arc::new(LeanIxonExpr(ctor.get(0)).decode()),
+          Arc::new(LeanIxonExpr(ctor.as_ctor().get(0)).decode()),
         )
       },
       5 => {
-        let ref_idx = ctor.get_u64(scalar_base(&ctor, 0));
-        IxonExpr::Str(ref_idx)
+        let ctor = LeanIxonExprStr::from_ctor(ctor);
+        IxonExpr::Str(ctor.get_num_64(0))
       },
       6 => {
-        let ref_idx = ctor.get_u64(scalar_base(&ctor, 0));
-        IxonExpr::Nat(ref_idx)
+        let ctor = LeanIxonExprNat::from_ctor(ctor);
+        IxonExpr::Nat(ctor.get_num_64(0))
       },
       7 => IxonExpr::App(
         Arc::new(LeanIxonExpr(ctor.get(0)).decode()),
@@ -189,17 +196,18 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         Arc::new(LeanIxonExpr(ctor.get(1)).decode()),
       ),
       10 => {
-        let non_dep = ctor.get_bool(scalar_base(&ctor, 0));
+        let ctor = LeanIxonExprLet::from_ctor(ctor);
+        let non_dep = ctor.get_num_8(0) != 0;
         IxonExpr::Let(
           non_dep,
-          Arc::new(LeanIxonExpr(ctor.get(0)).decode()),
-          Arc::new(LeanIxonExpr(ctor.get(1)).decode()),
-          Arc::new(LeanIxonExpr(ctor.get(2)).decode()),
+          Arc::new(LeanIxonExpr(ctor.as_ctor().get(0)).decode()),
+          Arc::new(LeanIxonExpr(ctor.as_ctor().get(1)).decode()),
+          Arc::new(LeanIxonExpr(ctor.as_ctor().get(2)).decode()),
         )
       },
       11 => {
-        let idx = ctor.get_u64(scalar_base(&ctor, 0));
-        IxonExpr::Share(idx)
+        let ctor = LeanIxonExprShare::from_ctor(ctor);
+        IxonExpr::Share(ctor.get_num_64(0))
       },
       _ => panic!("Invalid Ixon.Expr tag: {}", tag),
     }

--- a/src/ffi/ixon/expr.rs
+++ b/src/ffi/ixon/expr.rs
@@ -3,12 +3,7 @@
 use std::sync::Arc;
 
 use crate::ix::ixon::expr::Expr as IxonExpr;
-use crate::lean::{
-  LeanIxonExpr, LeanIxonExprAll, LeanIxonExprApp, LeanIxonExprLam,
-  LeanIxonExprLet, LeanIxonExprNat, LeanIxonExprPrj, LeanIxonExprRec,
-  LeanIxonExprRef, LeanIxonExprShare, LeanIxonExprSort, LeanIxonExprStr,
-  LeanIxonExprVar,
-};
+use crate::lean::LeanIxonExpr;
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanRef};
 
 /// Decode Array UInt64 from Lean.
@@ -28,97 +23,96 @@ fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
 impl LeanIxonExpr<LeanOwned> {
   /// Build Ixon.Expr (12 constructors).
   pub fn build(expr: &IxonExpr) -> Self {
-    let obj = match expr {
+    match expr {
       IxonExpr::Sort(idx) => {
-        let ctor = LeanIxonExprSort::alloc();
+        let ctor = LeanIxonExpr::alloc(0);
         ctor.set_num_64(0, *idx);
-        ctor.0
+        ctor
       },
       IxonExpr::Var(idx) => {
-        let ctor = LeanIxonExprVar::alloc();
+        let ctor = LeanIxonExpr::alloc(1);
         ctor.set_num_64(0, *idx);
-        ctor.0
+        ctor
       },
       IxonExpr::Ref(ref_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
           arr.set(i, LeanOwned::box_u64(*idx));
         }
-        let ctor = LeanIxonExprRef::alloc();
+        let ctor = LeanIxonExpr::alloc(2);
         ctor.set_obj(0, arr);
         ctor.set_num_64(0, *ref_idx);
-        ctor.0
+        ctor
       },
       IxonExpr::Rec(rec_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
           arr.set(i, LeanOwned::box_u64(*idx));
         }
-        let ctor = LeanIxonExprRec::alloc();
+        let ctor = LeanIxonExpr::alloc(3);
         ctor.set_obj(0, arr);
         ctor.set_num_64(0, *rec_idx);
-        ctor.0
+        ctor
       },
       IxonExpr::Prj(type_ref_idx, field_idx, val) => {
         let val_obj = Self::build(val);
-        let ctor = LeanIxonExprPrj::alloc();
+        let ctor = LeanIxonExpr::alloc(4);
         ctor.set_obj(0, val_obj);
         ctor.set_num_64(0, *type_ref_idx);
         ctor.set_num_64(1, *field_idx);
-        ctor.0
+        ctor
       },
       IxonExpr::Str(ref_idx) => {
-        let ctor = LeanIxonExprStr::alloc();
+        let ctor = LeanIxonExpr::alloc(5);
         ctor.set_num_64(0, *ref_idx);
-        ctor.0
+        ctor
       },
       IxonExpr::Nat(ref_idx) => {
-        let ctor = LeanIxonExprNat::alloc();
+        let ctor = LeanIxonExpr::alloc(6);
         ctor.set_num_64(0, *ref_idx);
-        ctor.0
+        ctor
       },
       IxonExpr::App(fun, arg) => {
         let fun_obj = Self::build(fun);
         let arg_obj = Self::build(arg);
-        let ctor = LeanIxonExprApp::alloc();
+        let ctor = LeanIxonExpr::alloc(7);
         ctor.set_obj(0, fun_obj);
         ctor.set_obj(1, arg_obj);
-        ctor.into()
+        ctor
       },
       IxonExpr::Lam(ty, body) => {
         let ty_obj = Self::build(ty);
         let body_obj = Self::build(body);
-        let ctor = LeanIxonExprLam::alloc();
+        let ctor = LeanIxonExpr::alloc(8);
         ctor.set_obj(0, ty_obj);
         ctor.set_obj(1, body_obj);
-        ctor.into()
+        ctor
       },
       IxonExpr::All(ty, body) => {
         let ty_obj = Self::build(ty);
         let body_obj = Self::build(body);
-        let ctor = LeanIxonExprAll::alloc();
+        let ctor = LeanIxonExpr::alloc(9);
         ctor.set_obj(0, ty_obj);
         ctor.set_obj(1, body_obj);
-        ctor.into()
+        ctor
       },
       IxonExpr::Let(non_dep, ty, val, body) => {
         let ty_obj = Self::build(ty);
         let val_obj = Self::build(val);
         let body_obj = Self::build(body);
-        let ctor = LeanIxonExprLet::alloc();
+        let ctor = LeanIxonExpr::alloc(10);
         ctor.set_obj(0, ty_obj);
         ctor.set_obj(1, val_obj);
         ctor.set_obj(2, body_obj);
         ctor.set_num_8(0, *non_dep as u8);
-        ctor.0
+        ctor
       },
       IxonExpr::Share(idx) => {
-        let ctor = LeanIxonExprShare::alloc();
+        let ctor = LeanIxonExpr::alloc(11);
         ctor.set_num_64(0, *idx);
-        ctor.0
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 
   /// Build an Array of Ixon.Expr.
@@ -138,45 +132,38 @@ impl<R: LeanRef> LeanIxonExpr<R> {
     let tag = ctor.tag();
     match tag {
       0 => {
-        let ctor = LeanIxonExprSort::from_ctor(ctor);
-        let idx = ctor.get_num_64(0);
+        let idx = self.get_num_64(0);
         IxonExpr::Sort(idx)
       },
       1 => {
-        let ctor = LeanIxonExprVar::from_ctor(ctor);
-        let idx = ctor.get_num_64(0);
+        let idx = self.get_num_64(0);
         IxonExpr::Var(idx)
       },
       2 => {
-        let ctor = LeanIxonExprRef::from_ctor(ctor);
-        let ref_idx = ctor.get_num_64(0);
-        let univ_idxs = decode_u64_array(ctor.get_obj(0).as_array());
+        let ref_idx = self.get_num_64(0);
+        let univ_idxs = decode_u64_array(self.get_obj(0).as_array());
         IxonExpr::Ref(ref_idx, univ_idxs)
       },
       3 => {
-        let ctor = LeanIxonExprRec::from_ctor(ctor);
-        let rec_idx = ctor.get_num_64(0);
-        let univ_idxs = decode_u64_array(ctor.get_obj(0).as_array());
+        let rec_idx = self.get_num_64(0);
+        let univ_idxs = decode_u64_array(self.get_obj(0).as_array());
         IxonExpr::Rec(rec_idx, univ_idxs)
       },
       4 => {
-        let ctor = LeanIxonExprPrj::from_ctor(ctor);
-        let type_ref_idx = ctor.get_num_64(0);
-        let field_idx = ctor.get_num_64(1);
+        let type_ref_idx = self.get_num_64(0);
+        let field_idx = self.get_num_64(1);
         IxonExpr::Prj(
           type_ref_idx,
           field_idx,
-          Arc::new(LeanIxonExpr(ctor.get_obj(0)).decode()),
+          Arc::new(LeanIxonExpr(self.get_obj(0)).decode()),
         )
       },
       5 => {
-        let ctor = LeanIxonExprStr::from_ctor(ctor);
-        let ref_idx = ctor.get_num_64(0);
+        let ref_idx = self.get_num_64(0);
         IxonExpr::Str(ref_idx)
       },
       6 => {
-        let ctor = LeanIxonExprNat::from_ctor(ctor);
-        let ref_idx = ctor.get_num_64(0);
+        let ref_idx = self.get_num_64(0);
         IxonExpr::Nat(ref_idx)
       },
       7 => IxonExpr::App(
@@ -192,18 +179,16 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         Arc::new(LeanIxonExpr(ctor.get(1)).decode()),
       ),
       10 => {
-        let ctor = LeanIxonExprLet::from_ctor(ctor);
-        let non_dep = ctor.get_num_8(0) != 0;
+        let non_dep = self.get_num_8(0) != 0;
         IxonExpr::Let(
           non_dep,
-          Arc::new(LeanIxonExpr(ctor.get_obj(0)).decode()),
-          Arc::new(LeanIxonExpr(ctor.get_obj(1)).decode()),
-          Arc::new(LeanIxonExpr(ctor.get_obj(2)).decode()),
+          Arc::new(LeanIxonExpr(self.get_obj(0)).decode()),
+          Arc::new(LeanIxonExpr(self.get_obj(1)).decode()),
+          Arc::new(LeanIxonExpr(self.get_obj(2)).decode()),
         )
       },
       11 => {
-        let ctor = LeanIxonExprShare::from_ctor(ctor);
-        let idx = ctor.get_num_64(0);
+        let idx = self.get_num_64(0);
         IxonExpr::Share(idx)
       },
       _ => panic!("Invalid Ixon.Expr tag: {}", tag),

--- a/src/ffi/ixon/expr.rs
+++ b/src/ffi/ixon/expr.rs
@@ -15,7 +15,7 @@ fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
         elem.unbox_usize() as u64
       } else {
         let ctor = elem.as_ctor();
-        ctor.get_u64(0, 0)
+        ctor.get_u64(ctor.scalar_base(0))
       }
     })
     .collect()
@@ -27,54 +27,54 @@ impl LeanIxonExpr<LeanOwned> {
     let obj = match expr {
       IxonExpr::Sort(idx) => {
         let ctor = LeanCtor::alloc(0, 0, 8);
-        ctor.set_u64(0, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       IxonExpr::Var(idx) => {
         let ctor = LeanCtor::alloc(1, 0, 8);
-        ctor.set_u64(0, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
       IxonExpr::Ref(ref_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
           let uint64_obj = LeanCtor::alloc(0, 0, 8);
-          uint64_obj.set_u64(0, 0, *idx);
+          uint64_obj.set_u64(uint64_obj.scalar_base(0), *idx);
           arr.set(i, uint64_obj);
         }
         let ctor = LeanCtor::alloc(2, 1, 8);
         ctor.set(0, arr);
-        ctor.set_u64(1, 0, *ref_idx);
+        ctor.set_u64(ctor.scalar_base(0), *ref_idx);
         ctor.into()
       },
       IxonExpr::Rec(rec_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
           let uint64_obj = LeanCtor::alloc(0, 0, 8);
-          uint64_obj.set_u64(0, 0, *idx);
+          uint64_obj.set_u64(uint64_obj.scalar_base(0), *idx);
           arr.set(i, uint64_obj);
         }
         let ctor = LeanCtor::alloc(3, 1, 8);
         ctor.set(0, arr);
-        ctor.set_u64(1, 0, *rec_idx);
+        ctor.set_u64(ctor.scalar_base(0), *rec_idx);
         ctor.into()
       },
       IxonExpr::Prj(type_ref_idx, field_idx, val) => {
         let val_obj = Self::build(val);
         let ctor = LeanCtor::alloc(4, 1, 16);
         ctor.set(0, val_obj);
-        ctor.set_u64(1, 0, *type_ref_idx);
-        ctor.set_u64(1, 8, *field_idx);
+        ctor.set_u64(ctor.scalar_base(0), *type_ref_idx);
+        ctor.set_u64(ctor.scalar_base(0) + 8, *field_idx);
         ctor.into()
       },
       IxonExpr::Str(ref_idx) => {
         let ctor = LeanCtor::alloc(5, 0, 8);
-        ctor.set_u64(0, 0, *ref_idx);
+        ctor.set_u64(ctor.scalar_base(0), *ref_idx);
         ctor.into()
       },
       IxonExpr::Nat(ref_idx) => {
         let ctor = LeanCtor::alloc(6, 0, 8);
-        ctor.set_u64(0, 0, *ref_idx);
+        ctor.set_u64(ctor.scalar_base(0), *ref_idx);
         ctor.into()
       },
       IxonExpr::App(fun, arg) => {
@@ -109,12 +109,12 @@ impl LeanIxonExpr<LeanOwned> {
         ctor.set(0, ty_obj);
         ctor.set(1, val_obj);
         ctor.set(2, body_obj);
-        ctor.set_bool(3, 0, *non_dep);
+        ctor.set_bool(ctor.scalar_base(0), *non_dep);
         ctor.into()
       },
       IxonExpr::Share(idx) => {
         let ctor = LeanCtor::alloc(11, 0, 8);
-        ctor.set_u64(0, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
     };
@@ -138,26 +138,26 @@ impl<R: LeanRef> LeanIxonExpr<R> {
     let tag = ctor.tag();
     match tag {
       0 => {
-        let idx = ctor.get_u64(0, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         IxonExpr::Sort(idx)
       },
       1 => {
-        let idx = ctor.get_u64(0, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         IxonExpr::Var(idx)
       },
       2 => {
-        let ref_idx = ctor.get_u64(1, 0);
+        let ref_idx = ctor.get_u64(ctor.scalar_base(0));
         let univ_idxs = decode_u64_array(ctor.get(0).as_array());
         IxonExpr::Ref(ref_idx, univ_idxs)
       },
       3 => {
-        let rec_idx = ctor.get_u64(1, 0);
+        let rec_idx = ctor.get_u64(ctor.scalar_base(0));
         let univ_idxs = decode_u64_array(ctor.get(0).as_array());
         IxonExpr::Rec(rec_idx, univ_idxs)
       },
       4 => {
-        let type_ref_idx = ctor.get_u64(1, 0);
-        let field_idx = ctor.get_u64(1, 8);
+        let type_ref_idx = ctor.get_u64(ctor.scalar_base(0));
+        let field_idx = ctor.get_u64(ctor.scalar_base(0) + 8);
         IxonExpr::Prj(
           type_ref_idx,
           field_idx,
@@ -165,11 +165,11 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         )
       },
       5 => {
-        let ref_idx = ctor.get_u64(0, 0);
+        let ref_idx = ctor.get_u64(ctor.scalar_base(0));
         IxonExpr::Str(ref_idx)
       },
       6 => {
-        let ref_idx = ctor.get_u64(0, 0);
+        let ref_idx = ctor.get_u64(ctor.scalar_base(0));
         IxonExpr::Nat(ref_idx)
       },
       7 => IxonExpr::App(
@@ -185,7 +185,7 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         Arc::new(LeanIxonExpr(ctor.get(1)).decode()),
       ),
       10 => {
-        let non_dep = ctor.get_u8(3, 0) != 0;
+        let non_dep = ctor.get_bool(ctor.scalar_base(0));
         IxonExpr::Let(
           non_dep,
           Arc::new(LeanIxonExpr(ctor.get(0)).decode()),
@@ -194,7 +194,7 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         )
       },
       11 => {
-        let idx = ctor.get_u64(0, 0);
+        let idx = ctor.get_u64(ctor.scalar_base(0));
         IxonExpr::Share(idx)
       },
       _ => panic!("Invalid Ixon.Expr tag: {}", tag),

--- a/src/ffi/ixon/expr.rs
+++ b/src/ffi/ixon/expr.rs
@@ -3,16 +3,13 @@
 use std::sync::Arc;
 
 use crate::ix::ixon::expr::Expr as IxonExpr;
-use crate::lean::LeanIxonExpr;
 use crate::lean::{
+  LeanIxonExpr, LeanIxonExprAll, LeanIxonExprApp, LeanIxonExprLam,
   LeanIxonExprLet, LeanIxonExprNat, LeanIxonExprPrj, LeanIxonExprRec,
   LeanIxonExprRef, LeanIxonExprShare, LeanIxonExprSort, LeanIxonExprStr,
   LeanIxonExprVar,
 };
-use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
-  scalar_base,
-};
+use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanRef};
 
 /// Decode Array UInt64 from Lean.
 fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
@@ -22,8 +19,7 @@ fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
       if elem.is_scalar() {
         elem.unbox_usize() as u64
       } else {
-        let ctor = elem.as_ctor();
-        ctor.get_u64(scalar_base(&ctor, 0))
+        elem.unbox_u64()
       }
     })
     .collect()
@@ -36,36 +32,32 @@ impl LeanIxonExpr<LeanOwned> {
       IxonExpr::Sort(idx) => {
         let ctor = LeanIxonExprSort::alloc();
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Var(idx) => {
         let ctor = LeanIxonExprVar::alloc();
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Ref(ref_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
-          let uint64_obj = LeanCtor::alloc(0, 0, 8);
-          uint64_obj.set_u64(scalar_base(&uint64_obj, 0), *idx);
-          arr.set(i, uint64_obj);
+          arr.set(i, LeanOwned::box_u64(*idx));
         }
         let ctor = LeanIxonExprRef::alloc();
         ctor.set_obj(0, arr);
         ctor.set_num_64(0, *ref_idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Rec(rec_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
-          let uint64_obj = LeanCtor::alloc(0, 0, 8);
-          uint64_obj.set_u64(scalar_base(&uint64_obj, 0), *idx);
-          arr.set(i, uint64_obj);
+          arr.set(i, LeanOwned::box_u64(*idx));
         }
         let ctor = LeanIxonExprRec::alloc();
         ctor.set_obj(0, arr);
         ctor.set_num_64(0, *rec_idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Prj(type_ref_idx, field_idx, val) => {
         let val_obj = Self::build(val);
@@ -73,40 +65,40 @@ impl LeanIxonExpr<LeanOwned> {
         ctor.set_obj(0, val_obj);
         ctor.set_num_64(0, *type_ref_idx);
         ctor.set_num_64(1, *field_idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Str(ref_idx) => {
         let ctor = LeanIxonExprStr::alloc();
         ctor.set_num_64(0, *ref_idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Nat(ref_idx) => {
         let ctor = LeanIxonExprNat::alloc();
         ctor.set_num_64(0, *ref_idx);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::App(fun, arg) => {
         let fun_obj = Self::build(fun);
         let arg_obj = Self::build(arg);
-        let ctor = LeanCtor::alloc(7, 2, 0);
-        ctor.set(0, fun_obj);
-        ctor.set(1, arg_obj);
+        let ctor = LeanIxonExprApp::alloc();
+        ctor.set_obj(0, fun_obj);
+        ctor.set_obj(1, arg_obj);
         ctor.into()
       },
       IxonExpr::Lam(ty, body) => {
         let ty_obj = Self::build(ty);
         let body_obj = Self::build(body);
-        let ctor = LeanCtor::alloc(8, 2, 0);
-        ctor.set(0, ty_obj);
-        ctor.set(1, body_obj);
+        let ctor = LeanIxonExprLam::alloc();
+        ctor.set_obj(0, ty_obj);
+        ctor.set_obj(1, body_obj);
         ctor.into()
       },
       IxonExpr::All(ty, body) => {
         let ty_obj = Self::build(ty);
         let body_obj = Self::build(body);
-        let ctor = LeanCtor::alloc(9, 2, 0);
-        ctor.set(0, ty_obj);
-        ctor.set(1, body_obj);
+        let ctor = LeanIxonExprAll::alloc();
+        ctor.set_obj(0, ty_obj);
+        ctor.set_obj(1, body_obj);
         ctor.into()
       },
       IxonExpr::Let(non_dep, ty, val, body) => {
@@ -118,12 +110,12 @@ impl LeanIxonExpr<LeanOwned> {
         ctor.set_obj(1, val_obj);
         ctor.set_obj(2, body_obj);
         ctor.set_num_8(0, *non_dep as u8);
-        ctor.into()
+        ctor.0
       },
       IxonExpr::Share(idx) => {
         let ctor = LeanIxonExprShare::alloc();
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor.0
       },
     };
     Self::new(obj)
@@ -147,22 +139,24 @@ impl<R: LeanRef> LeanIxonExpr<R> {
     match tag {
       0 => {
         let ctor = LeanIxonExprSort::from_ctor(ctor);
-        IxonExpr::Sort(ctor.get_num_64(0))
+        let idx = ctor.get_num_64(0);
+        IxonExpr::Sort(idx)
       },
       1 => {
         let ctor = LeanIxonExprVar::from_ctor(ctor);
-        IxonExpr::Var(ctor.get_num_64(0))
+        let idx = ctor.get_num_64(0);
+        IxonExpr::Var(idx)
       },
       2 => {
         let ctor = LeanIxonExprRef::from_ctor(ctor);
         let ref_idx = ctor.get_num_64(0);
-        let univ_idxs = decode_u64_array(ctor.as_ctor().get(0).as_array());
+        let univ_idxs = decode_u64_array(ctor.get_obj(0).as_array());
         IxonExpr::Ref(ref_idx, univ_idxs)
       },
       3 => {
         let ctor = LeanIxonExprRec::from_ctor(ctor);
         let rec_idx = ctor.get_num_64(0);
-        let univ_idxs = decode_u64_array(ctor.as_ctor().get(0).as_array());
+        let univ_idxs = decode_u64_array(ctor.get_obj(0).as_array());
         IxonExpr::Rec(rec_idx, univ_idxs)
       },
       4 => {
@@ -172,16 +166,18 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         IxonExpr::Prj(
           type_ref_idx,
           field_idx,
-          Arc::new(LeanIxonExpr(ctor.as_ctor().get(0)).decode()),
+          Arc::new(LeanIxonExpr(ctor.get_obj(0)).decode()),
         )
       },
       5 => {
         let ctor = LeanIxonExprStr::from_ctor(ctor);
-        IxonExpr::Str(ctor.get_num_64(0))
+        let ref_idx = ctor.get_num_64(0);
+        IxonExpr::Str(ref_idx)
       },
       6 => {
         let ctor = LeanIxonExprNat::from_ctor(ctor);
-        IxonExpr::Nat(ctor.get_num_64(0))
+        let ref_idx = ctor.get_num_64(0);
+        IxonExpr::Nat(ref_idx)
       },
       7 => IxonExpr::App(
         Arc::new(LeanIxonExpr(ctor.get(0)).decode()),
@@ -200,14 +196,15 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         let non_dep = ctor.get_num_8(0) != 0;
         IxonExpr::Let(
           non_dep,
-          Arc::new(LeanIxonExpr(ctor.as_ctor().get(0)).decode()),
-          Arc::new(LeanIxonExpr(ctor.as_ctor().get(1)).decode()),
-          Arc::new(LeanIxonExpr(ctor.as_ctor().get(2)).decode()),
+          Arc::new(LeanIxonExpr(ctor.get_obj(0)).decode()),
+          Arc::new(LeanIxonExpr(ctor.get_obj(1)).decode()),
+          Arc::new(LeanIxonExpr(ctor.get_obj(2)).decode()),
         )
       },
       11 => {
         let ctor = LeanIxonExprShare::from_ctor(ctor);
-        IxonExpr::Share(ctor.get_num_64(0))
+        let idx = ctor.get_num_64(0);
+        IxonExpr::Share(idx)
       },
       _ => panic!("Invalid Ixon.Expr tag: {}", tag),
     }

--- a/src/ffi/ixon/expr.rs
+++ b/src/ffi/ixon/expr.rs
@@ -6,6 +6,8 @@ use crate::ix::ixon::expr::Expr as IxonExpr;
 use crate::lean::LeanIxonExpr;
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
 
+use lean_ffi::object::scalar_base;
+
 /// Decode Array UInt64 from Lean.
 fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
   obj
@@ -15,7 +17,7 @@ fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
         elem.unbox_usize() as u64
       } else {
         let ctor = elem.as_ctor();
-        ctor.get_u64(ctor.scalar_base(0))
+        ctor.get_u64(scalar_base(&ctor, 0))
       }
     })
     .collect()
@@ -27,54 +29,55 @@ impl LeanIxonExpr<LeanOwned> {
     let obj = match expr {
       IxonExpr::Sort(idx) => {
         let ctor = LeanCtor::alloc(0, 0, 8);
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       IxonExpr::Var(idx) => {
         let ctor = LeanCtor::alloc(1, 0, 8);
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
       IxonExpr::Ref(ref_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
           let uint64_obj = LeanCtor::alloc(0, 0, 8);
-          uint64_obj.set_u64(uint64_obj.scalar_base(0), *idx);
+          uint64_obj.set_u64(scalar_base(&uint64_obj, 0), *idx);
           arr.set(i, uint64_obj);
         }
         let ctor = LeanCtor::alloc(2, 1, 8);
         ctor.set(0, arr);
-        ctor.set_u64(ctor.scalar_base(0), *ref_idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *ref_idx);
         ctor.into()
       },
       IxonExpr::Rec(rec_idx, univ_idxs) => {
         let arr = LeanArray::alloc(univ_idxs.len());
         for (i, idx) in univ_idxs.iter().enumerate() {
           let uint64_obj = LeanCtor::alloc(0, 0, 8);
-          uint64_obj.set_u64(uint64_obj.scalar_base(0), *idx);
+          uint64_obj.set_u64(scalar_base(&uint64_obj, 0), *idx);
           arr.set(i, uint64_obj);
         }
         let ctor = LeanCtor::alloc(3, 1, 8);
         ctor.set(0, arr);
-        ctor.set_u64(ctor.scalar_base(0), *rec_idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *rec_idx);
         ctor.into()
       },
       IxonExpr::Prj(type_ref_idx, field_idx, val) => {
         let val_obj = Self::build(val);
         let ctor = LeanCtor::alloc(4, 1, 16);
         ctor.set(0, val_obj);
-        ctor.set_u64(ctor.scalar_base(0), *type_ref_idx);
-        ctor.set_u64(ctor.scalar_base(0) + 8, *field_idx);
+        let s = scalar_base(&ctor, 0);
+        ctor.set_u64(s, *type_ref_idx);
+        ctor.set_u64(s + 8, *field_idx);
         ctor.into()
       },
       IxonExpr::Str(ref_idx) => {
         let ctor = LeanCtor::alloc(5, 0, 8);
-        ctor.set_u64(ctor.scalar_base(0), *ref_idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *ref_idx);
         ctor.into()
       },
       IxonExpr::Nat(ref_idx) => {
         let ctor = LeanCtor::alloc(6, 0, 8);
-        ctor.set_u64(ctor.scalar_base(0), *ref_idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *ref_idx);
         ctor.into()
       },
       IxonExpr::App(fun, arg) => {
@@ -109,12 +112,12 @@ impl LeanIxonExpr<LeanOwned> {
         ctor.set(0, ty_obj);
         ctor.set(1, val_obj);
         ctor.set(2, body_obj);
-        ctor.set_bool(ctor.scalar_base(0), *non_dep);
+        ctor.set_bool(scalar_base(&ctor, 0), *non_dep);
         ctor.into()
       },
       IxonExpr::Share(idx) => {
         let ctor = LeanCtor::alloc(11, 0, 8);
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
     };
@@ -138,26 +141,27 @@ impl<R: LeanRef> LeanIxonExpr<R> {
     let tag = ctor.tag();
     match tag {
       0 => {
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         IxonExpr::Sort(idx)
       },
       1 => {
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         IxonExpr::Var(idx)
       },
       2 => {
-        let ref_idx = ctor.get_u64(ctor.scalar_base(0));
+        let ref_idx = ctor.get_u64(scalar_base(&ctor, 0));
         let univ_idxs = decode_u64_array(ctor.get(0).as_array());
         IxonExpr::Ref(ref_idx, univ_idxs)
       },
       3 => {
-        let rec_idx = ctor.get_u64(ctor.scalar_base(0));
+        let rec_idx = ctor.get_u64(scalar_base(&ctor, 0));
         let univ_idxs = decode_u64_array(ctor.get(0).as_array());
         IxonExpr::Rec(rec_idx, univ_idxs)
       },
       4 => {
-        let type_ref_idx = ctor.get_u64(ctor.scalar_base(0));
-        let field_idx = ctor.get_u64(ctor.scalar_base(0) + 8);
+        let s = scalar_base(&ctor, 0);
+        let type_ref_idx = ctor.get_u64(s);
+        let field_idx = ctor.get_u64(s + 8);
         IxonExpr::Prj(
           type_ref_idx,
           field_idx,
@@ -165,11 +169,11 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         )
       },
       5 => {
-        let ref_idx = ctor.get_u64(ctor.scalar_base(0));
+        let ref_idx = ctor.get_u64(scalar_base(&ctor, 0));
         IxonExpr::Str(ref_idx)
       },
       6 => {
-        let ref_idx = ctor.get_u64(ctor.scalar_base(0));
+        let ref_idx = ctor.get_u64(scalar_base(&ctor, 0));
         IxonExpr::Nat(ref_idx)
       },
       7 => IxonExpr::App(
@@ -185,7 +189,7 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         Arc::new(LeanIxonExpr(ctor.get(1)).decode()),
       ),
       10 => {
-        let non_dep = ctor.get_bool(ctor.scalar_base(0));
+        let non_dep = ctor.get_bool(scalar_base(&ctor, 0));
         IxonExpr::Let(
           non_dep,
           Arc::new(LeanIxonExpr(ctor.get(0)).decode()),
@@ -194,7 +198,7 @@ impl<R: LeanRef> LeanIxonExpr<R> {
         )
       },
       11 => {
-        let idx = ctor.get_u64(ctor.scalar_base(0));
+        let idx = ctor.get_u64(scalar_base(&ctor, 0));
         IxonExpr::Share(idx)
       },
       _ => panic!("Invalid Ixon.Expr tag: {}", tag),

--- a/src/ffi/ixon/meta.rs
+++ b/src/ffi/ixon/meta.rs
@@ -14,9 +14,15 @@ use crate::lean::{
   LeanIxonDataValue, LeanIxonExprMetaArena, LeanIxonExprMetaData,
   LeanIxonNamed,
 };
-use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
-
-use lean_ffi::object::scalar_base;
+use crate::lean::{
+  LeanIxonConstantMetaAxio, LeanIxonConstantMetaCtor, LeanIxonConstantMetaDef,
+  LeanIxonConstantMetaIndc, LeanIxonConstantMetaQuot, LeanIxonConstantMetaRec,
+  LeanIxonDataValueBool, LeanIxonExprMetaApp, LeanIxonExprMetaBinder,
+  LeanIxonExprMetaLetBinder, LeanIxonExprMetaMdata, LeanIxonExprMetaPrj,
+};
+use lean_ffi::object::{
+  LeanArray, LeanBorrowed, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
+};
 
 use crate::lean::LeanIxAddress;
 use crate::lean::LeanIxBinderInfo;
@@ -102,8 +108,8 @@ impl LeanIxonDataValue<LeanOwned> {
         ctor.into()
       },
       IxonDataValue::OfBool(b) => {
-        let ctor = LeanCtor::alloc(1, 0, 1);
-        ctor.set_bool(scalar_base(&ctor, 0), *b);
+        let ctor = LeanIxonDataValueBool::alloc();
+        ctor.set_num_8(0, *b as u8);
         ctor.into()
       },
       IxonDataValue::OfName(addr) => {
@@ -140,8 +146,8 @@ impl<R: LeanRef> LeanIxonDataValue<R> {
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
       ),
       1 => {
-        let b = ctor.get_bool(scalar_base(&ctor, 0));
-        IxonDataValue::OfBool(b)
+        let ctor = LeanIxonDataValueBool::from_ctor(ctor);
+        IxonDataValue::OfBool(ctor.get_num_8(0) != 0)
       },
       2 => IxonDataValue::OfName(
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
@@ -182,34 +188,29 @@ impl LeanIxonExprMetaData<LeanOwned> {
 
       ExprMetaData::App { children } => {
         // Tag 1, 0 obj fields, 16 scalar bytes (2× u64)
-        let ctor = LeanCtor::alloc(1, 0, 16);
-        let s = scalar_base(&ctor, 0);
-        ctor.set_u64(s, children[0]);
-        ctor.set_u64(s + 8, children[1]);
+        let ctor = LeanIxonExprMetaApp::alloc();
+        ctor.set_num_64(0, children[0]);
+        ctor.set_num_64(1, children[1]);
         ctor.into()
       },
 
       ExprMetaData::Binder { name, info, children } => {
         // Tag 2, 1 obj field (name), scalar: 2× u64 + u8 (info)
-        // Lean ABI sorts scalars by size descending: [tyChild: u64 @ 8] [bodyChild: u64 @ 16] [info: u8 @ 24]
-        // Offsets from obj_cptr: 1*8=8 base for scalar area
-        let ctor = LeanCtor::alloc(2, 1, 17);
-        ctor.set(0, LeanIxAddress::build(name));
-        let s = scalar_base(&ctor, 0);
-        ctor.set_u64(s, children[0]);
-        ctor.set_u64(s + 8, children[1]);
-        ctor.set_u8(s + 16, LeanIxBinderInfo::to_u8(info));
+        let ctor = LeanIxonExprMetaBinder::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_num_64(0, children[0]);
+        ctor.set_num_64(1, children[1]);
+        ctor.set_num_8(0, LeanIxBinderInfo::to_u8(info));
         ctor.into()
       },
 
       ExprMetaData::LetBinder { name, children } => {
         // Tag 3, 1 obj field (name), 24 scalar bytes (3× u64)
-        let ctor = LeanCtor::alloc(3, 1, 24);
-        ctor.set(0, LeanIxAddress::build(name));
-        let s = scalar_base(&ctor, 0);
-        ctor.set_u64(s, children[0]);
-        ctor.set_u64(s + 8, children[1]);
-        ctor.set_u64(s + 16, children[2]);
+        let ctor = LeanIxonExprMetaLetBinder::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_num_64(0, children[0]);
+        ctor.set_num_64(1, children[1]);
+        ctor.set_num_64(2, children[2]);
         ctor.into()
       },
 
@@ -222,18 +223,18 @@ impl LeanIxonExprMetaData<LeanOwned> {
 
       ExprMetaData::Prj { struct_name, child } => {
         // Tag 5, 1 obj field (structName), 8 scalar bytes (1× u64)
-        let ctor = LeanCtor::alloc(5, 1, 8);
-        ctor.set(0, LeanIxAddress::build(struct_name));
-        ctor.set_u64(scalar_base(&ctor, 0), *child);
+        let ctor = LeanIxonExprMetaPrj::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(struct_name));
+        ctor.set_num_64(0, *child);
         ctor.into()
       },
 
       ExprMetaData::Mdata { mdata, child } => {
         // Tag 6, 1 obj field (mdata: Array KVMap), 8 scalar bytes (1× u64)
         let mdata_arr = build_kvmap_array(mdata);
-        let ctor = LeanCtor::alloc(6, 1, 8);
-        ctor.set(0, mdata_arr);
-        ctor.set_u64(scalar_base(&ctor, 0), *child);
+        let ctor = LeanIxonExprMetaMdata::alloc();
+        ctor.set_obj(0, mdata_arr);
+        ctor.set_num_64(0, *child);
         ctor.into()
       },
     };
@@ -254,20 +255,19 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
     match ctor.tag() {
       1 => {
         // app: 0 obj fields, 2× u64 scalar
-        let s = scalar_base(&ctor, 0);
-        let children = [ctor.get_u64(s), ctor.get_u64(s + 8)];
+        let ctor = LeanIxonExprMetaApp::from_ctor(ctor);
+        let children = [ctor.get_num_64(0), ctor.get_num_64(1)];
         ExprMetaData::App { children }
       },
 
       2 => {
-        // binder: 1 obj field (name), scalar (Lean ABI: u64s first, then u8):
-        // [tyChild: u64 @ 0] [bodyChild: u64 @ 8] [info: u8 @ 16]
+        // binder: 1 obj field (name), scalar: 2× u64 + u8 (info)
         let name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let s = scalar_base(&ctor, 0);
-        let ty_child = ctor.get_u64(s);
-        let body_child = ctor.get_u64(s + 8);
-        let info_byte = ctor.get_u8(s + 16);
+        let ctor = LeanIxonExprMetaBinder::from_ctor(ctor);
+        let ty_child = ctor.get_num_64(0);
+        let body_child = ctor.get_num_64(1);
+        let info_byte = ctor.get_num_8(0);
         let info = match info_byte {
           0 => BinderInfo::Default,
           1 => BinderInfo::Implicit,
@@ -282,9 +282,9 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // letBinder: 1 obj field (name), 3× u64 scalar
         let name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let s = scalar_base(&ctor, 0);
+        let ctor = LeanIxonExprMetaLetBinder::from_ctor(ctor);
         let children =
-          [ctor.get_u64(s), ctor.get_u64(s + 8), ctor.get_u64(s + 16)];
+          [ctor.get_num_64(0), ctor.get_num_64(1), ctor.get_num_64(2)];
         ExprMetaData::LetBinder { name, children }
       },
 
@@ -300,14 +300,16 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // prj: 1 obj field (structName), 1× u64 scalar
         let struct_name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let child = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonExprMetaPrj::from_ctor(ctor);
+        let child = ctor.get_num_64(0);
         ExprMetaData::Prj { struct_name, child }
       },
 
       6 => {
         // mdata: 1 obj field (mdata: Array KVMap), 1× u64 scalar
         let mdata = decode_kvmap_array(ctor.get(0).as_array());
-        let child = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonExprMetaMdata::from_ctor(ctor);
+        let child = ctor.get_num_64(0);
         ExprMetaData::Mdata { mdata, child }
       },
 
@@ -374,56 +376,55 @@ impl LeanIxonConstantMeta<LeanOwned> {
         type_root,
         value_root,
       } => {
-        let ctor = LeanCtor::alloc(1, 6, 16);
-        ctor.set(0, LeanIxAddress::build(name));
-        ctor.set(1, LeanIxAddress::build_array(lvls));
-        ctor.set(2, LeanIxReducibilityHints::build(hints));
-        ctor.set(3, LeanIxAddress::build_array(all));
-        ctor.set(4, LeanIxAddress::build_array(ctx));
-        ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        let s = scalar_base(&ctor, 0);
-        ctor.set_u64(s, *type_root);
-        ctor.set_u64(s + 8, *value_root);
+        let ctor = LeanIxonConstantMetaDef::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_obj(1, LeanIxAddress::build_array(lvls));
+        ctor.set_obj(2, LeanIxReducibilityHints::build(hints));
+        ctor.set_obj(3, LeanIxAddress::build_array(all));
+        ctor.set_obj(4, LeanIxAddress::build_array(ctx));
+        ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
+        ctor.set_num_64(0, *type_root);
+        ctor.set_num_64(1, *value_root);
         ctor.into()
       },
 
       ConstantMeta::Axio { name, lvls, arena, type_root } => {
-        let ctor = LeanCtor::alloc(2, 3, 8);
-        ctor.set(0, LeanIxAddress::build(name));
-        ctor.set(1, LeanIxAddress::build_array(lvls));
-        ctor.set(2, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
+        let ctor = LeanIxonConstantMetaAxio::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_obj(1, LeanIxAddress::build_array(lvls));
+        ctor.set_obj(2, LeanIxonExprMetaArena::build(arena));
+        ctor.set_num_64(0, *type_root);
         ctor.into()
       },
 
       ConstantMeta::Quot { name, lvls, arena, type_root } => {
-        let ctor = LeanCtor::alloc(3, 3, 8);
-        ctor.set(0, LeanIxAddress::build(name));
-        ctor.set(1, LeanIxAddress::build_array(lvls));
-        ctor.set(2, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
+        let ctor = LeanIxonConstantMetaQuot::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_obj(1, LeanIxAddress::build_array(lvls));
+        ctor.set_obj(2, LeanIxonExprMetaArena::build(arena));
+        ctor.set_num_64(0, *type_root);
         ctor.into()
       },
 
       ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root } => {
-        let ctor = LeanCtor::alloc(4, 6, 8);
-        ctor.set(0, LeanIxAddress::build(name));
-        ctor.set(1, LeanIxAddress::build_array(lvls));
-        ctor.set(2, LeanIxAddress::build_array(ctors));
-        ctor.set(3, LeanIxAddress::build_array(all));
-        ctor.set(4, LeanIxAddress::build_array(ctx));
-        ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
+        let ctor = LeanIxonConstantMetaIndc::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_obj(1, LeanIxAddress::build_array(lvls));
+        ctor.set_obj(2, LeanIxAddress::build_array(ctors));
+        ctor.set_obj(3, LeanIxAddress::build_array(all));
+        ctor.set_obj(4, LeanIxAddress::build_array(ctx));
+        ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
+        ctor.set_num_64(0, *type_root);
         ctor.into()
       },
 
       ConstantMeta::Ctor { name, lvls, induct, arena, type_root } => {
-        let ctor = LeanCtor::alloc(5, 4, 8);
-        ctor.set(0, LeanIxAddress::build(name));
-        ctor.set(1, LeanIxAddress::build_array(lvls));
-        ctor.set(2, LeanIxAddress::build(induct));
-        ctor.set(3, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
+        let ctor = LeanIxonConstantMetaCtor::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_obj(1, LeanIxAddress::build_array(lvls));
+        ctor.set_obj(2, LeanIxAddress::build(induct));
+        ctor.set_obj(3, LeanIxonExprMetaArena::build(arena));
+        ctor.set_num_64(0, *type_root);
         ctor.into()
       },
 
@@ -437,15 +438,15 @@ impl LeanIxonConstantMeta<LeanOwned> {
         type_root,
         rule_roots,
       } => {
-        let ctor = LeanCtor::alloc(6, 7, 8);
-        ctor.set(0, LeanIxAddress::build(name));
-        ctor.set(1, LeanIxAddress::build_array(lvls));
-        ctor.set(2, LeanIxAddress::build_array(rules));
-        ctor.set(3, LeanIxAddress::build_array(all));
-        ctor.set(4, LeanIxAddress::build_array(ctx));
-        ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set(6, build_u64_array(rule_roots));
-        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
+        let ctor = LeanIxonConstantMetaRec::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
+        ctor.set_obj(1, LeanIxAddress::build_array(lvls));
+        ctor.set_obj(2, LeanIxAddress::build_array(rules));
+        ctor.set_obj(3, LeanIxAddress::build_array(all));
+        ctor.set_obj(4, LeanIxAddress::build_array(ctx));
+        ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
+        ctor.set_obj(6, build_u64_array(rule_roots));
+        ctor.set_num_64(0, *type_root);
         ctor.into()
       },
     };
@@ -475,9 +476,9 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let s = scalar_base(&ctor, 0);
-        let type_root = ctor.get_u64(s);
-        let value_root = ctor.get_u64(s + 8);
+        let ctor = LeanIxonConstantMetaDef::from_ctor(ctor);
+        let type_root = ctor.get_num_64(0);
+        let value_root = ctor.get_num_64(1);
         ConstantMeta::Def {
           name,
           lvls,
@@ -497,7 +498,8 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let lvls = decode_address_array(ctor.get(1).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonConstantMetaAxio::from_ctor(ctor);
+        let type_root = ctor.get_num_64(0);
         ConstantMeta::Axio { name, lvls, arena, type_root }
       },
 
@@ -508,7 +510,8 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let lvls = decode_address_array(ctor.get(1).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonConstantMetaQuot::from_ctor(ctor);
+        let type_root = ctor.get_num_64(0);
         ConstantMeta::Quot { name, lvls, arena, type_root }
       },
 
@@ -522,7 +525,8 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonConstantMetaIndc::from_ctor(ctor);
+        let type_root = ctor.get_num_64(0);
         ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root }
       },
 
@@ -535,7 +539,8 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
           LeanIxAddress::from_borrowed(ctor.get(2).as_byte_array()).decode();
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(3).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonConstantMetaCtor::from_ctor(ctor);
+        let type_root = ctor.get_num_64(0);
         ConstantMeta::Ctor { name, lvls, induct, arena, type_root }
       },
 
@@ -550,7 +555,8 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
         let rule_roots = decode_u64_array(ctor.get(6).as_array());
-        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
+        let ctor = LeanIxonConstantMetaRec::from_ctor(ctor);
+        let type_root = ctor.get_num_64(0);
         ConstantMeta::Rec {
           name,
           lvls,

--- a/src/ffi/ixon/meta.rs
+++ b/src/ffi/ixon/meta.rs
@@ -101,7 +101,7 @@ impl LeanIxonDataValue<LeanOwned> {
       },
       IxonDataValue::OfBool(b) => {
         let ctor = LeanCtor::alloc(1, 0, 1);
-        ctor.set_bool(0, 0, *b);
+        ctor.set_bool(ctor.scalar_base(0), *b);
         ctor.into()
       },
       IxonDataValue::OfName(addr) => {
@@ -138,7 +138,7 @@ impl<R: LeanRef> LeanIxonDataValue<R> {
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
       ),
       1 => {
-        let b = ctor.get_u8(0, 0) != 0;
+        let b = ctor.get_bool(ctor.scalar_base(0));
         IxonDataValue::OfBool(b)
       },
       2 => IxonDataValue::OfName(
@@ -181,8 +181,7 @@ impl LeanIxonExprMetaData<LeanOwned> {
       ExprMetaData::App { children } => {
         // Tag 1, 0 obj fields, 16 scalar bytes (2× u64)
         let ctor = LeanCtor::alloc(1, 0, 16);
-        ctor.set_u64(0, 0, children[0]);
-        ctor.set_u64(0, 8, children[1]);
+        ctor.set_scalars::<2, u64>(ctor.scalar_base(0), *children);
         ctor.into()
       },
 
@@ -192,9 +191,9 @@ impl LeanIxonExprMetaData<LeanOwned> {
         // Offsets from obj_cptr: 1*8=8 base for scalar area
         let ctor = LeanCtor::alloc(2, 1, 17);
         ctor.set(0, LeanIxAddress::build(name));
-        ctor.set_u64(1, 0, children[0]);
-        ctor.set_u64(1, 8, children[1]);
-        ctor.set_u8(1, 16, LeanIxBinderInfo::to_u8(info));
+        let s = ctor.scalar_base(0);
+        ctor.set_scalars::<2, u64>(s, *children);
+        ctor.set_u8(s + 16, LeanIxBinderInfo::to_u8(info));
         ctor.into()
       },
 
@@ -202,9 +201,7 @@ impl LeanIxonExprMetaData<LeanOwned> {
         // Tag 3, 1 obj field (name), 24 scalar bytes (3× u64)
         let ctor = LeanCtor::alloc(3, 1, 24);
         ctor.set(0, LeanIxAddress::build(name));
-        ctor.set_u64(1, 0, children[0]);
-        ctor.set_u64(1, 8, children[1]);
-        ctor.set_u64(1, 16, children[2]);
+        ctor.set_scalars::<3, u64>(ctor.scalar_base(0), *children);
         ctor.into()
       },
 
@@ -219,7 +216,7 @@ impl LeanIxonExprMetaData<LeanOwned> {
         // Tag 5, 1 obj field (structName), 8 scalar bytes (1× u64)
         let ctor = LeanCtor::alloc(5, 1, 8);
         ctor.set(0, LeanIxAddress::build(struct_name));
-        ctor.set_u64(1, 0, *child);
+        ctor.set_u64(ctor.scalar_base(0), *child);
         ctor.into()
       },
 
@@ -228,7 +225,7 @@ impl LeanIxonExprMetaData<LeanOwned> {
         let mdata_arr = build_kvmap_array(mdata);
         let ctor = LeanCtor::alloc(6, 1, 8);
         ctor.set(0, mdata_arr);
-        ctor.set_u64(1, 0, *child);
+        ctor.set_u64(ctor.scalar_base(0), *child);
         ctor.into()
       },
     };
@@ -249,9 +246,8 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
     match ctor.tag() {
       1 => {
         // app: 0 obj fields, 2× u64 scalar
-        let fun_ = ctor.get_u64(0, 0);
-        let arg = ctor.get_u64(0, 8);
-        ExprMetaData::App { children: [fun_, arg] }
+        let children = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+        ExprMetaData::App { children }
       },
 
       2 => {
@@ -259,9 +255,9 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // [tyChild: u64 @ 0] [bodyChild: u64 @ 8] [info: u8 @ 16]
         let name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let ty_child = ctor.get_u64(1, 0);
-        let body_child = ctor.get_u64(1, 8);
-        let info_byte = ctor.get_u8(1, 16);
+        let s = ctor.scalar_base(0);
+        let [ty_child, body_child] = ctor.get_scalars::<2, u64>(s);
+        let info_byte = ctor.get_u8(s + 16);
         let info = match info_byte {
           0 => BinderInfo::Default,
           1 => BinderInfo::Implicit,
@@ -276,13 +272,8 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // letBinder: 1 obj field (name), 3× u64 scalar
         let name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let ty_child = ctor.get_u64(1, 0);
-        let val_child = ctor.get_u64(1, 8);
-        let body_child = ctor.get_u64(1, 16);
-        ExprMetaData::LetBinder {
-          name,
-          children: [ty_child, val_child, body_child],
-        }
+        let children = ctor.get_scalars::<3, u64>(ctor.scalar_base(0));
+        ExprMetaData::LetBinder { name, children }
       },
 
       4 => {
@@ -297,14 +288,14 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // prj: 1 obj field (structName), 1× u64 scalar
         let struct_name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let child = ctor.get_u64(1, 0);
+        let child = ctor.get_u64(ctor.scalar_base(0));
         ExprMetaData::Prj { struct_name, child }
       },
 
       6 => {
         // mdata: 1 obj field (mdata: Array KVMap), 1× u64 scalar
         let mdata = decode_kvmap_array(ctor.get(0).as_array());
-        let child = ctor.get_u64(1, 0);
+        let child = ctor.get_u64(ctor.scalar_base(0));
         ExprMetaData::Mdata { mdata, child }
       },
 
@@ -378,8 +369,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(3, LeanIxAddress::build_array(all));
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(6, 0, *type_root);
-        ctor.set_u64(6, 8, *value_root);
+        ctor.set_scalars::<2, u64>(ctor.scalar_base(0), [*type_root, *value_root]);
         ctor.into()
       },
 
@@ -388,7 +378,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(0, LeanIxAddress::build(name));
         ctor.set(1, LeanIxAddress::build_array(lvls));
         ctor.set(2, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(3, 0, *type_root);
+        ctor.set_u64(ctor.scalar_base(0), *type_root);
         ctor.into()
       },
 
@@ -397,7 +387,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(0, LeanIxAddress::build(name));
         ctor.set(1, LeanIxAddress::build_array(lvls));
         ctor.set(2, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(3, 0, *type_root);
+        ctor.set_u64(ctor.scalar_base(0), *type_root);
         ctor.into()
       },
 
@@ -409,7 +399,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(3, LeanIxAddress::build_array(all));
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(6, 0, *type_root);
+        ctor.set_u64(ctor.scalar_base(0), *type_root);
         ctor.into()
       },
 
@@ -419,7 +409,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(1, LeanIxAddress::build_array(lvls));
         ctor.set(2, LeanIxAddress::build(induct));
         ctor.set(3, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(4, 0, *type_root);
+        ctor.set_u64(ctor.scalar_base(0), *type_root);
         ctor.into()
       },
 
@@ -441,7 +431,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
         ctor.set(6, build_u64_array(rule_roots));
-        ctor.set_u64(7, 0, *type_root);
+        ctor.set_u64(ctor.scalar_base(0), *type_root);
         ctor.into()
       },
     };
@@ -471,8 +461,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(6, 0);
-        let value_root = ctor.get_u64(6, 8);
+        let [type_root, value_root] = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
         ConstantMeta::Def {
           name,
           lvls,
@@ -492,7 +481,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let lvls = decode_address_array(ctor.get(1).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(3, 0);
+        let type_root = ctor.get_u64(ctor.scalar_base(0));
         ConstantMeta::Axio { name, lvls, arena, type_root }
       },
 
@@ -503,7 +492,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let lvls = decode_address_array(ctor.get(1).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(3, 0);
+        let type_root = ctor.get_u64(ctor.scalar_base(0));
         ConstantMeta::Quot { name, lvls, arena, type_root }
       },
 
@@ -517,7 +506,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(6, 0);
+        let type_root = ctor.get_u64(ctor.scalar_base(0));
         ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root }
       },
 
@@ -530,7 +519,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
           LeanIxAddress::from_borrowed(ctor.get(2).as_byte_array()).decode();
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(3).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(4, 0);
+        let type_root = ctor.get_u64(ctor.scalar_base(0));
         ConstantMeta::Ctor { name, lvls, induct, arena, type_root }
       },
 
@@ -545,7 +534,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
         let rule_roots = decode_u64_array(ctor.get(6).as_array());
-        let type_root = ctor.get_u64(7, 0);
+        let type_root = ctor.get_u64(ctor.scalar_base(0));
         ConstantMeta::Rec {
           name,
           lvls,

--- a/src/ffi/ixon/meta.rs
+++ b/src/ffi/ixon/meta.rs
@@ -11,18 +11,16 @@ use crate::ix::ixon::metadata::{
 };
 use crate::lean::{
   LeanIxReducibilityHints, LeanIxonComm, LeanIxonConstantMeta,
-  LeanIxonDataValue, LeanIxonExprMetaArena, LeanIxonExprMetaData,
-  LeanIxonNamed,
-};
-use crate::lean::{
   LeanIxonConstantMetaAxio, LeanIxonConstantMetaCtor, LeanIxonConstantMetaDef,
   LeanIxonConstantMetaIndc, LeanIxonConstantMetaQuot, LeanIxonConstantMetaRec,
-  LeanIxonDataValueBool, LeanIxonExprMetaApp, LeanIxonExprMetaBinder,
-  LeanIxonExprMetaLetBinder, LeanIxonExprMetaMdata, LeanIxonExprMetaPrj,
+  LeanIxonDataValue, LeanIxonDataValueBool, LeanIxonDataValueInt,
+  LeanIxonDataValueName, LeanIxonDataValueNat, LeanIxonDataValueString,
+  LeanIxonDataValueSyntax, LeanIxonExprMetaApp, LeanIxonExprMetaArena,
+  LeanIxonExprMetaBinder, LeanIxonExprMetaData, LeanIxonExprMetaLetBinder,
+  LeanIxonExprMetaMdata, LeanIxonExprMetaPrj, LeanIxonExprMetaRef,
+  LeanIxonNamed,
 };
-use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
-};
+use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanProd, LeanRef};
 
 use crate::lean::LeanIxAddress;
 use crate::lean::LeanIxBinderInfo;
@@ -35,9 +33,8 @@ use crate::lean::LeanIxBinderInfo;
 pub fn build_ixon_kvmap(kvmap: &KVMap) -> LeanArray<LeanOwned> {
   let arr = LeanArray::alloc(kvmap.len());
   for (i, (addr, dv)) in kvmap.iter().enumerate() {
-    let pair = LeanCtor::alloc(0, 2, 0);
-    pair.set(0, LeanIxAddress::build(addr));
-    pair.set(1, LeanIxonDataValue::build(dv));
+    let pair =
+      LeanProd::new(LeanIxAddress::build(addr), LeanIxonDataValue::build(dv));
     arr.set(i, pair);
   }
   arr
@@ -103,33 +100,33 @@ impl LeanIxonDataValue<LeanOwned> {
   pub fn build(dv: &IxonDataValue) -> Self {
     let obj = match dv {
       IxonDataValue::OfString(addr) => {
-        let ctor = LeanCtor::alloc(0, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxonDataValueString::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       IxonDataValue::OfBool(b) => {
         let ctor = LeanIxonDataValueBool::alloc();
         ctor.set_num_8(0, *b as u8);
-        ctor.into()
+        ctor.0
       },
       IxonDataValue::OfName(addr) => {
-        let ctor = LeanCtor::alloc(2, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxonDataValueName::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       IxonDataValue::OfNat(addr) => {
-        let ctor = LeanCtor::alloc(3, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxonDataValueNat::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       IxonDataValue::OfInt(addr) => {
-        let ctor = LeanCtor::alloc(4, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxonDataValueInt::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
       IxonDataValue::OfSyntax(addr) => {
-        let ctor = LeanCtor::alloc(5, 1, 0);
-        ctor.set(0, LeanIxAddress::build(addr));
+        let ctor = LeanIxonDataValueSyntax::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(addr));
         ctor.into()
       },
     };
@@ -147,7 +144,8 @@ impl<R: LeanRef> LeanIxonDataValue<R> {
       ),
       1 => {
         let ctor = LeanIxonDataValueBool::from_ctor(ctor);
-        IxonDataValue::OfBool(ctor.get_num_8(0) != 0)
+        let b = ctor.get_num_8(0) != 0;
+        IxonDataValue::OfBool(b)
       },
       2 => IxonDataValue::OfName(
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
@@ -187,55 +185,49 @@ impl LeanIxonExprMetaData<LeanOwned> {
       ExprMetaData::Leaf => LeanOwned::box_usize(0),
 
       ExprMetaData::App { children } => {
-        // Tag 1, 0 obj fields, 16 scalar bytes (2× u64)
         let ctor = LeanIxonExprMetaApp::alloc();
         ctor.set_num_64(0, children[0]);
         ctor.set_num_64(1, children[1]);
-        ctor.into()
+        ctor.0
       },
 
       ExprMetaData::Binder { name, info, children } => {
-        // Tag 2, 1 obj field (name), scalar: 2× u64 + u8 (info)
         let ctor = LeanIxonExprMetaBinder::alloc();
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_num_64(0, children[0]);
         ctor.set_num_64(1, children[1]);
         ctor.set_num_8(0, LeanIxBinderInfo::to_u8(info));
-        ctor.into()
+        ctor.0
       },
 
       ExprMetaData::LetBinder { name, children } => {
-        // Tag 3, 1 obj field (name), 24 scalar bytes (3× u64)
         let ctor = LeanIxonExprMetaLetBinder::alloc();
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_num_64(0, children[0]);
         ctor.set_num_64(1, children[1]);
         ctor.set_num_64(2, children[2]);
-        ctor.into()
+        ctor.0
       },
 
       ExprMetaData::Ref { name } => {
-        // Tag 4, 1 obj field (name), 0 scalar bytes
-        let ctor = LeanCtor::alloc(4, 1, 0);
-        ctor.set(0, LeanIxAddress::build(name));
+        let ctor = LeanIxonExprMetaRef::alloc();
+        ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.into()
       },
 
       ExprMetaData::Prj { struct_name, child } => {
-        // Tag 5, 1 obj field (structName), 8 scalar bytes (1× u64)
         let ctor = LeanIxonExprMetaPrj::alloc();
         ctor.set_obj(0, LeanIxAddress::build(struct_name));
         ctor.set_num_64(0, *child);
-        ctor.into()
+        ctor.0
       },
 
       ExprMetaData::Mdata { mdata, child } => {
-        // Tag 6, 1 obj field (mdata: Array KVMap), 8 scalar bytes (1× u64)
         let mdata_arr = build_kvmap_array(mdata);
         let ctor = LeanIxonExprMetaMdata::alloc();
         ctor.set_obj(0, mdata_arr);
         ctor.set_num_64(0, *child);
-        ctor.into()
+        ctor.0
       },
     };
     Self::new(obj)
@@ -256,15 +248,17 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
       1 => {
         // app: 0 obj fields, 2× u64 scalar
         let ctor = LeanIxonExprMetaApp::from_ctor(ctor);
-        let children = [ctor.get_num_64(0), ctor.get_num_64(1)];
-        ExprMetaData::App { children }
+        let fun_ = ctor.get_num_64(0);
+        let arg = ctor.get_num_64(1);
+        ExprMetaData::App { children: [fun_, arg] }
       },
 
       2 => {
-        // binder: 1 obj field (name), scalar: 2× u64 + u8 (info)
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
+        // binder: 1 obj field (name), scalar (Lean ABI: u64s first, then u8):
         let ctor = LeanIxonExprMetaBinder::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
         let ty_child = ctor.get_num_64(0);
         let body_child = ctor.get_num_64(1);
         let info_byte = ctor.get_num_8(0);
@@ -280,12 +274,17 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
 
       3 => {
         // letBinder: 1 obj field (name), 3× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
         let ctor = LeanIxonExprMetaLetBinder::from_ctor(ctor);
-        let children =
-          [ctor.get_num_64(0), ctor.get_num_64(1), ctor.get_num_64(2)];
-        ExprMetaData::LetBinder { name, children }
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let ty_child = ctor.get_num_64(0);
+        let val_child = ctor.get_num_64(1);
+        let body_child = ctor.get_num_64(2);
+        ExprMetaData::LetBinder {
+          name,
+          children: [ty_child, val_child, body_child],
+        }
       },
 
       4 => {
@@ -298,17 +297,18 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
 
       5 => {
         // prj: 1 obj field (structName), 1× u64 scalar
-        let struct_name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
         let ctor = LeanIxonExprMetaPrj::from_ctor(ctor);
+        let struct_name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
         let child = ctor.get_num_64(0);
         ExprMetaData::Prj { struct_name, child }
       },
 
       6 => {
         // mdata: 1 obj field (mdata: Array KVMap), 1× u64 scalar
-        let mdata = decode_kvmap_array(ctor.get(0).as_array());
         let ctor = LeanIxonExprMetaMdata::from_ctor(ctor);
+        let mdata = decode_kvmap_array(ctor.get_obj(0).as_array());
         let child = ctor.get_num_64(0);
         ExprMetaData::Mdata { mdata, child }
       },
@@ -385,7 +385,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
         ctor.set_num_64(1, *value_root);
-        ctor.into()
+        ctor.0
       },
 
       ConstantMeta::Axio { name, lvls, arena, type_root } => {
@@ -394,7 +394,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.into()
+        ctor.0
       },
 
       ConstantMeta::Quot { name, lvls, arena, type_root } => {
@@ -403,7 +403,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.into()
+        ctor.0
       },
 
       ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root } => {
@@ -415,7 +415,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(4, LeanIxAddress::build_array(ctx));
         ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.into()
+        ctor.0
       },
 
       ConstantMeta::Ctor { name, lvls, induct, arena, type_root } => {
@@ -425,7 +425,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(2, LeanIxAddress::build(induct));
         ctor.set_obj(3, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.into()
+        ctor.0
       },
 
       ConstantMeta::Rec {
@@ -447,7 +447,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
         ctor.set_obj(6, build_u64_array(rule_roots));
         ctor.set_num_64(0, *type_root);
-        ctor.into()
+        ctor.0
       },
     };
     Self::new(obj)
@@ -467,16 +467,17 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
     match ctor.tag() {
       1 => {
         // defn: 6 obj fields, 2× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let lvls = decode_address_array(ctor.get(1).as_array());
-        let hints =
-          LeanIxReducibilityHints::new(ctor.get(2).to_owned_ref()).decode();
-        let all = decode_address_array(ctor.get(3).as_array());
-        let ctx = decode_address_array(ctor.get(4).as_array());
-        let arena =
-          LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
         let ctor = LeanIxonConstantMetaDef::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let hints =
+          LeanIxReducibilityHints::new(ctor.get_obj(2).to_owned_ref()).decode();
+        let all = decode_address_array(ctor.get_obj(3).as_array());
+        let ctx = decode_address_array(ctor.get_obj(4).as_array());
+        let arena =
+          LeanIxonExprMetaArena::new(ctor.get_obj(5).to_owned_ref()).decode();
         let type_root = ctor.get_num_64(0);
         let value_root = ctor.get_num_64(1);
         ConstantMeta::Def {
@@ -493,69 +494,75 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
 
       2 => {
         // axio: 3 obj fields, 1× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let lvls = decode_address_array(ctor.get(1).as_array());
-        let arena =
-          LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
         let ctor = LeanIxonConstantMetaAxio::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let arena =
+          LeanIxonExprMetaArena::new(ctor.get_obj(2).to_owned_ref()).decode();
         let type_root = ctor.get_num_64(0);
         ConstantMeta::Axio { name, lvls, arena, type_root }
       },
 
       3 => {
         // quot: 3 obj fields, 1× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let lvls = decode_address_array(ctor.get(1).as_array());
-        let arena =
-          LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
         let ctor = LeanIxonConstantMetaQuot::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let arena =
+          LeanIxonExprMetaArena::new(ctor.get_obj(2).to_owned_ref()).decode();
         let type_root = ctor.get_num_64(0);
         ConstantMeta::Quot { name, lvls, arena, type_root }
       },
 
       4 => {
         // indc: 6 obj fields, 1× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let lvls = decode_address_array(ctor.get(1).as_array());
-        let ctors = decode_address_array(ctor.get(2).as_array());
-        let all = decode_address_array(ctor.get(3).as_array());
-        let ctx = decode_address_array(ctor.get(4).as_array());
-        let arena =
-          LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
         let ctor = LeanIxonConstantMetaIndc::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let ctors = decode_address_array(ctor.get_obj(2).as_array());
+        let all = decode_address_array(ctor.get_obj(3).as_array());
+        let ctx = decode_address_array(ctor.get_obj(4).as_array());
+        let arena =
+          LeanIxonExprMetaArena::new(ctor.get_obj(5).to_owned_ref()).decode();
         let type_root = ctor.get_num_64(0);
         ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root }
       },
 
       5 => {
         // ctor: 4 obj fields, 1× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let lvls = decode_address_array(ctor.get(1).as_array());
-        let induct =
-          LeanIxAddress::from_borrowed(ctor.get(2).as_byte_array()).decode();
-        let arena =
-          LeanIxonExprMetaArena::new(ctor.get(3).to_owned_ref()).decode();
         let ctor = LeanIxonConstantMetaCtor::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let induct =
+          LeanIxAddress::from_borrowed(ctor.get_obj(2).as_byte_array())
+            .decode();
+        let arena =
+          LeanIxonExprMetaArena::new(ctor.get_obj(3).to_owned_ref()).decode();
         let type_root = ctor.get_num_64(0);
         ConstantMeta::Ctor { name, lvls, induct, arena, type_root }
       },
 
       6 => {
         // recr: 7 obj fields, 1× u64 scalar
-        let name =
-          LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let lvls = decode_address_array(ctor.get(1).as_array());
-        let rules = decode_address_array(ctor.get(2).as_array());
-        let all = decode_address_array(ctor.get(3).as_array());
-        let ctx = decode_address_array(ctor.get(4).as_array());
-        let arena =
-          LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let rule_roots = decode_u64_array(ctor.get(6).as_array());
         let ctor = LeanIxonConstantMetaRec::from_ctor(ctor);
+        let name =
+          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+            .decode();
+        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let rules = decode_address_array(ctor.get_obj(2).as_array());
+        let all = decode_address_array(ctor.get_obj(3).as_array());
+        let ctx = decode_address_array(ctor.get_obj(4).as_array());
+        let arena =
+          LeanIxonExprMetaArena::new(ctor.get_obj(5).to_owned_ref()).decode();
+        let rule_roots = decode_u64_array(ctor.get_obj(6).as_array());
         let type_root = ctor.get_num_64(0);
         ConstantMeta::Rec {
           name,
@@ -581,11 +588,9 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
 impl LeanIxonNamed<LeanOwned> {
   /// Build Ixon.Named { addr : Address, constMeta : ConstantMeta }
   pub fn build(addr: &Address, meta: &ConstantMeta) -> Self {
-    let addr_obj = LeanIxAddress::build(addr);
-    let meta_obj = LeanIxonConstantMeta::build(meta);
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, addr_obj);
-    ctor.set(1, meta_obj);
+    let ctor = LeanIxonNamed::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(addr));
+    ctor.set_obj(1, LeanIxonConstantMeta::build(meta));
     Self::new(ctor.into())
   }
 }
@@ -604,11 +609,9 @@ impl<R: LeanRef> LeanIxonNamed<R> {
 impl LeanIxonComm<LeanOwned> {
   /// Build Ixon.Comm { secret : Address, payload : Address }
   pub fn build(comm: &Comm) -> Self {
-    let secret_obj = LeanIxAddress::build(&comm.secret);
-    let payload_obj = LeanIxAddress::build(&comm.payload);
-    let ctor = LeanCtor::alloc(0, 2, 0);
-    ctor.set(0, secret_obj);
-    ctor.set(1, payload_obj);
+    let ctor = LeanIxonComm::alloc();
+    ctor.set_obj(0, LeanIxAddress::build(&comm.secret));
+    ctor.set_obj(1, LeanIxAddress::build(&comm.payload));
     Self::new(ctor.into())
   }
 }

--- a/src/ffi/ixon/meta.rs
+++ b/src/ffi/ixon/meta.rs
@@ -369,7 +369,10 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(3, LeanIxAddress::build_array(all));
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set_scalars::<2, u64>(ctor.scalar_base(0), [*type_root, *value_root]);
+        ctor.set_scalars::<2, u64>(
+          ctor.scalar_base(0),
+          [*type_root, *value_root],
+        );
         ctor.into()
       },
 
@@ -461,7 +464,8 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let [type_root, value_root] = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+        let [type_root, value_root] =
+          ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
         ConstantMeta::Def {
           name,
           lvls,

--- a/src/ffi/ixon/meta.rs
+++ b/src/ffi/ixon/meta.rs
@@ -16,6 +16,8 @@ use crate::lean::{
 };
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
 
+use lean_ffi::object::scalar_base;
+
 use crate::lean::LeanIxAddress;
 use crate::lean::LeanIxBinderInfo;
 
@@ -101,7 +103,7 @@ impl LeanIxonDataValue<LeanOwned> {
       },
       IxonDataValue::OfBool(b) => {
         let ctor = LeanCtor::alloc(1, 0, 1);
-        ctor.set_bool(ctor.scalar_base(0), *b);
+        ctor.set_bool(scalar_base(&ctor, 0), *b);
         ctor.into()
       },
       IxonDataValue::OfName(addr) => {
@@ -138,7 +140,7 @@ impl<R: LeanRef> LeanIxonDataValue<R> {
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
       ),
       1 => {
-        let b = ctor.get_bool(ctor.scalar_base(0));
+        let b = ctor.get_bool(scalar_base(&ctor, 0));
         IxonDataValue::OfBool(b)
       },
       2 => IxonDataValue::OfName(
@@ -181,7 +183,9 @@ impl LeanIxonExprMetaData<LeanOwned> {
       ExprMetaData::App { children } => {
         // Tag 1, 0 obj fields, 16 scalar bytes (2× u64)
         let ctor = LeanCtor::alloc(1, 0, 16);
-        ctor.set_scalars::<2, u64>(ctor.scalar_base(0), *children);
+        let s = scalar_base(&ctor, 0);
+        ctor.set_u64(s, children[0]);
+        ctor.set_u64(s + 8, children[1]);
         ctor.into()
       },
 
@@ -191,8 +195,9 @@ impl LeanIxonExprMetaData<LeanOwned> {
         // Offsets from obj_cptr: 1*8=8 base for scalar area
         let ctor = LeanCtor::alloc(2, 1, 17);
         ctor.set(0, LeanIxAddress::build(name));
-        let s = ctor.scalar_base(0);
-        ctor.set_scalars::<2, u64>(s, *children);
+        let s = scalar_base(&ctor, 0);
+        ctor.set_u64(s, children[0]);
+        ctor.set_u64(s + 8, children[1]);
         ctor.set_u8(s + 16, LeanIxBinderInfo::to_u8(info));
         ctor.into()
       },
@@ -201,7 +206,10 @@ impl LeanIxonExprMetaData<LeanOwned> {
         // Tag 3, 1 obj field (name), 24 scalar bytes (3× u64)
         let ctor = LeanCtor::alloc(3, 1, 24);
         ctor.set(0, LeanIxAddress::build(name));
-        ctor.set_scalars::<3, u64>(ctor.scalar_base(0), *children);
+        let s = scalar_base(&ctor, 0);
+        ctor.set_u64(s, children[0]);
+        ctor.set_u64(s + 8, children[1]);
+        ctor.set_u64(s + 16, children[2]);
         ctor.into()
       },
 
@@ -216,7 +224,7 @@ impl LeanIxonExprMetaData<LeanOwned> {
         // Tag 5, 1 obj field (structName), 8 scalar bytes (1× u64)
         let ctor = LeanCtor::alloc(5, 1, 8);
         ctor.set(0, LeanIxAddress::build(struct_name));
-        ctor.set_u64(ctor.scalar_base(0), *child);
+        ctor.set_u64(scalar_base(&ctor, 0), *child);
         ctor.into()
       },
 
@@ -225,7 +233,7 @@ impl LeanIxonExprMetaData<LeanOwned> {
         let mdata_arr = build_kvmap_array(mdata);
         let ctor = LeanCtor::alloc(6, 1, 8);
         ctor.set(0, mdata_arr);
-        ctor.set_u64(ctor.scalar_base(0), *child);
+        ctor.set_u64(scalar_base(&ctor, 0), *child);
         ctor.into()
       },
     };
@@ -246,7 +254,8 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
     match ctor.tag() {
       1 => {
         // app: 0 obj fields, 2× u64 scalar
-        let children = ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+        let s = scalar_base(&ctor, 0);
+        let children = [ctor.get_u64(s), ctor.get_u64(s + 8)];
         ExprMetaData::App { children }
       },
 
@@ -255,8 +264,9 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // [tyChild: u64 @ 0] [bodyChild: u64 @ 8] [info: u8 @ 16]
         let name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let s = ctor.scalar_base(0);
-        let [ty_child, body_child] = ctor.get_scalars::<2, u64>(s);
+        let s = scalar_base(&ctor, 0);
+        let ty_child = ctor.get_u64(s);
+        let body_child = ctor.get_u64(s + 8);
         let info_byte = ctor.get_u8(s + 16);
         let info = match info_byte {
           0 => BinderInfo::Default,
@@ -272,7 +282,9 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // letBinder: 1 obj field (name), 3× u64 scalar
         let name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let children = ctor.get_scalars::<3, u64>(ctor.scalar_base(0));
+        let s = scalar_base(&ctor, 0);
+        let children =
+          [ctor.get_u64(s), ctor.get_u64(s + 8), ctor.get_u64(s + 16)];
         ExprMetaData::LetBinder { name, children }
       },
 
@@ -288,14 +300,14 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
         // prj: 1 obj field (structName), 1× u64 scalar
         let struct_name =
           LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode();
-        let child = ctor.get_u64(ctor.scalar_base(0));
+        let child = ctor.get_u64(scalar_base(&ctor, 0));
         ExprMetaData::Prj { struct_name, child }
       },
 
       6 => {
         // mdata: 1 obj field (mdata: Array KVMap), 1× u64 scalar
         let mdata = decode_kvmap_array(ctor.get(0).as_array());
-        let child = ctor.get_u64(ctor.scalar_base(0));
+        let child = ctor.get_u64(scalar_base(&ctor, 0));
         ExprMetaData::Mdata { mdata, child }
       },
 
@@ -369,10 +381,9 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(3, LeanIxAddress::build_array(all));
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set_scalars::<2, u64>(
-          ctor.scalar_base(0),
-          [*type_root, *value_root],
-        );
+        let s = scalar_base(&ctor, 0);
+        ctor.set_u64(s, *type_root);
+        ctor.set_u64(s + 8, *value_root);
         ctor.into()
       },
 
@@ -381,7 +392,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(0, LeanIxAddress::build(name));
         ctor.set(1, LeanIxAddress::build_array(lvls));
         ctor.set(2, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(ctor.scalar_base(0), *type_root);
+        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
         ctor.into()
       },
 
@@ -390,7 +401,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(0, LeanIxAddress::build(name));
         ctor.set(1, LeanIxAddress::build_array(lvls));
         ctor.set(2, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(ctor.scalar_base(0), *type_root);
+        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
         ctor.into()
       },
 
@@ -402,7 +413,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(3, LeanIxAddress::build_array(all));
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(ctor.scalar_base(0), *type_root);
+        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
         ctor.into()
       },
 
@@ -412,7 +423,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(1, LeanIxAddress::build_array(lvls));
         ctor.set(2, LeanIxAddress::build(induct));
         ctor.set(3, LeanIxonExprMetaArena::build(arena));
-        ctor.set_u64(ctor.scalar_base(0), *type_root);
+        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
         ctor.into()
       },
 
@@ -434,7 +445,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set(4, LeanIxAddress::build_array(ctx));
         ctor.set(5, LeanIxonExprMetaArena::build(arena));
         ctor.set(6, build_u64_array(rule_roots));
-        ctor.set_u64(ctor.scalar_base(0), *type_root);
+        ctor.set_u64(scalar_base(&ctor, 0), *type_root);
         ctor.into()
       },
     };
@@ -464,8 +475,9 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let [type_root, value_root] =
-          ctor.get_scalars::<2, u64>(ctor.scalar_base(0));
+        let s = scalar_base(&ctor, 0);
+        let type_root = ctor.get_u64(s);
+        let value_root = ctor.get_u64(s + 8);
         ConstantMeta::Def {
           name,
           lvls,
@@ -485,7 +497,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let lvls = decode_address_array(ctor.get(1).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(ctor.scalar_base(0));
+        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
         ConstantMeta::Axio { name, lvls, arena, type_root }
       },
 
@@ -496,7 +508,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let lvls = decode_address_array(ctor.get(1).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(2).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(ctor.scalar_base(0));
+        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
         ConstantMeta::Quot { name, lvls, arena, type_root }
       },
 
@@ -510,7 +522,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let ctx = decode_address_array(ctor.get(4).as_array());
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(ctor.scalar_base(0));
+        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
         ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root }
       },
 
@@ -523,7 +535,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
           LeanIxAddress::from_borrowed(ctor.get(2).as_byte_array()).decode();
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(3).to_owned_ref()).decode();
-        let type_root = ctor.get_u64(ctor.scalar_base(0));
+        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
         ConstantMeta::Ctor { name, lvls, induct, arena, type_root }
       },
 
@@ -538,7 +550,7 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
         let arena =
           LeanIxonExprMetaArena::new(ctor.get(5).to_owned_ref()).decode();
         let rule_roots = decode_u64_array(ctor.get(6).as_array());
-        let type_root = ctor.get_u64(ctor.scalar_base(0));
+        let type_root = ctor.get_u64(scalar_base(&ctor, 0));
         ConstantMeta::Rec {
           name,
           lvls,

--- a/src/ffi/ixon/meta.rs
+++ b/src/ffi/ixon/meta.rs
@@ -11,13 +11,7 @@ use crate::ix::ixon::metadata::{
 };
 use crate::lean::{
   LeanIxReducibilityHints, LeanIxonComm, LeanIxonConstantMeta,
-  LeanIxonConstantMetaAxio, LeanIxonConstantMetaCtor, LeanIxonConstantMetaDef,
-  LeanIxonConstantMetaIndc, LeanIxonConstantMetaQuot, LeanIxonConstantMetaRec,
-  LeanIxonDataValue, LeanIxonDataValueBool, LeanIxonDataValueInt,
-  LeanIxonDataValueName, LeanIxonDataValueNat, LeanIxonDataValueString,
-  LeanIxonDataValueSyntax, LeanIxonExprMetaApp, LeanIxonExprMetaArena,
-  LeanIxonExprMetaBinder, LeanIxonExprMetaData, LeanIxonExprMetaLetBinder,
-  LeanIxonExprMetaMdata, LeanIxonExprMetaPrj, LeanIxonExprMetaRef,
+  LeanIxonDataValue, LeanIxonExprMetaArena, LeanIxonExprMetaData,
   LeanIxonNamed,
 };
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanProd, LeanRef};
@@ -98,39 +92,38 @@ fn decode_u64_array(obj: LeanArray<LeanBorrowed<'_>>) -> Vec<u64> {
 impl LeanIxonDataValue<LeanOwned> {
   /// Build Ixon.DataValue (for metadata)
   pub fn build(dv: &IxonDataValue) -> Self {
-    let obj = match dv {
+    match dv {
       IxonDataValue::OfString(addr) => {
-        let ctor = LeanIxonDataValueString::alloc();
+        let ctor = LeanIxonDataValue::alloc(0);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       IxonDataValue::OfBool(b) => {
-        let ctor = LeanIxonDataValueBool::alloc();
+        let ctor = LeanIxonDataValue::alloc(1);
         ctor.set_num_8(0, *b as u8);
-        ctor.0
+        ctor
       },
       IxonDataValue::OfName(addr) => {
-        let ctor = LeanIxonDataValueName::alloc();
+        let ctor = LeanIxonDataValue::alloc(2);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       IxonDataValue::OfNat(addr) => {
-        let ctor = LeanIxonDataValueNat::alloc();
+        let ctor = LeanIxonDataValue::alloc(3);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       IxonDataValue::OfInt(addr) => {
-        let ctor = LeanIxonDataValueInt::alloc();
+        let ctor = LeanIxonDataValue::alloc(4);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
       IxonDataValue::OfSyntax(addr) => {
-        let ctor = LeanIxonDataValueSyntax::alloc();
+        let ctor = LeanIxonDataValue::alloc(5);
         ctor.set_obj(0, LeanIxAddress::build(addr));
-        ctor.into()
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -143,8 +136,7 @@ impl<R: LeanRef> LeanIxonDataValue<R> {
         LeanIxAddress::from_borrowed(ctor.get(0).as_byte_array()).decode(),
       ),
       1 => {
-        let ctor = LeanIxonDataValueBool::from_ctor(ctor);
-        let b = ctor.get_num_8(0) != 0;
+        let b = self.get_num_8(0) != 0;
         IxonDataValue::OfBool(b)
       },
       2 => IxonDataValue::OfName(
@@ -181,56 +173,55 @@ impl LeanIxonExprMetaData<LeanOwned> {
   /// | prj        | 5   | 1 (structName: Address) | 8 (1× u64)             |
   /// | mdata      | 6   | 1 (mdata: Array)       | 8 (1× u64)              |
   pub fn build(node: &ExprMetaData) -> Self {
-    let obj = match node {
-      ExprMetaData::Leaf => LeanOwned::box_usize(0),
+    match node {
+      ExprMetaData::Leaf => Self::new(LeanOwned::box_usize(0)),
 
       ExprMetaData::App { children } => {
-        let ctor = LeanIxonExprMetaApp::alloc();
+        let ctor = LeanIxonExprMetaData::alloc(1);
         ctor.set_num_64(0, children[0]);
         ctor.set_num_64(1, children[1]);
-        ctor.0
+        ctor
       },
 
       ExprMetaData::Binder { name, info, children } => {
-        let ctor = LeanIxonExprMetaBinder::alloc();
+        let ctor = LeanIxonExprMetaData::alloc(2);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_num_64(0, children[0]);
         ctor.set_num_64(1, children[1]);
         ctor.set_num_8(0, LeanIxBinderInfo::to_u8(info));
-        ctor.0
+        ctor
       },
 
       ExprMetaData::LetBinder { name, children } => {
-        let ctor = LeanIxonExprMetaLetBinder::alloc();
+        let ctor = LeanIxonExprMetaData::alloc(3);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_num_64(0, children[0]);
         ctor.set_num_64(1, children[1]);
         ctor.set_num_64(2, children[2]);
-        ctor.0
+        ctor
       },
 
       ExprMetaData::Ref { name } => {
-        let ctor = LeanIxonExprMetaRef::alloc();
+        let ctor = LeanIxonExprMetaData::alloc(4);
         ctor.set_obj(0, LeanIxAddress::build(name));
-        ctor.into()
+        ctor
       },
 
       ExprMetaData::Prj { struct_name, child } => {
-        let ctor = LeanIxonExprMetaPrj::alloc();
+        let ctor = LeanIxonExprMetaData::alloc(5);
         ctor.set_obj(0, LeanIxAddress::build(struct_name));
         ctor.set_num_64(0, *child);
-        ctor.0
+        ctor
       },
 
       ExprMetaData::Mdata { mdata, child } => {
         let mdata_arr = build_kvmap_array(mdata);
-        let ctor = LeanIxonExprMetaMdata::alloc();
+        let ctor = LeanIxonExprMetaData::alloc(6);
         ctor.set_obj(0, mdata_arr);
         ctor.set_num_64(0, *child);
-        ctor.0
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -247,21 +238,19 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
     match ctor.tag() {
       1 => {
         // app: 0 obj fields, 2× u64 scalar
-        let ctor = LeanIxonExprMetaApp::from_ctor(ctor);
-        let fun_ = ctor.get_num_64(0);
-        let arg = ctor.get_num_64(1);
+        let fun_ = self.get_num_64(0);
+        let arg = self.get_num_64(1);
         ExprMetaData::App { children: [fun_, arg] }
       },
 
       2 => {
         // binder: 1 obj field (name), scalar (Lean ABI: u64s first, then u8):
-        let ctor = LeanIxonExprMetaBinder::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let ty_child = ctor.get_num_64(0);
-        let body_child = ctor.get_num_64(1);
-        let info_byte = ctor.get_num_8(0);
+        let ty_child = self.get_num_64(0);
+        let body_child = self.get_num_64(1);
+        let info_byte = self.get_num_8(0);
         let info = match info_byte {
           0 => BinderInfo::Default,
           1 => BinderInfo::Implicit,
@@ -274,13 +263,12 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
 
       3 => {
         // letBinder: 1 obj field (name), 3× u64 scalar
-        let ctor = LeanIxonExprMetaLetBinder::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let ty_child = ctor.get_num_64(0);
-        let val_child = ctor.get_num_64(1);
-        let body_child = ctor.get_num_64(2);
+        let ty_child = self.get_num_64(0);
+        let val_child = self.get_num_64(1);
+        let body_child = self.get_num_64(2);
         ExprMetaData::LetBinder {
           name,
           children: [ty_child, val_child, body_child],
@@ -297,19 +285,17 @@ impl<R: LeanRef> LeanIxonExprMetaData<R> {
 
       5 => {
         // prj: 1 obj field (structName), 1× u64 scalar
-        let ctor = LeanIxonExprMetaPrj::from_ctor(ctor);
         let struct_name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let child = ctor.get_num_64(0);
+        let child = self.get_num_64(0);
         ExprMetaData::Prj { struct_name, child }
       },
 
       6 => {
         // mdata: 1 obj field (mdata: Array KVMap), 1× u64 scalar
-        let ctor = LeanIxonExprMetaMdata::from_ctor(ctor);
-        let mdata = decode_kvmap_array(ctor.get_obj(0).as_array());
-        let child = ctor.get_num_64(0);
+        let mdata = decode_kvmap_array(self.get_obj(0).as_array());
+        let child = self.get_num_64(0);
         ExprMetaData::Mdata { mdata, child }
       },
 
@@ -363,8 +349,8 @@ impl LeanIxonConstantMeta<LeanOwned> {
   /// | ctor    | 5   | 4 (name, lvls, induct, arena) | 8 (1× u64) |
   /// | recr    | 6   | 7 (name, lvls, rules, all, ctx, arena, ruleRoots) | 8 (1× u64) |
   pub fn build(meta: &ConstantMeta) -> Self {
-    let obj = match meta {
-      ConstantMeta::Empty => LeanOwned::box_usize(0),
+    match meta {
+      ConstantMeta::Empty => Self::new(LeanOwned::box_usize(0)),
 
       ConstantMeta::Def {
         name,
@@ -376,7 +362,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         type_root,
         value_root,
       } => {
-        let ctor = LeanIxonConstantMetaDef::alloc();
+        let ctor = LeanIxonConstantMeta::alloc(1);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxReducibilityHints::build(hints));
@@ -385,29 +371,29 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
         ctor.set_num_64(1, *value_root);
-        ctor.0
+        ctor
       },
 
       ConstantMeta::Axio { name, lvls, arena, type_root } => {
-        let ctor = LeanIxonConstantMetaAxio::alloc();
+        let ctor = LeanIxonConstantMeta::alloc(2);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.0
+        ctor
       },
 
       ConstantMeta::Quot { name, lvls, arena, type_root } => {
-        let ctor = LeanIxonConstantMetaQuot::alloc();
+        let ctor = LeanIxonConstantMeta::alloc(3);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.0
+        ctor
       },
 
       ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root } => {
-        let ctor = LeanIxonConstantMetaIndc::alloc();
+        let ctor = LeanIxonConstantMeta::alloc(4);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxAddress::build_array(ctors));
@@ -415,17 +401,17 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(4, LeanIxAddress::build_array(ctx));
         ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.0
+        ctor
       },
 
       ConstantMeta::Ctor { name, lvls, induct, arena, type_root } => {
-        let ctor = LeanIxonConstantMetaCtor::alloc();
+        let ctor = LeanIxonConstantMeta::alloc(5);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxAddress::build(induct));
         ctor.set_obj(3, LeanIxonExprMetaArena::build(arena));
         ctor.set_num_64(0, *type_root);
-        ctor.0
+        ctor
       },
 
       ConstantMeta::Rec {
@@ -438,7 +424,7 @@ impl LeanIxonConstantMeta<LeanOwned> {
         type_root,
         rule_roots,
       } => {
-        let ctor = LeanIxonConstantMetaRec::alloc();
+        let ctor = LeanIxonConstantMeta::alloc(6);
         ctor.set_obj(0, LeanIxAddress::build(name));
         ctor.set_obj(1, LeanIxAddress::build_array(lvls));
         ctor.set_obj(2, LeanIxAddress::build_array(rules));
@@ -447,10 +433,9 @@ impl LeanIxonConstantMeta<LeanOwned> {
         ctor.set_obj(5, LeanIxonExprMetaArena::build(arena));
         ctor.set_obj(6, build_u64_array(rule_roots));
         ctor.set_num_64(0, *type_root);
-        ctor.0
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 }
 
@@ -467,19 +452,18 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
     match ctor.tag() {
       1 => {
         // defn: 6 obj fields, 2× u64 scalar
-        let ctor = LeanIxonConstantMetaDef::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let lvls = decode_address_array(self.get_obj(1).as_array());
         let hints =
-          LeanIxReducibilityHints::new(ctor.get_obj(2).to_owned_ref()).decode();
-        let all = decode_address_array(ctor.get_obj(3).as_array());
-        let ctx = decode_address_array(ctor.get_obj(4).as_array());
+          LeanIxReducibilityHints::new(self.get_obj(2).to_owned_ref()).decode();
+        let all = decode_address_array(self.get_obj(3).as_array());
+        let ctx = decode_address_array(self.get_obj(4).as_array());
         let arena =
-          LeanIxonExprMetaArena::new(ctor.get_obj(5).to_owned_ref()).decode();
-        let type_root = ctor.get_num_64(0);
-        let value_root = ctor.get_num_64(1);
+          LeanIxonExprMetaArena::new(self.get_obj(5).to_owned_ref()).decode();
+        let type_root = self.get_num_64(0);
+        let value_root = self.get_num_64(1);
         ConstantMeta::Def {
           name,
           lvls,
@@ -494,76 +478,71 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
 
       2 => {
         // axio: 3 obj fields, 1× u64 scalar
-        let ctor = LeanIxonConstantMetaAxio::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let lvls = decode_address_array(self.get_obj(1).as_array());
         let arena =
-          LeanIxonExprMetaArena::new(ctor.get_obj(2).to_owned_ref()).decode();
-        let type_root = ctor.get_num_64(0);
+          LeanIxonExprMetaArena::new(self.get_obj(2).to_owned_ref()).decode();
+        let type_root = self.get_num_64(0);
         ConstantMeta::Axio { name, lvls, arena, type_root }
       },
 
       3 => {
         // quot: 3 obj fields, 1× u64 scalar
-        let ctor = LeanIxonConstantMetaQuot::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let lvls = decode_address_array(self.get_obj(1).as_array());
         let arena =
-          LeanIxonExprMetaArena::new(ctor.get_obj(2).to_owned_ref()).decode();
-        let type_root = ctor.get_num_64(0);
+          LeanIxonExprMetaArena::new(self.get_obj(2).to_owned_ref()).decode();
+        let type_root = self.get_num_64(0);
         ConstantMeta::Quot { name, lvls, arena, type_root }
       },
 
       4 => {
         // indc: 6 obj fields, 1× u64 scalar
-        let ctor = LeanIxonConstantMetaIndc::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let lvls = decode_address_array(ctor.get_obj(1).as_array());
-        let ctors = decode_address_array(ctor.get_obj(2).as_array());
-        let all = decode_address_array(ctor.get_obj(3).as_array());
-        let ctx = decode_address_array(ctor.get_obj(4).as_array());
+        let lvls = decode_address_array(self.get_obj(1).as_array());
+        let ctors = decode_address_array(self.get_obj(2).as_array());
+        let all = decode_address_array(self.get_obj(3).as_array());
+        let ctx = decode_address_array(self.get_obj(4).as_array());
         let arena =
-          LeanIxonExprMetaArena::new(ctor.get_obj(5).to_owned_ref()).decode();
-        let type_root = ctor.get_num_64(0);
+          LeanIxonExprMetaArena::new(self.get_obj(5).to_owned_ref()).decode();
+        let type_root = self.get_num_64(0);
         ConstantMeta::Indc { name, lvls, ctors, all, ctx, arena, type_root }
       },
 
       5 => {
         // ctor: 4 obj fields, 1× u64 scalar
-        let ctor = LeanIxonConstantMetaCtor::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let lvls = decode_address_array(ctor.get_obj(1).as_array());
+        let lvls = decode_address_array(self.get_obj(1).as_array());
         let induct =
-          LeanIxAddress::from_borrowed(ctor.get_obj(2).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(2).as_byte_array())
             .decode();
         let arena =
-          LeanIxonExprMetaArena::new(ctor.get_obj(3).to_owned_ref()).decode();
-        let type_root = ctor.get_num_64(0);
+          LeanIxonExprMetaArena::new(self.get_obj(3).to_owned_ref()).decode();
+        let type_root = self.get_num_64(0);
         ConstantMeta::Ctor { name, lvls, induct, arena, type_root }
       },
 
       6 => {
         // recr: 7 obj fields, 1× u64 scalar
-        let ctor = LeanIxonConstantMetaRec::from_ctor(ctor);
         let name =
-          LeanIxAddress::from_borrowed(ctor.get_obj(0).as_byte_array())
+          LeanIxAddress::from_borrowed(self.get_obj(0).as_byte_array())
             .decode();
-        let lvls = decode_address_array(ctor.get_obj(1).as_array());
-        let rules = decode_address_array(ctor.get_obj(2).as_array());
-        let all = decode_address_array(ctor.get_obj(3).as_array());
-        let ctx = decode_address_array(ctor.get_obj(4).as_array());
+        let lvls = decode_address_array(self.get_obj(1).as_array());
+        let rules = decode_address_array(self.get_obj(2).as_array());
+        let all = decode_address_array(self.get_obj(3).as_array());
+        let ctx = decode_address_array(self.get_obj(4).as_array());
         let arena =
-          LeanIxonExprMetaArena::new(ctor.get_obj(5).to_owned_ref()).decode();
-        let rule_roots = decode_u64_array(ctor.get_obj(6).as_array());
-        let type_root = ctor.get_num_64(0);
+          LeanIxonExprMetaArena::new(self.get_obj(5).to_owned_ref()).decode();
+        let rule_roots = decode_u64_array(self.get_obj(6).as_array());
+        let type_root = self.get_num_64(0);
         ConstantMeta::Rec {
           name,
           lvls,
@@ -588,10 +567,10 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
 impl LeanIxonNamed<LeanOwned> {
   /// Build Ixon.Named { addr : Address, constMeta : ConstantMeta }
   pub fn build(addr: &Address, meta: &ConstantMeta) -> Self {
-    let ctor = LeanIxonNamed::alloc();
+    let ctor = LeanIxonNamed::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(addr));
     ctor.set_obj(1, LeanIxonConstantMeta::build(meta));
-    Self::new(ctor.into())
+    ctor
   }
 }
 
@@ -609,10 +588,10 @@ impl<R: LeanRef> LeanIxonNamed<R> {
 impl LeanIxonComm<LeanOwned> {
   /// Build Ixon.Comm { secret : Address, payload : Address }
   pub fn build(comm: &Comm) -> Self {
-    let ctor = LeanIxonComm::alloc();
+    let ctor = LeanIxonComm::alloc(0);
     ctor.set_obj(0, LeanIxAddress::build(&comm.secret));
     ctor.set_obj(1, LeanIxAddress::build(&comm.payload));
-    Self::new(ctor.into())
+    ctor
   }
 }
 

--- a/src/ffi/ixon/univ.rs
+++ b/src/ffi/ixon/univ.rs
@@ -3,41 +3,37 @@
 use std::sync::Arc;
 
 use crate::ix::ixon::univ::Univ;
-use crate::lean::{
-  LeanIxonUniv, LeanIxonUnivIMax, LeanIxonUnivMax, LeanIxonUnivSucc,
-  LeanIxonUnivVar,
-};
+use crate::lean::LeanIxonUniv;
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanRef};
 
 impl LeanIxonUniv<LeanOwned> {
   /// Build Ixon.Univ
   pub fn build(univ: &Univ) -> Self {
-    let obj = match univ {
-      Univ::Zero => LeanOwned::box_usize(0),
+    match univ {
+      Univ::Zero => Self::new(LeanOwned::box_usize(0)),
       Univ::Succ(inner) => {
-        let ctor = LeanIxonUnivSucc::alloc();
+        let ctor = LeanIxonUniv::alloc(1);
         ctor.set_obj(0, Self::build(inner));
-        ctor.into()
+        ctor
       },
       Univ::Max(a, b) => {
-        let ctor = LeanIxonUnivMax::alloc();
+        let ctor = LeanIxonUniv::alloc(2);
         ctor.set_obj(0, Self::build(a));
         ctor.set_obj(1, Self::build(b));
-        ctor.into()
+        ctor
       },
       Univ::IMax(a, b) => {
-        let ctor = LeanIxonUnivIMax::alloc();
+        let ctor = LeanIxonUniv::alloc(3);
         ctor.set_obj(0, Self::build(a));
         ctor.set_obj(1, Self::build(b));
-        ctor.into()
+        ctor
       },
       Univ::Var(idx) => {
-        let ctor = LeanIxonUnivVar::alloc();
+        let ctor = LeanIxonUniv::alloc(4);
         ctor.set_num_64(0, *idx);
-        ctor.0
+        ctor
       },
-    };
-    Self::new(obj)
+    }
   }
 
   /// Build an Array of Ixon.Univ.
@@ -68,10 +64,7 @@ impl<R: LeanRef> LeanIxonUniv<R> {
         Arc::new(LeanIxonUniv(ctor.get(0)).decode()),
         Arc::new(LeanIxonUniv(ctor.get(1)).decode()),
       ),
-      4 => {
-        let ctor = LeanIxonUnivVar::from_ctor(ctor);
-        Univ::Var(ctor.get_num_64(0))
-      },
+      4 => Univ::Var(self.get_num_64(0)),
       tag => panic!("Invalid Ixon.Univ tag: {tag}"),
     }
   }

--- a/src/ffi/ixon/univ.rs
+++ b/src/ffi/ixon/univ.rs
@@ -3,12 +3,11 @@
 use std::sync::Arc;
 
 use crate::ix::ixon::univ::Univ;
-use crate::lean::LeanIxonUniv;
-use lean_ffi::object::{
-  LeanArray, LeanBorrowed, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
+use crate::lean::{
+  LeanIxonUniv, LeanIxonUnivIMax, LeanIxonUnivMax, LeanIxonUnivSucc,
+  LeanIxonUnivVar,
 };
-
-use crate::lean::LeanIxonUnivVar;
+use lean_ffi::object::{LeanArray, LeanBorrowed, LeanOwned, LeanRef};
 
 impl LeanIxonUniv<LeanOwned> {
   /// Build Ixon.Univ
@@ -16,26 +15,26 @@ impl LeanIxonUniv<LeanOwned> {
     let obj = match univ {
       Univ::Zero => LeanOwned::box_usize(0),
       Univ::Succ(inner) => {
-        let ctor = LeanCtor::alloc(1, 1, 0);
-        ctor.set(0, Self::build(inner));
+        let ctor = LeanIxonUnivSucc::alloc();
+        ctor.set_obj(0, Self::build(inner));
         ctor.into()
       },
       Univ::Max(a, b) => {
-        let ctor = LeanCtor::alloc(2, 2, 0);
-        ctor.set(0, Self::build(a));
-        ctor.set(1, Self::build(b));
+        let ctor = LeanIxonUnivMax::alloc();
+        ctor.set_obj(0, Self::build(a));
+        ctor.set_obj(1, Self::build(b));
         ctor.into()
       },
       Univ::IMax(a, b) => {
-        let ctor = LeanCtor::alloc(3, 2, 0);
-        ctor.set(0, Self::build(a));
-        ctor.set(1, Self::build(b));
+        let ctor = LeanIxonUnivIMax::alloc();
+        ctor.set_obj(0, Self::build(a));
+        ctor.set_obj(1, Self::build(b));
         ctor.into()
       },
       Univ::Var(idx) => {
         let ctor = LeanIxonUnivVar::alloc();
         ctor.set_num_64(0, *idx);
-        ctor.into()
+        ctor.0
       },
     };
     Self::new(obj)

--- a/src/ffi/ixon/univ.rs
+++ b/src/ffi/ixon/univ.rs
@@ -6,6 +6,8 @@ use crate::ix::ixon::univ::Univ;
 use crate::lean::LeanIxonUniv;
 use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
 
+use lean_ffi::object::scalar_base;
+
 impl LeanIxonUniv<LeanOwned> {
   /// Build Ixon.Univ
   pub fn build(univ: &Univ) -> Self {
@@ -30,7 +32,7 @@ impl LeanIxonUniv<LeanOwned> {
       },
       Univ::Var(idx) => {
         let ctor = LeanCtor::alloc(4, 0, 8);
-        ctor.set_u64(ctor.scalar_base(0), *idx);
+        ctor.set_u64(scalar_base(&ctor, 0), *idx);
         ctor.into()
       },
     };
@@ -65,7 +67,7 @@ impl<R: LeanRef> LeanIxonUniv<R> {
         Arc::new(LeanIxonUniv(ctor.get(0)).decode()),
         Arc::new(LeanIxonUniv(ctor.get(1)).decode()),
       ),
-      4 => Univ::Var(ctor.get_u64(ctor.scalar_base(0))),
+      4 => Univ::Var(ctor.get_u64(scalar_base(&ctor, 0))),
       tag => panic!("Invalid Ixon.Univ tag: {tag}"),
     }
   }

--- a/src/ffi/ixon/univ.rs
+++ b/src/ffi/ixon/univ.rs
@@ -4,9 +4,11 @@ use std::sync::Arc;
 
 use crate::ix::ixon::univ::Univ;
 use crate::lean::LeanIxonUniv;
-use lean_ffi::object::{LeanArray, LeanBorrowed, LeanCtor, LeanOwned, LeanRef};
+use lean_ffi::object::{
+  LeanArray, LeanBorrowed, LeanCtor, LeanCtorScalar, LeanOwned, LeanRef,
+};
 
-use lean_ffi::object::scalar_base;
+use crate::lean::LeanIxonUnivVar;
 
 impl LeanIxonUniv<LeanOwned> {
   /// Build Ixon.Univ
@@ -31,8 +33,8 @@ impl LeanIxonUniv<LeanOwned> {
         ctor.into()
       },
       Univ::Var(idx) => {
-        let ctor = LeanCtor::alloc(4, 0, 8);
-        ctor.set_u64(scalar_base(&ctor, 0), *idx);
+        let ctor = LeanIxonUnivVar::alloc();
+        ctor.set_num_64(0, *idx);
         ctor.into()
       },
     };
@@ -67,7 +69,10 @@ impl<R: LeanRef> LeanIxonUniv<R> {
         Arc::new(LeanIxonUniv(ctor.get(0)).decode()),
         Arc::new(LeanIxonUniv(ctor.get(1)).decode()),
       ),
-      4 => Univ::Var(ctor.get_u64(scalar_base(&ctor, 0))),
+      4 => {
+        let ctor = LeanIxonUnivVar::from_ctor(ctor);
+        Univ::Var(ctor.get_num_64(0))
+      },
       tag => panic!("Invalid Ixon.Univ tag: {tag}"),
     }
   }

--- a/src/ffi/ixon/univ.rs
+++ b/src/ffi/ixon/univ.rs
@@ -30,7 +30,7 @@ impl LeanIxonUniv<LeanOwned> {
       },
       Univ::Var(idx) => {
         let ctor = LeanCtor::alloc(4, 0, 8);
-        ctor.set_u64(0, 0, *idx);
+        ctor.set_u64(ctor.scalar_base(0), *idx);
         ctor.into()
       },
     };
@@ -65,7 +65,7 @@ impl<R: LeanRef> LeanIxonUniv<R> {
         Arc::new(LeanIxonUniv(ctor.get(0)).decode()),
         Arc::new(LeanIxonUniv(ctor.get(1)).decode()),
       ),
-      4 => Univ::Var(ctor.get_u64(0, 0)),
+      4 => Univ::Var(ctor.get_u64(ctor.scalar_base(0))),
       tag => panic!("Invalid Ixon.Univ tag: {tag}"),
     }
   }

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -27,7 +27,8 @@ use std::sync::Arc;
 use lean_ffi::nat::Nat;
 use lean_ffi::object::{LeanBorrowed, LeanList, LeanRef, LeanShared};
 
-use lean_ffi::object::scalar_base;
+use crate::lean::{LeanIxInductiveVal, LeanIxRecursorVal};
+use lean_ffi::object::LeanCtorScalar;
 
 use crate::ix::env::{
   AxiomVal, BinderInfo, ConstantInfo, ConstantVal, ConstructorVal, DataValue,
@@ -524,10 +525,10 @@ pub fn decode_constant_info(
         .map(|o| decode_name(o, cache.global))
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
-      let s = scalar_base(&inner, 0);
-      let is_rec = inner.get_bool(s);
-      let is_unsafe = inner.get_bool(s + 1);
-      let is_reflexive = inner.get_bool(s + 2);
+      let induct_wrapper = LeanIxInductiveVal::from_ctor(inner);
+      let is_rec = induct_wrapper.get_num_8(0) != 0;
+      let is_unsafe = induct_wrapper.get_num_8(1) != 0;
+      let is_reflexive = induct_wrapper.get_num_8(2) != 0;
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -581,9 +582,9 @@ pub fn decode_constant_info(
         .into_iter()
         .map(|o| decode_recursor_rule(o, cache))
         .collect();
-      let s = scalar_base(&inner, 0);
-      let k = inner.get_bool(s);
-      let is_unsafe = inner.get_bool(s + 1);
+      let rec_wrapper = LeanIxRecursorVal::from_ctor(inner);
+      let k = rec_wrapper.get_num_8(0) != 0;
+      let is_unsafe = rec_wrapper.get_num_8(1) != 0;
       ConstantInfo::RecInfo(RecursorVal {
         cnst: constant_val,
         all,

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use lean_ffi::nat::Nat;
 use lean_ffi::object::{LeanBorrowed, LeanList, LeanRef, LeanShared};
 
+use lean_ffi::object::scalar_base;
+
 use crate::ix::env::{
   AxiomVal, BinderInfo, ConstantInfo, ConstantVal, ConstructorVal, DataValue,
   DefinitionSafety, DefinitionVal, Env, Expr, InductiveVal, Int, Level,
@@ -522,8 +524,10 @@ pub fn decode_constant_info(
         .map(|o| decode_name(o, cache.global))
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
-      let [is_rec, is_unsafe, is_reflexive] =
-        inner.get_scalars::<3, bool>(inner.scalar_base(0));
+      let s = scalar_base(&inner, 0);
+      let is_rec = inner.get_bool(s);
+      let is_unsafe = inner.get_bool(s + 1);
+      let is_reflexive = inner.get_bool(s + 2);
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -577,7 +581,9 @@ pub fn decode_constant_info(
         .into_iter()
         .map(|o| decode_recursor_rule(o, cache))
         .collect();
-      let [k, is_unsafe] = inner.get_scalars::<2, bool>(inner.scalar_base(0));
+      let s = scalar_base(&inner, 0);
+      let k = inner.get_bool(s);
+      let is_unsafe = inner.get_bool(s + 1);
       ConstantInfo::RecInfo(RecursorVal {
         cnst: constant_val,
         all,

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -428,8 +428,8 @@ pub fn decode_constant_info(
   cache: &mut Cache<'_>,
 ) -> ConstantInfo {
   let ctor = obj.as_ctor();
-  let [inner_val] = ctor.objs::<1>();
-  let inner = inner_val.as_ctor();
+  let [inner_obj] = ctor.objs::<1>();
+  let inner = inner_obj.as_ctor();
 
   match ctor.tag() {
     0 => {
@@ -510,9 +510,8 @@ pub fn decode_constant_info(
       ConstantInfo::QuotInfo(QuotVal { cnst: constant_val, kind })
     },
     5 => {
-      let inner_ctor = inner;
       let [constant_val, num_params, num_indices, all, ctors, num_nested] =
-        inner_ctor.objs::<6>();
+        inner.objs::<6>();
       let constant_val = decode_constant_val(constant_val, cache);
       let num_params = Nat::from_obj(&num_params);
       let num_indices = Nat::from_obj(&num_indices);
@@ -525,10 +524,10 @@ pub fn decode_constant_info(
         .map(|o| decode_name(o, cache.global))
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
-      let inner = LeanIxInductiveVal::from_ctor(inner_ctor);
-      let is_rec = inner.get_num_8(0) != 0;
-      let is_unsafe = inner.get_num_8(1) != 0;
-      let is_reflexive = inner.get_num_8(2) != 0;
+      let inner_val = LeanIxInductiveVal(inner_obj);
+      let is_rec = inner_val.get_num_8(0) != 0;
+      let is_unsafe = inner_val.get_num_8(1) != 0;
+      let is_reflexive = inner_val.get_num_8(2) != 0;
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -560,7 +559,6 @@ pub fn decode_constant_info(
       })
     },
     7 => {
-      let inner_ctor = inner;
       let [
         constant_val,
         all,
@@ -569,7 +567,7 @@ pub fn decode_constant_info(
         num_motives,
         num_minors,
         rules,
-      ] = inner_ctor.objs::<7>();
+      ] = inner.objs::<7>();
       let constant_val = decode_constant_val(constant_val, cache);
       let all: Vec<_> = collect_list_borrowed(all.as_list())
         .into_iter()
@@ -583,9 +581,9 @@ pub fn decode_constant_info(
         .into_iter()
         .map(|o| decode_recursor_rule(o, cache))
         .collect();
-      let inner = LeanIxRecursorVal::from_ctor(inner_ctor);
-      let k = inner.get_num_8(0) != 0;
-      let is_unsafe = inner.get_num_8(1) != 0;
+      let inner_val = LeanIxRecursorVal(inner_obj);
+      let k = inner_val.get_num_8(0) != 0;
+      let is_unsafe = inner_val.get_num_8(1) != 0;
       ConstantInfo::RecInfo(RecursorVal {
         cnst: constant_val,
         all,

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -522,7 +522,8 @@ pub fn decode_constant_info(
         .map(|o| decode_name(o, cache.global))
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
-      let [is_rec, is_unsafe, is_reflexive] = inner.get_bools::<3>(inner.scalar_base(0));
+      let [is_rec, is_unsafe, is_reflexive] =
+        inner.get_bools::<3>(inner.scalar_base(0));
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -554,8 +555,15 @@ pub fn decode_constant_info(
       })
     },
     7 => {
-      let [constant_val, all, num_params, num_indices, num_motives, num_minors, rules] =
-        inner.objs::<7>();
+      let [
+        constant_val,
+        all,
+        num_params,
+        num_indices,
+        num_motives,
+        num_minors,
+        rules,
+      ] = inner.objs::<7>();
       let constant_val = decode_constant_val(constant_val, cache);
       let all: Vec<_> = collect_list_borrowed(all.as_list())
         .into_iter()

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -523,7 +523,7 @@ pub fn decode_constant_info(
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
       let [is_rec, is_unsafe, is_reflexive] =
-        inner.get_bools::<3>(inner.scalar_base(0));
+        inner.get_scalars::<3, bool>(inner.scalar_base(0));
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -577,7 +577,7 @@ pub fn decode_constant_info(
         .into_iter()
         .map(|o| decode_recursor_rule(o, cache))
         .collect();
-      let [k, is_unsafe] = inner.get_bools::<2>(inner.scalar_base(0));
+      let [k, is_unsafe] = inner.get_scalars::<2, bool>(inner.scalar_base(0));
       ConstantInfo::RecInfo(RecursorVal {
         cnst: constant_val,
         all,

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -28,7 +28,6 @@ use lean_ffi::nat::Nat;
 use lean_ffi::object::{LeanBorrowed, LeanList, LeanRef, LeanShared};
 
 use crate::lean::{LeanIxInductiveVal, LeanIxRecursorVal};
-use lean_ffi::object::LeanCtorScalar;
 
 use crate::ix::env::{
   AxiomVal, BinderInfo, ConstantInfo, ConstantVal, ConstructorVal, DataValue,
@@ -511,8 +510,9 @@ pub fn decode_constant_info(
       ConstantInfo::QuotInfo(QuotVal { cnst: constant_val, kind })
     },
     5 => {
+      let inner_ctor = inner;
       let [constant_val, num_params, num_indices, all, ctors, num_nested] =
-        inner.objs::<6>();
+        inner_ctor.objs::<6>();
       let constant_val = decode_constant_val(constant_val, cache);
       let num_params = Nat::from_obj(&num_params);
       let num_indices = Nat::from_obj(&num_indices);
@@ -525,10 +525,10 @@ pub fn decode_constant_info(
         .map(|o| decode_name(o, cache.global))
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
-      let induct_wrapper = LeanIxInductiveVal::from_ctor(inner);
-      let is_rec = induct_wrapper.get_num_8(0) != 0;
-      let is_unsafe = induct_wrapper.get_num_8(1) != 0;
-      let is_reflexive = induct_wrapper.get_num_8(2) != 0;
+      let inner = LeanIxInductiveVal::from_ctor(inner_ctor);
+      let is_rec = inner.get_num_8(0) != 0;
+      let is_unsafe = inner.get_num_8(1) != 0;
+      let is_reflexive = inner.get_num_8(2) != 0;
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -560,6 +560,7 @@ pub fn decode_constant_info(
       })
     },
     7 => {
+      let inner_ctor = inner;
       let [
         constant_val,
         all,
@@ -568,7 +569,7 @@ pub fn decode_constant_info(
         num_motives,
         num_minors,
         rules,
-      ] = inner.objs::<7>();
+      ] = inner_ctor.objs::<7>();
       let constant_val = decode_constant_val(constant_val, cache);
       let all: Vec<_> = collect_list_borrowed(all.as_list())
         .into_iter()
@@ -582,9 +583,9 @@ pub fn decode_constant_info(
         .into_iter()
         .map(|o| decode_recursor_rule(o, cache))
         .collect();
-      let rec_wrapper = LeanIxRecursorVal::from_ctor(inner);
-      let k = rec_wrapper.get_num_8(0) != 0;
-      let is_unsafe = rec_wrapper.get_num_8(1) != 0;
+      let inner = LeanIxRecursorVal::from_ctor(inner_ctor);
+      let k = inner.get_num_8(0) != 0;
+      let is_unsafe = inner.get_num_8(1) != 0;
       ConstantInfo::RecInfo(RecursorVal {
         cnst: constant_val,
         all,

--- a/src/ffi/lean_env.rs
+++ b/src/ffi/lean_env.rs
@@ -508,15 +508,8 @@ pub fn decode_constant_info(
       ConstantInfo::QuotInfo(QuotVal { cnst: constant_val, kind })
     },
     5 => {
-      let [
-        constant_val,
-        num_params,
-        num_indices,
-        all,
-        ctors,
-        num_nested,
-        bools,
-      ] = inner.objs();
+      let [constant_val, num_params, num_indices, all, ctors, num_nested] =
+        inner.objs::<6>();
       let constant_val = decode_constant_val(constant_val, cache);
       let num_params = Nat::from_obj(&num_params);
       let num_indices = Nat::from_obj(&num_indices);
@@ -529,8 +522,7 @@ pub fn decode_constant_info(
         .map(|o| decode_name(o, cache.global))
         .collect();
       let num_nested = Nat::from_obj(&num_nested);
-      let [is_rec, is_unsafe, is_reflexive, ..] =
-        (bools.as_raw() as usize).to_le_bytes().map(|b| b == 1);
+      let [is_rec, is_unsafe, is_reflexive] = inner.get_bools::<3>(inner.scalar_base(0));
       ConstantInfo::InductInfo(InductiveVal {
         cnst: constant_val,
         num_params,
@@ -562,16 +554,8 @@ pub fn decode_constant_info(
       })
     },
     7 => {
-      let [
-        constant_val,
-        all,
-        num_params,
-        num_indices,
-        num_motives,
-        num_minors,
-        rules,
-        bools,
-      ] = inner.objs();
+      let [constant_val, all, num_params, num_indices, num_motives, num_minors, rules] =
+        inner.objs::<7>();
       let constant_val = decode_constant_val(constant_val, cache);
       let all: Vec<_> = collect_list_borrowed(all.as_list())
         .into_iter()
@@ -585,8 +569,7 @@ pub fn decode_constant_info(
         .into_iter()
         .map(|o| decode_recursor_rule(o, cache))
         .collect();
-      let [k, is_unsafe, ..] =
-        (bools.as_raw() as usize).to_le_bytes().map(|b| b == 1);
+      let [k, is_unsafe] = inner.get_bools::<2>(inner.scalar_base(0));
       ConstantInfo::RecInfo(RecursorVal {
         cnst: constant_val,
         all,

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -1,329 +1,426 @@
 //! Ix-specific Lean domain type definitions.
 //!
-//! Generic Lean FFI wrappers live in the `lean_ffi` crate. This module defines
-//! typed newtypes for ix-specific Lean types using `lean_ffi::lean_domain_type!`.
+//! Ctor-backed types use `lean_inductive!` which declares the domain type,
+//! variant wrappers, layout metadata, and typed accessors in one shot.
+//! Types without a ctor layout (simple enums, opaque objects, arenas) use
+//! bare `lean_domain_type!`.
 
 use lean_ffi::object::{LeanBorrowed, LeanByteArray, LeanOwned, LeanRef};
 
+// =============================================================================
+// Types without ctor layouts (simple enums, opaque objects, arenas)
+// =============================================================================
+
 lean_ffi::lean_domain_type! {
-  // Ix core types
-  /// Lean `Ix.Name` object.
-  LeanIxName;
-  /// Lean `Ix.Level` object.
-  LeanIxLevel;
-  /// Lean `Ix.Expr` object.
-  LeanIxExpr;
-  /// Lean `Ix.ConstantInfo` object.
-  LeanIxConstantInfo;
-  /// Lean `Ix.ConstantVal` object.
-  LeanIxConstantVal;
-  /// Lean `Ix.ReducibilityHints` object.
-  LeanIxReducibilityHints;
-  /// Lean `Ix.Literal` object.
-  LeanIxLiteral;
-  /// Lean `Ix.BinderInfo` object.
+  // Simple enums (passed as raw unboxed tag values)
   LeanIxBinderInfo;
-  /// Lean `Ix.RecursorRule` object.
-  LeanIxRecursorRule;
-  /// Lean `Ix.RawEnvironment` object.
-  LeanIxRawEnvironment;
-  /// Lean `Ix.Environment` object.
-  LeanIxEnvironment;
-  /// Lean `Ix.RustCondensedBlocks` object.
-  LeanIxCondensedBlocks;
-  /// Lean `Ix.CompileM.RustCompilePhases` object.
-  LeanIxCompilePhases;
-
-  // Ix data types
-  /// Lean `Ix.Int` object.
-  LeanIxInt;
-  /// Lean `Ix.Substring` object.
-  LeanIxSubstring;
-  /// Lean `Ix.SourceInfo` object.
-  LeanIxSourceInfo;
-  /// Lean `Ix.SyntaxPreresolved` object.
-  LeanIxSyntaxPreresolved;
-  /// Lean `Ix.Syntax` object.
-  LeanIxSyntax;
-  /// Lean `Ix.DataValue` object.
-  LeanIxDataValue;
-
-  // Ixon types
-  /// Lean `Ixon.DefKind` object.
   LeanIxonDefKind;
-  /// Lean `Ixon.DefinitionSafety` object.
   LeanIxonDefinitionSafety;
-  /// Lean `Ixon.QuotKind` object.
   LeanIxonQuotKind;
-  /// Lean `Ixon.Univ` object.
-  LeanIxonUniv;
-  /// Lean `Ixon.Expr` object.
-  LeanIxonExpr;
-  /// Lean `Ixon.Definition` object.
-  LeanIxonDefinition;
-  /// Lean `Ixon.RecursorRule` object.
-  LeanIxonRecursorRule;
-  /// Lean `Ixon.Recursor` object.
-  LeanIxonRecursor;
-  /// Lean `Ixon.Axiom` object.
-  LeanIxonAxiom;
-  /// Lean `Ixon.Quotient` object.
-  LeanIxonQuotient;
-  /// Lean `Ixon.Constructor` object.
-  LeanIxonConstructor;
-  /// Lean `Ixon.Inductive` object.
-  LeanIxonInductive;
-  /// Lean `Ixon.InductiveProj` object.
-  LeanIxonInductiveProj;
-  /// Lean `Ixon.ConstructorProj` object.
-  LeanIxonConstructorProj;
-  /// Lean `Ixon.RecursorProj` object.
-  LeanIxonRecursorProj;
-  /// Lean `Ixon.DefinitionProj` object.
-  LeanIxonDefinitionProj;
-  /// Lean `Ixon.MutConst` object.
-  LeanIxonMutConst;
-  /// Lean `Ixon.ConstantInfo` object.
-  LeanIxonConstantInfo;
-  /// Lean `Ixon.Constant` object.
-  LeanIxonConstant;
-  /// Lean `Ixon.DataValue` object.
-  LeanIxonDataValue;
-  /// Lean `Ixon.ExprMetaData` object.
-  LeanIxonExprMetaData;
-  /// Lean `Ixon.ExprMetaArena` object.
+
+  // Opaque / arena types
+  LeanIxRawEnvironment;
+  LeanIxEnvironment;
   LeanIxonExprMetaArena;
-  /// Lean `Ixon.ConstantMeta` object.
-  LeanIxonConstantMeta;
-  /// Lean `Ixon.Named` object.
-  LeanIxonNamed;
-  /// Lean `Ixon.Comm` object.
-  LeanIxonComm;
-  /// Lean `Ixon.RawEnv` object.
-  LeanIxonRawEnv;
-  /// Lean `Ixon.RawConst` object.
-  LeanIxonRawConst;
-  /// Lean `Ixon.RawNamed` object.
-  LeanIxonRawNamed;
-  /// Lean `Ixon.RawBlob` object.
-  LeanIxonRawBlob;
-  /// Lean `Ixon.RawComm` object.
-  LeanIxonRawComm;
-  /// Lean `Ixon.RawNameEntry` object.
-  LeanIxonRawNameEntry;
 
-  // Aiur types
-  /// Lean `Aiur.Bytecode.Toplevel` object.
-  LeanAiurToplevel;
-  /// Lean `Aiur.CommitmentParameters` object.
+  // Aiur parameter types (no scalar fields, used opaquely)
   LeanAiurCommitmentParameters;
-  /// Lean `Aiur.FriParameters` object.
   LeanAiurFriParameters;
-
-  // Lean kernel inner structures and variants
-  /// Lean `Ix.AxiomVal` object.
-  LeanIxAxiomVal;
-  /// Lean `Ix.DefinitionVal` object.
-  LeanIxDefinitionVal;
-  /// Lean `Ix.OpaqueVal` object.
-  LeanIxOpaqueVal;
-  /// Lean `Ix.QuotVal` object.
-  LeanIxQuotVal;
-  /// Lean `Ix.InductiveVal` object.
-  LeanIxInductiveVal;
-  /// Lean `Ix.ConstructorVal` object.
-  LeanIxConstructorVal;
-  /// Lean `Ix.RecursorVal` object.
-  LeanIxRecursorVal;
-  /// Lean `Ix.ReducibilityHints.Regular` object.
-  LeanIxReducibilityHintsRegular;
-
-  // Aiur inner types
-  /// Lean `Aiur.Bytecode.Function` object.
-  LeanAiurFunction;
-
-  // Ixon multi-scalar variant types
-  /// Lean `Ixon.ExprMetaData.App` (tag 1) object.
-  LeanIxonExprMetaApp;
-  /// Lean `Ixon.ExprMetaData.Binder` (tag 2) object.
-  LeanIxonExprMetaBinder;
-  /// Lean `Ixon.ExprMetaData.LetBinder` (tag 3) object.
-  LeanIxonExprMetaLetBinder;
-  /// Lean `Ixon.ConstantMeta.Def` (tag 1) object.
-  LeanIxonConstantMetaDef;
-  /// Lean `Ixon.Expr.Prj` (tag 4) object.
-  LeanIxonExprPrj;
-
-  // Ixon/Ix inductive variant types
-  /// Lean `Ixon.ConstantMeta.Axio` (tag 2) object.
-  LeanIxonConstantMetaAxio;
-  /// Lean `Ixon.ConstantMeta.Quot` (tag 3) object.
-  LeanIxonConstantMetaQuot;
-  /// Lean `Ixon.ConstantMeta.Indc` (tag 4) object.
-  LeanIxonConstantMetaIndc;
-  /// Lean `Ixon.ConstantMeta.Ctor` (tag 5) object.
-  LeanIxonConstantMetaCtor;
-  /// Lean `Ixon.ConstantMeta.Rec` (tag 6) object.
-  LeanIxonConstantMetaRec;
-  /// Lean `Ixon.ExprMetaData.Prj` (tag 5) object.
-  LeanIxonExprMetaPrj;
-  /// Lean `Ixon.ExprMetaData.Mdata` (tag 6) object.
-  LeanIxonExprMetaMdata;
-  /// Lean `Ixon.DataValue.OfBool` (tag 1) object.
-  LeanIxonDataValueBool;
-  /// Lean `Ixon.Expr.Sort` (tag 0) object.
-  LeanIxonExprSort;
-  /// Lean `Ixon.Expr.Var` (tag 1) object.
-  LeanIxonExprVar;
-  /// Lean `Ixon.Expr.Ref` (tag 2) object.
-  LeanIxonExprRef;
-  /// Lean `Ixon.Expr.Rec` (tag 3) object.
-  LeanIxonExprRec;
-  /// Lean `Ixon.Expr.Str` (tag 5) object.
-  LeanIxonExprStr;
-  /// Lean `Ixon.Expr.Nat` (tag 6) object.
-  LeanIxonExprNat;
-  /// Lean `Ixon.Expr.Let` (tag 10) object.
-  LeanIxonExprLet;
-  /// Lean `Ixon.Expr.Share` (tag 11) object.
-  LeanIxonExprShare;
-  /// Lean `Ixon.Univ.Var` (tag 4) object.
-  LeanIxonUnivVar;
-  /// Lean `Ix.Expr.Lam` (tag 6) object.
-  LeanIxExprLam;
-  /// Lean `Ix.Expr.ForallE` (tag 7) object.
-  LeanIxExprForallE;
-  /// Lean `Ix.Expr.LetE` (tag 8) object.
-  LeanIxExprLetE;
-  /// Lean `Ix.SourceInfo.Synthetic` (tag 1) object.
-  LeanIxSourceInfoSynthetic;
-  /// Lean `Ix.DataValue.OfBool` (tag 1) object.
-  LeanIxDataValueBool;
-
-  // Block types
-  /// Lean `BlockCompareResult.Mismatch` (tag 1) object.
-  LeanIxBlockCompareResultMismatch;
-  /// Lean `Ix.Block` object.
-  LeanIxBlock;
-
-  // SerializeError variant types
-  /// Lean `Ixon.SerializeError.InvalidTag` (tag 1) object.
-  LeanIxSerializeErrorInvalidTag;
-  /// Lean `Ixon.SerializeError.InvalidFlag` (tag 2) object.
-  LeanIxSerializeErrorInvalidFlag;
-  /// Lean `Ixon.SerializeError.InvalidVariant` (tag 3) object.
-  LeanIxSerializeErrorInvalidVariant;
-  /// Lean `Ixon.SerializeError.InvalidBool` (tag 4) object.
-  LeanIxSerializeErrorInvalidBool;
-  /// Lean `Ixon.SerializeError.InvalidShareIndex` (tag 6) object.
-  LeanIxSerializeErrorInvalidShareIndex;
-
-  // DecompileError variant types (tags 0-4 share layout: 2 obj + 1 u64)
-  /// Lean `Ix.DecompileError.InvalidRefIndex` (tag 0) object.
-  LeanIxDecompileErrorRefIndex;
-  /// Lean `Ix.DecompileError.InvalidUnivIndex` (tag 1) object.
-  LeanIxDecompileErrorUnivIndex;
-  /// Lean `Ix.DecompileError.InvalidShareIndex` (tag 2) object.
-  LeanIxDecompileErrorShareIndex;
-  /// Lean `Ix.DecompileError.InvalidRecIndex` (tag 3) object.
-  LeanIxDecompileErrorRecIndex;
-  /// Lean `Ix.DecompileError.InvalidUnivVarIndex` (tag 4) object.
-  LeanIxDecompileErrorUnivVarIndex;
-
-  // Error types
-  /// Lean `Ixon.SerializeError` object.
-  LeanIxSerializeError;
-  /// Lean `Ix.DecompileM.DecompileError` object.
-  LeanIxDecompileError;
-  /// Lean `Ix.CompileM.CompileError` object.
-  LeanIxCompileError;
-  /// Lean `BlockCompareResult` object.
-  LeanIxBlockCompareResult;
-  /// Lean `BlockCompareDetail` object.
-  LeanIxBlockCompareDetail;
 }
 
 // =============================================================================
-// LeanCtorScalar impls — structures, inner vals, and inductive variants
+// Ixon structures (single-constructor, tag 0)
 // =============================================================================
 
-// Ixon structures (ixon/constant.rs)
-lean_ffi::impl_ctor_scalar!(LeanIxonDefinition     { NUM_OBJ = 2, NUM_64 = 1, NUM_8 = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxonRecursorRule   { NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonRecursor       { NUM_OBJ = 2, NUM_64 = 5, NUM_8 = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxonAxiom          { NUM_OBJ = 1, NUM_64 = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonQuotient       { NUM_OBJ = 1, NUM_64 = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstructor    { NUM_OBJ = 1, NUM_64 = 4, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonInductive      { NUM_OBJ = 2, NUM_64 = 4, NUM_8 = 3 });
-lean_ffi::impl_ctor_scalar!(LeanIxonInductiveProj  { NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstructorProj { NUM_OBJ = 1, NUM_64 = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxonRecursorProj   { NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonDefinitionProj { NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::lean_inductive! {
+  LeanIxonDefinition { num_obj: 2, num_64: 1, num_8: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRecursorRule { num_obj: 1, num_64: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRecursor { num_obj: 2, num_64: 5, num_8: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonAxiom { num_obj: 1, num_64: 1, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonQuotient { num_obj: 1, num_64: 1, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonConstructor { num_obj: 1, num_64: 4, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonInductive { num_obj: 2, num_64: 4, num_8: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonInductiveProj { num_obj: 1, num_64: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonConstructorProj { num_obj: 1, num_64: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRecursorProj { num_obj: 1, num_64: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonDefinitionProj { num_obj: 1, num_64: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonNamed { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonComm { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonConstant { num_obj: 4 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRawConst { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRawNamed { num_obj: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRawBlob { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRawComm { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRawNameEntry { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxonRawEnv { num_obj: 5 }
+}
 
-// Structures (ixon/compare.rs + compile.rs)
-lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareDetail { NUM_OBJ = 1, NUM_64 = 2 });
+// =============================================================================
+// Ixon multi-variant inductives
+// =============================================================================
 
-// Lean kernel inner val structures (ix/constant.rs + lean_env.rs)
-lean_ffi::impl_ctor_scalar!(LeanIxAxiomVal          { NUM_OBJ = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxDefinitionVal     { NUM_OBJ = 4, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxOpaqueVal         { NUM_OBJ = 3, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxQuotVal           { NUM_OBJ = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxInductiveVal      { NUM_OBJ = 6, NUM_8 = 3 });
-lean_ffi::impl_ctor_scalar!(LeanIxConstructorVal    { NUM_OBJ = 5, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxRecursorVal       { NUM_OBJ = 7, NUM_8 = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxReducibilityHintsRegular { TAG = 2, NUM_32 = 1 });
+lean_ffi::lean_inductive! {
+  LeanIxonUniv {
+    LeanIxonUnivVar  { tag: 4, num_64: 1 },
+    LeanIxonUnivSucc { tag: 1, num_obj: 1 },
+    LeanIxonUnivMax  { tag: 2, num_obj: 2 },
+    LeanIxonUnivIMax { tag: 3, num_obj: 2 },
+  }
+}
 
-// Aiur structures
-lean_ffi::impl_ctor_scalar!(LeanAiurFunction        { NUM_OBJ = 2, NUM_8 = 2 });
+lean_ffi::lean_inductive! {
+  LeanIxonExpr {
+    LeanIxonExprSort  { num_64: 1 },
+    LeanIxonExprVar   { tag: 1, num_64: 1 },
+    LeanIxonExprRef   { tag: 2, num_obj: 1, num_64: 1 },
+    LeanIxonExprRec   { tag: 3, num_obj: 1, num_64: 1 },
+    LeanIxonExprPrj   { tag: 4, num_obj: 1, num_64: 2 },
+    LeanIxonExprStr   { tag: 5, num_64: 1 },
+    LeanIxonExprNat   { tag: 6, num_64: 1 },
+    LeanIxonExprApp   { tag: 7, num_obj: 2 },
+    LeanIxonExprLam   { tag: 8, num_obj: 2 },
+    LeanIxonExprAll   { tag: 9, num_obj: 2 },
+    LeanIxonExprLet   { tag: 10, num_obj: 3, num_8: 1 },
+    LeanIxonExprShare { tag: 11, num_64: 1 },
+  }
+}
 
-// Ixon inductive variants (multi-scalar)
-lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaApp        { TAG = 1, NUM_64 = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaBinder     { TAG = 2, NUM_OBJ = 1, NUM_64 = 2, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaLetBinder  { TAG = 3, NUM_OBJ = 1, NUM_64 = 3 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaDef    { TAG = 1, NUM_OBJ = 6, NUM_64 = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprPrj            { TAG = 4, NUM_OBJ = 1, NUM_64 = 2 });
+lean_ffi::lean_inductive! {
+  LeanIxonExprMetaData {
+    LeanIxonExprMetaApp       { tag: 1, num_64: 2 },
+    LeanIxonExprMetaBinder    { tag: 2, num_obj: 1, num_64: 2, num_8: 1 },
+    LeanIxonExprMetaLetBinder { tag: 3, num_obj: 1, num_64: 3 },
+    LeanIxonExprMetaRef       { tag: 4, num_obj: 1 },
+    LeanIxonExprMetaPrj       { tag: 5, num_obj: 1, num_64: 1 },
+    LeanIxonExprMetaMdata     { tag: 6, num_obj: 1, num_64: 1 },
+  }
+}
 
-// Ixon/Ix inductive variants (single-scalar)
-lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaAxio   { TAG = 2, NUM_OBJ = 3, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaQuot   { TAG = 3, NUM_OBJ = 3, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaIndc   { TAG = 4, NUM_OBJ = 6, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaCtor   { TAG = 5, NUM_OBJ = 4, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaRec    { TAG = 6, NUM_OBJ = 7, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaPrj        { TAG = 5, NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaMdata      { TAG = 6, NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonDataValueBool      { TAG = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprSort           { TAG = 0, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprVar            { TAG = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprRef            { TAG = 2, NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprRec            { TAG = 3, NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprStr            { TAG = 5, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprNat            { TAG = 6, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprLet            { TAG = 10, NUM_OBJ = 3, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonExprShare          { TAG = 11, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonUnivVar            { TAG = 4, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxExprLam              { TAG = 6, NUM_OBJ = 4, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxExprForallE          { TAG = 7, NUM_OBJ = 4, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxExprLetE             { TAG = 8, NUM_OBJ = 5, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxSourceInfoSynthetic  { TAG = 1, NUM_OBJ = 2, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxDataValueBool        { TAG = 1, NUM_8 = 1 });
+lean_ffi::lean_inductive! {
+  LeanIxonConstantMeta {
+    LeanIxonConstantMetaDef  { tag: 1, num_obj: 6, num_64: 2 },
+    LeanIxonConstantMetaAxio { tag: 2, num_obj: 3, num_64: 1 },
+    LeanIxonConstantMetaQuot { tag: 3, num_obj: 3, num_64: 1 },
+    LeanIxonConstantMetaIndc { tag: 4, num_obj: 6, num_64: 1 },
+    LeanIxonConstantMetaCtor { tag: 5, num_obj: 4, num_64: 1 },
+    LeanIxonConstantMetaRec  { tag: 6, num_obj: 7, num_64: 1 },
+  }
+}
 
-// SerializeError variant types
-lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidTag        { TAG = 1, NUM_OBJ = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidFlag       { TAG = 2, NUM_OBJ = 1, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidVariant    { TAG = 3, NUM_OBJ = 1, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidBool       { TAG = 4, NUM_8 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidShareIndex { TAG = 6, NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::lean_inductive! {
+  LeanIxonDataValue {
+    LeanIxonDataValueString { num_obj: 1 },
+    LeanIxonDataValueBool   { tag: 1, num_8: 1 },
+    LeanIxonDataValueName   { tag: 2, num_obj: 1 },
+    LeanIxonDataValueNat    { tag: 3, num_obj: 1 },
+    LeanIxonDataValueInt    { tag: 4, num_obj: 1 },
+    LeanIxonDataValueSyntax { tag: 5, num_obj: 1 },
+  }
+}
 
-// DecompileError variant types (tags 0-4: 2 obj + 1 u64)
-lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorRefIndex      { NUM_OBJ = 2, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorUnivIndex     { TAG = 1, NUM_OBJ = 2, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorShareIndex    { TAG = 2, NUM_OBJ = 2, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorRecIndex      { TAG = 3, NUM_OBJ = 2, NUM_64 = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorUnivVarIndex  { TAG = 4, NUM_OBJ = 2, NUM_64 = 1 });
+lean_ffi::lean_inductive! {
+  LeanIxonMutConst {
+    LeanIxonMutConstDefn { num_obj: 1 },
+    LeanIxonMutConstIndc { tag: 1, num_obj: 1 },
+    LeanIxonMutConstRecr { tag: 2, num_obj: 1 },
+  }
+}
 
-// Block types
-lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareResultMismatch { TAG = 1, NUM_64 = 3 });
-lean_ffi::impl_ctor_scalar!(LeanIxBlock             { NUM_OBJ = 2, NUM_64 = 1 });
+lean_ffi::lean_inductive! {
+  LeanIxonConstantInfo {
+    LeanIxonConstantInfoDefn { num_obj: 1 },
+    LeanIxonConstantInfoRecr { tag: 1, num_obj: 1 },
+    LeanIxonConstantInfoAxio { tag: 2, num_obj: 1 },
+    LeanIxonConstantInfoQuot { tag: 3, num_obj: 1 },
+    LeanIxonConstantInfoCPrj { tag: 4, num_obj: 1 },
+    LeanIxonConstantInfoRPrj { tag: 5, num_obj: 1 },
+    LeanIxonConstantInfoIPrj { tag: 6, num_obj: 1 },
+    LeanIxonConstantInfoDPrj { tag: 7, num_obj: 1 },
+    LeanIxonConstantInfoMuts { tag: 8, num_obj: 1 },
+  }
+}
+
+// =============================================================================
+// Ix structures (single-constructor, tag 0)
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanIxConstantVal { num_obj: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxRecursorRule { num_obj: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxTheoremVal { num_obj: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxCondensedBlocks { num_obj: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxCompilePhases { num_obj: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxSubstring { num_obj: 3 }
+}
+
+// =============================================================================
+// Ix multi-variant inductives
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanIxName {
+    LeanIxNameAnonymous { num_obj: 1 },
+    LeanIxNameStr       { tag: 1, num_obj: 3 },
+    LeanIxNameNum       { tag: 2, num_obj: 3 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxLevel {
+    LeanIxLevelZero  { num_obj: 1 },
+    LeanIxLevelSucc  { tag: 1, num_obj: 2 },
+    LeanIxLevelMax   { tag: 2, num_obj: 3 },
+    LeanIxLevelImax  { tag: 3, num_obj: 3 },
+    LeanIxLevelParam { tag: 4, num_obj: 2 },
+    LeanIxLevelMvar  { tag: 5, num_obj: 2 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxExpr {
+    LeanIxExprBvar    { num_obj: 2 },
+    LeanIxExprFvar    { tag: 1, num_obj: 2 },
+    LeanIxExprMvar    { tag: 2, num_obj: 2 },
+    LeanIxExprSort    { tag: 3, num_obj: 2 },
+    LeanIxExprConst   { tag: 4, num_obj: 3 },
+    LeanIxExprApp     { tag: 5, num_obj: 3 },
+    LeanIxExprLam     { tag: 6, num_obj: 4, num_8: 1 },
+    LeanIxExprForallE { tag: 7, num_obj: 4, num_8: 1 },
+    LeanIxExprLetE    { tag: 8, num_obj: 5, num_8: 1 },
+    LeanIxExprLit     { tag: 9, num_obj: 2 },
+    LeanIxExprMdata   { tag: 10, num_obj: 3 },
+    LeanIxExprProj    { tag: 11, num_obj: 4 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxConstantInfo {
+    LeanIxConstantInfoAxiom  { num_obj: 1 },
+    LeanIxConstantInfoDefn   { tag: 1, num_obj: 1 },
+    LeanIxConstantInfoThm    { tag: 2, num_obj: 1 },
+    LeanIxConstantInfoOpaque { tag: 3, num_obj: 1 },
+    LeanIxConstantInfoQuot   { tag: 4, num_obj: 1 },
+    LeanIxConstantInfoInduct { tag: 5, num_obj: 1 },
+    LeanIxConstantInfoCtor   { tag: 6, num_obj: 1 },
+    LeanIxConstantInfoRec    { tag: 7, num_obj: 1 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxReducibilityHints {
+    LeanIxReducibilityHintsRegular { tag: 2, num_32: 1 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxLiteral {
+    LeanIxLiteralNat { num_obj: 1 },
+    LeanIxLiteralStr { tag: 1, num_obj: 1 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxInt {
+    LeanIxIntOfNat   { num_obj: 1 },
+    LeanIxIntNegSucc { tag: 1, num_obj: 1 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxSourceInfo {
+    LeanIxSourceInfoOriginal  { num_obj: 4 },
+    LeanIxSourceInfoSynthetic { tag: 1, num_obj: 2, num_8: 1 },
+    LeanIxSourceInfoNone      { tag: 2 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxSyntax {
+    LeanIxSyntaxMissing {},
+    LeanIxSyntaxNode  { tag: 1, num_obj: 3 },
+    LeanIxSyntaxAtom  { tag: 2, num_obj: 2 },
+    LeanIxSyntaxIdent { tag: 3, num_obj: 4 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxSyntaxPreresolved {
+    LeanIxSyntaxPreresolvedA { num_obj: 1 },
+    LeanIxSyntaxPreresolvedB { tag: 1, num_obj: 2 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxDataValue {
+    LeanIxDataValueString  { num_obj: 1 },
+    LeanIxDataValueBool    { tag: 1, num_8: 1 },
+    LeanIxDataValueName    { tag: 2, num_obj: 1 },
+    LeanIxDataValueNat     { tag: 3, num_obj: 1 },
+    LeanIxDataValueInt     { tag: 4, num_obj: 1 },
+    LeanIxDataValueSyntax  { tag: 5, num_obj: 1 },
+  }
+}
+
+// =============================================================================
+// Lean kernel inner val types (used in Ix.ConstantInfo decode)
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanIxAxiomVal { num_obj: 1, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxDefinitionVal { num_obj: 4, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxOpaqueVal { num_obj: 3, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxQuotVal { num_obj: 1, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxInductiveVal { num_obj: 6, num_8: 3 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxConstructorVal { num_obj: 5, num_8: 1 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxRecursorVal { num_obj: 7, num_8: 2 }
+}
+
+// =============================================================================
+// Aiur types
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanAiurToplevel { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanAiurFunction { num_obj: 2, num_8: 2 }
+}
+
+// =============================================================================
+// Block / comparison types
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanIxBlockCompareResult {
+    LeanIxBlockCompareResultMatch    {},
+    LeanIxBlockCompareResultMismatch { tag: 1, num_64: 3 },
+    LeanIxBlockCompareResultNotFound { tag: 2 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxBlockCompareDetail { num_obj: 1, num_64: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanIxBlock { num_obj: 2, num_64: 1 }
+}
+
+// =============================================================================
+// Error types
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanIxSerializeError {
+    LeanIxSerializeErrorUnexpectedEof    { num_obj: 1 },
+    LeanIxSerializeErrorInvalidTag       { tag: 1, num_obj: 1, num_8: 1 },
+    LeanIxSerializeErrorInvalidFlag      { tag: 2, num_obj: 1, num_8: 1 },
+    LeanIxSerializeErrorInvalidVariant   { tag: 3, num_obj: 1, num_64: 1 },
+    LeanIxSerializeErrorInvalidBool      { tag: 4, num_8: 1 },
+    LeanIxSerializeErrorInvalidShareIndex { tag: 6, num_obj: 1, num_64: 1 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxDecompileError {
+    LeanIxDecompileErrorRefIndex           { num_obj: 2, num_64: 1 },
+    LeanIxDecompileErrorUnivIndex          { tag: 1, num_obj: 2, num_64: 1 },
+    LeanIxDecompileErrorShareIndex         { tag: 2, num_obj: 2, num_64: 1 },
+    LeanIxDecompileErrorRecIndex           { tag: 3, num_obj: 2, num_64: 1 },
+    LeanIxDecompileErrorUnivVarIndex       { tag: 4, num_obj: 2, num_64: 1 },
+    LeanIxDecompileErrorMissingAddress     { tag: 5, num_obj: 1 },
+    LeanIxDecompileErrorMissingMetadata    { tag: 6, num_obj: 1 },
+    LeanIxDecompileErrorBlobNotFound       { tag: 7, num_obj: 1 },
+    LeanIxDecompileErrorBadBlobFormat      { tag: 8, num_obj: 2 },
+    LeanIxDecompileErrorBadConstantFormat  { tag: 9, num_obj: 1 },
+    LeanIxDecompileErrorSerialize          { tag: 10, num_obj: 1 },
+  }
+}
+
+lean_ffi::lean_inductive! {
+  LeanIxCompileError {
+    LeanIxCompileErrorMissingConstant    { num_obj: 1 },
+    LeanIxCompileErrorMissingAddress     { tag: 1, num_obj: 1 },
+    LeanIxCompileErrorInvalidMutualBlock { tag: 2, num_obj: 1 },
+    LeanIxCompileErrorUnsupportedExpr    { tag: 3, num_obj: 1 },
+    LeanIxCompileErrorUnknownUnivParam   { tag: 4, num_obj: 2 },
+    LeanIxCompileErrorSerialize          { tag: 5, num_obj: 1 },
+  }
+}
+
+// =============================================================================
+// Iroh types
+// =============================================================================
+
+lean_ffi::lean_inductive! {
+  LeanPutResponse { num_obj: 2 }
+}
+lean_ffi::lean_inductive! {
+  LeanGetResponse { num_obj: 3 }
+}
+
+// =============================================================================
+// LeanIxAddress — manual newtype over LeanByteArray
+// =============================================================================
 
 /// Lean `Address` object — newtype over `LeanByteArray`.
 ///

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -120,6 +120,116 @@ lean_ffi::lean_domain_type! {
   /// Lean `Aiur.FriParameters` object.
   LeanAiurFriParameters;
 
+  // Ix inner val types (ConstantInfo variants)
+  /// Lean `Ix.AxiomVal` object.
+  LeanIxAxiomVal;
+  /// Lean `Ix.DefinitionVal` object.
+  LeanIxDefinitionVal;
+  /// Lean `Ix.OpaqueVal` object.
+  LeanIxOpaqueVal;
+  /// Lean `Ix.QuotVal` object.
+  LeanIxQuotVal;
+  /// Lean `Ix.InductiveVal` object.
+  LeanIxInductiveVal;
+  /// Lean `Ix.ConstructorVal` object.
+  LeanIxConstructorVal;
+  /// Lean `Ix.RecursorVal` object.
+  LeanIxRecursorVal;
+  /// Lean `Ix.ReducibilityHints.Regular` object.
+  LeanIxReducibilityHintsRegular;
+
+  // Aiur inner types
+  /// Lean `Aiur.Bytecode.Function` object.
+  LeanAiurFunction;
+
+  // Ixon multi-scalar variant types
+  /// Lean `Ixon.ExprMetaData.App` (tag 1) object.
+  LeanIxonExprMetaApp;
+  /// Lean `Ixon.ExprMetaData.Binder` (tag 2) object.
+  LeanIxonExprMetaBinder;
+  /// Lean `Ixon.ExprMetaData.LetBinder` (tag 3) object.
+  LeanIxonExprMetaLetBinder;
+  /// Lean `Ixon.ConstantMeta.Def` (tag 1) object.
+  LeanIxonConstantMetaDef;
+  /// Lean `Ixon.Expr.Prj` (tag 4) object.
+  LeanIxonExprPrj;
+
+  // Ixon single-scalar variant types
+  /// Lean `Ixon.ConstantMeta.Axio` (tag 2) object.
+  LeanIxonConstantMetaAxio;
+  /// Lean `Ixon.ConstantMeta.Quot` (tag 3) object.
+  LeanIxonConstantMetaQuot;
+  /// Lean `Ixon.ConstantMeta.Indc` (tag 4) object.
+  LeanIxonConstantMetaIndc;
+  /// Lean `Ixon.ConstantMeta.Ctor` (tag 5) object.
+  LeanIxonConstantMetaCtor;
+  /// Lean `Ixon.ConstantMeta.Rec` (tag 6) object.
+  LeanIxonConstantMetaRec;
+  /// Lean `Ixon.ExprMetaData.Prj` (tag 5) object.
+  LeanIxonExprMetaPrj;
+  /// Lean `Ixon.ExprMetaData.Mdata` (tag 6) object.
+  LeanIxonExprMetaMdata;
+  /// Lean `Ixon.DataValue.OfBool` (tag 1) object.
+  LeanIxonDataValueBool;
+  /// Lean `Ixon.Expr.Sort` (tag 0) object.
+  LeanIxonExprSort;
+  /// Lean `Ixon.Expr.Var` (tag 1) object.
+  LeanIxonExprVar;
+  /// Lean `Ixon.Expr.Ref` (tag 2) object.
+  LeanIxonExprRef;
+  /// Lean `Ixon.Expr.Rec` (tag 3) object.
+  LeanIxonExprRec;
+  /// Lean `Ixon.Expr.Str` (tag 5) object.
+  LeanIxonExprStr;
+  /// Lean `Ixon.Expr.Nat` (tag 6) object.
+  LeanIxonExprNat;
+  /// Lean `Ixon.Expr.Let` (tag 10) object.
+  LeanIxonExprLet;
+  /// Lean `Ixon.Expr.Share` (tag 11) object.
+  LeanIxonExprShare;
+  /// Lean `Ixon.Univ.Var` (tag 4) object.
+  LeanIxonUnivVar;
+  /// Lean `Ix.Expr.Lam` (tag 6) object.
+  LeanIxExprLam;
+  /// Lean `Ix.Expr.ForallE` (tag 7) object.
+  LeanIxExprForallE;
+  /// Lean `Ix.Expr.LetE` (tag 8) object.
+  LeanIxExprLetE;
+  /// Lean `Ix.SourceInfo.Synthetic` (tag 1) object.
+  LeanIxSourceInfoSynthetic;
+  /// Lean `Ix.DataValue.OfBool` (tag 1) object.
+  LeanIxDataValueBool;
+
+  // Block types
+  /// Lean `BlockCompareResult.Mismatch` (tag 1) object.
+  LeanIxBlockCompareResultMismatch;
+  /// Lean `Ix.Block` object.
+  LeanIxBlock;
+
+  // SerializeError variant types
+  /// Lean `Ixon.SerializeError.InvalidTag` (tag 1) object.
+  LeanIxSerializeErrorInvalidTag;
+  /// Lean `Ixon.SerializeError.InvalidFlag` (tag 2) object.
+  LeanIxSerializeErrorInvalidFlag;
+  /// Lean `Ixon.SerializeError.InvalidVariant` (tag 3) object.
+  LeanIxSerializeErrorInvalidVariant;
+  /// Lean `Ixon.SerializeError.InvalidBool` (tag 4) object.
+  LeanIxSerializeErrorInvalidBool;
+  /// Lean `Ixon.SerializeError.InvalidShareIndex` (tag 6) object.
+  LeanIxSerializeErrorInvalidShareIndex;
+
+  // DecompileError variant types (tags 0-4 share layout: 2 obj + 1 u64)
+  /// Lean `Ix.DecompileError.InvalidRefIndex` (tag 0) object.
+  LeanIxDecompileErrorRefIndex;
+  /// Lean `Ix.DecompileError.InvalidUnivIndex` (tag 1) object.
+  LeanIxDecompileErrorUnivIndex;
+  /// Lean `Ix.DecompileError.InvalidShareIndex` (tag 2) object.
+  LeanIxDecompileErrorShareIndex;
+  /// Lean `Ix.DecompileError.InvalidRecIndex` (tag 3) object.
+  LeanIxDecompileErrorRecIndex;
+  /// Lean `Ix.DecompileError.InvalidUnivVarIndex` (tag 4) object.
+  LeanIxDecompileErrorUnivVarIndex;
+
   // Error types
   /// Lean `Ixon.SerializeError` object.
   LeanIxSerializeError;
@@ -138,20 +248,82 @@ lean_ffi::lean_domain_type! {
 // =============================================================================
 
 // ixon/constant.rs structures
-lean_ffi::impl_ctor_scalar!(LeanIxonDefinition     { NUM_8B = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonRecursorRule   { NUM_8B = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonRecursor       { NUM_8B = 5 });
-lean_ffi::impl_ctor_scalar!(LeanIxonAxiom          { NUM_8B = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonQuotient       { NUM_8B = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstructor    { NUM_8B = 4 });
-lean_ffi::impl_ctor_scalar!(LeanIxonInductive      { NUM_8B = 4 });
-lean_ffi::impl_ctor_scalar!(LeanIxonInductiveProj  { NUM_8B = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonConstructorProj { NUM_8B = 2 });
-lean_ffi::impl_ctor_scalar!(LeanIxonRecursorProj   { NUM_8B = 1 });
-lean_ffi::impl_ctor_scalar!(LeanIxonDefinitionProj { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonDefinition     { NUM_OBJ = 2, NUM_64 = 1, NUM_8 = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxonRecursorRule   { NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonRecursor       { NUM_OBJ = 2, NUM_64 = 5, NUM_8 = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxonAxiom          { NUM_OBJ = 1, NUM_64 = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonQuotient       { NUM_OBJ = 1, NUM_64 = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstructor    { NUM_OBJ = 1, NUM_64 = 4, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonInductive      { NUM_OBJ = 2, NUM_64 = 4, NUM_8 = 3 });
+lean_ffi::impl_ctor_scalar!(LeanIxonInductiveProj  { NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstructorProj { NUM_OBJ = 1, NUM_64 = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxonRecursorProj   { NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonDefinitionProj { NUM_OBJ = 1, NUM_64 = 1 });
 
 // ixon/compare.rs + compile.rs
-lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareDetail { NUM_8B = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareDetail { NUM_OBJ = 1, NUM_64 = 2 });
+
+// Ix inner val types (ix/constant.rs + lean_env.rs)
+lean_ffi::impl_ctor_scalar!(LeanIxAxiomVal          { NUM_OBJ = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxDefinitionVal     { NUM_OBJ = 4, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxOpaqueVal         { NUM_OBJ = 3, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxQuotVal           { NUM_OBJ = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxInductiveVal      { NUM_OBJ = 6, NUM_8 = 3 });
+lean_ffi::impl_ctor_scalar!(LeanIxConstructorVal    { NUM_OBJ = 5, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxRecursorVal       { NUM_OBJ = 7, NUM_8 = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxReducibilityHintsRegular { TAG = 2, NUM_32 = 1 });
+
+// Aiur inner types
+lean_ffi::impl_ctor_scalar!(LeanAiurFunction        { NUM_OBJ = 2, NUM_8 = 2 });
+
+// Ixon multi-scalar variant types
+lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaApp        { TAG = 1, NUM_64 = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaBinder     { TAG = 2, NUM_OBJ = 1, NUM_64 = 2, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaLetBinder  { TAG = 3, NUM_OBJ = 1, NUM_64 = 3 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaDef    { TAG = 1, NUM_OBJ = 6, NUM_64 = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprPrj            { TAG = 4, NUM_OBJ = 1, NUM_64 = 2 });
+
+// Ixon single-scalar variant types
+lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaAxio   { TAG = 2, NUM_OBJ = 3, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaQuot   { TAG = 3, NUM_OBJ = 3, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaIndc   { TAG = 4, NUM_OBJ = 6, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaCtor   { TAG = 5, NUM_OBJ = 4, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaRec    { TAG = 6, NUM_OBJ = 7, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaPrj        { TAG = 5, NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaMdata      { TAG = 6, NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonDataValueBool      { TAG = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprSort           { TAG = 0, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprVar            { TAG = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprRef            { TAG = 2, NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprRec            { TAG = 3, NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprStr            { TAG = 5, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprNat            { TAG = 6, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprLet            { TAG = 10, NUM_OBJ = 3, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonExprShare          { TAG = 11, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonUnivVar            { TAG = 4, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxExprLam              { TAG = 6, NUM_OBJ = 4, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxExprForallE          { TAG = 7, NUM_OBJ = 4, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxExprLetE             { TAG = 8, NUM_OBJ = 5, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxSourceInfoSynthetic  { TAG = 1, NUM_OBJ = 2, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxDataValueBool        { TAG = 1, NUM_8 = 1 });
+
+// SerializeError variant types
+lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidTag        { TAG = 1, NUM_OBJ = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidFlag       { TAG = 2, NUM_OBJ = 1, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidVariant    { TAG = 3, NUM_OBJ = 1, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidBool       { TAG = 4, NUM_8 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxSerializeErrorInvalidShareIndex { TAG = 6, NUM_OBJ = 1, NUM_64 = 1 });
+
+// DecompileError variant types (tags 0-4: 2 obj + 1 u64)
+lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorRefIndex      { NUM_OBJ = 2, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorUnivIndex     { TAG = 1, NUM_OBJ = 2, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorShareIndex    { TAG = 2, NUM_OBJ = 2, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorRecIndex      { TAG = 3, NUM_OBJ = 2, NUM_64 = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxDecompileErrorUnivVarIndex  { TAG = 4, NUM_OBJ = 2, NUM_64 = 1 });
+
+// Block types
+lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareResultMismatch { TAG = 1, NUM_64 = 3 });
+lean_ffi::impl_ctor_scalar!(LeanIxBlock             { NUM_OBJ = 2, NUM_64 = 1 });
 
 /// Lean `Address` object — newtype over `LeanByteArray`.
 ///

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -8,7 +8,7 @@
 use lean_ffi::object::{LeanBorrowed, LeanByteArray, LeanOwned, LeanRef};
 
 // =============================================================================
-// Types without ctor layouts (simple enums, opaque objects, arenas)
+// Types without ctor layouts
 // =============================================================================
 
 lean_ffi::lean_domain_type! {
@@ -18,410 +18,274 @@ lean_ffi::lean_domain_type! {
   LeanIxonDefinitionSafety;
   LeanIxonQuotKind;
 
-  // Opaque / arena types
+  // Opaque types (passed through without field access)
   LeanIxRawEnvironment;
   LeanIxEnvironment;
   LeanIxonExprMetaArena;
-
-  // Aiur parameter types (no scalar fields, used opaquely)
   LeanAiurCommitmentParameters;
   LeanAiurFriParameters;
 }
 
 // =============================================================================
-// Ixon structures (single-constructor)
+// Ctor-backed types
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxonDefinition [ { num_obj: 2, num_64: 1, num_8: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRecursorRule [ { num_obj: 1, num_64: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRecursor [ { num_obj: 2, num_64: 5, num_8: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonAxiom [ { num_obj: 1, num_64: 1, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonQuotient [ { num_obj: 1, num_64: 1, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonConstructor [ { num_obj: 1, num_64: 4, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonInductive [ { num_obj: 2, num_64: 4, num_8: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonInductiveProj [ { num_obj: 1, num_64: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonConstructorProj [ { num_obj: 1, num_64: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRecursorProj [ { num_obj: 1, num_64: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonDefinitionProj [ { num_obj: 1, num_64: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonNamed [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonComm [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonConstant [ { num_obj: 4 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRawConst [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRawNamed [ { num_obj: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRawBlob [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRawComm [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRawNameEntry [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxonRawEnv [ { num_obj: 5 } ]
-}
+  // --- Ixon structures (single-constructor) ---
 
-// =============================================================================
-// Ixon multi-variant inductives
-// =============================================================================
+  LeanIxonDefinition      [ { num_obj: 2, num_64: 1, num_8: 2 } ];
+  LeanIxonRecursorRule    [ { num_obj: 1, num_64: 1 } ];
+  LeanIxonRecursor        [ { num_obj: 2, num_64: 5, num_8: 2 } ];
+  LeanIxonAxiom           [ { num_obj: 1, num_64: 1, num_8: 1 } ];
+  LeanIxonQuotient        [ { num_obj: 1, num_64: 1, num_8: 1 } ];
+  LeanIxonConstructor     [ { num_obj: 1, num_64: 4, num_8: 1 } ];
+  LeanIxonInductive       [ { num_obj: 2, num_64: 4, num_8: 3 } ];
+  LeanIxonInductiveProj   [ { num_obj: 1, num_64: 1 } ];
+  LeanIxonConstructorProj [ { num_obj: 1, num_64: 2 } ];
+  LeanIxonRecursorProj    [ { num_obj: 1, num_64: 1 } ];
+  LeanIxonDefinitionProj  [ { num_obj: 1, num_64: 1 } ];
+  LeanIxonNamed           [ { num_obj: 2 } ];
+  LeanIxonComm            [ { num_obj: 2 } ];
+  LeanIxonConstant        [ { num_obj: 4 } ];
+  LeanIxonRawConst        [ { num_obj: 2 } ];
+  LeanIxonRawNamed        [ { num_obj: 3 } ];
+  LeanIxonRawBlob         [ { num_obj: 2 } ];
+  LeanIxonRawComm         [ { num_obj: 2 } ];
+  LeanIxonRawNameEntry    [ { num_obj: 2 } ];
+  LeanIxonRawEnv          [ { num_obj: 5 } ];
 
-lean_ffi::lean_inductive! {
+  // --- Ixon multi-variant inductives ---
+
   LeanIxonUniv [
-    { },                              // tag 0: zero
-    { num_obj: 1 },                   // tag 1: succ
-    { num_obj: 2 },                   // tag 2: max
-    { num_obj: 2 },                   // tag 3: imax
-    { num_64: 1 },                    // tag 4: var
-  ]
-}
+    { },                                      // tag 0: zero
+    { num_obj: 1 },                           // tag 1: succ
+    { num_obj: 2 },                           // tag 2: max
+    { num_obj: 2 },                           // tag 3: imax
+    { num_64: 1 },                            // tag 4: var
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxonExpr [
-    { num_64: 1 },                    // tag 0: sort
-    { num_64: 1 },                    // tag 1: var
-    { num_obj: 1, num_64: 1 },        // tag 2: ref
-    { num_obj: 1, num_64: 1 },        // tag 3: rec
-    { num_obj: 1, num_64: 2 },        // tag 4: prj
-    { num_64: 1 },                    // tag 5: str
-    { num_64: 1 },                    // tag 6: nat
-    { num_obj: 2 },                   // tag 7: app
-    { num_obj: 2 },                   // tag 8: lam
-    { num_obj: 2 },                   // tag 9: all
-    { num_obj: 3, num_8: 1 },         // tag 10: let
-    { num_64: 1 },                    // tag 11: share
-  ]
-}
+    { num_64: 1 },                            // tag 0: sort
+    { num_64: 1 },                            // tag 1: var
+    { num_obj: 1, num_64: 1 },                // tag 2: ref
+    { num_obj: 1, num_64: 1 },                // tag 3: rec
+    { num_obj: 1, num_64: 2 },                // tag 4: prj
+    { num_64: 1 },                            // tag 5: str
+    { num_64: 1 },                            // tag 6: nat
+    { num_obj: 2 },                           // tag 7: app
+    { num_obj: 2 },                           // tag 8: lam
+    { num_obj: 2 },                           // tag 9: all
+    { num_obj: 3, num_8: 1 },                 // tag 10: let
+    { num_64: 1 },                            // tag 11: share
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxonExprMetaData [
-    { },                              // tag 0: leaf (scalar)
-    { num_64: 2 },                    // tag 1: app
-    { num_obj: 1, num_64: 2, num_8: 1 }, // tag 2: binder
-    { num_obj: 1, num_64: 3 },        // tag 3: letBinder
-    { num_obj: 1 },                   // tag 4: ref
-    { num_obj: 1, num_64: 1 },        // tag 5: prj
-    { num_obj: 1, num_64: 1 },        // tag 6: mdata
-  ]
-}
+    { },                                      // tag 0: leaf (scalar)
+    { num_64: 2 },                            // tag 1: app
+    { num_obj: 1, num_64: 2, num_8: 1 },      // tag 2: binder
+    { num_obj: 1, num_64: 3 },                // tag 3: letBinder
+    { num_obj: 1 },                           // tag 4: ref
+    { num_obj: 1, num_64: 1 },                // tag 5: prj
+    { num_obj: 1, num_64: 1 },                // tag 6: mdata
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxonConstantMeta [
-    { },                              // tag 0: empty (scalar)
-    { num_obj: 6, num_64: 2 },        // tag 1: defn
-    { num_obj: 3, num_64: 1 },        // tag 2: axio
-    { num_obj: 3, num_64: 1 },        // tag 3: quot
-    { num_obj: 6, num_64: 1 },        // tag 4: indc
-    { num_obj: 4, num_64: 1 },        // tag 5: ctor
-    { num_obj: 7, num_64: 1 },        // tag 6: recr
-  ]
-}
+    { },                                      // tag 0: empty (scalar)
+    { num_obj: 6, num_64: 2 },                // tag 1: defn
+    { num_obj: 3, num_64: 1 },                // tag 2: axio
+    { num_obj: 3, num_64: 1 },                // tag 3: quot
+    { num_obj: 6, num_64: 1 },                // tag 4: indc
+    { num_obj: 4, num_64: 1 },                // tag 5: ctor
+    { num_obj: 7, num_64: 1 },                // tag 6: recr
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxonDataValue [
-    { num_obj: 1 },                   // tag 0: ofString
-    { num_8: 1 },                     // tag 1: ofBool
-    { num_obj: 1 },                   // tag 2: ofName
-    { num_obj: 1 },                   // tag 3: ofNat
-    { num_obj: 1 },                   // tag 4: ofInt
-    { num_obj: 1 },                   // tag 5: ofSyntax
-  ]
-}
+    { num_obj: 1 },                           // tag 0: ofString
+    { num_8: 1 },                             // tag 1: ofBool
+    { num_obj: 1 },                           // tag 2: ofName
+    { num_obj: 1 },                           // tag 3: ofNat
+    { num_obj: 1 },                           // tag 4: ofInt
+    { num_obj: 1 },                           // tag 5: ofSyntax
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxonMutConst [
-    { num_obj: 1 },                   // tag 0: defn
-    { num_obj: 1 },                   // tag 1: indc
-    { num_obj: 1 },                   // tag 2: recr
-  ]
-}
+    { num_obj: 1 },                           // tag 0: defn
+    { num_obj: 1 },                           // tag 1: indc
+    { num_obj: 1 },                           // tag 2: recr
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxonConstantInfo [
-    { num_obj: 1 },                   // tag 0: defn
-    { num_obj: 1 },                   // tag 1: recr
-    { num_obj: 1 },                   // tag 2: axio
-    { num_obj: 1 },                   // tag 3: quot
-    { num_obj: 1 },                   // tag 4: cPrj
-    { num_obj: 1 },                   // tag 5: rPrj
-    { num_obj: 1 },                   // tag 6: iPrj
-    { num_obj: 1 },                   // tag 7: dPrj
-    { num_obj: 1 },                   // tag 8: muts
-  ]
-}
+    { num_obj: 1 },                           // tag 0: defn
+    { num_obj: 1 },                           // tag 1: recr
+    { num_obj: 1 },                           // tag 2: axio
+    { num_obj: 1 },                           // tag 3: quot
+    { num_obj: 1 },                           // tag 4: cPrj
+    { num_obj: 1 },                           // tag 5: rPrj
+    { num_obj: 1 },                           // tag 6: iPrj
+    { num_obj: 1 },                           // tag 7: dPrj
+    { num_obj: 1 },                           // tag 8: muts
+  ];
 
-// =============================================================================
-// Ix structures (single-constructor)
-// =============================================================================
+  // --- Ix structures (single-constructor) ---
 
-lean_ffi::lean_inductive! {
-  LeanIxConstantVal [ { num_obj: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxRecursorRule [ { num_obj: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxTheoremVal [ { num_obj: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxCondensedBlocks [ { num_obj: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxCompilePhases [ { num_obj: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxSubstring [ { num_obj: 3 } ]
-}
+  LeanIxConstantVal     [ { num_obj: 3 } ];
+  LeanIxRecursorRule    [ { num_obj: 3 } ];
+  LeanIxTheoremVal      [ { num_obj: 3 } ];
+  LeanIxCondensedBlocks [ { num_obj: 3 } ];
+  LeanIxCompilePhases   [ { num_obj: 3 } ];
+  LeanIxSubstring       [ { num_obj: 3 } ];
 
-// =============================================================================
-// Ix multi-variant inductives
-// =============================================================================
+  // --- Ix multi-variant inductives ---
 
-lean_ffi::lean_inductive! {
   LeanIxName [
-    { num_obj: 1 },                   // tag 0: anonymous
-    { num_obj: 3 },                   // tag 1: str
-    { num_obj: 3 },                   // tag 2: num
-  ]
-}
+    { num_obj: 1 },                           // tag 0: anonymous
+    { num_obj: 3 },                           // tag 1: str
+    { num_obj: 3 },                           // tag 2: num
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxLevel [
-    { num_obj: 1 },                   // tag 0: zero
-    { num_obj: 2 },                   // tag 1: succ
-    { num_obj: 3 },                   // tag 2: max
-    { num_obj: 3 },                   // tag 3: imax
-    { num_obj: 2 },                   // tag 4: param
-    { num_obj: 2 },                   // tag 5: mvar
-  ]
-}
+    { num_obj: 1 },                           // tag 0: zero
+    { num_obj: 2 },                           // tag 1: succ
+    { num_obj: 3 },                           // tag 2: max
+    { num_obj: 3 },                           // tag 3: imax
+    { num_obj: 2 },                           // tag 4: param
+    { num_obj: 2 },                           // tag 5: mvar
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxExpr [
-    { num_obj: 2 },                   // tag 0: bvar
-    { num_obj: 2 },                   // tag 1: fvar
-    { num_obj: 2 },                   // tag 2: mvar
-    { num_obj: 2 },                   // tag 3: sort
-    { num_obj: 3 },                   // tag 4: const
-    { num_obj: 3 },                   // tag 5: app
-    { num_obj: 4, num_8: 1 },         // tag 6: lam
-    { num_obj: 4, num_8: 1 },         // tag 7: forallE
-    { num_obj: 5, num_8: 1 },         // tag 8: letE
-    { num_obj: 2 },                   // tag 9: lit
-    { num_obj: 3 },                   // tag 10: mdata
-    { num_obj: 4 },                   // tag 11: proj
-  ]
-}
+    { num_obj: 2 },                           // tag 0: bvar
+    { num_obj: 2 },                           // tag 1: fvar
+    { num_obj: 2 },                           // tag 2: mvar
+    { num_obj: 2 },                           // tag 3: sort
+    { num_obj: 3 },                           // tag 4: const
+    { num_obj: 3 },                           // tag 5: app
+    { num_obj: 4, num_8: 1 },                 // tag 6: lam
+    { num_obj: 4, num_8: 1 },                 // tag 7: forallE
+    { num_obj: 5, num_8: 1 },                 // tag 8: letE
+    { num_obj: 2 },                           // tag 9: lit
+    { num_obj: 3 },                           // tag 10: mdata
+    { num_obj: 4 },                           // tag 11: proj
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxConstantInfo [
-    { num_obj: 1 },                   // tag 0: axiom
-    { num_obj: 1 },                   // tag 1: defn
-    { num_obj: 1 },                   // tag 2: thm
-    { num_obj: 1 },                   // tag 3: opaque
-    { num_obj: 1 },                   // tag 4: quot
-    { num_obj: 1 },                   // tag 5: induct
-    { num_obj: 1 },                   // tag 6: ctor
-    { num_obj: 1 },                   // tag 7: rec
-  ]
-}
+    { num_obj: 1 },                           // tag 0: axiom
+    { num_obj: 1 },                           // tag 1: defn
+    { num_obj: 1 },                           // tag 2: thm
+    { num_obj: 1 },                           // tag 3: opaque
+    { num_obj: 1 },                           // tag 4: quot
+    { num_obj: 1 },                           // tag 5: induct
+    { num_obj: 1 },                           // tag 6: ctor
+    { num_obj: 1 },                           // tag 7: rec
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxReducibilityHints [
-    { },                              // tag 0: opaque (scalar)
-    { },                              // tag 1: abbrev (scalar)
-    { num_32: 1 },                    // tag 2: regular
-  ]
-}
+    { },                                      // tag 0: opaque (scalar)
+    { },                                      // tag 1: abbrev (scalar)
+    { num_32: 1 },                            // tag 2: regular
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxLiteral [
-    { num_obj: 1 },                   // tag 0: nat
-    { num_obj: 1 },                   // tag 1: str
-  ]
-}
+    { num_obj: 1 },                           // tag 0: nat
+    { num_obj: 1 },                           // tag 1: str
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxInt [
-    { num_obj: 1 },                   // tag 0: ofNat
-    { num_obj: 1 },                   // tag 1: negSucc
-  ]
-}
+    { num_obj: 1 },                           // tag 0: ofNat
+    { num_obj: 1 },                           // tag 1: negSucc
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxSourceInfo [
-    { num_obj: 4 },                   // tag 0: original
-    { num_obj: 2, num_8: 1 },         // tag 1: synthetic
-    { },                              // tag 2: none
-  ]
-}
+    { num_obj: 4 },                           // tag 0: original
+    { num_obj: 2, num_8: 1 },                 // tag 1: synthetic
+    { },                                      // tag 2: none
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxSyntax [
-    { },                              // tag 0: missing
-    { num_obj: 3 },                   // tag 1: node
-    { num_obj: 2 },                   // tag 2: atom
-    { num_obj: 4 },                   // tag 3: ident
-  ]
-}
+    { },                                      // tag 0: missing
+    { num_obj: 3 },                           // tag 1: node
+    { num_obj: 2 },                           // tag 2: atom
+    { num_obj: 4 },                           // tag 3: ident
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxSyntaxPreresolved [
-    { num_obj: 1 },                   // tag 0: namespace
-    { num_obj: 2 },                   // tag 1: decl
-  ]
-}
+    { num_obj: 1 },                           // tag 0: namespace
+    { num_obj: 2 },                           // tag 1: decl
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxDataValue [
-    { num_obj: 1 },                   // tag 0: ofString
-    { num_8: 1 },                     // tag 1: ofBool
-    { num_obj: 1 },                   // tag 2: ofName
-    { num_obj: 1 },                   // tag 3: ofNat
-    { num_obj: 1 },                   // tag 4: ofInt
-    { num_obj: 1 },                   // tag 5: ofSyntax
-  ]
-}
+    { num_obj: 1 },                           // tag 0: ofString
+    { num_8: 1 },                             // tag 1: ofBool
+    { num_obj: 1 },                           // tag 2: ofName
+    { num_obj: 1 },                           // tag 3: ofNat
+    { num_obj: 1 },                           // tag 4: ofInt
+    { num_obj: 1 },                           // tag 5: ofSyntax
+  ];
 
-// =============================================================================
-// Lean kernel inner val types (used in Ix.ConstantInfo decode)
-// =============================================================================
+  // --- Lean kernel inner val types (used in Ix.ConstantInfo decode) ---
 
-lean_ffi::lean_inductive! {
-  LeanIxAxiomVal [ { num_obj: 1, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxDefinitionVal [ { num_obj: 4, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxOpaqueVal [ { num_obj: 3, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxQuotVal [ { num_obj: 1, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxInductiveVal [ { num_obj: 6, num_8: 3 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxConstructorVal [ { num_obj: 5, num_8: 1 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxRecursorVal [ { num_obj: 7, num_8: 2 } ]
-}
+  LeanIxAxiomVal       [ { num_obj: 1, num_8: 1 } ];
+  LeanIxDefinitionVal  [ { num_obj: 4, num_8: 1 } ];
+  LeanIxOpaqueVal      [ { num_obj: 3, num_8: 1 } ];
+  LeanIxQuotVal        [ { num_obj: 1, num_8: 1 } ];
+  LeanIxInductiveVal   [ { num_obj: 6, num_8: 3 } ];
+  LeanIxConstructorVal [ { num_obj: 5, num_8: 1 } ];
+  LeanIxRecursorVal    [ { num_obj: 7, num_8: 2 } ];
 
-// =============================================================================
-// Aiur types
-// =============================================================================
+  // --- Aiur types ---
 
-lean_ffi::lean_inductive! {
-  LeanAiurToplevel [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanAiurFunction [ { num_obj: 2, num_8: 2 } ]
-}
+  LeanAiurToplevel [ { num_obj: 2 } ];
+  LeanAiurFunction [ { num_obj: 2, num_8: 2 } ];
 
-// =============================================================================
-// Block / comparison types
-// =============================================================================
+  // --- Block / comparison types ---
 
-lean_ffi::lean_inductive! {
   LeanIxBlockCompareResult [
-    { },                              // tag 0: match
-    { num_64: 3 },                    // tag 1: mismatch
-    { },                              // tag 2: notFound
-  ]
-}
+    { },                                      // tag 0: match
+    { num_64: 3 },                            // tag 1: mismatch
+    { },                                      // tag 2: notFound
+  ];
 
-lean_ffi::lean_inductive! {
-  LeanIxBlockCompareDetail [ { num_obj: 1, num_64: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanIxBlock [ { num_obj: 2, num_64: 1 } ]
-}
+  LeanIxBlockCompareDetail [ { num_obj: 1, num_64: 2 } ];
+  LeanIxBlock              [ { num_obj: 2, num_64: 1 } ];
 
-// =============================================================================
-// Error types
-// =============================================================================
+  // --- Error types ---
 
-lean_ffi::lean_inductive! {
   LeanIxSerializeError [
-    { num_obj: 1 },                   // tag 0: unexpectedEof
-    { num_obj: 1, num_8: 1 },         // tag 1: invalidTag
-    { num_obj: 1, num_8: 1 },         // tag 2: invalidFlag
-    { num_obj: 1, num_64: 1 },        // tag 3: invalidVariant
-    { num_8: 1 },                     // tag 4: invalidBool
-    { },                              // tag 5: addressError
-    { num_obj: 1, num_64: 1 },        // tag 6: invalidShareIndex
-  ]
-}
+    { num_obj: 1 },                           // tag 0: unexpectedEof
+    { num_obj: 1, num_8: 1 },                 // tag 1: invalidTag
+    { num_obj: 1, num_8: 1 },                 // tag 2: invalidFlag
+    { num_obj: 1, num_64: 1 },                // tag 3: invalidVariant
+    { num_8: 1 },                             // tag 4: invalidBool
+    { },                                      // tag 5: addressError
+    { num_obj: 1, num_64: 1 },                // tag 6: invalidShareIndex
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxDecompileError [
-    { num_obj: 2, num_64: 1 },        // tag 0: invalidRefIndex
-    { num_obj: 2, num_64: 1 },        // tag 1: invalidUnivIndex
-    { num_obj: 2, num_64: 1 },        // tag 2: invalidShareIndex
-    { num_obj: 2, num_64: 1 },        // tag 3: invalidRecIndex
-    { num_obj: 2, num_64: 1 },        // tag 4: invalidUnivVarIndex
-    { num_obj: 1 },                   // tag 5: missingAddress
-    { num_obj: 1 },                   // tag 6: missingMetadata
-    { num_obj: 1 },                   // tag 7: blobNotFound
-    { num_obj: 2 },                   // tag 8: badBlobFormat
-    { num_obj: 1 },                   // tag 9: badConstantFormat
-    { num_obj: 1 },                   // tag 10: serialize
-  ]
-}
+    { num_obj: 2, num_64: 1 },                // tag 0: invalidRefIndex
+    { num_obj: 2, num_64: 1 },                // tag 1: invalidUnivIndex
+    { num_obj: 2, num_64: 1 },                // tag 2: invalidShareIndex
+    { num_obj: 2, num_64: 1 },                // tag 3: invalidRecIndex
+    { num_obj: 2, num_64: 1 },                // tag 4: invalidUnivVarIndex
+    { num_obj: 1 },                           // tag 5: missingAddress
+    { num_obj: 1 },                           // tag 6: missingMetadata
+    { num_obj: 1 },                           // tag 7: blobNotFound
+    { num_obj: 2 },                           // tag 8: badBlobFormat
+    { num_obj: 1 },                           // tag 9: badConstantFormat
+    { num_obj: 1 },                           // tag 10: serialize
+  ];
 
-lean_ffi::lean_inductive! {
   LeanIxCompileError [
-    { num_obj: 1 },                   // tag 0: missingConstant
-    { num_obj: 1 },                   // tag 1: missingAddress
-    { num_obj: 1 },                   // tag 2: invalidMutualBlock
-    { num_obj: 1 },                   // tag 3: unsupportedExpr
-    { num_obj: 2 },                   // tag 4: unknownUnivParam
-    { num_obj: 1 },                   // tag 5: serialize
-  ]
-}
+    { num_obj: 1 },                           // tag 0: missingConstant
+    { num_obj: 1 },                           // tag 1: missingAddress
+    { num_obj: 1 },                           // tag 2: invalidMutualBlock
+    { num_obj: 1 },                           // tag 3: unsupportedExpr
+    { num_obj: 2 },                           // tag 4: unknownUnivParam
+    { num_obj: 1 },                           // tag 5: serialize
+  ];
 
-// =============================================================================
-// Iroh types
-// =============================================================================
+  // --- Iroh types ---
 
-lean_ffi::lean_inductive! {
-  LeanPutResponse [ { num_obj: 2 } ]
-}
-lean_ffi::lean_inductive! {
-  LeanGetResponse [ { num_obj: 3 } ]
+  LeanPutResponse [ { num_obj: 2 } ];
+  LeanGetResponse [ { num_obj: 3 } ];
 }
 
 // =============================================================================

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -1,7 +1,7 @@
 //! Ix-specific Lean domain type definitions.
 //!
 //! Ctor-backed types use `lean_inductive!` which declares the domain type,
-//! variant wrappers, layout metadata, and typed accessors in one shot.
+//! layout metadata (one entry per Lean constructor), and typed accessors.
 //! Types without a ctor layout (simple enums, opaque objects, arenas) use
 //! bare `lean_domain_type!`.
 
@@ -29,68 +29,68 @@ lean_ffi::lean_domain_type! {
 }
 
 // =============================================================================
-// Ixon structures (single-constructor, tag 0)
+// Ixon structures (single-constructor)
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxonDefinition { num_obj: 2, num_64: 1, num_8: 2 }
+  LeanIxonDefinition [ { num_obj: 2, num_64: 1, num_8: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRecursorRule { num_obj: 1, num_64: 1 }
+  LeanIxonRecursorRule [ { num_obj: 1, num_64: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRecursor { num_obj: 2, num_64: 5, num_8: 2 }
+  LeanIxonRecursor [ { num_obj: 2, num_64: 5, num_8: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonAxiom { num_obj: 1, num_64: 1, num_8: 1 }
+  LeanIxonAxiom [ { num_obj: 1, num_64: 1, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonQuotient { num_obj: 1, num_64: 1, num_8: 1 }
+  LeanIxonQuotient [ { num_obj: 1, num_64: 1, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonConstructor { num_obj: 1, num_64: 4, num_8: 1 }
+  LeanIxonConstructor [ { num_obj: 1, num_64: 4, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonInductive { num_obj: 2, num_64: 4, num_8: 3 }
+  LeanIxonInductive [ { num_obj: 2, num_64: 4, num_8: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonInductiveProj { num_obj: 1, num_64: 1 }
+  LeanIxonInductiveProj [ { num_obj: 1, num_64: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonConstructorProj { num_obj: 1, num_64: 2 }
+  LeanIxonConstructorProj [ { num_obj: 1, num_64: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRecursorProj { num_obj: 1, num_64: 1 }
+  LeanIxonRecursorProj [ { num_obj: 1, num_64: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonDefinitionProj { num_obj: 1, num_64: 1 }
+  LeanIxonDefinitionProj [ { num_obj: 1, num_64: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonNamed { num_obj: 2 }
+  LeanIxonNamed [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonComm { num_obj: 2 }
+  LeanIxonComm [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonConstant { num_obj: 4 }
+  LeanIxonConstant [ { num_obj: 4 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRawConst { num_obj: 2 }
+  LeanIxonRawConst [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRawNamed { num_obj: 3 }
+  LeanIxonRawNamed [ { num_obj: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRawBlob { num_obj: 2 }
+  LeanIxonRawBlob [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRawComm { num_obj: 2 }
+  LeanIxonRawComm [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRawNameEntry { num_obj: 2 }
+  LeanIxonRawNameEntry [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxonRawEnv { num_obj: 5 }
+  LeanIxonRawEnv [ { num_obj: 5 } ]
 }
 
 // =============================================================================
@@ -98,107 +98,110 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxonUniv {
-    LeanIxonUnivVar  { tag: 4, num_64: 1 },
-    LeanIxonUnivSucc { tag: 1, num_obj: 1 },
-    LeanIxonUnivMax  { tag: 2, num_obj: 2 },
-    LeanIxonUnivIMax { tag: 3, num_obj: 2 },
-  }
+  LeanIxonUniv [
+    { },                              // tag 0: zero
+    { num_obj: 1 },                   // tag 1: succ
+    { num_obj: 2 },                   // tag 2: max
+    { num_obj: 2 },                   // tag 3: imax
+    { num_64: 1 },                    // tag 4: var
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxonExpr {
-    LeanIxonExprSort  { num_64: 1 },
-    LeanIxonExprVar   { tag: 1, num_64: 1 },
-    LeanIxonExprRef   { tag: 2, num_obj: 1, num_64: 1 },
-    LeanIxonExprRec   { tag: 3, num_obj: 1, num_64: 1 },
-    LeanIxonExprPrj   { tag: 4, num_obj: 1, num_64: 2 },
-    LeanIxonExprStr   { tag: 5, num_64: 1 },
-    LeanIxonExprNat   { tag: 6, num_64: 1 },
-    LeanIxonExprApp   { tag: 7, num_obj: 2 },
-    LeanIxonExprLam   { tag: 8, num_obj: 2 },
-    LeanIxonExprAll   { tag: 9, num_obj: 2 },
-    LeanIxonExprLet   { tag: 10, num_obj: 3, num_8: 1 },
-    LeanIxonExprShare { tag: 11, num_64: 1 },
-  }
+  LeanIxonExpr [
+    { num_64: 1 },                    // tag 0: sort
+    { num_64: 1 },                    // tag 1: var
+    { num_obj: 1, num_64: 1 },        // tag 2: ref
+    { num_obj: 1, num_64: 1 },        // tag 3: rec
+    { num_obj: 1, num_64: 2 },        // tag 4: prj
+    { num_64: 1 },                    // tag 5: str
+    { num_64: 1 },                    // tag 6: nat
+    { num_obj: 2 },                   // tag 7: app
+    { num_obj: 2 },                   // tag 8: lam
+    { num_obj: 2 },                   // tag 9: all
+    { num_obj: 3, num_8: 1 },         // tag 10: let
+    { num_64: 1 },                    // tag 11: share
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxonExprMetaData {
-    LeanIxonExprMetaApp       { tag: 1, num_64: 2 },
-    LeanIxonExprMetaBinder    { tag: 2, num_obj: 1, num_64: 2, num_8: 1 },
-    LeanIxonExprMetaLetBinder { tag: 3, num_obj: 1, num_64: 3 },
-    LeanIxonExprMetaRef       { tag: 4, num_obj: 1 },
-    LeanIxonExprMetaPrj       { tag: 5, num_obj: 1, num_64: 1 },
-    LeanIxonExprMetaMdata     { tag: 6, num_obj: 1, num_64: 1 },
-  }
+  LeanIxonExprMetaData [
+    { },                              // tag 0: leaf (scalar)
+    { num_64: 2 },                    // tag 1: app
+    { num_obj: 1, num_64: 2, num_8: 1 }, // tag 2: binder
+    { num_obj: 1, num_64: 3 },        // tag 3: letBinder
+    { num_obj: 1 },                   // tag 4: ref
+    { num_obj: 1, num_64: 1 },        // tag 5: prj
+    { num_obj: 1, num_64: 1 },        // tag 6: mdata
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxonConstantMeta {
-    LeanIxonConstantMetaDef  { tag: 1, num_obj: 6, num_64: 2 },
-    LeanIxonConstantMetaAxio { tag: 2, num_obj: 3, num_64: 1 },
-    LeanIxonConstantMetaQuot { tag: 3, num_obj: 3, num_64: 1 },
-    LeanIxonConstantMetaIndc { tag: 4, num_obj: 6, num_64: 1 },
-    LeanIxonConstantMetaCtor { tag: 5, num_obj: 4, num_64: 1 },
-    LeanIxonConstantMetaRec  { tag: 6, num_obj: 7, num_64: 1 },
-  }
+  LeanIxonConstantMeta [
+    { },                              // tag 0: empty (scalar)
+    { num_obj: 6, num_64: 2 },        // tag 1: defn
+    { num_obj: 3, num_64: 1 },        // tag 2: axio
+    { num_obj: 3, num_64: 1 },        // tag 3: quot
+    { num_obj: 6, num_64: 1 },        // tag 4: indc
+    { num_obj: 4, num_64: 1 },        // tag 5: ctor
+    { num_obj: 7, num_64: 1 },        // tag 6: recr
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxonDataValue {
-    LeanIxonDataValueString { num_obj: 1 },
-    LeanIxonDataValueBool   { tag: 1, num_8: 1 },
-    LeanIxonDataValueName   { tag: 2, num_obj: 1 },
-    LeanIxonDataValueNat    { tag: 3, num_obj: 1 },
-    LeanIxonDataValueInt    { tag: 4, num_obj: 1 },
-    LeanIxonDataValueSyntax { tag: 5, num_obj: 1 },
-  }
+  LeanIxonDataValue [
+    { num_obj: 1 },                   // tag 0: ofString
+    { num_8: 1 },                     // tag 1: ofBool
+    { num_obj: 1 },                   // tag 2: ofName
+    { num_obj: 1 },                   // tag 3: ofNat
+    { num_obj: 1 },                   // tag 4: ofInt
+    { num_obj: 1 },                   // tag 5: ofSyntax
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxonMutConst {
-    LeanIxonMutConstDefn { num_obj: 1 },
-    LeanIxonMutConstIndc { tag: 1, num_obj: 1 },
-    LeanIxonMutConstRecr { tag: 2, num_obj: 1 },
-  }
+  LeanIxonMutConst [
+    { num_obj: 1 },                   // tag 0: defn
+    { num_obj: 1 },                   // tag 1: indc
+    { num_obj: 1 },                   // tag 2: recr
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxonConstantInfo {
-    LeanIxonConstantInfoDefn { num_obj: 1 },
-    LeanIxonConstantInfoRecr { tag: 1, num_obj: 1 },
-    LeanIxonConstantInfoAxio { tag: 2, num_obj: 1 },
-    LeanIxonConstantInfoQuot { tag: 3, num_obj: 1 },
-    LeanIxonConstantInfoCPrj { tag: 4, num_obj: 1 },
-    LeanIxonConstantInfoRPrj { tag: 5, num_obj: 1 },
-    LeanIxonConstantInfoIPrj { tag: 6, num_obj: 1 },
-    LeanIxonConstantInfoDPrj { tag: 7, num_obj: 1 },
-    LeanIxonConstantInfoMuts { tag: 8, num_obj: 1 },
-  }
+  LeanIxonConstantInfo [
+    { num_obj: 1 },                   // tag 0: defn
+    { num_obj: 1 },                   // tag 1: recr
+    { num_obj: 1 },                   // tag 2: axio
+    { num_obj: 1 },                   // tag 3: quot
+    { num_obj: 1 },                   // tag 4: cPrj
+    { num_obj: 1 },                   // tag 5: rPrj
+    { num_obj: 1 },                   // tag 6: iPrj
+    { num_obj: 1 },                   // tag 7: dPrj
+    { num_obj: 1 },                   // tag 8: muts
+  ]
 }
 
 // =============================================================================
-// Ix structures (single-constructor, tag 0)
+// Ix structures (single-constructor)
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxConstantVal { num_obj: 3 }
+  LeanIxConstantVal [ { num_obj: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxRecursorRule { num_obj: 3 }
+  LeanIxRecursorRule [ { num_obj: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxTheoremVal { num_obj: 3 }
+  LeanIxTheoremVal [ { num_obj: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxCondensedBlocks { num_obj: 3 }
+  LeanIxCondensedBlocks [ { num_obj: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxCompilePhases { num_obj: 3 }
+  LeanIxCompilePhases [ { num_obj: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxSubstring { num_obj: 3 }
+  LeanIxSubstring [ { num_obj: 3 } ]
 }
 
 // =============================================================================
@@ -206,107 +209,109 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxName {
-    LeanIxNameAnonymous { num_obj: 1 },
-    LeanIxNameStr       { tag: 1, num_obj: 3 },
-    LeanIxNameNum       { tag: 2, num_obj: 3 },
-  }
+  LeanIxName [
+    { num_obj: 1 },                   // tag 0: anonymous
+    { num_obj: 3 },                   // tag 1: str
+    { num_obj: 3 },                   // tag 2: num
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxLevel {
-    LeanIxLevelZero  { num_obj: 1 },
-    LeanIxLevelSucc  { tag: 1, num_obj: 2 },
-    LeanIxLevelMax   { tag: 2, num_obj: 3 },
-    LeanIxLevelImax  { tag: 3, num_obj: 3 },
-    LeanIxLevelParam { tag: 4, num_obj: 2 },
-    LeanIxLevelMvar  { tag: 5, num_obj: 2 },
-  }
+  LeanIxLevel [
+    { num_obj: 1 },                   // tag 0: zero
+    { num_obj: 2 },                   // tag 1: succ
+    { num_obj: 3 },                   // tag 2: max
+    { num_obj: 3 },                   // tag 3: imax
+    { num_obj: 2 },                   // tag 4: param
+    { num_obj: 2 },                   // tag 5: mvar
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxExpr {
-    LeanIxExprBvar    { num_obj: 2 },
-    LeanIxExprFvar    { tag: 1, num_obj: 2 },
-    LeanIxExprMvar    { tag: 2, num_obj: 2 },
-    LeanIxExprSort    { tag: 3, num_obj: 2 },
-    LeanIxExprConst   { tag: 4, num_obj: 3 },
-    LeanIxExprApp     { tag: 5, num_obj: 3 },
-    LeanIxExprLam     { tag: 6, num_obj: 4, num_8: 1 },
-    LeanIxExprForallE { tag: 7, num_obj: 4, num_8: 1 },
-    LeanIxExprLetE    { tag: 8, num_obj: 5, num_8: 1 },
-    LeanIxExprLit     { tag: 9, num_obj: 2 },
-    LeanIxExprMdata   { tag: 10, num_obj: 3 },
-    LeanIxExprProj    { tag: 11, num_obj: 4 },
-  }
+  LeanIxExpr [
+    { num_obj: 2 },                   // tag 0: bvar
+    { num_obj: 2 },                   // tag 1: fvar
+    { num_obj: 2 },                   // tag 2: mvar
+    { num_obj: 2 },                   // tag 3: sort
+    { num_obj: 3 },                   // tag 4: const
+    { num_obj: 3 },                   // tag 5: app
+    { num_obj: 4, num_8: 1 },         // tag 6: lam
+    { num_obj: 4, num_8: 1 },         // tag 7: forallE
+    { num_obj: 5, num_8: 1 },         // tag 8: letE
+    { num_obj: 2 },                   // tag 9: lit
+    { num_obj: 3 },                   // tag 10: mdata
+    { num_obj: 4 },                   // tag 11: proj
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxConstantInfo {
-    LeanIxConstantInfoAxiom  { num_obj: 1 },
-    LeanIxConstantInfoDefn   { tag: 1, num_obj: 1 },
-    LeanIxConstantInfoThm    { tag: 2, num_obj: 1 },
-    LeanIxConstantInfoOpaque { tag: 3, num_obj: 1 },
-    LeanIxConstantInfoQuot   { tag: 4, num_obj: 1 },
-    LeanIxConstantInfoInduct { tag: 5, num_obj: 1 },
-    LeanIxConstantInfoCtor   { tag: 6, num_obj: 1 },
-    LeanIxConstantInfoRec    { tag: 7, num_obj: 1 },
-  }
+  LeanIxConstantInfo [
+    { num_obj: 1 },                   // tag 0: axiom
+    { num_obj: 1 },                   // tag 1: defn
+    { num_obj: 1 },                   // tag 2: thm
+    { num_obj: 1 },                   // tag 3: opaque
+    { num_obj: 1 },                   // tag 4: quot
+    { num_obj: 1 },                   // tag 5: induct
+    { num_obj: 1 },                   // tag 6: ctor
+    { num_obj: 1 },                   // tag 7: rec
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxReducibilityHints {
-    LeanIxReducibilityHintsRegular { tag: 2, num_32: 1 },
-  }
+  LeanIxReducibilityHints [
+    { },                              // tag 0: opaque (scalar)
+    { },                              // tag 1: abbrev (scalar)
+    { num_32: 1 },                    // tag 2: regular
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxLiteral {
-    LeanIxLiteralNat { num_obj: 1 },
-    LeanIxLiteralStr { tag: 1, num_obj: 1 },
-  }
+  LeanIxLiteral [
+    { num_obj: 1 },                   // tag 0: nat
+    { num_obj: 1 },                   // tag 1: str
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxInt {
-    LeanIxIntOfNat   { num_obj: 1 },
-    LeanIxIntNegSucc { tag: 1, num_obj: 1 },
-  }
+  LeanIxInt [
+    { num_obj: 1 },                   // tag 0: ofNat
+    { num_obj: 1 },                   // tag 1: negSucc
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxSourceInfo {
-    LeanIxSourceInfoOriginal  { num_obj: 4 },
-    LeanIxSourceInfoSynthetic { tag: 1, num_obj: 2, num_8: 1 },
-    LeanIxSourceInfoNone      { tag: 2 },
-  }
+  LeanIxSourceInfo [
+    { num_obj: 4 },                   // tag 0: original
+    { num_obj: 2, num_8: 1 },         // tag 1: synthetic
+    { },                              // tag 2: none
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxSyntax {
-    LeanIxSyntaxMissing {},
-    LeanIxSyntaxNode  { tag: 1, num_obj: 3 },
-    LeanIxSyntaxAtom  { tag: 2, num_obj: 2 },
-    LeanIxSyntaxIdent { tag: 3, num_obj: 4 },
-  }
+  LeanIxSyntax [
+    { },                              // tag 0: missing
+    { num_obj: 3 },                   // tag 1: node
+    { num_obj: 2 },                   // tag 2: atom
+    { num_obj: 4 },                   // tag 3: ident
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxSyntaxPreresolved {
-    LeanIxSyntaxPreresolvedA { num_obj: 1 },
-    LeanIxSyntaxPreresolvedB { tag: 1, num_obj: 2 },
-  }
+  LeanIxSyntaxPreresolved [
+    { num_obj: 1 },                   // tag 0: namespace
+    { num_obj: 2 },                   // tag 1: decl
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxDataValue {
-    LeanIxDataValueString  { num_obj: 1 },
-    LeanIxDataValueBool    { tag: 1, num_8: 1 },
-    LeanIxDataValueName    { tag: 2, num_obj: 1 },
-    LeanIxDataValueNat     { tag: 3, num_obj: 1 },
-    LeanIxDataValueInt     { tag: 4, num_obj: 1 },
-    LeanIxDataValueSyntax  { tag: 5, num_obj: 1 },
-  }
+  LeanIxDataValue [
+    { num_obj: 1 },                   // tag 0: ofString
+    { num_8: 1 },                     // tag 1: ofBool
+    { num_obj: 1 },                   // tag 2: ofName
+    { num_obj: 1 },                   // tag 3: ofNat
+    { num_obj: 1 },                   // tag 4: ofInt
+    { num_obj: 1 },                   // tag 5: ofSyntax
+  ]
 }
 
 // =============================================================================
@@ -314,25 +319,25 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxAxiomVal { num_obj: 1, num_8: 1 }
+  LeanIxAxiomVal [ { num_obj: 1, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxDefinitionVal { num_obj: 4, num_8: 1 }
+  LeanIxDefinitionVal [ { num_obj: 4, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxOpaqueVal { num_obj: 3, num_8: 1 }
+  LeanIxOpaqueVal [ { num_obj: 3, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxQuotVal { num_obj: 1, num_8: 1 }
+  LeanIxQuotVal [ { num_obj: 1, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxInductiveVal { num_obj: 6, num_8: 3 }
+  LeanIxInductiveVal [ { num_obj: 6, num_8: 3 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxConstructorVal { num_obj: 5, num_8: 1 }
+  LeanIxConstructorVal [ { num_obj: 5, num_8: 1 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxRecursorVal { num_obj: 7, num_8: 2 }
+  LeanIxRecursorVal [ { num_obj: 7, num_8: 2 } ]
 }
 
 // =============================================================================
@@ -340,10 +345,10 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanAiurToplevel { num_obj: 2 }
+  LeanAiurToplevel [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanAiurFunction { num_obj: 2, num_8: 2 }
+  LeanAiurFunction [ { num_obj: 2, num_8: 2 } ]
 }
 
 // =============================================================================
@@ -351,18 +356,18 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxBlockCompareResult {
-    LeanIxBlockCompareResultMatch    {},
-    LeanIxBlockCompareResultMismatch { tag: 1, num_64: 3 },
-    LeanIxBlockCompareResultNotFound { tag: 2 },
-  }
+  LeanIxBlockCompareResult [
+    { },                              // tag 0: match
+    { num_64: 3 },                    // tag 1: mismatch
+    { },                              // tag 2: notFound
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxBlockCompareDetail { num_obj: 1, num_64: 2 }
+  LeanIxBlockCompareDetail [ { num_obj: 1, num_64: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanIxBlock { num_obj: 2, num_64: 1 }
+  LeanIxBlock [ { num_obj: 2, num_64: 1 } ]
 }
 
 // =============================================================================
@@ -370,41 +375,42 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanIxSerializeError {
-    LeanIxSerializeErrorUnexpectedEof    { num_obj: 1 },
-    LeanIxSerializeErrorInvalidTag       { tag: 1, num_obj: 1, num_8: 1 },
-    LeanIxSerializeErrorInvalidFlag      { tag: 2, num_obj: 1, num_8: 1 },
-    LeanIxSerializeErrorInvalidVariant   { tag: 3, num_obj: 1, num_64: 1 },
-    LeanIxSerializeErrorInvalidBool      { tag: 4, num_8: 1 },
-    LeanIxSerializeErrorInvalidShareIndex { tag: 6, num_obj: 1, num_64: 1 },
-  }
+  LeanIxSerializeError [
+    { num_obj: 1 },                   // tag 0: unexpectedEof
+    { num_obj: 1, num_8: 1 },         // tag 1: invalidTag
+    { num_obj: 1, num_8: 1 },         // tag 2: invalidFlag
+    { num_obj: 1, num_64: 1 },        // tag 3: invalidVariant
+    { num_8: 1 },                     // tag 4: invalidBool
+    { },                              // tag 5: addressError
+    { num_obj: 1, num_64: 1 },        // tag 6: invalidShareIndex
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxDecompileError {
-    LeanIxDecompileErrorRefIndex           { num_obj: 2, num_64: 1 },
-    LeanIxDecompileErrorUnivIndex          { tag: 1, num_obj: 2, num_64: 1 },
-    LeanIxDecompileErrorShareIndex         { tag: 2, num_obj: 2, num_64: 1 },
-    LeanIxDecompileErrorRecIndex           { tag: 3, num_obj: 2, num_64: 1 },
-    LeanIxDecompileErrorUnivVarIndex       { tag: 4, num_obj: 2, num_64: 1 },
-    LeanIxDecompileErrorMissingAddress     { tag: 5, num_obj: 1 },
-    LeanIxDecompileErrorMissingMetadata    { tag: 6, num_obj: 1 },
-    LeanIxDecompileErrorBlobNotFound       { tag: 7, num_obj: 1 },
-    LeanIxDecompileErrorBadBlobFormat      { tag: 8, num_obj: 2 },
-    LeanIxDecompileErrorBadConstantFormat  { tag: 9, num_obj: 1 },
-    LeanIxDecompileErrorSerialize          { tag: 10, num_obj: 1 },
-  }
+  LeanIxDecompileError [
+    { num_obj: 2, num_64: 1 },        // tag 0: invalidRefIndex
+    { num_obj: 2, num_64: 1 },        // tag 1: invalidUnivIndex
+    { num_obj: 2, num_64: 1 },        // tag 2: invalidShareIndex
+    { num_obj: 2, num_64: 1 },        // tag 3: invalidRecIndex
+    { num_obj: 2, num_64: 1 },        // tag 4: invalidUnivVarIndex
+    { num_obj: 1 },                   // tag 5: missingAddress
+    { num_obj: 1 },                   // tag 6: missingMetadata
+    { num_obj: 1 },                   // tag 7: blobNotFound
+    { num_obj: 2 },                   // tag 8: badBlobFormat
+    { num_obj: 1 },                   // tag 9: badConstantFormat
+    { num_obj: 1 },                   // tag 10: serialize
+  ]
 }
 
 lean_ffi::lean_inductive! {
-  LeanIxCompileError {
-    LeanIxCompileErrorMissingConstant    { num_obj: 1 },
-    LeanIxCompileErrorMissingAddress     { tag: 1, num_obj: 1 },
-    LeanIxCompileErrorInvalidMutualBlock { tag: 2, num_obj: 1 },
-    LeanIxCompileErrorUnsupportedExpr    { tag: 3, num_obj: 1 },
-    LeanIxCompileErrorUnknownUnivParam   { tag: 4, num_obj: 2 },
-    LeanIxCompileErrorSerialize          { tag: 5, num_obj: 1 },
-  }
+  LeanIxCompileError [
+    { num_obj: 1 },                   // tag 0: missingConstant
+    { num_obj: 1 },                   // tag 1: missingAddress
+    { num_obj: 1 },                   // tag 2: invalidMutualBlock
+    { num_obj: 1 },                   // tag 3: unsupportedExpr
+    { num_obj: 2 },                   // tag 4: unknownUnivParam
+    { num_obj: 1 },                   // tag 5: serialize
+  ]
 }
 
 // =============================================================================
@@ -412,10 +418,10 @@ lean_ffi::lean_inductive! {
 // =============================================================================
 
 lean_ffi::lean_inductive! {
-  LeanPutResponse { num_obj: 2 }
+  LeanPutResponse [ { num_obj: 2 } ]
 }
 lean_ffi::lean_inductive! {
-  LeanGetResponse { num_obj: 3 }
+  LeanGetResponse [ { num_obj: 3 } ]
 }
 
 // =============================================================================

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -120,7 +120,7 @@ lean_ffi::lean_domain_type! {
   /// Lean `Aiur.FriParameters` object.
   LeanAiurFriParameters;
 
-  // Ix inner val types (ConstantInfo variants)
+  // Lean kernel inner structures and variants
   /// Lean `Ix.AxiomVal` object.
   LeanIxAxiomVal;
   /// Lean `Ix.DefinitionVal` object.
@@ -154,7 +154,7 @@ lean_ffi::lean_domain_type! {
   /// Lean `Ixon.Expr.Prj` (tag 4) object.
   LeanIxonExprPrj;
 
-  // Ixon single-scalar variant types
+  // Ixon/Ix inductive variant types
   /// Lean `Ixon.ConstantMeta.Axio` (tag 2) object.
   LeanIxonConstantMetaAxio;
   /// Lean `Ixon.ConstantMeta.Quot` (tag 3) object.
@@ -244,10 +244,10 @@ lean_ffi::lean_domain_type! {
 }
 
 // =============================================================================
-// LeanCtorScalar impls for Ixon structure types
+// LeanCtorScalar impls — structures, inner vals, and inductive variants
 // =============================================================================
 
-// ixon/constant.rs structures
+// Ixon structures (ixon/constant.rs)
 lean_ffi::impl_ctor_scalar!(LeanIxonDefinition     { NUM_OBJ = 2, NUM_64 = 1, NUM_8 = 2 });
 lean_ffi::impl_ctor_scalar!(LeanIxonRecursorRule   { NUM_OBJ = 1, NUM_64 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxonRecursor       { NUM_OBJ = 2, NUM_64 = 5, NUM_8 = 2 });
@@ -260,10 +260,10 @@ lean_ffi::impl_ctor_scalar!(LeanIxonConstructorProj { NUM_OBJ = 1, NUM_64 = 2 })
 lean_ffi::impl_ctor_scalar!(LeanIxonRecursorProj   { NUM_OBJ = 1, NUM_64 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxonDefinitionProj { NUM_OBJ = 1, NUM_64 = 1 });
 
-// ixon/compare.rs + compile.rs
+// Structures (ixon/compare.rs + compile.rs)
 lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareDetail { NUM_OBJ = 1, NUM_64 = 2 });
 
-// Ix inner val types (ix/constant.rs + lean_env.rs)
+// Lean kernel inner val structures (ix/constant.rs + lean_env.rs)
 lean_ffi::impl_ctor_scalar!(LeanIxAxiomVal          { NUM_OBJ = 1, NUM_8 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxDefinitionVal     { NUM_OBJ = 4, NUM_8 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxOpaqueVal         { NUM_OBJ = 3, NUM_8 = 1 });
@@ -273,17 +273,17 @@ lean_ffi::impl_ctor_scalar!(LeanIxConstructorVal    { NUM_OBJ = 5, NUM_8 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxRecursorVal       { NUM_OBJ = 7, NUM_8 = 2 });
 lean_ffi::impl_ctor_scalar!(LeanIxReducibilityHintsRegular { TAG = 2, NUM_32 = 1 });
 
-// Aiur inner types
+// Aiur structures
 lean_ffi::impl_ctor_scalar!(LeanAiurFunction        { NUM_OBJ = 2, NUM_8 = 2 });
 
-// Ixon multi-scalar variant types
+// Ixon inductive variants (multi-scalar)
 lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaApp        { TAG = 1, NUM_64 = 2 });
 lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaBinder     { TAG = 2, NUM_OBJ = 1, NUM_64 = 2, NUM_8 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxonExprMetaLetBinder  { TAG = 3, NUM_OBJ = 1, NUM_64 = 3 });
 lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaDef    { TAG = 1, NUM_OBJ = 6, NUM_64 = 2 });
 lean_ffi::impl_ctor_scalar!(LeanIxonExprPrj            { TAG = 4, NUM_OBJ = 1, NUM_64 = 2 });
 
-// Ixon single-scalar variant types
+// Ixon/Ix inductive variants (single-scalar)
 lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaAxio   { TAG = 2, NUM_OBJ = 3, NUM_64 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaQuot   { TAG = 3, NUM_OBJ = 3, NUM_64 = 1 });
 lean_ffi::impl_ctor_scalar!(LeanIxonConstantMetaIndc   { TAG = 4, NUM_OBJ = 6, NUM_64 = 1 });

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -133,6 +133,26 @@ lean_ffi::lean_domain_type! {
   LeanIxBlockCompareDetail;
 }
 
+// =============================================================================
+// LeanCtorScalar impls for Ixon structure types
+// =============================================================================
+
+// ixon/constant.rs structures
+lean_ffi::impl_ctor_scalar!(LeanIxonDefinition     { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonRecursorRule   { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonRecursor       { NUM_8B = 5 });
+lean_ffi::impl_ctor_scalar!(LeanIxonAxiom          { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonQuotient       { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstructor    { NUM_8B = 4 });
+lean_ffi::impl_ctor_scalar!(LeanIxonInductive      { NUM_8B = 4 });
+lean_ffi::impl_ctor_scalar!(LeanIxonInductiveProj  { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonConstructorProj { NUM_8B = 2 });
+lean_ffi::impl_ctor_scalar!(LeanIxonRecursorProj   { NUM_8B = 1 });
+lean_ffi::impl_ctor_scalar!(LeanIxonDefinitionProj { NUM_8B = 1 });
+
+// ixon/compare.rs + compile.rs
+lean_ffi::impl_ctor_scalar!(LeanIxBlockCompareDetail { NUM_8B = 2 });
+
 /// Lean `Address` object — newtype over `LeanByteArray`.
 ///
 /// Address is a single-field struct in Lean, so it's unboxed to ByteArray


### PR DESCRIPTION
Update `lean-ffi` which now has more ergonomic methods for working with `LeanCtor` scalar types.

After https://github.com/argumentcomputer/lean-ffi/pull/8