### PR TITLE
feat: Polymorphic benchmark `bgroup`

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -130,9 +130,8 @@ jobs:
           {
             echo '## Benchmark for `${{ matrix.bench }}` at ${{ env.COMMIT_LINK }}';
             echo "";
-            for file in benchmark-report-*.md; do
-              cat "$file"
-              echo ""
+            for file in .lake/benches/*/report.md; do
+              [ -f "$file" ] && cat "$file" && echo ""
             done
             echo "${{ env.WORKFLOW_LINK }}";
           } > ${{ github.workspace }}/comment-body.md

--- a/Benchmarks/Aiur.lean
+++ b/Benchmarks/Aiur.lean
@@ -64,67 +64,27 @@ def friParameters : Aiur.FriParameters := {
   queryProofOfWorkBits := 0
 }
 
-def proveE2E (name: Lean.Name) : IO UInt32 := do
-  let compiled ← match toplevel.compile with
-    | .error e => IO.eprintln e; return 1
-    | .ok compiled => pure compiled
-  let system := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
-  let funIdx := compiled.getFuncIdx name |>.get!
-  let (claim, proof, _) := system.prove friParameters funIdx #[10] default
-  match system.verify friParameters claim proof with
-  | .ok _ => return 0
-  | .error e => IO.eprintln e; return 1
-
-/-- Compile `toplevel` once so the per-stage benchmarks can reuse the result. -/
-def compileToplevel : IO Aiur.CompiledToplevel := do
-  match toplevel.compile with
-  | .error e => throw (IO.userError e)
-  | .ok compiled => pure compiled
-
--- End-to-end proof generation and verification benchmark. `samplingMode`
--- defaults to `.auto`, which will fall back to flat for this slow bench.
-def proveE2EBench : IO $ Array BenchReport :=
-  bgroup "prove E2E" {} do
-    benchIO "fib 10" proveE2E `main
-
--- Individual benchmarks of each step from `proveE2E`. Each stage has different
--- `α`/`β` types, so they live in their own `bgroup` even though they share
--- the `nat_fib` group name on disk.
-
-def toplevelBench : IO $ Array BenchReport :=
-  bgroup "nat_fib" {} do
-    bench "simplify toplevel" Aiur.Toplevel.checkAndSimplify toplevel
-
-def compileBench : IO $ Array BenchReport := do
-  match toplevel.checkAndSimplify with
-  | .error e => throw (IO.userError s!"{repr e}")
-  | .ok decls =>
-    bgroup "nat_fib" {} do
-      bench "compile decls" Aiur.TypedDecls.toBytecode decls
-
-def buildAiurSystemBench : IO $ Array BenchReport := do
-  let compiled ← compileToplevel
-  bgroup "nat_fib" {} do
-    bench "build AiurSystem" (Aiur.AiurSystem.build compiled.bytecode) commitmentParameters
-
-def proveBench : IO $ Array BenchReport := do
-  let compiled ← compileToplevel
-  let system := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
-  let funIdx := compiled.getFuncIdx `main |>.get!
-  bgroup "nat_fib" {} do
-    bench "prove fib 10" (Aiur.AiurSystem.prove system friParameters funIdx #[10]) default
-
-def verifyBench : IO $ Array BenchReport := do
-  let compiled ← compileToplevel
-  let system := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
-  let funIdx := compiled.getFuncIdx `main |>.get!
-  let (claim, proof, _) := system.prove friParameters funIdx #[10] default
-  bgroup "nat_fib" {} do
-    bench "verify fib 10" (Aiur.AiurSystem.verify system friParameters claim) proof
-
+-- Stages the e2e proving pipeline through `benchStep`: each call times a stage
+-- and threads its output into the next. `prove fib 10` is one-shot because a
+-- single iteration already runs in the hundreds of milliseconds.
+--
+-- `simplify toplevel` and `compile decls` are side-benches that measure
+-- sub-steps of `Toplevel.compile`. They sit inside a `skipE2E` block so they
+-- show up in the report without double-counting against `compile`.
 def main : IO Unit := do
-  let _ ← toplevelBench
-  let _ ← compileBench
-  let _ ← buildAiurSystemBench
-  let _ ← proveBench
-  let _ ← verifyBench
+  let decls ← match toplevel.checkAndSimplify with
+    | .error e => throw (IO.userError s!"{repr e}")
+    | .ok decls => pure decls
+  let _ ← bgroup "nat_fib" { e2e := true } do
+    skipE2E
+    bench "simplify toplevel" Aiur.Toplevel.checkAndSimplify toplevel
+    bench "compile decls" Aiur.TypedDecls.toBytecode decls
+    countInE2E
+    let compiled ← benchStepE "compile" Aiur.Toplevel.compile toplevel
+    let system ← benchStep "build AiurSystem"
+        (Aiur.AiurSystem.build compiled.bytecode) commitmentParameters
+    let funIdx := compiled.getFuncIdx `main |>.get!
+    let (claim, proof, _) ← benchStep "prove fib 10"
+        (Aiur.AiurSystem.prove system friParameters funIdx #[10]) default (oneShot := true)
+    let _ ← benchStepE "verify fib 10"
+        (Aiur.AiurSystem.verify system friParameters claim) proof

--- a/Ix/Benchmark/Bench.lean
+++ b/Ix/Benchmark/Bench.lean
@@ -73,36 +73,40 @@ structure BenchGroup where
   name : String
   config : Config
 
-inductive BenchFn ( α β : Type) where
-| pure (fn : α → β)
-| io (fn : α → IO β)
+/--
+A registered benchmark ready to run. Its function and argument are held inside
+the `run` closure, so one `bgroup` can collect benches with different input
+and output types in a single `Array`:
 
-structure Benchmarkable (α β : Type) where
+```
+bench "sort ints"   (List.mergeSort (α := Int))    [3, 1, 2]
+bench "length str"  String.length                  "hello"
+```
+-/
+structure Benchmarkable where
   name : String
-  func : BenchFn α β
-  arg : α
-
-/-- If the function is pure, we need to wrap it in `blackBoxIO` so that Lean doesn't optimize away the result -/
-def Benchmarkable.getFn (b : Benchmarkable α β) : α → IO β :=
-  match b.func with
-  | .pure f => blackBoxIO f
-  | .io f => f
+  /-- Runs one iteration. Pure functions are wrapped in `blackBoxIO` so the
+      compiler can't elide the call. -/
+  run : IO Unit
+  /-- If `true`, this bench runs in one-shot mode (a single un-sampled
+      iteration) even when the group is otherwise sampled. Set to `true` on
+      individual slow stages like proof generation. -/
+  oneShot : Bool := false
 
 /-- Runs the benchmark repeatedly for `warmupTime` seconds and returns the
     mean per-iteration time in nanoseconds. Iteration counts increase linearly
     (1, 2, 3, 4, …) between clock checks to minimize the overhead of
     `IO.monoNanosNow` syscalls. -/
-def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) (style : CliStyle) (benchId : String) : IO Float := do
+def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable) (style : CliStyle) (benchId : String) : IO Float := do
   style.printEphemeral s!"Benchmarking {benchId}: Warming up for {bg.config.warmupTime.floatPretty 2}s"
   let warmupNanos := Cronos.secToNano bg.config.warmupTime
-  let func := bench.getFn
   let startTime ← IO.monoNanosNow
   let mut totalIters : Nat := 0
   let mut elapsed : Nat := 0
   let mut batchSize : Nat := 1
   while elapsed < warmupNanos do
     for _ in List.range batchSize do
-      let _res ← func bench.arg
+      bench.run
     totalIters := totalIters + batchSize
     let now ← IO.monoNanosNow
     elapsed := now - startTime
@@ -110,14 +114,22 @@ def BenchGroup.warmup (bg : BenchGroup) (bench : Benchmarkable α β) (style : C
   let mean := Float.ofNat elapsed / Float.ofNat (totalIters.max 1)
   return mean
 
+-- Formats a sample-iters array as a compact preview: first 3 entries,
+-- then `...`, then the last entry (e.g. `[94, 188, 282, ..., 9400]`).
+def formatItersPreview (iters : Array Nat) : String :=
+  if iters.size ≤ 4 then
+    s!"[{", ".intercalate (iters.toList.map toString)}]"
+  else
+    let head := (iters.extract 0 3).toList.map toString
+    s!"[{", ".intercalate head}, ..., {iters.back!}]"
+
 -- Core sampling loop that runs the benchmark function and returns the array of measured timings
-def runSample (sampleIters : Array Nat) (bench : Benchmarkable α β) : IO (Array Nat) := do
-  let func := bench.getFn
+def runSample (sampleIters : Array Nat) (bench : Benchmarkable) : IO (Array Nat) := do
   let mut timings : Array Nat := #[]
   for iters in sampleIters do
     let start ← IO.monoNanosNow
     for _i in Array.range iters do
-      let _res ← func bench.arg
+      bench.run
     let finish ← IO.monoNanosNow
     timings := timings.push (finish - start)
   return timings
@@ -127,7 +139,7 @@ Runs the sample as a sequence of constant iterations per data point, where the i
 
 Returns the iteration counts and elapsed time per data point.
 -/
-def BenchGroup.sampleFlat (bg : BenchGroup) (bench : Benchmarkable α β)
+def BenchGroup.sampleFlat (bg : BenchGroup) (bench : Benchmarkable)
 (warmupMean : Float) (style : CliStyle) (benchId : String) : IO (Array Nat × Array Nat) := do
   let targetTime := bg.config.sampleTime.toNanos
   let timePerSample := targetTime / (Float.ofNat bg.config.numSamples)
@@ -135,9 +147,9 @@ def BenchGroup.sampleFlat (bg : BenchGroup) (bench : Benchmarkable α β)
   let totalIters := itersPerSample * bg.config.numSamples
   let expectedTime := warmupMean * Float.ofNat itersPerSample * bg.config.numSamples.toSeconds
   printRunning bg.config style benchId expectedTime totalIters itersPerSample
-  if bg.config.verbosity == .verbose then
-    IO.println s!"Flat sample. Iters per sample: {itersPerSample}"
   let sampleIters := Array.replicate bg.config.numSamples itersPerSample
+  if bg.config.verbosity == .verbose then
+    IO.println s!"Iterations per sample: {formatItersPreview sampleIters}"
   let timings ← runSample sampleIters bench
   return (sampleIters, timings)
 
@@ -148,7 +160,7 @@ The sum of this series should be roughly equivalent to the total `sampleTime`.
 
 Returns the iteration counts and elapsed time per sample.
 -/
-def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable α β) (warmupMean : Float) (style : CliStyle) (benchId : String) : IO (Array Nat × Array Nat) := do
+def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable) (warmupMean : Float) (style : CliStyle) (benchId : String) : IO (Array Nat × Array Nat) := do
   let totalRuns := bg.config.numSamples * (bg.config.numSamples + 1) / 2
   let targetTime := bg.config.sampleTime.toNanos
   -- `d` has a minimum value of 1 if the `warmupMean` is sufficiently large
@@ -158,7 +170,7 @@ def BenchGroup.sampleLinear (bg : BenchGroup) (bench : Benchmarkable α β) (war
   let sampleIters := (Array.range bg.config.numSamples).map (fun x => (x + 1) * d)
   printRunning bg.config style benchId expectedTime sampleIters.sum d
   if bg.config.verbosity == .verbose then
-    IO.println s!"Linear sample. Iters increase by a factor of {d} per sample"
+    IO.println s!"Iterations per sample: {formatItersPreview sampleIters}"
   let timings ← runSample sampleIters bench
   return (sampleIters, timings)
 
@@ -231,7 +243,7 @@ def BenchGroup.compare (bg : BenchGroup) (baseSample : Data) (baseEstimates : Es
 def BenchGroup.getComparison (bg : BenchGroup) (benchName : String)
     (avgTimes : Distribution) (config : Config) (resolvedMode : SamplingMode)
     (style : CliStyle) : IO (Option ComparisonData) := do
-  let benchPath := System.mkFilePath [".", ".lake", "benches", bg.name, benchName]
+  let benchPath := config.outputDir / bg.name / benchName
   let fileExt := toString config.serde
   -- Base data is at `new` since we haven't written the latest result to disk yet, which moves the prior data to `base`
   let basePath := benchPath / "new"
@@ -254,77 +266,72 @@ def BenchGroup.getComparison (bg : BenchGroup) (benchName : String)
   return some $ bg.compare baseRun.data baseEstimates avgTimes gen
 
 def saveComparison (groupName : String) (benchName : String) (comparison : ComparisonData) (config : Config) : IO Unit := do
-  let changePath := System.mkFilePath [".", ".lake", "benches", groupName, benchName, "change"]
+  let changePath := config.outputDir / groupName / benchName / "change"
   storeFile config.serde comparison.relativeEstimates (changePath / s!"estimates.{toString config.serde}")
 
-def mkDirs (groupName : String) (benchName : String) : IO (System.FilePath × System.FilePath) := do
-  let benchPath := System.mkFilePath [".", ".lake", "benches", groupName, benchName]
+def mkDirs (outputDir : System.FilePath) (groupName : String) (benchName : String) : IO (System.FilePath × System.FilePath) := do
+  let benchPath := outputDir / groupName / benchName
   let (basePath, changePath, newPath) := (benchPath / "base", benchPath / "change", benchPath / "new")
-  let (baseDir, changeDir, newDir) := (basePath.toString, changePath.toString, newPath.toString)
-  let _out ← IO.Process.run {cmd := "mkdir", args := #["-p", baseDir, changeDir, newDir] }
+  IO.FS.createDirAll basePath
+  IO.FS.createDirAll changePath
+  IO.FS.createDirAll newPath
   return (basePath, newPath)
 
-def moveBaseFile (file : System.FilePath) (baseDir : String) : IO Unit := do
-  if (← System.FilePath.pathExists file) then do
-    -- Move prior bench from `new` to `base`
-    let _ ← IO.Process.run { cmd := "mv", args := #[file.toString, baseDir] }
+def moveBaseFile (file : System.FilePath) (baseDir : System.FilePath) : IO Unit := do
+  if (← System.FilePath.pathExists file) then
+    -- Move prior bench from `new` to `base`, preserving the filename.
+    if let some fname := file.fileName then
+      IO.FS.rename file (baseDir / fname)
 
--- Results are always saved to `.lake/benches/<benchName>/new`. If files of the same serde format already exist from a prior run, move them to `base`.
+-- Results are always saved to `<outputDir>/<groupName>/<benchName>/new`. If files of the same serde format already exist from a prior run, move them to `base`.
 -- `config.samplingMode` must be the resolved mode (`.flat` / `.linear`) — callers must never pass `.auto` here.
 def saveMeasurement (groupName : String) (benchName : String) (mData : MeasurementData) (config : Config) : IO Unit := do
-  let (basePath, newPath) ← mkDirs groupName benchName
-  let baseDir := basePath.toString
+  let (basePath, newPath) ← mkDirs config.outputDir groupName benchName
   let fileExt := toString config.serde
   if let some compData := mData.comparison then
     saveComparison groupName benchName compData config
   let (newEstimatesFile, newSampleFile) := (newPath / s!"estimates.{fileExt}", newPath / s!"sample.{fileExt}")
   let newThroughputFile := newPath / s!"throughput.{fileExt}"
-  moveBaseFile newSampleFile baseDir
-  moveBaseFile newEstimatesFile baseDir
-  moveBaseFile newThroughputFile baseDir
+  moveBaseFile newSampleFile basePath
+  moveBaseFile newEstimatesFile basePath
+  moveBaseFile newThroughputFile basePath
   let sampleRun : SampleRun := { data := mData.data, config }
   storeFile config.serde sampleRun newSampleFile
   storeFile config.serde mData.absoluteEstimates newEstimatesFile
   if let some t := mData.throughput then
     storeFile config.serde t newThroughputFile
 
-def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
+def oneShotBench (groupName : String) (b : Benchmarkable)
     (tput : Option Throughput) (config : Config) (style : CliStyle) : IO BenchReport := do
   let benchId := s!"{groupName}/{b.name}"
   style.printEphemeral s!"Benchmarking {benchId}"
+  if config.verbosity == .verbose then
+    IO.println "Sampling mode: one-shot"
   let start ← IO.monoNanosNow
-  let _res ← b.getFn b.arg
+  b.run
   let finish ← IO.monoNanosNow
   let benchTime := finish - start
   style.overwrite
   -- Use the same 24-char column layout as sampled mode
-  let timeStr := s!"time:   {Ansi.bold (benchTime.toFloat.formatNanos)}"
-  if benchId.length > 23 then
-    IO.println (Ansi.green benchId)
-    IO.println s!"{indent24}{timeStr}"
-  else
-    let pad := String.ofList (List.replicate (24 - benchId.length) ' ')
-    IO.println s!"{Ansi.green benchId}{pad}{timeStr}"
+  printBenchLine benchId s!"time:   {Ansi.bold (benchTime.toFloat.formatNanos)}"
   if let some t := tput then
     IO.println s!"{indent24}thrpt:  {Ansi.bold (t.formatRate benchTime.toFloat)}"
-  let (basePath, newPath) ← mkDirs groupName b.name
-  let fileExt := toString config.serde
-  let newFile := newPath / s!"one-shot.{fileExt}"
+  let (basePath, newPath) ← mkDirs config.outputDir groupName b.name
+  let oneShotFile := s!"one-shot.{toString config.serde}"
+  let newFile := newPath / oneShotFile
   let (baseBench, percentChange) ← if (← System.FilePath.pathExists newFile) then do
     let baseBench : OneShot ← loadFile config.serde newFile
     let baseTime := baseBench.benchTime.toFloat
     let percentChange := (benchTime.toFloat - baseTime) / baseTime
-    IO.println s!"{indent24}change: {percentChangeToString percentChange}"
-    let _ ← IO.Process.run { cmd := "mv", args := #[newFile.toString, basePath.toString] }
+    IO.println s!"{indent24}change: {Ansi.bold (percentChangeToString percentChange)}"
+    IO.FS.rename newFile (basePath / oneShotFile)
     pure (some baseBench, some percentChange)
   else
-    let _ ← IO.Process.run { cmd := "mkdir", args := #["-p", newPath.toString] }
     pure (.none, .none)
   -- One-shot mode embeds throughput inside the OneShot record so there is no
   -- separate throughput file on disk — switching between sample and one-shot
   -- modes never overlaps on the same filename.
   let newBench : OneShot := { benchTime, throughput := tput }
-  IO.println ""
   storeFile config.serde newBench newFile
   let benchReport : BenchReport := {
     function := b.name,
@@ -335,135 +342,218 @@ def oneShotBench {α β : Type} (groupName : String) (b : Benchmarkable α β)
   }
   return benchReport
 
+/--
+Runs a single benchmark end-to-end: warms up (sampled mode only), takes
+measurements, prints the result line, writes timings to disk, and returns the
+`BenchReport`. Picks one-shot mode if either `config.oneShot` or
+`b.oneShot` is set; otherwise samples according to `config.samplingMode`.
+-/
+def runSingleBench (groupName : String) (b : Benchmarkable)
+    (tput : Option Throughput) (config : Config) (style : CliStyle) : IO BenchReport := do
+  let benchId := s!"{groupName}/{b.name}"
+  let bg : BenchGroup := { name := groupName, config }
+  -- Per-bench override: bench is one-shot if either the group config or the
+  -- bench itself is marked one-shot, so a mostly-sampled group can still
+  -- include e.g. a slow setup stage that takes seconds per iteration.
+  let isOneShot := config.oneShot || b.oneShot
+  if isOneShot then
+    oneShotBench groupName b tput config style
+  else
+    -- Ephemeral: "Benchmarking {id}" → overwrite → "Warming up" → overwrite → "Collecting" → overwrite → permanent results
+    style.printEphemeral s!"Benchmarking {benchId}"
+    let warmupMean ← bg.warmup b style benchId
+    -- Resolve `.auto` to a concrete mode now so both sampling and the
+    -- downstream regression-vs-mean choice see the same decision.
+    let resolvedMode := chooseSamplingMode bg.config warmupMean
+    if bg.config.verbosity == .verbose then
+      let modeName := match resolvedMode with
+        | .flat => "flat"
+        | .linear => "linear"
+        | .auto => "auto"
+      let picked := if bg.config.samplingMode == .auto then " (picked by auto)" else ""
+      IO.println s!"Sampling mode: {modeName}{picked}"
+    -- From here on use `resolvedConfig` (never `.auto`) so the `SampleRun`
+    -- persisted to disk and the regression branch agree on the actual mode.
+    let resolvedConfig := { bg.config with samplingMode := resolvedMode }
+    let (iters, times) ← match resolvedMode with
+      | .flat => bg.sampleFlat b warmupMean style benchId
+      | .linear => bg.sampleLinear b warmupMean style benchId
+      | .auto => bg.sampleFlat b warmupMean style benchId -- unreachable
+    -- Show "Analyzing" ephemeral while bootstrap runs (matches criterion.rs)
+    style.printEphemeral s!"Benchmarking {benchId}: Analyzing"
+    let data := iters.zip times
+    let avgTimes : Distribution := { d := data.map (fun (x,y) => Float.ofNat y / Float.ofNat x) }
+    let gen ← IO.stdGenRef.get
+    let mut (distributions, estimates) := avgTimes.estimates resolvedConfig gen
+    let mut rSquared : Option Float := none
+    if resolvedMode == .linear
+    then
+      let data' : Data := { d := data }
+      let (distribution, slope, r2) := data'.regression resolvedConfig gen
+      estimates := { estimates with slope := .some slope }
+      distributions := { distributions with slope := .some distribution }
+      rSquared := some r2
+    -- Outlier analysis: classify per-sample average times and compute the
+    -- variance-inflation metric (consumed by `printResults` under the verbosity gate).
+    let outliers := avgTimes.classifyOutliers
+    let ov := outlierVariance estimates.mean estimates.stdDev (Float.ofNat resolvedConfig.numSamples)
+    let comparisonData : Option ComparisonData ← bg.getComparison b.name avgTimes resolvedConfig resolvedMode style
+    let measurement : MeasurementData :=  {
+      data := { d := data },
+      avgTimes,
+      absoluteEstimates := estimates,
+      distributions,
+      comparison := comparisonData
+      throughput := tput
+      rSquared,
+      outlierVariance := some ov,
+      outliers := some outliers
+    }
+    style.overwrite
+    printResults groupName resolvedConfig b.name measurement
+    saveMeasurement groupName b.name measurement resolvedConfig
+    return {
+      function := b.name,
+      newBench := (.sample estimates),
+      baseBench := (comparisonData.map (.sample ·.baseEstimates)),
+      percentChange := comparisonData.map (·.relativeEstimates.mean.pointEstimate),
+      throughput := tput
+    }
+
 /-!
 ## Monadic bgroup builder
 
-`bgroup` takes a `BgroupM` do-block instead of a list of pre-built benches so
-the user can interleave `throughput` (which updates the current group config's
-throughput field) with `bench` / `benchIO` registrations. Each registration
-captures a snapshot of `config.throughput` at that moment.
+Inside a `bgroup` do-block, benches run in the order they appear. `benchStep`
+returns the result of its function so you can feed it to the next stage with
+`let x ← benchStep …`; `bench` is the discard-the-result variant. `throughput`
+and `skipE2E` / `countInE2E` are stateful toggles — they affect every bench
+that comes after the call, so you can set them once and register several
+benches, or flip them between registrations.
 -/
 
 /-- Internal state threaded through a `bgroup` do-block. -/
-structure GroupState (α β : Type) where
+structure GroupState where
+  /-- Group name, used when forming per-bench `benchId`s. -/
+  groupName : String
   config : Config
-  /-- Registered benches paired with the `config.throughput` snapshot taken at registration time. -/
-  benches : Array (Benchmarkable α β × Option Throughput) := #[]
+  /-- Reports collected as each bench runs, in declaration order. -/
+  reports : Array BenchReport := #[]
+  /-- Sum of per-bench times (ns) for benches that were counted toward the
+      end-to-end total. Each bench reads `config.countInE2E` when it runs
+      (flip with `skipE2E` / `countInE2E`) and adds its time here if set.
+      Reported as the e2e total when `config.e2e` is on. -/
+  e2eSumNs : Float := 0.0
 
 /-- Monad used inside a `bgroup` do-block. -/
-abbrev BgroupM (α β : Type) := StateT (GroupState α β) IO
+abbrev BgroupM := StateT GroupState IO
 
 namespace BgroupM
 
-/--
-Sets the throughput for subsequent `bench`/`benchIO` calls in the current
-`bgroup`. Prior registrations keep the value they captured at registration time.
--/
-def throughput (t : Throughput) : BgroupM α β Unit :=
+/-- Attach throughput info to subsequent benches in this group. Each bench
+    records whatever throughput is current when it runs, so setting this
+    in the middle of a group only affects benches that come after. -/
+def throughput (t : Throughput) : BgroupM Unit :=
   modify fun s => { s with config := { s.config with throughput := some t } }
 
-/-- Clears the current throughput so subsequent registrations capture `none`. -/
-def clearThroughput : BgroupM α β Unit :=
+/-- Stops attaching throughput info to subsequent benches. -/
+def clearThroughput : BgroupM Unit :=
   modify fun s => { s with config := { s.config with throughput := none } }
 
-/--
-Registers a pure benchmark with the current `bgroup`. The pure `fn` is wrapped
-in `blackBoxIO` internally so the compiler cannot optimize its result away.
--/
-def bench (name : String) (fn : α → β) (arg : α) : BgroupM α β Unit :=
-  modify fun s =>
-    let b : Benchmarkable α β := { name, func := BenchFn.pure fn, arg }
-    { s with benches := s.benches.push (b, s.config.throughput) }
+/-- Stops subsequent benches from contributing to the end-to-end total (when
+    `config.e2e` is on). Pair with `countInE2E` to flip back on. Typical use:
+    group side-benches (micro-measurements already covered by a bigger
+    pipeline stage) under `skipE2E` so they don't double-count. -/
+def skipE2E : BgroupM Unit :=
+  modify fun s => { s with config := { s.config with countInE2E := false } }
+
+/-- Resumes counting subsequent benches toward the end-to-end total. -/
+def countInE2E : BgroupM Unit :=
+  modify fun s => { s with config := { s.config with countInE2E := true } }
+
+/-- Runs `b` via `runSingleBench`, appends the resulting `BenchReport` to the
+    group state, adds the bench's time to the e2e total if `countInE2E` is
+    set, and returns the `β` the bench stashed in `resultRef`. -/
+def runCapturedBench (b : Benchmarkable) (resultRef : IO.Ref (Option β)) : BgroupM β := do
+  let st ← get
+  let style : CliStyle := { overwriteEnabled := st.config.verbosity != .verbose }
+  let report ← runSingleBench st.groupName b st.config.throughput st.config style
+  IO.println ""
+  let delta := if st.config.countInE2E then report.newBench.getTime else 0.0
+  modify fun s => { s with
+    reports  := s.reports.push report
+    e2eSumNs := s.e2eSumNs + delta
+  }
+  match ← resultRef.get with
+  | some r => return r
+  | none => throw (IO.userError s!"benchStep '{b.name}' produced no result")
 
 /--
-Registers an `IO`-returning benchmark with the current `bgroup`. `IO` benches are
-not black-boxed because the `IO` return already prevents the optimizer from
-eliminating the call.
+Benchmarks `fn arg` and returns the last iteration's result so it can feed the
+next pipeline stage. Equivalent to a `let x := fn arg` that also times the
+call:
+
+```
+bgroup "pipeline" {} do
+  let parsed  ← benchStep "parse"    parseFile   input
+  let checked ← benchStep "check"    typecheck   parsed
+  let _       ← benchStep "emit"     emit        checked
+```
+
+Pass `oneShot := true` for stages whose single iteration already takes long
+enough that sampling would be wasteful.
 -/
-def benchIO (name : String) (fn : α → IO β) (arg : α) : BgroupM α β Unit :=
-  modify fun s =>
-    let b : Benchmarkable α β := { name, func := BenchFn.io fn, arg }
-    { s with benches := s.benches.push (b, s.config.throughput) }
+def benchStep (name : String) (fn : α → β) (arg : α) (oneShot : Bool := false) : BgroupM β := do
+  let resultRef ← IO.mkRef (none : Option β)
+  let run : IO Unit := do resultRef.set (some (← blackBoxIO fn arg))
+  runCapturedBench { name, run, oneShot } resultRef
+
+/-- Like `benchStep`, but for `fn : α → IO β`. The final iteration's `β` is
+    captured and returned; every iteration's side effects have already run
+    during measurement. -/
+def benchStepIO (name : String) (fn : α → IO β) (arg : α) (oneShot : Bool := false) : BgroupM β := do
+  let resultRef ← IO.mkRef (none : Option β)
+  let run : IO Unit := do resultRef.set (some (← fn arg))
+  runCapturedBench { name, run, oneShot } resultRef
+
+/--
+Like `benchStep`, but for `fn : α → Except ε β`. Returns `β` on success and
+throws an `IO.userError` carrying `{name}: {e}` on `.error`, so a pipeline
+can chain through fallible stages without an extra `match`:
+
+```
+let decls ← benchStepE "simplify" Toplevel.checkAndSimplify toplevel
+-- decls : TypedDecls (unwrapped from Except CheckError TypedDecls)
+```
+-/
+def benchStepE [ToString ε] (name : String) (fn : α → Except ε β) (arg : α)
+    (oneShot : Bool := false) : BgroupM β := do
+  match ← benchStep name fn arg oneShot with
+  | .ok x    => return x
+  | .error e => throw (IO.userError s!"{name}: {e}")
+
+/-- Benchmarks `fn arg` and discards the result. Use this when a stage's
+    output isn't needed downstream — surrounding `skipE2E` / `countInE2E`
+    controls whether the time counts toward the end-to-end total. -/
+def bench (name : String) (fn : α → β) (arg : α) (oneShot : Bool := false) : BgroupM Unit := do
+  let _ ← benchStep name fn arg oneShot
+  return ()
+
+/-- Like `bench`, but for `fn : α → IO β`. -/
+def benchIO (name : String) (fn : α → IO β) (arg : α) (oneShot : Bool := false) : BgroupM Unit := do
+  let _ ← benchStepIO name fn arg oneShot
+  return ()
 
 end BgroupM
 
--- TODO: Make sure compiler isn't caching partial evaluation result for future runs of the same function (measure first vs subsequent runs)
-/-- Runs each benchmark registered by `action` and analyzes the results. -/
-def bgroup {α β : Type} (name: String) (config : Config := {})
-    (action : BgroupM α β Unit) : IO $ Array BenchReport := do
+/-- Runs the benches in `action` under the given name and config, then — after
+    all benches have finished — prints the average throughput, the end-to-end
+    total, and the Markdown comparison table, each gated by its corresponding
+    `config` flag. Returns the collected `BenchReport`s. -/
+def bgroup (name: String) (config : Config := {})
+    (action : BgroupM Unit) : IO $ Array BenchReport := do
   let config ← getConfigEnv config
-  let (_, state) ← action.run { config, benches := #[] }
-  let bg : BenchGroup := { name, config }
-  -- Verbose mode makes all output permanent (no ephemeral line overwriting)
-  let style : CliStyle := { overwriteEnabled := config.verbosity != .verbose }
-  let mut reports : Array BenchReport := #[]
-  for (b, tput) in state.benches do
-    let benchId := s!"{name}/{b.name}"
-    let report : BenchReport ← if config.oneShot then do
-      oneShotBench name b tput config style
-    else
-      -- Ephemeral: "Benchmarking {id}" → overwrite → "Warming up" → overwrite → "Collecting" → overwrite → permanent results
-      style.printEphemeral s!"Benchmarking {benchId}"
-      let warmupMean ← bg.warmup b style benchId
-      -- Resolve `.auto` to a concrete mode now so both sampling and the
-      -- downstream regression-vs-mean choice see the same decision.
-      let resolvedMode := chooseSamplingMode bg.config warmupMean
-      if bg.config.verbosity == .verbose then
-        let modeName := match resolvedMode with
-          | .flat => "flat"
-          | .linear => "linear"
-          | .auto => "auto"
-        let picked := if bg.config.samplingMode == .auto then " (picked by auto)" else ""
-        IO.println s!"Sampling mode: {modeName}{picked}"
-      -- From here on use `resolvedConfig` (never `.auto`) so the `SampleRun`
-      -- persisted to disk and the regression branch agree on the actual mode.
-      let resolvedConfig := { bg.config with samplingMode := resolvedMode }
-      let (iters, times) ← match resolvedMode with
-        | .flat => bg.sampleFlat b warmupMean style benchId
-        | .linear => bg.sampleLinear b warmupMean style benchId
-        | .auto => bg.sampleFlat b warmupMean style benchId -- unreachable
-      -- Show "Analyzing" ephemeral while bootstrap runs (matches criterion.rs)
-      style.printEphemeral s!"Benchmarking {benchId}: Analyzing"
-      let data := iters.zip times
-      let avgTimes : Distribution := { d := data.map (fun (x,y) => Float.ofNat y / Float.ofNat x) }
-      let gen ← IO.stdGenRef.get
-      let mut (distributions, estimates) := avgTimes.estimates resolvedConfig gen
-      let mut rSquared : Option Float := none
-      if resolvedMode == .linear
-      then
-        let data' : Data := { d := data }
-        let (distribution, slope, r2) := data'.regression resolvedConfig gen
-        estimates := { estimates with slope := .some slope }
-        distributions := { distributions with slope := .some distribution }
-        rSquared := some r2
-      -- Outlier analysis: classify per-sample average times and compute the
-      -- variance-inflation metric (consumed by `printResults` under the verbosity gate).
-      let outliers := avgTimes.classifyOutliers
-      let ov := outlierVariance estimates.mean estimates.stdDev (Float.ofNat resolvedConfig.numSamples)
-      let comparisonData : Option ComparisonData ← bg.getComparison b.name avgTimes resolvedConfig resolvedMode style
-      let measurement : MeasurementData :=  {
-        data := { d := data },
-        avgTimes,
-        absoluteEstimates := estimates,
-        distributions,
-        comparison := comparisonData
-        throughput := tput
-        rSquared,
-        outlierVariance := some ov,
-        outliers := some outliers
-      }
-      style.overwrite
-      printResults name resolvedConfig b.name measurement
-      saveMeasurement name b.name measurement resolvedConfig
-      let benchReport : BenchReport := {
-        function := b.name,
-        newBench := (.sample estimates),
-        baseBench := (comparisonData.map (.sample ·.baseEstimates)),
-        percentChange := comparisonData.map (·.relativeEstimates.mean.pointEstimate),
-        throughput := tput
-      }
-      pure benchReport
-    reports := reports.push report
+  let (_, state) ← action.run { groupName := name, config }
+  let reports := state.reports
   if config.avgThroughput then
     match weightedAverageThroughput reports with
     | some (t, primaryAvg, secondaryAvg) =>
@@ -473,12 +563,44 @@ def bgroup {α β : Type} (name: String) (config : Config := {})
         IO.println s!"Average throughput (bytes): {Float.formatBytesRate bytesAvg}"
     | none =>
       IO.eprintln "Average throughput: skipped (no throughput set, or mixed Throughput variants across benches)"
+  -- End-to-end total: sum of per-stage mean/one-shot times, compared against
+  -- the prior saved total for change tracking. Not itself sampled.
+  let reports ← if config.e2e then do
+    let totalNs : Float := state.e2eSumNs
+    let reportDir := config.outputDir / name
+    let e2eFile := reportDir / s!"e2e.{toString config.serde}"
+    let priorTotal : Option Float ← if ← System.FilePath.pathExists e2eFile then do
+      let prior : E2ETotal ← loadFile config.serde e2eFile
+      pure (some prior.totalNs)
+    else pure none
+    let percentChange : Option Float := priorTotal.bind fun prior =>
+      if prior == 0 then none else some ((totalNs - prior) / prior)
+    -- Summary line: matches per-bench 24-char column layout.
+    printBenchLine s!"{name}/end-to-end" s!"time:   {Ansi.bold totalNs.formatNanos}"
+    if let some pc := percentChange then
+      IO.println s!"{indent24}change: {Ansi.bold (percentChangeToString pc)}"
+    IO.println ""
+    -- Persist for next run, then (if we're writing a report) append the total
+    -- as a synthetic row so the Markdown table includes it.
+    IO.FS.createDirAll reportDir
+    storeFile config.serde { totalNs : E2ETotal } e2eFile
+    let totalToOneShot (t : Float) : BenchResult :=
+      .oneShot { benchTime := t.round.toUInt64.toNat, throughput := none }
+    pure <| reports.push {
+      function     := "end-to-end"
+      newBench     := totalToOneShot totalNs
+      baseBench    := priorTotal.map totalToOneShot
+      percentChange
+      throughput   := none
+    }
+  else pure reports
   if config.report then
-    let table := mkReportPretty name reports
-    IO.println table
-    let reportDir := System.mkFilePath [".", ".lake", "benches", name]
-    let _ ← IO.Process.run { cmd := "mkdir", args := #["-p", reportDir.toString] }
-    IO.FS.writeFile (reportDir / "report.md") table
+    -- Plaintext table (`## {name}\n\n...`) to stdout; GitHub-flavored Markdown
+    -- (table wrapped in `<details>`) to disk for the PR-workflow comment.
+    IO.println (mkReportPlain name reports)
+    let reportDir := config.outputDir / name
+    IO.FS.createDirAll reportDir
+    IO.FS.writeFile (reportDir / "report.md") (mkReportMarkdown name reports)
   return reports
 
 end

--- a/Ix/Benchmark/Common.lean
+++ b/Ix/Benchmark/Common.lean
@@ -116,6 +116,9 @@ structure Config where
   oneShot : Bool := false
   /-- Whether to generate a Markdown report of all timings including comparison to disk if possible-/
   report : Bool := false
+  /-- Root directory for all benchmark output (measurements, comparisons,
+      reports). Defaults to `.lake/benches`. Override via `BENCH_OUTPUT_DIR`. -/
+  outputDir : System.FilePath := ".lake" / "benches"
   /--
   Throughput for the next benchmark registered in a `bgroup` do-block. Each
   `bench`/`benchIO` call inside a `bgroup` captures a snapshot of this field
@@ -130,6 +133,21 @@ structure Config where
   `Throughput` variant; otherwise the average is skipped with a warning.
   -/
   avgThroughput : Bool := false
+  /--
+  If `true`, `bgroup` sums each bench's mean/one-shot time at the end of the
+  group and emits an "end-to-end" total. The total is serialized to
+  `<outputDir>/<groupName>/e2e.<fmt>` so the next run can report a percent
+  change against it, and (if `report` is also on) included as a row in the
+  aggregated Markdown table. Overridable via `BENCH_E2E=1`.
+  -/
+  e2e : Bool := false
+  /--
+  Whether the next bench in this group counts toward the end-to-end total.
+  Defaults to `true`; flip with `BgroupM.skipE2E` / `BgroupM.countInE2E`.
+  A bench reads this flag when it runs, so benches registered before the
+  toggle keep their earlier setting.
+  -/
+  countInE2E : Bool := true
   /-- Diagnostic output level. Overridable via `BENCH_VERBOSITY` env var
       (see `getConfigEnv`). -/
   verbosity : Verbosity := .normal
@@ -141,6 +159,8 @@ Overrides config values with the corresponding `BENCH_*` env vars.
 
 - `BENCH_SERDE`: `"ixon"` to use Ixon format, otherwise JSON (default)
 - `BENCH_REPORT`: `"1"` to generate a Markdown report
+- `BENCH_OUTPUT_DIR`: root directory for all benchmark output (default `.lake/benches`)
+- `BENCH_E2E`: `"1"` to emit an end-to-end total (sum of per-stage times) at the end of each group
 - `BENCH_VERBOSITY`: `q` (quiet) | `v` (verbose); omit for normal
 
 Example: `BENCH_VERBOSITY=v lake exe bench-shardmap`
@@ -148,12 +168,14 @@ Example: `BENCH_VERBOSITY=v lake exe bench-shardmap`
 def getConfigEnv (config : Config) : IO Config := do
   let serde : SerdeFormat := if (← IO.getEnv "BENCH_SERDE") == some "ixon" then .ixon else config.serde
   let report := if let some val := (← IO.getEnv "BENCH_REPORT") then val == "1" else config.report
+  let outputDir := if let some dir := (← IO.getEnv "BENCH_OUTPUT_DIR") then dir else config.outputDir
+  let e2e := if let some val := (← IO.getEnv "BENCH_E2E") then val == "1" else config.e2e
   let verbosity : Verbosity ← do
     match (← IO.getEnv "BENCH_VERBOSITY") with
     | some "q" => pure .quiet
     | some "v" => pure .verbose
     | _ => pure config.verbosity
-  return { config with serde, report, verbosity }
+  return { config with serde, report, outputDir, e2e, verbosity }
 
 @[inline] def Float.toNanos (f : Float) : Float := f * 10 ^ 9
 

--- a/Ix/Benchmark/Distribution.lean
+++ b/Ix/Benchmark/Distribution.lean
@@ -148,9 +148,9 @@ inductive OutlierEffect where
 /-- Summary of the outlier-variance analysis for a sample. -/
 structure OutlierVariance where
   effect : OutlierEffect
-  /-- English description slotted into criterion's `variance introduced by
-      outliers: N% ({desc} inflated)` message — one of `"unaffected"`,
-      `"slightly"`, `"moderately"`, or `"severely"`. -/
+  /-- English description slotted into the `variance attributable to outliers:
+      N% ({desc})` message — one of `"unaffected"`, `"slightly inflated"`,
+      `"moderately inflated"`, or `"severely inflated"`. -/
   desc : String
   /-- Quantitative fraction in `[0, 1]`. -/
   fraction : Float

--- a/Ix/Benchmark/OneShot.lean
+++ b/Ix/Benchmark/OneShot.lean
@@ -9,4 +9,11 @@ structure OneShot where
   throughput : Option Throughput := none
   deriving Lean.ToJson, Lean.FromJson, Repr
 
+/-- Group-level end-to-end total: the sum of per-stage mean/one-shot times
+    for every bench in a group. Persisted to disk so successive runs can
+    report a percent change against the previous total. -/
+structure E2ETotal where
+  totalNs : Float
+  deriving Lean.ToJson, Lean.FromJson, Repr
+
 end

--- a/Ix/Benchmark/Report.lean
+++ b/Ix/Benchmark/Report.lean
@@ -111,6 +111,27 @@ def compareToThreshold (estimate : Estimate) (noiseThreshold : Float) : Comparis
 /-- Criterion.rs uses a fixed 24-char column for the time/thrpt labels. -/
 def indent24 : String := String.ofList (List.replicate 24 ' ')
 
+/-- Prints a benchmark summary line in criterion.rs's 24-char column layout:
+    the green `name` occupies the first column, `body` the second.
+
+    Short names (≤23 chars) fit alongside `body` on one line:
+    ```
+    group/bench           time: [lo mid hi] ...
+    ```
+    Longer names take their own line with `body` indented underneath:
+    ```
+    group/very-long-bench-name
+                          time: [lo mid hi] ...
+    ``` -/
+def printBenchLine (name : String) (body : String) : IO Unit := do
+  let green := Ansi.green name
+  if name.length > 23 then
+    IO.println green
+    IO.println s!"{indent24}{body}"
+  else
+    let pad := String.ofList (List.replicate (24 - name.length) ' ')
+    IO.println s!"{green}{pad}{body}"
+
 def printRunning (config : Config) (style : CliStyle) (benchId : String) (expectedTime : Float) (numIters : Nat) (warningFactor : Nat) : IO Unit := do
   if warningFactor == 1 then
     -- Clear the ephemeral line before printing the permanent warning
@@ -136,16 +157,11 @@ def printResults (groupName : String) (config : Config) (benchName : String)
   -- Name line + time, matching criterion.rs's 24-char column layout:
   -- Short name (≤ 23 chars): name + pad + time on one line
   -- Long name (> 23 chars): name on its own line, time on the next
-  let r2Suffix := match m.rSquared with
-    | some r2 => s!" R²={r2.floatPretty 3}"
-    | none => ""
-  let timeLine := s!"time:   [{Ansi.faint ciLb.formatNanos} {Ansi.bold typicalEstimate.pointEstimate.formatNanos} {Ansi.faint ciUb.formatNanos}]{r2Suffix}"
-  if fullName.length > 23 then
-    IO.println (Ansi.green fullName)
-    IO.println s!"{indent24}{timeLine}"
-  else
-    let pad := String.ofList (List.replicate (24 - fullName.length) ' ')
-    IO.println s!"{Ansi.green fullName}{pad}{timeLine}"
+  let modeSuffix := match m.rSquared with
+    | some r2 => s!" [linear R²={r2.floatPretty 3}]"
+    | none => " [flat]"
+  let timeLine := s!"time:   [{Ansi.faint ciLb.formatNanos} {Ansi.bold typicalEstimate.pointEstimate.formatNanos} {Ansi.faint ciUb.formatNanos}]{modeSuffix}"
+  printBenchLine fullName timeLine
 
   -- Throughput line (if present)
   if let some t := m.throughput then
@@ -200,30 +216,32 @@ def printResults (groupName : String) (config : Config) (benchName : String)
         | .NonSignificant => "Change within noise threshold."
       IO.println s!"{indent24}{explanation}"
 
-  -- Outlier-variance warning + Tukey breakdown. Verbosity gating matches
-  -- Haskell criterion's `Internal.hs:89-92`:
-  --   • verbose             → always print the variance line AND breakdown
-  --   • normal + > slight   → print the variance line AND breakdown
-  --   • normal + ≤ slight   → silent
-  --   • quiet               → silent regardless
+  -- Tukey breakdown and Boyer model-based variance line are independent:
+  --   • Tukey (count > 0): print in non-quiet. Concrete per-sample spikes.
+  --   • Boyer variance:   print in verbose always; in normal only when the
+  --                       effect is at least moderate. It's a shape-derived
+  --                       metric that can fire with no Tukey outliers.
   if verbosity != .quiet then
+    if let some outs := m.outliers then
+      Outliers.note outs m.avgTimes.d.size
     if let some ov := m.outlierVariance then
       let effectAboveSlight := match ov.effect with
         | .moderate | .severe => true
         | _ => false
-      let showVariance := verbosity == .verbose || (effectAboveSlight && verbosity != .quiet)
-      if showVariance then
-        if let some outs := m.outliers then
-          Outliers.note outs m.avgTimes.d.size
+      if verbosity == .verbose || effectAboveSlight then
         let pct := (ov.fraction * 100).floatPretty 0
-        IO.println s!"variance introduced by outliers: {pct}% ({ov.desc})"
+        IO.println s!"variance attributable to outliers: {pct}% ({ov.desc})"
 
 /-! ## Markdown table -/
 
-def percentChangeToString (pc : Float) : String :=
+def percentChangeToString (pc : Float) (markdown : Bool := false) : String :=
   let rounded := (100 * pc).floatPretty 2
-  if pc < 0 then s!"{rounded.drop 1}% faster"
-  else if pc > 0 then s!"{rounded}% slower"
+  if pc < 0 then
+    if markdown then s!"**🟢 {rounded.drop 1}% faster**"
+    else s!"{rounded.drop 1}% faster"
+  else if pc > 0 then
+    if markdown then s!"**🔴 {rounded}% slower**"
+    else s!"{rounded}% slower"
   else "No change"
 
 structure ColumnWidths where
@@ -234,7 +252,7 @@ structure ColumnWidths where
   /-- `none` ⇒ the Throughput column is not rendered for this group. -/
   throughput : Option Nat
 
-def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidths :=
+def getColumnWidths' (markdown : Bool) (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidths :=
   let fnLen := row.function.length
   let function := if fnLen > maxWidths.function then fnLen else maxWidths.function
   let newBenchLen := row.newBench.getTime.formatNanos.length
@@ -245,7 +263,7 @@ def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidth
     else maxWidths.baseBench
   else maxWidths.baseBench
   let percentChange := if let some percentChange := row.percentChange then
-    let percentChangeStr := percentChangeToString percentChange
+    let percentChangeStr := percentChangeToString percentChange (markdown := markdown)
     let percentLen := percentChangeStr.length
     if percentLen > maxWidths.percentChange then percentLen
     else maxWidths.percentChange
@@ -258,7 +276,7 @@ def getColumnWidths' (maxWidths : ColumnWidths) (row: BenchReport) : ColumnWidth
       some (if tLen > w then tLen else w)
   { function, newBench, baseBench, percentChange, throughput }
 
-def getColumnWidths (report : Array BenchReport) : ColumnWidths :=
+def getColumnWidths (markdown : Bool) (report : Array BenchReport) : ColumnWidths :=
   let hasThroughput := report.any (·.throughput.isSome)
   let maxWidths : ColumnWidths := {
     function := "Function".length
@@ -267,7 +285,7 @@ def getColumnWidths (report : Array BenchReport) : ColumnWidths :=
     percentChange := "% change".length
     throughput := if hasThroughput then some "Throughput".length else none
   }
-  report.foldl getColumnWidths' maxWidths
+  report.foldl (getColumnWidths' markdown) maxWidths
 
 def padWhitespace (input : String) (width : Nat) : String :=
   let padWidth := width - input.length
@@ -278,33 +296,36 @@ def padWhitespace (input : String) (width : Nat) : String :=
 def padDashes (width : Nat) : String :=
   String.ofList (List.replicate width '-')
 
-def mkReportPretty' (columnWidths : ColumnWidths) (reportPretty : String) (row : BenchReport) : String :=
+/-- Formats a single `BenchReport` as one pipe-delimited table row
+    (terminated with `\n`), padded to the given column widths. `markdown`
+    controls whether the `% change` cell is decorated with bold/emoji for
+    GitHub rendering or rendered as plain text for CLI stdout. -/
+def renderRow (markdown : Bool) (columnWidths : ColumnWidths) (row : BenchReport) : String :=
   let functionStr := padWhitespace row.function columnWidths.function
-  let newBenchStr := row.newBench.getTime.formatNanos
-  let newBenchStr := padWhitespace newBenchStr columnWidths.newBench
+  let newBenchStr := padWhitespace row.newBench.getTime.formatNanos columnWidths.newBench
   let baseBenchStr := if let some baseBench := row.baseBench then
     baseBench.getTime.formatNanos
   else "None"
   let baseBenchStr := padWhitespace baseBenchStr columnWidths.baseBench
   let percentChangeStr := if let some percentChange := row.percentChange then
-    percentChangeToString percentChange
+    percentChangeToString percentChange (markdown := markdown)
   else "N/A"
   let percentChangeStr := padWhitespace percentChangeStr columnWidths.percentChange
+  -- Pad first, then style: ANSI escapes are zero-width visually but add
+  -- bytes to the string, so wrapping after padding keeps column alignment.
+  -- Markdown mode emphasizes via `**...**` inside `percentChangeToString`.
+  let percentChangeStr := if markdown || row.percentChange.isNone then percentChangeStr
+    else Ansi.bold percentChangeStr
   let throughputCell := match columnWidths.throughput with
     | none => ""
     | some w => s!" {padWhitespace row.throughputStr w} |"
-  let rowPretty :=
-    s!"| {functionStr} | {newBenchStr} | {baseBenchStr} | {percentChangeStr} |{throughputCell}\n"
-  reportPretty ++ rowPretty
+  s!"| {functionStr} | {newBenchStr} | {baseBenchStr} | {percentChangeStr} |{throughputCell}\n"
 
-/--
-Generates a Markdown table with comparative benchmark timings.
-Each table row contains the benchmark function name, the new timing, the base
-timing, the percent change between the two, and (optionally) a throughput rate.
--/
-def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
-  let columnWidths := getColumnWidths report
-  let title := s!"## {groupName}\n\n"
+/-- Builds the comparison table (header + rows). `markdown := true` enables
+    GitHub-Markdown decorations in the `% change` column (bold, color emoji);
+    `markdown := false` yields plain text suitable for CLI stdout. -/
+def mkReportTable (markdown : Bool) (report : Array BenchReport) : String :=
+  let columnWidths := getColumnWidths markdown report
   let (fn, new, base, percent) := (
     padWhitespace "Function" columnWidths.function,
     padWhitespace "New Benchmark" columnWidths.newBench,
@@ -322,7 +343,18 @@ def mkReportPretty (groupName : String) (report : Array BenchReport) : String :=
     | some w => (s!" {padWhitespace "Throughput" w} |", s!"-{padDashes w}-|")
   let header := s!"| {fn} | {new} | {base} | {percent} |{throughputHeader}\n"
   let dashes := s!"|-{d1}-|-{d2}-|-{d3}-|-{d4}-|{throughputDashes}\n"
-  let reportPretty := title ++ header ++ dashes
-  report.foldl (mkReportPretty' columnWidths) reportPretty
+  report.foldl (fun acc row => acc ++ renderRow markdown columnWidths row) (header ++ dashes)
+
+/-- GitHub-flavored Markdown report: table wrapped in a collapsible `<details>`
+    block. Used for the on-disk `report.md` that the PR workflow pastes into
+    the benchmark comment. -/
+def mkReportMarkdown (groupName : String) (report : Array BenchReport) : String :=
+  s!"<details>\n<summary><b>{groupName}</b></summary>\n\n{mkReportTable true report}\n</details>\n"
+
+/-- Plain-text report: table under a `## {groupName}` heading, no Markdown
+    decorations in the cells. Used for CLI stdout where `<details>` tags
+    would render as literal HTML and emoji/bold would just be noise. -/
+def mkReportPlain (groupName : String) (report : Array BenchReport) : String :=
+  s!"## {groupName}\n\n{mkReportTable false report}"
 
 end

--- a/Ix/Benchmark/Serde.lean
+++ b/Ix/Benchmark/Serde.lean
@@ -274,6 +274,14 @@ instance : Serialize OneShot where
   put := putOneShot
   get := getOneShot
 
+def putE2ETotal (t : E2ETotal) : PutM Unit := putFloat t.totalNs
+
+def getE2ETotal : GetM E2ETotal := return { totalNs := ← getFloat }
+
+instance : Serialize E2ETotal where
+  put := putE2ETotal
+  get := getE2ETotal
+
 /-- Writes JSON to disk at `benchPath/fileName` -/
 def storeJson [Lean.ToJson α] (data : α) (benchPath : System.FilePath) : IO Unit := do
   let json := Lean.toJson data


### PR DESCRIPTION
- Wraps `Benchmarkable` functions in an `IO Unit` closure that allows mixing different types of benchmarks in the same `bgroup`
- Adds `benchStep`, `benchStepIO` and `benchStepE` methods that return the output of the last bench iteration, which allows threading into the inputs of a pipelined benchmark. Updates the Aiur benchmark accordingly, so the benches now read like a normal program
- Adds an `E2E` metric that adds all sampled mean and one-shot results into a final end-to-end wall-clock time, which is then printed and/or included in the Markdown report as its own row. Code blocks containing benchmarks can skip this calculation with the `skipE2E` function, and toggle it back on with `countInE2E`.
- Fixes report pretty-printing for the `bench-pr.yml` workflow