### PR TITLE
Fixed goldilocks extension degree

### DIFF
--- a/Ix/Aiur/Stages/Bytecode.lean
+++ b/Ix/Aiur/Stages/Bytecode.lean
@@ -78,7 +78,7 @@ structure FunctionLayout where
 def FunctionLayout.width (l : FunctionLayout) : Nat :=
   l.inputSize + l.selectors + l.auxiliaries
 
-abbrev goldilocksExtensionDegree : Nat := 4
+abbrev goldilocksExtensionDegree : Nat := 2
 
 def FunctionLayout.totalWidth (l : FunctionLayout) : Nat :=
   l.width + goldilocksExtensionDegree * (1 + l.lookups)


### PR DESCRIPTION
Fixes the Goldilocks extension degree in the statistics. It is 2 not 4. BabyBear is the one who needs 4.
Updated stats:
```
=== Circuit Statistics ===
Circuits: 618
Total width: 27988
Total FFT cost: 65032656
Total cache hits: 139515
Total saved cost: 43.34%
------------------------------------------------------------------------------------------------------------------
Name                                                                   Width Height  Hits FFT cost       %     %++
------------------------------------------------------------------------------------------------------------------
blake3_g_function                                                        224   7719     9 22329372  34.34%  34.34%
memory[3]                                                                 14  19454 49796  3880468   5.97%  40.30%
address_eq                                                               109   2903  7177  3639964   5.60%  45.90%
blake3_compress_inner_j                                                  278    966     0  2662890   4.09%  49.99%
expr_inst1                                                                40   5187  1986  2560445   3.94%  53.93%
blake3_compress_chunks                                                    27   7283     0  2522966   3.88%  57.81%
k_infer                                                                   92   2197   350  2243843   3.45%  61.26%
expr_inst1_walk                                                           53   3536     0  2209147   3.40%  64.66%
get_expr                                                                 102   1442     0  1543478   2.37%  67.03%
whnf_with_spine                                                           89   1527    49  1437376   2.21%  69.24%
convert_expr                                                             112   1240   524  1427148   2.19%  71.44%
read_byte                                                                 16   6262     2  1263662   1.94%  73.38%
blake3_compress                                                         1118    138     0  1096732   1.69%  75.07%
list_lookup_u64.Ptr.Univ                                                  37   2266    56   934497   1.44%  76.50%
expr_lbr                                                                  39   1972  7598   841792   1.29%  77.80%
find_prj_addr_at_pos                                                      38   1764     0   722916   1.11%  78.91%
get_app_telescope                                                         95    740     0   670056   1.03%  79.94%
validate_expr_well_scoped                                                 50   1154   626   586949   0.90%  80.84%
list_snoc.G                                                               20   2561     0   579938   0.89%  81.73%
memory[4]                                                                 15   3290 23644   576599   0.89%  82.62%
...
```