### PR TITLE
Hyperoptimize the `blake3_compress_chunks` circuit

### DIFF
--- a/Ix/IxVM/Blake3.lean
+++ b/Ix/IxVM/Blake3.lean
@@ -42,7 +42,7 @@ def blake3 := ⟦
 
   fn blake3(input: ByteStream) -> [[G; 4]; 8] {
     let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
-    blake3_compress_layer(blake3_compress_chunks(input, [[0; 4]; 16], 0, 0, [0; 8], IV, Layer.Nil))
+    blake3_compress_layer(load(blake3_compress_chunks(input, [[0; 4]; 16], 0, 0, [0; 8], IV, store(Layer.Nil))))
   }
 
   fn blake3_next_layer(layer: Layer, digest: [[G; 4]; 8], root: G) -> (MaybeDigest, Layer) {
@@ -93,8 +93,8 @@ def blake3 := ⟦
     chunk_index: G,
     chunk_count: U64,
     block_digest: [[G; 4]; 8],
-    layer: Layer
-  ) -> Layer {
+    layer: &Layer
+  ) -> &Layer {
     let CHUNK_START = 1;
     let CHUNK_END = 2;
     let PARENT = 4;
@@ -105,15 +105,15 @@ def blake3 := ⟦
         match chunk_count {
           [0, 0, 0, 0, 0, 0, 0, 0] =>
             let flags = ROOT + CHUNK_START + CHUNK_END;
-            Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, 0, flags)),
+            store(Layer.Push(layer, blake3_compress(block_digest, block_buffer, chunk_count, 0, flags))),
           _ => layer,
         },
 
-      (ListNode.Nil, 0, _) => Layer.Push(store(layer), block_digest),
+      (ListNode.Nil, 0, _) => store(Layer.Push(layer, block_digest)),
 
       (ListNode.Nil, _, _) =>
         let flags = CHUNK_END + u64_is_zero(chunk_count) * ROOT + eq_zero(chunk_index - block_index) * CHUNK_START;
-        Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, block_index, flags)),
+        store(Layer.Push(layer, blake3_compress(block_digest, block_buffer, chunk_count, block_index, flags))),
 
       (ListNode.Cons(head, input), 63, _) =>
         -- Block full: assign the last byte, then hand the completed buffer to
@@ -148,8 +148,8 @@ def blake3 := ⟦
     chunk_index: G,
     chunk_count: U64,
     block_digest: [[G; 4]; 8],
-    layer: Layer
-  ) -> Layer {
+    layer: &Layer
+  ) -> &Layer {
     let CHUNK_START = 1;
     let CHUNK_END = 2;
     let ROOT = 8;
@@ -158,7 +158,7 @@ def blake3 := ⟦
       1023 =>
         let flags = ROOT * list_is_empty(input) * u64_is_zero(chunk_count) + CHUNK_END;
         let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
-        let layer = Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, 64, flags));
+        let layer = store(Layer.Push(layer, blake3_compress(block_digest, block_buffer, chunk_count, 64, flags)));
         blake3_compress_chunks(input, empty_buffer, 0, 0, relaxed_u64_succ(chunk_count), IV, layer),
       _ =>
         let chunk_end_flag = list_is_empty(input) * CHUNK_END;

--- a/Ix/IxVM/Blake3.lean
+++ b/Ix/IxVM/Blake3.lean
@@ -42,7 +42,7 @@ def blake3 := ⟦
 
   fn blake3(input: ByteStream) -> [[G; 4]; 8] {
     let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
-    blake3_compress_layer(load(blake3_compress_chunks(input, [[0; 4]; 16], 0, 0, [0; 8], IV, store(Layer.Nil))))
+    blake3_compress_layer(load(blake3_compress_chunks(input, store(ListNode.Nil), 0, 0, [0; 8], IV, store(Layer.Nil))))
   }
 
   fn blake3_next_layer(layer: Layer, digest: [[G; 4]; 8], root: G) -> (MaybeDigest, Layer) {
@@ -86,9 +86,123 @@ def blake3 := ⟦
     }
   }
 
