### PR TITLE
Aiur: drop the tag slot for single-variant enums

### DIFF
--- a/Ix/Aiur/Compiler/Layout.lean
+++ b/Ix/Aiur/Compiler/Layout.lean
@@ -69,7 +69,10 @@ def DataType.sizeBound (decls : Decls) : Nat → Std.HashSet Global → DataType
       let ctorSizes ← dt.constructors.mapM
         (Concrete.Constructor.sizeBound decls bound visited)
       let maxFields := ctorSizes.foldl max 0
-      pure (maxFields + 1)
+      -- Single-variant enums need no tag slot: the layout matches a plain
+      -- tuple of the sole constructor's fields.
+      if dt.constructors.length == 1 then pure maxFields
+      else pure (maxFields + 1)
 end
 
 /-- Outer interface: the recursion bound is `decls.size + 1`, which the

--- a/Ix/Aiur/Compiler/Lower.lean
+++ b/Ix/Aiur/Compiler/Lower.lean
@@ -31,6 +31,9 @@ structure ConstructorLayout where
   index : Nat
   size : Nat
   offsets : Array Nat
+  -- True when the parent datatype has a single constructor: no tag slot, so
+  -- construction omits the tag const and matches need no discrimination.
+  tagless : Bool
   deriving Inhabited
 
 inductive Layout
@@ -47,11 +50,12 @@ def Concrete.Decls.layoutMap (decls : Decls) : Except String LayoutMap := do
     | .dataType dataType => do
       let dataTypeSize ← dataType.size decls
       let layoutMap := layoutMap.insert dataType.name (.dataType dataTypeSize)
