### PR TITLE
Clean up deny.toml to silence unused entries

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -71,7 +71,6 @@ feature-depth = 1
 # output a note when they are encountered.
 ignore = [
     "RUSTSEC-2024-0436", # `paste` crate is unmaintained
-    "RUSTSEC-2023-0089", # `atomic-polyfill` crate is unmaintained
     "RUSTSEC-2025-0141", # `bincode` crate is unmaintained
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
@@ -97,10 +96,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "CC0-1.0",
-    "Zlib",
-    "MPL-2.0",
     "ISC",
-    "CDLA-Permissive-2.0",
     "Unlicense"
 ]
 # The confidence threshold for detecting a license from license text.
@@ -239,11 +235,13 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = [
+    "https://github.com/Plonky3/Plonky3",
+]
 
 [sources.allow-org]
 # github.com organizations to allow git sources for
-github = []
+github = ["argumentcomputer"]
 # gitlab.com organizations to allow git sources for
 gitlab = []
 # bitbucket.org organizations to allow git sources for


### PR DESCRIPTION
- Drop unused license allowances (Zlib, MPL-2.0, CDLA-Permissive-2.0)
- Drop unused RUSTSEC-2023-0089 advisory ignore
- Allow git sources from argumentcomputer org and Plonky3/Plonky3