+  -- Hot chunk loop. The 64-byte block buffer is NOT threaded here as a
+  -- `[[G; 4]; 16]` value — that cost 64 columns of `inputSize` plus a +64-aux
+  -- `assign_block_value` call on every row. Instead bytes accumulate into a
+  -- reverse-ordered linked list (`byte_acc`); each hot row is a single `store`.
   fn blake3_compress_chunks(
     input: ByteStream,
-    block_buffer: [[G; 4]; 16],
+    byte_acc: ByteStream,
+    block_index: G,
+    chunk_index: G,
+    chunk_count: U64,
+    block_digest: [[G; 4]; 8],
+    layer: &Layer
+  ) -> &Layer {
+    match load(input) {
+      -- Input exhausted: hand off to the cold finalize circuit.
+      ListNode.Nil =>
+        blake3_finish(byte_acc, block_index, chunk_index, chunk_count, block_digest, layer),
+      ListNode.Cons(head, input) =>
+        let byte_acc = store(ListNode.Cons(head, byte_acc));
+        match block_index {
+          63 => blake3_compress_block(input, byte_acc, chunk_index, chunk_count, block_digest, layer),
+          _ => blake3_compress_chunks(input, byte_acc, block_index + 1, chunk_index + 1, chunk_count, block_digest, layer),
+        },
+    }
+  }
+
+  -- Materializes a 64-byte accumulator list into a `[[G; 4]; 16]` block. The
+  -- list is reverse-ordered (head = most recently appended byte = position 63).
+  -- 64 unrolled `load`s, one circuit row per call — keeps the 64-wide buffer
+  -- out of the hot loop and out of `inputSize`.
+  fn bytes_to_block(byte_acc: ByteStream) -> [[G; 4]; 16] {
+    let ListNode.Cons(b63, l) = load(byte_acc);
+    let ListNode.Cons(b62, l) = load(l);
+    let ListNode.Cons(b61, l) = load(l);
+    let ListNode.Cons(b60, l) = load(l);
+    let ListNode.Cons(b59, l) = load(l);
+    let ListNode.Cons(b58, l) = load(l);
+    let ListNode.Cons(b57, l) = load(l);
+    let ListNode.Cons(b56, l) = load(l);
+    let ListNode.Cons(b55, l) = load(l);
+    let ListNode.Cons(b54, l) = load(l);
+    let ListNode.Cons(b53, l) = load(l);
+    let ListNode.Cons(b52, l) = load(l);
+    let ListNode.Cons(b51, l) = load(l);
+    let ListNode.Cons(b50, l) = load(l);
+    let ListNode.Cons(b49, l) = load(l);
+    let ListNode.Cons(b48, l) = load(l);
+    let ListNode.Cons(b47, l) = load(l);
+    let ListNode.Cons(b46, l) = load(l);
+    let ListNode.Cons(b45, l) = load(l);
+    let ListNode.Cons(b44, l) = load(l);
+    let ListNode.Cons(b43, l) = load(l);
+    let ListNode.Cons(b42, l) = load(l);
+    let ListNode.Cons(b41, l) = load(l);
+    let ListNode.Cons(b40, l) = load(l);
+    let ListNode.Cons(b39, l) = load(l);
+    let ListNode.Cons(b38, l) = load(l);
+    let ListNode.Cons(b37, l) = load(l);
+    let ListNode.Cons(b36, l) = load(l);
+    let ListNode.Cons(b35, l) = load(l);
+    let ListNode.Cons(b34, l) = load(l);
+    let ListNode.Cons(b33, l) = load(l);
+    let ListNode.Cons(b32, l) = load(l);
+    let ListNode.Cons(b31, l) = load(l);
+    let ListNode.Cons(b30, l) = load(l);
+    let ListNode.Cons(b29, l) = load(l);
+    let ListNode.Cons(b28, l) = load(l);
+    let ListNode.Cons(b27, l) = load(l);
+    let ListNode.Cons(b26, l) = load(l);
+    let ListNode.Cons(b25, l) = load(l);
+    let ListNode.Cons(b24, l) = load(l);
+    let ListNode.Cons(b23, l) = load(l);
+    let ListNode.Cons(b22, l) = load(l);
+    let ListNode.Cons(b21, l) = load(l);
+    let ListNode.Cons(b20, l) = load(l);
+    let ListNode.Cons(b19, l) = load(l);
+    let ListNode.Cons(b18, l) = load(l);
+    let ListNode.Cons(b17, l) = load(l);
+    let ListNode.Cons(b16, l) = load(l);
+    let ListNode.Cons(b15, l) = load(l);
+    let ListNode.Cons(b14, l) = load(l);
+    let ListNode.Cons(b13, l) = load(l);
+    let ListNode.Cons(b12, l) = load(l);
+    let ListNode.Cons(b11, l) = load(l);
+    let ListNode.Cons(b10, l) = load(l);
+    let ListNode.Cons(b9, l) = load(l);
+    let ListNode.Cons(b8, l) = load(l);
+    let ListNode.Cons(b7, l) = load(l);
+    let ListNode.Cons(b6, l) = load(l);
+    let ListNode.Cons(b5, l) = load(l);
+    let ListNode.Cons(b4, l) = load(l);
+    let ListNode.Cons(b3, l) = load(l);
+    let ListNode.Cons(b2, l) = load(l);
+    let ListNode.Cons(b1, l) = load(l);
+    let ListNode.Cons(b0, _) = load(l);
+    [
+      [b0, b1, b2, b3], [b4, b5, b6, b7], [b8, b9, b10, b11], [b12, b13, b14, b15],
+      [b16, b17, b18, b19], [b20, b21, b22, b23], [b24, b25, b26, b27], [b28, b29, b30, b31],
+      [b32, b33, b34, b35], [b36, b37, b38, b39], [b40, b41, b42, b43], [b44, b45, b46, b47],
+      [b48, b49, b50, b51], [b52, b53, b54, b55], [b56, b57, b58, b59], [b60, b61, b62, b63]
+    ]
+  }
+
+  -- Prepends `n` zero bytes to a partial block accumulator so it can be fed to
+  -- `bytes_to_block`. Cold: only the trailing partial block of a hash uses it.
+  fn pad_block(acc: ByteStream, n: G) -> ByteStream {
+    match n {
+      0 => acc,
+      _ => pad_block(store(ListNode.Cons(0, acc)), n - 1),
+    }
+  }
+
+  -- Cold finalize circuit for `blake3_compress_chunks`: input is exhausted, so
+  -- emit the trailing layer node. Quarantines the `blake3_compress` call and
+  -- the partial-block materialization out of the hot chunk loop.
+  fn blake3_finish(
+    byte_acc: ByteStream,
     block_index: G,
     chunk_index: G,
     chunk_count: U64,
@@ -97,54 +211,29 @@ def blake3 := ⟦
   ) -> &Layer {
     let CHUNK_START = 1;
     let CHUNK_END = 2;
-    let PARENT = 4;
     let ROOT = 8;
-    let input_node = load(input);
-    match (input_node, block_index, chunk_index) {
-      (ListNode.Nil, 0, 0) =>
+    match (block_index, chunk_index) {
+      (0, 0) =>
         match chunk_count {
           [0, 0, 0, 0, 0, 0, 0, 0] =>
             let flags = ROOT + CHUNK_START + CHUNK_END;
-            store(Layer.Push(layer, blake3_compress(block_digest, block_buffer, chunk_count, 0, flags))),
+            store(Layer.Push(layer, blake3_compress(block_digest, [[0; 4]; 16], chunk_count, 0, flags))),
           _ => layer,
         },
-
-      (ListNode.Nil, 0, _) => store(Layer.Push(layer, block_digest)),
-
-      (ListNode.Nil, _, _) =>
+      (0, _) => store(Layer.Push(layer, block_digest)),
+      (_, _) =>
         let flags = CHUNK_END + u64_is_zero(chunk_count) * ROOT + eq_zero(chunk_index - block_index) * CHUNK_START;
-        store(Layer.Push(layer, blake3_compress(block_digest, block_buffer, chunk_count, block_index, flags))),
-
-      (ListNode.Cons(head, input), 63, _) =>
-        -- Block full: assign the last byte, then hand the completed buffer to
-        -- the cold `blake3_compress_block` circuit. Keeps the `blake3_compress`
-        -- call (+32 aux output) and the flag/store machinery out of this hot
-        -- circuit's width — those columns would be trash on the ~91% of rows
-        -- that hit the buffer-fill arm below.
-        let block_buffer = assign_block_value(block_buffer, block_index, head);
-        blake3_compress_block(input, block_buffer, chunk_index, chunk_count, block_digest, layer),
-
-      (ListNode.Cons(head, input), _, _) =>
-        let block_buffer = assign_block_value(block_buffer, block_index, head);
-        blake3_compress_chunks(
-            input,
-            block_buffer,
-            block_index + 1,
-            chunk_index + 1,
-            chunk_count,
-            block_digest,
-            layer
-        ),
+        let block = bytes_to_block(pad_block(byte_acc, 64 - block_index));
+        store(Layer.Push(layer, blake3_compress(block_digest, block, chunk_count, block_index, flags))),
     }
   }
 
   -- Cold continuation of `blake3_compress_chunks`: runs once per filled 64-byte
-  -- block (~1.8% of chunk-loop rows). Quarantines the `blake3_compress` call
-  -- (+32 aux), `relaxed_u64_succ`, `store` and flag helpers into their own
-  -- circuit so they do not widen the hot buffer-fill circuit.
+  -- block. Materializes the byte accumulator, runs `blake3_compress`, pushes the
+  -- digest, and resets the accumulator for the next block.
   fn blake3_compress_block(
     input: ByteStream,
-    block_buffer: [[G; 4]; 16],
+    byte_acc: ByteStream,
     chunk_index: G,
     chunk_count: U64,
     block_digest: [[G; 4]; 8],
@@ -153,20 +242,20 @@ def blake3 := ⟦
     let CHUNK_START = 1;
     let CHUNK_END = 2;
     let ROOT = 8;
-    let empty_buffer = [[0; 4]; 16];
+    let block = bytes_to_block(byte_acc);
     match chunk_index {
       1023 =>
         let flags = ROOT * list_is_empty(input) * u64_is_zero(chunk_count) + CHUNK_END;
         let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
-        let layer = store(Layer.Push(layer, blake3_compress(block_digest, block_buffer, chunk_count, 64, flags)));
-        blake3_compress_chunks(input, empty_buffer, 0, 0, relaxed_u64_succ(chunk_count), IV, layer),
+        let layer = store(Layer.Push(layer, blake3_compress(block_digest, block, chunk_count, 64, flags)));
+        blake3_compress_chunks(input, store(ListNode.Nil), 0, 0, relaxed_u64_succ(chunk_count), IV, layer),
       _ =>
         let chunk_end_flag = list_is_empty(input) * CHUNK_END;
         let root_flag = list_is_empty(input) * u64_is_zero(chunk_count) * ROOT;
         let chunk_start_flag = eq_zero(chunk_index - 63) * CHUNK_START;
         let flags = chunk_end_flag + root_flag + chunk_start_flag;
-        let block_digest = blake3_compress(block_digest, block_buffer, chunk_count, 64, flags);
-        blake3_compress_chunks(input, empty_buffer, 0, chunk_index + 1, chunk_count, block_digest, layer),
+        let block_digest = blake3_compress(block_digest, block, chunk_count, 64, flags);
+        blake3_compress_chunks(input, store(ListNode.Nil), 0, chunk_index + 1, chunk_count, block_digest, layer),
     }
   }
 
@@ -376,75 +465,6 @@ def blake3 := ⟦
       u32_xor(state[6], state[14]),
       u32_xor(state[7], state[15])
     ]