+      let tagless := dataType.constructors.length == 1
       let pass := fun (acc, index) constructor => do
         let offsets ← constructor.argTypes.foldlM (init := #[0]) fun offsets typ => do
           let typSyze ← typ.size decls
           pure $ offsets.push ((offsets[offsets.size - 1]?.getD 0) + typSyze)
-        let decl := .constructor { size := dataTypeSize, offsets, index }
+        let decl := .constructor { size := dataTypeSize, offsets, index, tagless }
         let name := dataType.name.pushNamespace constructor.nameHead
         pure (acc.insert name decl, index + 1)
       let (layoutMap, _) ← dataType.constructors.foldlM pass (layoutMap, 0)
@@ -150,13 +154,21 @@ def toIndex
       pushOp (.const (.ofNat layout.index))
     | some (.constructor layout) => do
       let size := layout.size
-      let paddingOp := Bytecode.Op.const (.ofNat layout.index)
-      let index ← pushOp paddingOp
-      if index.size < size then
-        let padding := (← pushOp paddingOp)[0]!
-        pure $ index ++ Array.replicate (size - index.size) padding
+      -- Tagless single-variant: no tag slot. A nullary ctor is then a width-0
+      -- (unit-like) value; with fields it pads up to `size` from empty.
+      if layout.tagless then
+        if size == 0 then pure #[]
+        else
+          let padding := (← pushOp (.const (.ofNat 0)))[0]!
+          pure $ Array.replicate size padding
       else
-        pure index
+        let paddingOp := Bytecode.Op.const (.ofNat layout.index)
+        let index ← pushOp paddingOp
+        if index.size < size then
+          let padding := (← pushOp paddingOp)[0]!
+          pure $ index ++ Array.replicate (size - index.size) padding
+        else
+          pure index
     | _ => throw s!"ref: layout missing for `{name}`"
   | .field _ _ g => pushOp (Bytecode.Op.const g)
   | .tuple _ _ terms | .array _ _ terms =>
@@ -186,7 +198,11 @@ def toIndex
       pushOp (.call layout.index args layout.outputSize unconstrained) layout.outputSize
     | some (.constructor layout) => do
       let size := layout.size
-      let index ← pushOp (.const (.ofNat layout.index))
+      -- Tagless single-variant: omit the tag const; args fill the layout from
+      -- offset 0, exactly like a tuple.
+      let index ←
+        if layout.tagless then pure #[]
+        else pushOp (.const (.ofNat layout.index))
       let index ← buildArgs layoutMap bindings args index
       if index.size < size then
         let padding := (← pushOp (.const (.ofNat 0)))[0]!
@@ -519,24 +535,30 @@ def Concrete.addCase
       set { initState with selIdx := (← get).selIdx }
       pure (cases.push (g, term), defaultBlock)
     | .ref global pats => do
-      let (index, offsets) ← match layoutMap[global]? with
-        | some (.function layout) => pure (layout.index, layout.offsets)
-        | some (.constructor layout) => pure (layout.index, layout.offsets)
+      let (index, offsets, tagless) ← match layoutMap[global]? with
+        | some (.function layout) => pure (layout.index, layout.offsets, false)
+        | some (.constructor layout) => pure (layout.index, layout.offsets, layout.tagless)
         | _ => throw s!"addCase: layout missing for `{global}`"
       -- Bind each sub-pattern `Local` to the corresponding slice of `idxs`.
-      -- `idxs[0]` is the tag; argument `i` occupies `idxs[1 + offsets[i] ..
-      -- 1 + offsets[i+1]]`.
+      -- A tagged layout reserves `idxs[0]` for the tag, so argument `i` occupies
+      -- `idxs[1 + offsets[i] .. 1 + offsets[i+1]]`. A tagless (single-variant)
+      -- layout has no tag slot, so the base is `0` — a tuple-identical layout.
+      let base := if tagless then 0 else 1
       let ptrBindings : Std.HashMap Local (Array Bytecode.ValIdx) :=
         (Array.range pats.size).foldl (init := bindings) fun acc i =>
-          let startOff := 1 + (offsets[i]?.getD 0)
-          let endOff := 1 + (offsets[i+1]?.getD startOff)
+          let startOff := base + (offsets[i]?.getD 0)
+          let endOff := base + (offsets[i+1]?.getD (offsets[i]?.getD 0))
           let slice := idxs.extract startOff endOff
           let patLocal := pats[i]?.getD (.idx 0)
           acc.insert patLocal slice
       let initState ← get
       let term ← term.compile returnTyp layoutMap ptrBindings yieldCtrl
       set { initState with selIdx := (← get).selIdx }
-      pure (cases.push (.ofNat index, term), defaultBlock)
+      -- Single-variant: emit the arm as the unconditional default. With no other
+      -- cases the `.match`/`.matchContinue` always falls through to it, so no tag
+      -- discrimination occurs (`idxs[0]` is a field, never a tag).
+      if tagless then pure (cases, .some term)
+      else pure (cases.push (.ofNat index, term), defaultBlock)
     | .wildcard => do
       let initState ← get
       let term ← term.compile returnTyp layoutMap bindings yieldCtrl

--- a/Ix/Aiur/Semantics/Flatten.lean
+++ b/Ix/Aiur/Semantics/Flatten.lean
@@ -149,14 +149,17 @@ def typFlatSizeBound (decls : Source.Decls) : Nat → HashSet Global → Typ →
         | _ => 0
   | _+1, _, .mvar _ => 0
 
-/-- Flat size of a datatype (max constructor size + 1 for the tag). -/
+/-- Flat size of a datatype (max constructor size + 1 for the tag; the `+ 1`
+is dropped for single-variant enums, which carry no tag). -/
 def dataTypeFlatSizeBound (decls : Source.Decls) : Nat → HashSet Global → DataType → Nat
   | 0, _, _ => 1
   | bound+1, visited, dt =>
       let ctorSizes := dt.constructors.map fun ctor =>
         ctor.argTypes.foldl (init := 0)
           (fun acc t => acc + typFlatSizeBound decls bound visited t)
-      ctorSizes.foldl max 0 + 1
+      -- Single-variant enums carry no tag slot (tuple-identical layout).
+      if dt.constructors.length == 1 then ctorSizes.foldl max 0
+      else ctorSizes.foldl max 0 + 1
 
 end
 
@@ -194,10 +197,14 @@ def flattenValue (decls : Decls) (funcIdx : Global → Option Nat) :
   | .ctor g args =>
       match decls.getByKey g with
       | some (.constructor dt ctor) =>
-          let ctorIndex := dt.constructors.findIdx? (· == ctor) |>.getD 0
           let dtSize := dataTypeFlatSize decls {} dt
           let argsFlat := args.attach.flatMap (fun ⟨v, _⟩ => flattenValue decls funcIdx v)
-          let flat := #[.ofNat ctorIndex] ++ argsFlat
+          -- Single-variant enums carry no tag slot (tuple-identical layout).
+          let flat :=
+            if dt.constructors.length == 1 then argsFlat
+            else
+              let ctorIndex := dt.constructors.findIdx? (· == ctor) |>.getD 0
+              #[.ofNat ctorIndex] ++ argsFlat
           let padding := dtSize - flat.size
           flat ++ Array.replicate padding 0
       | _ => args.attach.flatMap (fun ⟨v, _⟩ => flattenValue decls funcIdx v)


### PR DESCRIPTION
An enum with one constructor has a constant tag (always index 0) and needs no discrimination, so the tag column is dead weight. Lay such enums out identically to a plain tuple of the sole constructor's fields:

- size formulas (Concrete.DataType.sizeBound, dataTypeFlatSizeBound) omit the +1 tag slot when constructors.length == 1
- flattenValue / `.app` / `.ref` lowering skip the tag const at construction
- ConstructorLayout carries a `tagless` flag; addCase reads fields at offset base 0 (not 1) and routes the sole arm to the match's unconditional default (empty cases => no tag comparison)

lake exe check Nat.add_comm: total width 32379 -> 32239, total FFT cost 56064915 -> 56051199; 81 circuits shrink, none regress; the width-50 memory bucket is eliminated.