### PR TITLE
chore: Remove rust-major dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       separator: "-"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     # Create separate pull requests for major vs minor/patch version updates, as major bumps will likely introduce breaking changes and Dependabot will put each one in its own PR.
     groups:
       rust-minor:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       separator: "-"
     schedule:
       interval: "weekly"
-    # Create separate pull requests for major vs minor/patch version updates, as major bumps will likely introduce breaking changes
+    # Create separate pull requests for major vs minor/patch version updates, as major bumps will likely introduce breaking changes and Dependabot will put each one in its own PR.
     groups:
       rust-minor:
         patterns:
@@ -14,15 +14,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      rust-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
-    allow:
-      # Update both direct and indirect dependencies
-      - dependency-type: "all"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot has difficulty grouping Rust major version dependency updates due to non-trivial `Cargo.lock` changes, so it falls back to opening one PR per major version (see https://github.com/argumentcomputer/ix/pull/406, https://github.com/argumentcomputer/ix/pull/405). This PR removes the rust-major group altogether since it will likely never be used.

Other changes:
- Removes PRs for indirect dependencies to reduce noise, since we have Dependabot alerts and cargo-deny to notify for security updates. Otherwise a periodic `cargo update` will take care of them.
- Raises the open PR limit to 10 so we are less likely to miss updates for major versions.
- Adds a one week cooldown to mitigate supply chain attacks.