-  }
-
-  fn assign_block_value(block: [[G; 4]; 16], idx: G, val: G) -> [[G; 4]; 16] {
-    match idx {
-      0 => set(block, 0, set(block[0], 0, val)),
-      1 => set(block, 0, set(block[0], 1, val)),
-      2 => set(block, 0, set(block[0], 2, val)),
-      3 => set(block, 0, set(block[0], 3, val)),
-      4 => set(block, 1, set(block[1], 0, val)),
-      5 => set(block, 1, set(block[1], 1, val)),
-      6 => set(block, 1, set(block[1], 2, val)),
-      7 => set(block, 1, set(block[1], 3, val)),
-      8 => set(block, 2, set(block[2], 0, val)),
-      9 => set(block, 2, set(block[2], 1, val)),
-      10 => set(block, 2, set(block[2], 2, val)),
-      11 => set(block, 2, set(block[2], 3, val)),
-      12 => set(block, 3, set(block[3], 0, val)),
-      13 => set(block, 3, set(block[3], 1, val)),
-      14 => set(block, 3, set(block[3], 2, val)),
-      15 => set(block, 3, set(block[3], 3, val)),
-      16 => set(block, 4, set(block[4], 0, val)),
-      17 => set(block, 4, set(block[4], 1, val)),
-      18 => set(block, 4, set(block[4], 2, val)),
-      19 => set(block, 4, set(block[4], 3, val)),
-      20 => set(block, 5, set(block[5], 0, val)),
-      21 => set(block, 5, set(block[5], 1, val)),
-      22 => set(block, 5, set(block[5], 2, val)),
-      23 => set(block, 5, set(block[5], 3, val)),
-      24 => set(block, 6, set(block[6], 0, val)),
-      25 => set(block, 6, set(block[6], 1, val)),
-      26 => set(block, 6, set(block[6], 2, val)),
-      27 => set(block, 6, set(block[6], 3, val)),
-      28 => set(block, 7, set(block[7], 0, val)),
-      29 => set(block, 7, set(block[7], 1, val)),
-      30 => set(block, 7, set(block[7], 2, val)),
-      31 => set(block, 7, set(block[7], 3, val)),
-      32 => set(block, 8, set(block[8], 0, val)),
-      33 => set(block, 8, set(block[8], 1, val)),
-      34 => set(block, 8, set(block[8], 2, val)),
-      35 => set(block, 8, set(block[8], 3, val)),
-      36 => set(block, 9, set(block[9], 0, val)),
-      37 => set(block, 9, set(block[9], 1, val)),
-      38 => set(block, 9, set(block[9], 2, val)),
-      39 => set(block, 9, set(block[9], 3, val)),
-      40 => set(block, 10, set(block[10], 0, val)),
-      41 => set(block, 10, set(block[10], 1, val)),
-      42 => set(block, 10, set(block[10], 2, val)),
-      43 => set(block, 10, set(block[10], 3, val)),
-      44 => set(block, 11, set(block[11], 0, val)),
-      45 => set(block, 11, set(block[11], 1, val)),
-      46 => set(block, 11, set(block[11], 2, val)),
-      47 => set(block, 11, set(block[11], 3, val)),
-      48 => set(block, 12, set(block[12], 0, val)),
-      49 => set(block, 12, set(block[12], 1, val)),
-      50 => set(block, 12, set(block[12], 2, val)),
-      51 => set(block, 12, set(block[12], 3, val)),
-      52 => set(block, 13, set(block[13], 0, val)),
-      53 => set(block, 13, set(block[13], 1, val)),
-      54 => set(block, 13, set(block[13], 2, val)),
-      55 => set(block, 13, set(block[13], 3, val)),
-      56 => set(block, 14, set(block[14], 0, val)),
-      57 => set(block, 14, set(block[14], 1, val)),
-      58 => set(block, 14, set(block[14], 2, val)),
-      59 => set(block, 14, set(block[14], 3, val)),
-      60 => set(block, 15, set(block[15], 0, val)),
-      61 => set(block, 15, set(block[15], 1, val)),
-      62 => set(block, 15, set(block[15], 2, val)),
-      63 => set(block, 15, set(block[15], 3, val)),
-    }
   }
 ⟧
 

--- a/Ix/IxVM/Blake3.lean
+++ b/Ix/IxVM/Blake3.lean
@@ -277,10 +277,12 @@ def blake3 := ⟦
     let [b10, b11, b12, b13, b14, b15, b16, b17] = u8_bit_decomposition(b1);
     let [b20, b21, b22, b23, b24, b25, b26, b27] = u8_bit_decomposition(b2);
     let [b30, b31, b32, b33, b34, b35, b36, b37] = u8_bit_decomposition(b3);
-    let b0 = u8_recompose([b14, b15, b16, b17, b20, b21, b22, b23]);
-    let b1 = u8_recompose([b24, b25, b26, b27, b30, b31, b32, b33]);
-    let b2 = u8_recompose([b34, b35, b36, b37, b00, b01, b02, b03]);
-    let b3 = u8_recompose([b04, b05, b06, b07, b10, b11, b12, b13]);
+    -- Each rotated byte is the weighted sum of 8 bits. Written inline: it is
+    -- pure arithmetic, so it costs no aux column or lookup.
+    let b0 = b14 + 2 * b15 + 4 * b16 + 8 * b17 + 16 * b20 + 32 * b21 + 64 * b22 + 128 * b23;
+    let b1 = b24 + 2 * b25 + 4 * b26 + 8 * b27 + 16 * b30 + 32 * b31 + 64 * b32 + 128 * b33;
+    let b2 = b34 + 2 * b35 + 4 * b36 + 8 * b37 + 16 * b00 + 32 * b01 + 64 * b02 + 128 * b03;
+    let b3 = b04 + 2 * b05 + 4 * b06 + 8 * b07 + 16 * b10 + 32 * b11 + 64 * b12 + 128 * b13;
     let b = [b0, b1, b2, b3]; -- Right-rotated 12
 
     let a = u32_add(u32_add(a, b), y);
@@ -293,10 +295,10 @@ def blake3 := ⟦
     let [b10, b11, b12, b13, b14, b15, b16, b17] = u8_bit_decomposition(b1);
     let [b20, b21, b22, b23, b24, b25, b26, b27] = u8_bit_decomposition(b2);
     let [b30, b31, b32, b33, b34, b35, b36, b37] = u8_bit_decomposition(b3);
-    let b0 = u8_recompose([b07, b10, b11, b12, b13, b14, b15, b16]);
-    let b1 = u8_recompose([b17, b20, b21, b22, b23, b24, b25, b26]);
-    let b2 = u8_recompose([b27, b30, b31, b32, b33, b34, b35, b36]);
-    let b3 = u8_recompose([b37, b00, b01, b02, b03, b04, b05, b06]);
+    let b0 = b07 + 2 * b10 + 4 * b11 + 8 * b12 + 16 * b13 + 32 * b14 + 64 * b15 + 128 * b16;
+    let b1 = b17 + 2 * b20 + 4 * b21 + 8 * b22 + 16 * b23 + 32 * b24 + 64 * b25 + 128 * b26;
+    let b2 = b27 + 2 * b30 + 4 * b31 + 8 * b32 + 16 * b33 + 32 * b34 + 64 * b35 + 128 * b36;
+    let b3 = b37 + 2 * b00 + 4 * b01 + 8 * b02 + 16 * b03 + 32 * b04 + 64 * b05 + 128 * b06;
     let b = [b0, b1, b2, b3]; -- Right-rotated 7
 
     [a, b, c, d]

--- a/Ix/IxVM/Blake3.lean
+++ b/Ix/IxVM/Blake3.lean
@@ -115,37 +115,14 @@ def blake3 := ⟦
         let flags = CHUNK_END + u64_is_zero(chunk_count) * ROOT + eq_zero(chunk_index - block_index) * CHUNK_START;
         Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, block_index, flags)),
 
-      (ListNode.Cons(head, input), 63, 1023) =>
-        let flags = ROOT * list_is_empty(input) * u64_is_zero(chunk_count) + CHUNK_END;
-        let block_buffer = assign_block_value(block_buffer, block_index, head);
-        let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
-        let empty_buffer = [[0; 4]; 16];
-        let layer = Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, 64, flags));
-        blake3_compress_chunks(input, empty_buffer, 0, 0, relaxed_u64_succ(chunk_count), IV, layer),
-
       (ListNode.Cons(head, input), 63, _) =>
+        -- Block full: assign the last byte, then hand the completed buffer to
+        -- the cold `blake3_compress_block` circuit. Keeps the `blake3_compress`
+        -- call (+32 aux output) and the flag/store machinery out of this hot
+        -- circuit's width — those columns would be trash on the ~91% of rows
+        -- that hit the buffer-fill arm below.
         let block_buffer = assign_block_value(block_buffer, block_index, head);
-        let chunk_end_flag = list_is_empty(input) * CHUNK_END;
-        let root_flag = list_is_empty(input) * u64_is_zero(chunk_count) * ROOT;
-        let chunk_start_flag = eq_zero(chunk_index - block_index) * CHUNK_START;
-        let flags = chunk_end_flag + root_flag + chunk_start_flag;
-        let block_digest = blake3_compress(
-            block_digest,
-            block_buffer,
-            chunk_count,
-            64,
-            flags
-        );
-        let empty_buffer = [[0; 4]; 16];
-        blake3_compress_chunks(
-            input,
-            empty_buffer,
-            0,
-            chunk_index + 1,
-            chunk_count,
-            block_digest,
-            layer
-        ),
+        blake3_compress_block(input, block_buffer, chunk_index, chunk_count, block_digest, layer),
 
       (ListNode.Cons(head, input), _, _) =>
         let block_buffer = assign_block_value(block_buffer, block_index, head);
@@ -158,6 +135,38 @@ def blake3 := ⟦
             block_digest,
             layer
         ),
+    }
+  }
+
+  -- Cold continuation of `blake3_compress_chunks`: runs once per filled 64-byte
+  -- block (~1.8% of chunk-loop rows). Quarantines the `blake3_compress` call
+  -- (+32 aux), `relaxed_u64_succ`, `store` and flag helpers into their own
+  -- circuit so they do not widen the hot buffer-fill circuit.
+  fn blake3_compress_block(
+    input: ByteStream,
+    block_buffer: [[G; 4]; 16],
+    chunk_index: G,
+    chunk_count: U64,
+    block_digest: [[G; 4]; 8],
+    layer: Layer
+  ) -> Layer {
+    let CHUNK_START = 1;
+    let CHUNK_END = 2;
+    let ROOT = 8;
+    let empty_buffer = [[0; 4]; 16];
+    match chunk_index {
+      1023 =>
+        let flags = ROOT * list_is_empty(input) * u64_is_zero(chunk_count) + CHUNK_END;
+        let IV = [[103, 230, 9, 106], [133, 174, 103, 187], [114, 243, 110, 60], [58, 245, 79, 165], [127, 82, 14, 81], [140, 104, 5, 155], [171, 217, 131, 31], [25, 205, 224, 91]];
+        let layer = Layer.Push(store(layer), blake3_compress(block_digest, block_buffer, chunk_count, 64, flags));
+        blake3_compress_chunks(input, empty_buffer, 0, 0, relaxed_u64_succ(chunk_count), IV, layer),
+      _ =>
+        let chunk_end_flag = list_is_empty(input) * CHUNK_END;
+        let root_flag = list_is_empty(input) * u64_is_zero(chunk_count) * ROOT;
+        let chunk_start_flag = eq_zero(chunk_index - 63) * CHUNK_START;
+        let flags = chunk_end_flag + root_flag + chunk_start_flag;
+        let block_digest = blake3_compress(block_digest, block_buffer, chunk_count, 64, flags);
+        blake3_compress_chunks(input, empty_buffer, 0, chunk_index + 1, chunk_count, block_digest, layer),
     }
   }
 

--- a/Ix/IxVM/ByteStream.lean
+++ b/Ix/IxVM/ByteStream.lean
@@ -43,12 +43,6 @@ def byteStream := ⟦
     }
   }
 
-  -- Reconstructs a byte from its bits in little-endian.
-  fn u8_recompose(bits: U64) -> G {
-    let [b0, b1, b2, b3, b4, b5, b6, b7] = bits;
-    b0 + 2 * b1 + 4 * b2 + 8 * b3 + 16 * b4 + 32 * b5 + 64 * b6 + 128 * b7
-  }
-
   fn u32_add(a: [G; 4], b: [G; 4]) -> [G; 4] {
     let [a0, a1, a2, a3] = a;
     let [b0, b1, b2, b3] = b;

--- a/Ix/IxVM/ByteStream.lean
+++ b/Ix/IxVM/ByteStream.lean
@@ -59,12 +59,15 @@ def byteStream := ⟦
     -- Byte 1
     let (sum1, overflow1) = u8_add(a1, b1);
     let (sum1_with_carry, carry1a) = u8_add(sum1, carry1);
-    let carry2 = u8_xor(overflow1, carry1a);
+    -- `overflow1` and `carry1a` cannot both be 1: a carry out of `a1 + b1`
+    -- forces `sum1 <= 254`, so `sum1 + carry1` cannot carry. Combining them is
+    -- a field add, not a u8 xor — no aux column, no lookup.
+    let carry2 = overflow1 + carry1a;
 
     -- Byte 2
     let (sum2, overflow2) = u8_add(a2, b2);
     let (sum2_with_carry, carry2a) = u8_add(sum2, carry2);
-    let carry3 = u8_xor(overflow2, carry2a);
+    let carry3 = overflow2 + carry2a;
 
     -- Byte 3
     let (sum3, _x) = u8_add(a3, b3);
@@ -106,22 +109,22 @@ def byteStream := ⟦
     let (s0, c1) = u8_add(a0, b0);
     let (t1, o1) = u8_add(a1, b1);
     let (s1, c1a) = u8_add(t1, c1);
-    let c2 = u8_xor(o1, c1a);
+    let c2 = o1 + c1a;
     let (t2, o2) = u8_add(a2, b2);
     let (s2, c2a) = u8_add(t2, c2);
-    let c3 = u8_xor(o2, c2a);
+    let c3 = o2 + c2a;
     let (t3, o3) = u8_add(a3, b3);
     let (s3, c3a) = u8_add(t3, c3);
-    let c4 = u8_xor(o3, c3a);
+    let c4 = o3 + c3a;
     let (t4, o4) = u8_add(a4, b4);
     let (s4, c4a) = u8_add(t4, c4);
-    let c5 = u8_xor(o4, c4a);
+    let c5 = o4 + c4a;
     let (t5, o5) = u8_add(a5, b5);
     let (s5, c5a) = u8_add(t5, c5);
-    let c6 = u8_xor(o5, c5a);
+    let c6 = o5 + c5a;
     let (t6, o6) = u8_add(a6, b6);
     let (s6, c6a) = u8_add(t6, c6);
-    let c7 = u8_xor(o6, c6a);
+    let c7 = o6 + c6a;
     let (t7, _) = u8_add(a7, b7);
     let (s7, _) = u8_add(t7, c7);
     [s0, s1, s2, s3, s4, s5, s6, s7]
@@ -180,7 +183,7 @@ def byteStream := ⟦
     -- Byte 1
     let (sum1, overflow1) = u8_add(u64[6], bs[0]);
     let (sum1_with_carry, carry1a) = u8_add(sum1, carry1);
-    let carry2 = u8_xor(overflow1, carry1a);
+    let carry2 = overflow1 + carry1a;
 
     -- Other bytes
     let (sum2, carry3) = u8_add(u64[5], carry2);
@@ -200,12 +203,12 @@ def byteStream := ⟦
     -- Byte 1
     let (sum1, overflow1) = u8_add(a[2], b[2]);
     let (sum1_with_carry, carry1a) = u8_add(sum1, carry1);
-    let carry2 = u8_xor(overflow1, carry1a);
+    let carry2 = overflow1 + carry1a;
 
     -- Byte 2
     let (sum2, overflow2) = u8_add(a[1], b[1]);
     let (sum2_with_carry, carry2a) = u8_add(sum2, carry2);
-    let carry3 = u8_xor(overflow2, carry2a);
+    let carry3 = overflow2 + carry2a;
 
     -- Byte 3
     let (sum3, _x) = u8_add(a[0], b[0]);

--- a/Ix/IxVM/Sha256.lean
+++ b/Ix/IxVM/Sha256.lean
@@ -679,25 +679,27 @@ def sha256 := ⟦
       let e_2_bits = u8_bit_decomposition(acc[4][1]);
       let e_3_bits = u8_bit_decomposition(acc[4][0]);
 
+      -- Each rotated/shifted byte is the weighted sum of 8 bits. Written
+      -- inline: it is pure arithmetic, so it costs no aux column or lookup.
       let e_rotr6 = [
-        u8_recompose([e_3_bits[6], e_3_bits[7], e_0_bits[0], e_0_bits[1], e_0_bits[2], e_0_bits[3], e_0_bits[4], e_0_bits[5]]),
-        u8_recompose([e_2_bits[6], e_2_bits[7], e_3_bits[0], e_3_bits[1], e_3_bits[2], e_3_bits[3], e_3_bits[4], e_3_bits[5]]),
-        u8_recompose([e_1_bits[6], e_1_bits[7], e_2_bits[0], e_2_bits[1], e_2_bits[2], e_2_bits[3], e_2_bits[4], e_2_bits[5]]),
-        u8_recompose([e_0_bits[6], e_0_bits[7], e_1_bits[0], e_1_bits[1], e_1_bits[2], e_1_bits[3], e_1_bits[4], e_1_bits[5]])
+        e_3_bits[6] + 2 * e_3_bits[7] + 4 * e_0_bits[0] + 8 * e_0_bits[1] + 16 * e_0_bits[2] + 32 * e_0_bits[3] + 64 * e_0_bits[4] + 128 * e_0_bits[5],
+        e_2_bits[6] + 2 * e_2_bits[7] + 4 * e_3_bits[0] + 8 * e_3_bits[1] + 16 * e_3_bits[2] + 32 * e_3_bits[3] + 64 * e_3_bits[4] + 128 * e_3_bits[5],
+        e_1_bits[6] + 2 * e_1_bits[7] + 4 * e_2_bits[0] + 8 * e_2_bits[1] + 16 * e_2_bits[2] + 32 * e_2_bits[3] + 64 * e_2_bits[4] + 128 * e_2_bits[5],
+        e_0_bits[6] + 2 * e_0_bits[7] + 4 * e_1_bits[0] + 8 * e_1_bits[1] + 16 * e_1_bits[2] + 32 * e_1_bits[3] + 64 * e_1_bits[4] + 128 * e_1_bits[5]
       ];
 
       let e_rotr11 = [
-        u8_recompose([e_0_bits[3], e_0_bits[4], e_0_bits[5], e_0_bits[6], e_0_bits[7], e_1_bits[0], e_1_bits[1], e_1_bits[2]]),
-        u8_recompose([e_3_bits[3], e_3_bits[4], e_3_bits[5], e_3_bits[6], e_3_bits[7], e_0_bits[0], e_0_bits[1], e_0_bits[2]]),
-        u8_recompose([e_2_bits[3], e_2_bits[4], e_2_bits[5], e_2_bits[6], e_2_bits[7], e_3_bits[0], e_3_bits[1], e_3_bits[2]]),
-        u8_recompose([e_1_bits[3], e_1_bits[4], e_1_bits[5], e_1_bits[6], e_1_bits[7], e_2_bits[0], e_2_bits[1], e_2_bits[2]])
+        e_0_bits[3] + 2 * e_0_bits[4] + 4 * e_0_bits[5] + 8 * e_0_bits[6] + 16 * e_0_bits[7] + 32 * e_1_bits[0] + 64 * e_1_bits[1] + 128 * e_1_bits[2],
+        e_3_bits[3] + 2 * e_3_bits[4] + 4 * e_3_bits[5] + 8 * e_3_bits[6] + 16 * e_3_bits[7] + 32 * e_0_bits[0] + 64 * e_0_bits[1] + 128 * e_0_bits[2],
+        e_2_bits[3] + 2 * e_2_bits[4] + 4 * e_2_bits[5] + 8 * e_2_bits[6] + 16 * e_2_bits[7] + 32 * e_3_bits[0] + 64 * e_3_bits[1] + 128 * e_3_bits[2],
+        e_1_bits[3] + 2 * e_1_bits[4] + 4 * e_1_bits[5] + 8 * e_1_bits[6] + 16 * e_1_bits[7] + 32 * e_2_bits[0] + 64 * e_2_bits[1] + 128 * e_2_bits[2]
       ];
 
       let e_rotr25 = [
-        u8_recompose([e_2_bits[1], e_2_bits[2], e_2_bits[3], e_2_bits[4], e_2_bits[5], e_2_bits[6], e_2_bits[7], e_3_bits[0]]),
-        u8_recompose([e_1_bits[1], e_1_bits[2], e_1_bits[3], e_1_bits[4], e_1_bits[5], e_1_bits[6], e_1_bits[7], e_2_bits[0]]),
-        u8_recompose([e_0_bits[1], e_0_bits[2], e_0_bits[3], e_0_bits[4], e_0_bits[5], e_0_bits[6], e_0_bits[7], e_1_bits[0]]),
-        u8_recompose([e_3_bits[1], e_3_bits[2], e_3_bits[3], e_3_bits[4], e_3_bits[5], e_3_bits[6], e_3_bits[7], e_0_bits[0]])
+        e_2_bits[1] + 2 * e_2_bits[2] + 4 * e_2_bits[3] + 8 * e_2_bits[4] + 16 * e_2_bits[5] + 32 * e_2_bits[6] + 64 * e_2_bits[7] + 128 * e_3_bits[0],
+        e_1_bits[1] + 2 * e_1_bits[2] + 4 * e_1_bits[3] + 8 * e_1_bits[4] + 16 * e_1_bits[5] + 32 * e_1_bits[6] + 64 * e_1_bits[7] + 128 * e_2_bits[0],
+        e_0_bits[1] + 2 * e_0_bits[2] + 4 * e_0_bits[3] + 8 * e_0_bits[4] + 16 * e_0_bits[5] + 32 * e_0_bits[6] + 64 * e_0_bits[7] + 128 * e_1_bits[0],
+        e_3_bits[1] + 2 * e_3_bits[2] + 4 * e_3_bits[3] + 8 * e_3_bits[4] + 16 * e_3_bits[5] + 32 * e_3_bits[6] + 64 * e_3_bits[7] + 128 * e_0_bits[0]
       ];
 
       let e_not = [255 - acc[4][0], 255 - acc[4][1], 255 - acc[4][2], 255 - acc[4][3]];
@@ -712,24 +714,24 @@ def sha256 := ⟦
       let a_3_bits = u8_bit_decomposition(acc[0][0]);
 
       let a_rotr2 = [
-        u8_recompose([a_3_bits[2], a_3_bits[3], a_3_bits[4], a_3_bits[5], a_3_bits[6], a_3_bits[7], a_0_bits[0], a_0_bits[1]]),
-        u8_recompose([a_2_bits[2], a_2_bits[3], a_2_bits[4], a_2_bits[5], a_2_bits[6], a_2_bits[7], a_3_bits[0], a_3_bits[1]]),
-        u8_recompose([a_1_bits[2], a_1_bits[3], a_1_bits[4], a_1_bits[5], a_1_bits[6], a_1_bits[7], a_2_bits[0], a_2_bits[1]]),
-        u8_recompose([a_0_bits[2], a_0_bits[3], a_0_bits[4], a_0_bits[5], a_0_bits[6], a_0_bits[7], a_1_bits[0], a_1_bits[1]])
+        a_3_bits[2] + 2 * a_3_bits[3] + 4 * a_3_bits[4] + 8 * a_3_bits[5] + 16 * a_3_bits[6] + 32 * a_3_bits[7] + 64 * a_0_bits[0] + 128 * a_0_bits[1],
+        a_2_bits[2] + 2 * a_2_bits[3] + 4 * a_2_bits[4] + 8 * a_2_bits[5] + 16 * a_2_bits[6] + 32 * a_2_bits[7] + 64 * a_3_bits[0] + 128 * a_3_bits[1],
+        a_1_bits[2] + 2 * a_1_bits[3] + 4 * a_1_bits[4] + 8 * a_1_bits[5] + 16 * a_1_bits[6] + 32 * a_1_bits[7] + 64 * a_2_bits[0] + 128 * a_2_bits[1],
+        a_0_bits[2] + 2 * a_0_bits[3] + 4 * a_0_bits[4] + 8 * a_0_bits[5] + 16 * a_0_bits[6] + 32 * a_0_bits[7] + 64 * a_1_bits[0] + 128 * a_1_bits[1]
       ];
 
       let a_rotr13 = [
-        u8_recompose([a_0_bits[5], a_0_bits[6], a_0_bits[7], a_1_bits[0], a_1_bits[1], a_1_bits[2], a_1_bits[3], a_1_bits[4]]),
-        u8_recompose([a_3_bits[5], a_3_bits[6], a_3_bits[7], a_0_bits[0], a_0_bits[1], a_0_bits[2], a_0_bits[3], a_0_bits[4]]),
-        u8_recompose([a_2_bits[5], a_2_bits[6], a_2_bits[7], a_3_bits[0], a_3_bits[1], a_3_bits[2], a_3_bits[3], a_3_bits[4]]),
-        u8_recompose([a_1_bits[5], a_1_bits[6], a_1_bits[7], a_2_bits[0], a_2_bits[1], a_2_bits[2], a_2_bits[3], a_2_bits[4]])
+        a_0_bits[5] + 2 * a_0_bits[6] + 4 * a_0_bits[7] + 8 * a_1_bits[0] + 16 * a_1_bits[1] + 32 * a_1_bits[2] + 64 * a_1_bits[3] + 128 * a_1_bits[4],
+        a_3_bits[5] + 2 * a_3_bits[6] + 4 * a_3_bits[7] + 8 * a_0_bits[0] + 16 * a_0_bits[1] + 32 * a_0_bits[2] + 64 * a_0_bits[3] + 128 * a_0_bits[4],
+        a_2_bits[5] + 2 * a_2_bits[6] + 4 * a_2_bits[7] + 8 * a_3_bits[0] + 16 * a_3_bits[1] + 32 * a_3_bits[2] + 64 * a_3_bits[3] + 128 * a_3_bits[4],
+        a_1_bits[5] + 2 * a_1_bits[6] + 4 * a_1_bits[7] + 8 * a_2_bits[0] + 16 * a_2_bits[1] + 32 * a_2_bits[2] + 64 * a_2_bits[3] + 128 * a_2_bits[4]
       ];
 
       let a_rotr22 = [
-        u8_recompose([a_1_bits[6], a_1_bits[7], a_2_bits[0], a_2_bits[1], a_2_bits[2], a_2_bits[3], a_2_bits[4], a_2_bits[5]]),
-        u8_recompose([a_0_bits[6], a_0_bits[7], a_1_bits[0], a_1_bits[1], a_1_bits[2], a_1_bits[3], a_1_bits[4], a_1_bits[5]]),
-        u8_recompose([a_3_bits[6], a_3_bits[7], a_0_bits[0], a_0_bits[1], a_0_bits[2], a_0_bits[3], a_0_bits[4], a_0_bits[5]]),
-        u8_recompose([a_2_bits[6], a_2_bits[7], a_3_bits[0], a_3_bits[1], a_3_bits[2], a_3_bits[3], a_3_bits[4], a_3_bits[5]])
+        a_1_bits[6] + 2 * a_1_bits[7] + 4 * a_2_bits[0] + 8 * a_2_bits[1] + 16 * a_2_bits[2] + 32 * a_2_bits[3] + 64 * a_2_bits[4] + 128 * a_2_bits[5],
+        a_0_bits[6] + 2 * a_0_bits[7] + 4 * a_1_bits[0] + 8 * a_1_bits[1] + 16 * a_1_bits[2] + 32 * a_1_bits[3] + 64 * a_1_bits[4] + 128 * a_1_bits[5],
+        a_3_bits[6] + 2 * a_3_bits[7] + 4 * a_0_bits[0] + 8 * a_0_bits[1] + 16 * a_0_bits[2] + 32 * a_0_bits[3] + 64 * a_0_bits[4] + 128 * a_0_bits[5],
+        a_2_bits[6] + 2 * a_2_bits[7] + 4 * a_3_bits[0] + 8 * a_3_bits[1] + 16 * a_3_bits[2] + 32 * a_3_bits[3] + 64 * a_3_bits[4] + 128 * a_3_bits[5]
       ];
 
       let s0 = u32_xor(a_rotr2, u32_xor(a_rotr13, a_rotr22));
@@ -759,24 +761,24 @@ def sha256 := ⟦
     let [«W_i-15_b3_0», «W_i-15_b3_1», «W_i-15_b3_2», «W_i-15_b3_3», «W_i-15_b3_4», «W_i-15_b3_5», «W_i-15_b3_6», «W_i-15_b3_7»] = u8_bit_decomposition(«W_i-15_b3»);
 
     let «W_i-15_rotr7» = [
-      u8_recompose([«W_i-15_b3_7», «W_i-15_b0_0», «W_i-15_b0_1», «W_i-15_b0_2», «W_i-15_b0_3», «W_i-15_b0_4», «W_i-15_b0_5», «W_i-15_b0_6»]),
-      u8_recompose([«W_i-15_b2_7», «W_i-15_b3_0», «W_i-15_b3_1», «W_i-15_b3_2», «W_i-15_b3_3», «W_i-15_b3_4», «W_i-15_b3_5», «W_i-15_b3_6»]),
-      u8_recompose([«W_i-15_b1_7», «W_i-15_b2_0», «W_i-15_b2_1», «W_i-15_b2_2», «W_i-15_b2_3», «W_i-15_b2_4», «W_i-15_b2_5», «W_i-15_b2_6»]),
-      u8_recompose([«W_i-15_b0_7», «W_i-15_b1_0», «W_i-15_b1_1», «W_i-15_b1_2», «W_i-15_b1_3», «W_i-15_b1_4», «W_i-15_b1_5», «W_i-15_b1_6»])
+      «W_i-15_b3_7» + 2 * «W_i-15_b0_0» + 4 * «W_i-15_b0_1» + 8 * «W_i-15_b0_2» + 16 * «W_i-15_b0_3» + 32 * «W_i-15_b0_4» + 64 * «W_i-15_b0_5» + 128 * «W_i-15_b0_6»,
+      «W_i-15_b2_7» + 2 * «W_i-15_b3_0» + 4 * «W_i-15_b3_1» + 8 * «W_i-15_b3_2» + 16 * «W_i-15_b3_3» + 32 * «W_i-15_b3_4» + 64 * «W_i-15_b3_5» + 128 * «W_i-15_b3_6»,
+      «W_i-15_b1_7» + 2 * «W_i-15_b2_0» + 4 * «W_i-15_b2_1» + 8 * «W_i-15_b2_2» + 16 * «W_i-15_b2_3» + 32 * «W_i-15_b2_4» + 64 * «W_i-15_b2_5» + 128 * «W_i-15_b2_6»,
+      «W_i-15_b0_7» + 2 * «W_i-15_b1_0» + 4 * «W_i-15_b1_1» + 8 * «W_i-15_b1_2» + 16 * «W_i-15_b1_3» + 32 * «W_i-15_b1_4» + 64 * «W_i-15_b1_5» + 128 * «W_i-15_b1_6»
     ];
 
     let «W_i-15_rotr18» = [
-      u8_recompose([«W_i-15_b1_2», «W_i-15_b1_3», «W_i-15_b1_4», «W_i-15_b1_5», «W_i-15_b1_6», «W_i-15_b1_7», «W_i-15_b2_0», «W_i-15_b2_1»]),
-      u8_recompose([«W_i-15_b0_2», «W_i-15_b0_3», «W_i-15_b0_4», «W_i-15_b0_5», «W_i-15_b0_6», «W_i-15_b0_7», «W_i-15_b1_0», «W_i-15_b1_1»]),
-      u8_recompose([«W_i-15_b3_2», «W_i-15_b3_3», «W_i-15_b3_4», «W_i-15_b3_5», «W_i-15_b3_6», «W_i-15_b3_7», «W_i-15_b0_0», «W_i-15_b0_1»]),
-      u8_recompose([«W_i-15_b2_2», «W_i-15_b2_3», «W_i-15_b2_4», «W_i-15_b2_5», «W_i-15_b2_6», «W_i-15_b2_7», «W_i-15_b3_0», «W_i-15_b3_1»])
+      «W_i-15_b1_2» + 2 * «W_i-15_b1_3» + 4 * «W_i-15_b1_4» + 8 * «W_i-15_b1_5» + 16 * «W_i-15_b1_6» + 32 * «W_i-15_b1_7» + 64 * «W_i-15_b2_0» + 128 * «W_i-15_b2_1»,
+      «W_i-15_b0_2» + 2 * «W_i-15_b0_3» + 4 * «W_i-15_b0_4» + 8 * «W_i-15_b0_5» + 16 * «W_i-15_b0_6» + 32 * «W_i-15_b0_7» + 64 * «W_i-15_b1_0» + 128 * «W_i-15_b1_1»,
+      «W_i-15_b3_2» + 2 * «W_i-15_b3_3» + 4 * «W_i-15_b3_4» + 8 * «W_i-15_b3_5» + 16 * «W_i-15_b3_6» + 32 * «W_i-15_b3_7» + 64 * «W_i-15_b0_0» + 128 * «W_i-15_b0_1»,
+      «W_i-15_b2_2» + 2 * «W_i-15_b2_3» + 4 * «W_i-15_b2_4» + 8 * «W_i-15_b2_5» + 16 * «W_i-15_b2_6» + 32 * «W_i-15_b2_7» + 64 * «W_i-15_b3_0» + 128 * «W_i-15_b3_1»
     ];
 
     let «W_i-15_shr3» = [
-      u8_recompose([«W_i-15_b3_3», «W_i-15_b3_4», «W_i-15_b3_5», «W_i-15_b3_6», «W_i-15_b3_7», 0,             0,             0]),
-      u8_recompose([«W_i-15_b2_3», «W_i-15_b2_4», «W_i-15_b2_5», «W_i-15_b2_6», «W_i-15_b2_7», «W_i-15_b3_0», «W_i-15_b3_1», «W_i-15_b3_2»]),
-      u8_recompose([«W_i-15_b1_3», «W_i-15_b1_4», «W_i-15_b1_5», «W_i-15_b1_6», «W_i-15_b1_7», «W_i-15_b2_0», «W_i-15_b2_1», «W_i-15_b2_2»]),
-      u8_recompose([«W_i-15_b0_3», «W_i-15_b0_4», «W_i-15_b0_5», «W_i-15_b0_6», «W_i-15_b0_7», «W_i-15_b1_0», «W_i-15_b1_1», «W_i-15_b1_2»])
+      «W_i-15_b3_3» + 2 * «W_i-15_b3_4» + 4 * «W_i-15_b3_5» + 8 * «W_i-15_b3_6» + 16 * «W_i-15_b3_7»,
+      «W_i-15_b2_3» + 2 * «W_i-15_b2_4» + 4 * «W_i-15_b2_5» + 8 * «W_i-15_b2_6» + 16 * «W_i-15_b2_7» + 32 * «W_i-15_b3_0» + 64 * «W_i-15_b3_1» + 128 * «W_i-15_b3_2»,
+      «W_i-15_b1_3» + 2 * «W_i-15_b1_4» + 4 * «W_i-15_b1_5» + 8 * «W_i-15_b1_6» + 16 * «W_i-15_b1_7» + 32 * «W_i-15_b2_0» + 64 * «W_i-15_b2_1» + 128 * «W_i-15_b2_2»,
+      «W_i-15_b0_3» + 2 * «W_i-15_b0_4» + 4 * «W_i-15_b0_5» + 8 * «W_i-15_b0_6» + 16 * «W_i-15_b0_7» + 32 * «W_i-15_b1_0» + 64 * «W_i-15_b1_1» + 128 * «W_i-15_b1_2»
     ];
 
     let [«W_i-2_b3», «W_i-2_b2», «W_i-2_b1», «W_i-2_b0»] = «W_i-2»;
@@ -786,24 +788,24 @@ def sha256 := ⟦
     let [«W_i-2_b3_0», «W_i-2_b3_1», «W_i-2_b3_2», «W_i-2_b3_3», «W_i-2_b3_4», «W_i-2_b3_5», «W_i-2_b3_6», «W_i-2_b3_7»] = u8_bit_decomposition(«W_i-2_b3»);
 
     let «W_i-2_rotr17» = [
-      u8_recompose([«W_i-2_b1_1», «W_i-2_b1_2», «W_i-2_b1_3», «W_i-2_b1_4», «W_i-2_b1_5», «W_i-2_b1_6», «W_i-2_b1_7», «W_i-2_b2_0»]),
-      u8_recompose([«W_i-2_b0_1», «W_i-2_b0_2», «W_i-2_b0_3», «W_i-2_b0_4», «W_i-2_b0_5», «W_i-2_b0_6», «W_i-2_b0_7», «W_i-2_b1_0»]),
-      u8_recompose([«W_i-2_b3_1», «W_i-2_b3_2», «W_i-2_b3_3», «W_i-2_b3_4», «W_i-2_b3_5», «W_i-2_b3_6», «W_i-2_b3_7», «W_i-2_b0_0»]),
-      u8_recompose([«W_i-2_b2_1», «W_i-2_b2_2», «W_i-2_b2_3», «W_i-2_b2_4», «W_i-2_b2_5», «W_i-2_b2_6», «W_i-2_b2_7», «W_i-2_b3_0»])
+      «W_i-2_b1_1» + 2 * «W_i-2_b1_2» + 4 * «W_i-2_b1_3» + 8 * «W_i-2_b1_4» + 16 * «W_i-2_b1_5» + 32 * «W_i-2_b1_6» + 64 * «W_i-2_b1_7» + 128 * «W_i-2_b2_0»,
+      «W_i-2_b0_1» + 2 * «W_i-2_b0_2» + 4 * «W_i-2_b0_3» + 8 * «W_i-2_b0_4» + 16 * «W_i-2_b0_5» + 32 * «W_i-2_b0_6» + 64 * «W_i-2_b0_7» + 128 * «W_i-2_b1_0»,
+      «W_i-2_b3_1» + 2 * «W_i-2_b3_2» + 4 * «W_i-2_b3_3» + 8 * «W_i-2_b3_4» + 16 * «W_i-2_b3_5» + 32 * «W_i-2_b3_6» + 64 * «W_i-2_b3_7» + 128 * «W_i-2_b0_0»,
+      «W_i-2_b2_1» + 2 * «W_i-2_b2_2» + 4 * «W_i-2_b2_3» + 8 * «W_i-2_b2_4» + 16 * «W_i-2_b2_5» + 32 * «W_i-2_b2_6» + 64 * «W_i-2_b2_7» + 128 * «W_i-2_b3_0»
     ];
 
     let «W_i-2_rotr19» = [
-      u8_recompose([«W_i-2_b1_3», «W_i-2_b1_4», «W_i-2_b1_5», «W_i-2_b1_6», «W_i-2_b1_7», «W_i-2_b2_0», «W_i-2_b2_1», «W_i-2_b2_2»]),
-      u8_recompose([«W_i-2_b0_3», «W_i-2_b0_4», «W_i-2_b0_5», «W_i-2_b0_6», «W_i-2_b0_7», «W_i-2_b1_0», «W_i-2_b1_1», «W_i-2_b1_2»]),
-      u8_recompose([«W_i-2_b3_3», «W_i-2_b3_4», «W_i-2_b3_5», «W_i-2_b3_6», «W_i-2_b3_7», «W_i-2_b0_0», «W_i-2_b0_1», «W_i-2_b0_2»]),
-      u8_recompose([«W_i-2_b2_3», «W_i-2_b2_4», «W_i-2_b2_5», «W_i-2_b2_6», «W_i-2_b2_7», «W_i-2_b3_0», «W_i-2_b3_1», «W_i-2_b3_2»])
+      «W_i-2_b1_3» + 2 * «W_i-2_b1_4» + 4 * «W_i-2_b1_5» + 8 * «W_i-2_b1_6» + 16 * «W_i-2_b1_7» + 32 * «W_i-2_b2_0» + 64 * «W_i-2_b2_1» + 128 * «W_i-2_b2_2»,
+      «W_i-2_b0_3» + 2 * «W_i-2_b0_4» + 4 * «W_i-2_b0_5» + 8 * «W_i-2_b0_6» + 16 * «W_i-2_b0_7» + 32 * «W_i-2_b1_0» + 64 * «W_i-2_b1_1» + 128 * «W_i-2_b1_2»,
+      «W_i-2_b3_3» + 2 * «W_i-2_b3_4» + 4 * «W_i-2_b3_5» + 8 * «W_i-2_b3_6» + 16 * «W_i-2_b3_7» + 32 * «W_i-2_b0_0» + 64 * «W_i-2_b0_1» + 128 * «W_i-2_b0_2»,
+      «W_i-2_b2_3» + 2 * «W_i-2_b2_4» + 4 * «W_i-2_b2_5» + 8 * «W_i-2_b2_6» + 16 * «W_i-2_b2_7» + 32 * «W_i-2_b3_0» + 64 * «W_i-2_b3_1» + 128 * «W_i-2_b3_2»
     ];
 
     let «W_i-2_shr10» = [
-      u8_recompose([0; 8]),
-      u8_recompose([«W_i-2_b3_2», «W_i-2_b3_3», «W_i-2_b3_4», «W_i-2_b3_5», «W_i-2_b3_6», «W_i-2_b3_7», 0,            0]),
-      u8_recompose([«W_i-2_b2_2», «W_i-2_b2_3», «W_i-2_b2_4», «W_i-2_b2_5», «W_i-2_b2_6», «W_i-2_b2_7», «W_i-2_b3_0», «W_i-2_b3_1»]),
-      u8_recompose([«W_i-2_b1_2», «W_i-2_b1_3», «W_i-2_b1_4», «W_i-2_b1_5», «W_i-2_b1_6», «W_i-2_b1_7», «W_i-2_b2_0», «W_i-2_b2_1»])
+      0,
+      «W_i-2_b3_2» + 2 * «W_i-2_b3_3» + 4 * «W_i-2_b3_4» + 8 * «W_i-2_b3_5» + 16 * «W_i-2_b3_6» + 32 * «W_i-2_b3_7»,
+      «W_i-2_b2_2» + 2 * «W_i-2_b2_3» + 4 * «W_i-2_b2_4» + 8 * «W_i-2_b2_5» + 16 * «W_i-2_b2_6» + 32 * «W_i-2_b2_7» + 64 * «W_i-2_b3_0» + 128 * «W_i-2_b3_1»,
+      «W_i-2_b1_2» + 2 * «W_i-2_b1_3» + 4 * «W_i-2_b1_4» + 8 * «W_i-2_b1_5» + 16 * «W_i-2_b1_6» + 32 * «W_i-2_b1_7» + 64 * «W_i-2_b2_0» + 128 * «W_i-2_b2_1»
     ];
 
     let «W_i_s0» = u32_xor(«W_i-15_rotr7», u32_xor(«W_i-15_rotr18», «W_i-15_shr3»));


### PR DESCRIPTION
## Summary

The blake3 circuits dominated the `lake exe kernel String.Internal.append`
proving-cost profile. This PR cuts total FFT cost by **19.1%** (3109M →
2516M) through five incremental, individually-measured changes, and
removes two now-dead helpers.

## Background

Aiur compiles each function to a zk circuit. A circuit's width is
`inputSize + selectors + auxiliaries + 4·(1 + lookups)`, where
`auxiliaries` and `lookups` are the **maximum over the match arms** — so
width is set by the *widest* arm; a wide cold arm wastes columns on every
row. Cost is `width × height × log2(height)`. Op costs that matter here:
`call` +outputSize aux +1 lookup; `store`/`load` +1 lookup; `u8_*` ops +1
lookup each; pure field `add`/`sub`/`mul`-by-const cost zero columns.

## Changes

### 1. Factor block-completion out of the hot loop

`blake3_compress_chunks` width 341 was set by its coldest arms
`(Cons,63,1023)` / `(Cons,63,_)` — the only ones carrying both
`assign_block_value` (+64 aux) and `blake3_compress` (+32 aux) plus flag
helpers and `store`, yet firing on ~1.8% of rows. Extracted that tail
into a cold `blake3_compress_block` circuit; the two arms merged into
one. **341 → 281.**

### 2. Thread `Layer` by pointer

`enum Layer { Push(&Layer, [[G;4];8]), Nil }` is a 34-wide value type.
`blake3_compress_chunks` took and returned it by value — 34 columns of
`inputSize` every row plus 34 aux on every recursive call. Switched to
`layer: &Layer -> &Layer`; `blake3` adds a `store`/`load` at the
boundary so `blake3_compress_layer` keeps its by-value signature.
**281 → 215.**

### 3. Accumulate block bytes in a list, not a 64-wide buffer

`blake3_compress_chunks` threaded `block_buffer: [[G;4];16]` (64 columns
of `inputSize`) and filled it via `assign_block_value`, whose
`[[G;4];16]` return cost +64 aux every hot row. Circuit memory is
content-addressed (no in-place mutation), so a threaded 64-element
accumulator costs 64 columns somewhere on every row — a linked list does
not. Replaced it with a reverse-ordered byte accumulator list:
- Hot loop: `store(ListNode.Cons(head, byte_acc))`, one store/row.
- `bytes_to_block` materializes a full 64-byte list into `[[G;4];16]` via
  64 unrolled `load`s — one cold row per completed block.
- `pad_block` zero-pads the trailing partial block.
- `blake3_finish` absorbs the input-exhausted arms.
- `assign_block_value` is now dead and removed.

**215 → 75.**

### 4. Combine carry bits with field add, not u8 xor

The byte adders (`u32_add`, `u32_be_add`, `u64_add`,
`relaxed_u64_be_add_2_bytes`) propagated carries with
`u8_xor(overflow_i, carry_ia)` — a circuit op (+1 aux, +1 lookup). The
two bits are mutually exclusive (a carry out of `a_i + b_i` forces the
partial sum `<= 254`, so `+ carry_in` cannot carry), so their xor is a
plain field add costing zero columns. Replaced every carry-combining
`u8_xor` with `+`. **u32_add 70 → 60.**

### 5. Inline `u8_recompose` and delete it

`u8_recompose([b0..b7]) = b0 + 2*b1 + ... + 128*b7` is pure arithmetic,
but each call cost +1 aux +1 lookup. Inlined all uses as explicit
weighted sums — 8 in `blake3_g_function`, ~36 across `sha256_compress`
and `define_W_i` — then deleted the now-unused definition.
**blake3_g_function 250 → 210.**

## Results

Measured with `lake exe kernel String.Internal.append`:

| metric | baseline | this PR |
|---|---|---|
| `blake3_compress_chunks` width | 341 | 75 (−78%) |
| `blake3_compress_chunks` FFT | 426M | 94M |
| `u32_add` width | 70 | 60 |
| `u32_add` FFT | 602M | 516M |
| `blake3_g_function` width | 250 | 210 |
| `blake3_g_function` FFT | 310M | 261M |
| `assign_block_value` FFT | 157M | eliminated |
| total FFT cost | 3109M | 2516M (−19.1%) |

New cold circuits introduced: `bytes_to_block`, `pad_block`,
`blake3_finish`, `blake3_compress_block` — all small.

## Validation

`lake test -- --ignored aiur-hashes` passes (145 assertions, exit 0),
covering blake3 and sha256 across sizes 0–3168 including block and chunk
boundaries. `lake exe kernel String.Internal.append` runs clean.