### PR TITLE
perf(ix): lazy, zero-copy anon env load for the Aiur check path

### DIFF
--- a/Ix/Cli/CheckCmd.lean
+++ b/Ix/Cli/CheckCmd.lean
@@ -183,7 +183,10 @@ def forEachClaim
   match ixePath with
   | some path =>
     let bytes ← IO.FS.readBinFile path
-    let ixonEnv ← match Ixon.rsDeEnv bytes with
+    -- Anon load: lazy zero-copy constants, binder metadata dropped. The Aiur
+    -- check circuit consumes only anonymous constants, blobs, and per-Defn
+    -- reducibility hints — mirrors the Rust kernel's `get_anon_mmap`.
+    let ixonEnv ← match Ixon.deEnvAnon bytes with
       | .error e =>
         IO.eprintln s!"Failed to deserialize {path}: {e}"; return 1
       | .ok env => pure env
@@ -331,7 +334,8 @@ private def blockAddrOf (addr : Address) (c : Ixon.Constant) : Address :=
 def ownedConstsForBlocks (ixonEnv : Ixon.Env) (blocks : Array Address) : Array Address := Id.run do
   let blockSet : Std.HashSet Address := blocks.foldl (·.insert ·) {}
   let mut o : Array Address := #[]
-  for (addr, c) in ixonEnv.consts do
+  for (addr, lc) in ixonEnv.consts do
+    let some c := lc.get? | continue
     if blockSet.contains (blockAddrOf addr c) then o := o.push addr
   return o
 
@@ -348,7 +352,7 @@ def loadEnvAndShards (manifestPath ixePath : String) :
     IO (Except String (Ixon.Env × Array (Array Address))) := do
   match parseIxesAllShards (← IO.FS.readBinFile manifestPath) with
   | .error e => return .error s!"manifest parse failed: {e}"
-  | .ok shards => match Ixon.rsDeEnv (← IO.FS.readBinFile ixePath) with
+  | .ok shards => match Ixon.deEnvAnon (← IO.FS.readBinFile ixePath) with
     | .error e => return .error s!"deserialize {ixePath} failed: {e}"
     | .ok env => return .ok (env, shards)
 
@@ -405,7 +409,8 @@ def shardsCover (ixonEnv : Ixon.Env) (shards : Array (Array Address)) : IO Bool 
   -- assign every const to a shard via its block; count + detect unowned.
   let mut counts : Array Nat := Array.replicate shards.size 0
   let mut unowned : Nat := 0
-  for (addr, c) in ixonEnv.consts do
+  for (addr, lc) in ixonEnv.consts do
+    let some c := lc.get? | continue
     match blockToShard.get? (blockAddrOf addr c) with
     | some k => counts := counts.modify k (· + 1)  -- total: no-op if out of range
     | none => unowned := unowned + 1

--- a/Ix/Commit.lean
+++ b/Ix/Commit.lean
@@ -28,7 +28,8 @@ open Ixon (PutM runPut putConstant putExpr Comm)
 def mkCompileEnv (phases : Ix.CompileM.CompilePhases) : Ix.CompileM.CompileEnv :=
   { env := phases.rawEnv
   , nameToNamed := phases.compileEnv.named
-  , constants := phases.compileEnv.consts
+  , constants := phases.compileEnv.consts.fold (init := {})
+      fun m a lc => m.insert a (lc.get?.getD default)
   , blobs := phases.compileEnv.blobs
   , totalBytes := 0 }
 

--- a/Ix/CompileM.lean
+++ b/Ix/CompileM.lean
@@ -1615,7 +1615,8 @@ def compileEnv (env : Ix.Environment) (blocks : Ix.CondensedBlocks) (dbg : Bool 
   let allBlobs := nameBlobs.fold (fun m k v => m.insert k v) compileEnv.blobs
 
   let ixonEnv : Ixon.Env := {
-    consts := compileEnv.constants
+    consts := compileEnv.constants.fold (init := {})
+      fun m a c => m.insert a (Ixon.LazyConstant.ofConstant c)
     named := compileEnv.nameToNamed
     blobs := allBlobs
     names := namesMap
@@ -1908,7 +1909,8 @@ def compileEnvParallel (env : Ix.Environment) (blocks : Ix.CondensedBlocks)
     IO.println s!"  [Lean Compile] Blobs: {blockBlobCount} from blocks, {nameBlobCount} from names, {overlapCount} overlap, {finalBlobCount} final"
 
   let ixonEnv : Ixon.Env := {
-    consts := constants
+    consts := constants.fold (init := {})
+      fun m a c => m.insert a (Ixon.LazyConstant.ofConstant c)
     named := nameToNamed
     blobs := allBlobs
     names := namesMap

--- a/Ix/DecompileM.lean
+++ b/Ix/DecompileM.lean
@@ -712,7 +712,7 @@ def decompileProjection (cnst : Constant) (cMeta : ConstantMeta)
 def decompileOne (env : DecompileEnv) (ixonEnv : Ixon.Env)
     (_ixName : Ix.Name) (named : Ixon.Named)
     : Except String (Array (Ix.Name × Ix.ConstantInfo)) :=
-  match ixonEnv.consts.get? named.addr with
+  match ixonEnv.getConst? named.addr with
   | none => .ok #[]
   | some cnst =>
     let m : DecompileM (Array (Ix.Name × Ix.ConstantInfo)) :=
@@ -730,17 +730,17 @@ def decompileOne (env : DecompileEnv) (ixonEnv : Ixon.Env)
         let info ← decompileRecursor rec cnst named.constMeta
         pure #[(info.getCnst.name, info)]
       | .dPrj proj =>
-        match ixonEnv.consts.get? proj.block with
+        match ixonEnv.getConst? proj.block with
         | some { info := .muts mutuals, sharing, refs, univs } =>
           decompileProjection cnst named.constMeta mutuals sharing refs univs
         | _ => pure #[]
       | .iPrj proj =>
-        match ixonEnv.consts.get? proj.block with
+        match ixonEnv.getConst? proj.block with
         | some { info := .muts mutuals, sharing, refs, univs } =>
           decompileProjection cnst named.constMeta mutuals sharing refs univs
         | _ => pure #[]
       | .rPrj proj =>
-        match ixonEnv.consts.get? proj.block with
+        match ixonEnv.getConst? proj.block with
         | some { info := .muts mutuals, sharing, refs, univs } =>
           decompileProjection cnst named.constMeta mutuals sharing refs univs
         | _ => pure #[]

--- a/Ix/IxVM/ClaimHarness.lean
+++ b/Ix/IxVM/ClaimHarness.lean
@@ -97,7 +97,7 @@ partial def closureFrom (env : Ixon.Env) (target : Address) : Std.HashSet Addres
     worklist := worklist.pop
     if visited.contains addr then continue
     visited := visited.insert addr
-    let some c := env.consts.get? addr | continue
+    let some c := env.getConst? addr | continue
     for r in c.refs do worklist := worklist.push r
     match c.info with
     | .iPrj p | .cPrj p => worklist := worklist.push p.block
@@ -111,8 +111,9 @@ partial def closureFrom (env : Ixon.Env) (target : Address) : Std.HashSet Addres
     one entry per const, keyed by its index. Returns the buffer and the
     count `n` (which the Aiur entrypoint receives as input). -/
 def buildSerdeIOBuffer (ixonEnv : Ixon.Env) : Aiur.IOBuffer × Nat :=
-  ixonEnv.consts.valuesIter.fold (init := (default, 0)) fun (ioBuffer, i) c =>
-    let (_, bytes) := Ixon.Serialize.put c |>.run default
+  ixonEnv.consts.valuesIter.fold (init := (default, 0)) fun (ioBuffer, i) lc =>
+    -- The lazy entry already holds the serialized bytes; no re-serialization.
+    let bytes := lc.rawBytes
     (ioBuffer.extend 0 #[.ofNat i] (bytes.data.map .ofUInt8), i + 1)
 
 /-- Encode a `Lean.ReducibilityHints` as a single `G` per the convention
@@ -139,9 +140,11 @@ private def hintToG : Lean.ReducibilityHints → Aiur.G
 def addEntries (ixonEnv : Ixon.Env) (keep : Address → Bool)
     (ioBuffer : Aiur.IOBuffer) : Aiur.IOBuffer := Id.run do
   let mut ioBuffer := ioBuffer
-  for (addr, c) in ixonEnv.consts do
+  for (addr, lc) in ixonEnv.consts do
     if !keep addr then continue
-    let (_, bytes) := Ixon.Serialize.put c |>.run default
+    -- The kernel re-hashes these bytes against the key, so feed the exact
+    -- serialized form the lazy entry holds — no materialization needed.
+    let bytes := lc.rawBytes
     let key : Array Aiur.G := addr.hash.data.map .ofUInt8
     ioBuffer := ioBuffer.extend 0 key (bytes.data.map .ofUInt8)
   for (addr, rawBytes) in ixonEnv.blobs do

--- a/Ix/Ixon.lean
+++ b/Ix/Ixon.lean
@@ -1050,6 +1050,83 @@ def deExpr (bytes : ByteArray) : Except String Expr := runGet getExpr bytes
 def serConstant (c : Constant) : ByteArray := runPut (putConstant c)
 def deConstant (bytes : ByteArray) : Except String Constant := runGet getConstant bytes
 
+/-- Parse a `Constant` starting at byte offset `off` within `buf`, WITHOUT
+    copying out a sub-buffer. The window length bounds the constant, so any
+    bytes after it in `buf` are simply left unread (no trailing-bytes check).
+    Zero-copy apart from the small interior string/nat reads `getConstant`
+    performs regardless. -/
+def deConstantAt (buf : ByteArray) (off : Nat) : Except String Constant :=
+  match getConstant.run { idx := off, bytes := buf } with
+  | .ok a _ => .ok a
+  | .error e _ => .error e
+
+/-- Lazily-materialized constant: an offset window `(buf, off, len)` into a
+    shared backing `ByteArray` plus an optional pre-materialized `Constant`.
+    Mirrors the Rust kernel's `LazyConstant` (`src/ix/ixon/lazy.rs`) — the
+    `ofSlice` form is the analog of its window-into-a-shared-buffer
+    (`from_mmap_slice`) variant, except here the shared buffer is the resident
+    `.ixe` bytes rather than an mmap.
+
+    The lazy load path (`ofSlice`, used by `deEnvAnon`) points every constant
+    at a window into the *one* `.ixe` buffer already resident in memory — no
+    per-constant copy and no materialization. A freshly loaded env's
+    steady-state cost is therefore just that single buffer (plus tiny per-entry
+    offset records), which is what keeps loading e.g. `mathlib.ixe` from
+    blowing past 100 GB when only a small closure is actually checked. Constant
+    bodies are parsed on demand, and only for the closure that is visited.
+
+    The build/compile path (`ofConstant`) serializes once into its own buffer
+    and pre-populates `cache` so repeated `get`s during compilation are free. -/
+structure LazyConstant where
+  /-- Shared backing buffer. For `ofSlice` this is the whole `.ixe` buffer; for
+      `ofConstant` it is a standalone buffer holding just this constant's
+      serialized bytes. -/
+  buf : ByteArray
+  /-- Start offset of this constant's Tag4 body within `buf`. -/
+  off : Nat := 0
+  /-- Length of this constant's Tag4 body. -/
+  len : Nat
+  /-- Pre-materialized constant. `some` only for the build path; the lazy load
+      path leaves this `none` and parses the window fresh on each `get`. -/
+  cache : Option Constant := none
+  deriving Inhabited
+
+namespace LazyConstant
+
+/-- Build from a structured constant (build/compile path). Serializes once into
+    a standalone buffer and caches so `get` is free and `rawBytes` is ready. -/
+def ofConstant (c : Constant) : LazyConstant :=
+  let b := serConstant c
+  { buf := b, off := 0, len := b.size, cache := some c }
+
+/-- Build from an offset window into a shared buffer (zero-copy lazy load).
+    `buf[off:off+len]` must be exactly `serConstant`'s output for the address
+    this entry is stored under. -/
+def ofSlice (buf : ByteArray) (off len : Nat) : LazyConstant :=
+  { buf, off, len, cache := none }
+
+/-- Materialize the constant, surfacing parse errors. Returns the cached value
+    when present, otherwise parses the window in place (no copy). -/
+def get (lc : LazyConstant) : Except String Constant :=
+  match lc.cache with
+  | some c => .ok c
+  | none => deConstantAt lc.buf lc.off
+
+/-- Materialize the constant, discarding parse errors. -/
+def get? (lc : LazyConstant) : Option Constant :=
+  match lc.cache with
+  | some c => some c
+  | none => (deConstantAt lc.buf lc.off).toOption
+
+/-- Raw serialized bytes (the Tag4 constant body). Returns the backing buffer
+    directly when the window spans all of it (the standalone case), and only
+    copies out a sub-slice for a true window into a larger shared buffer. -/
+def rawBytes (lc : LazyConstant) : ByteArray :=
+  if lc.off == 0 && lc.len == lc.buf.size then lc.buf
+  else lc.buf.extract lc.off (lc.off + lc.len)
+
+end LazyConstant
+
 /-! ## Metadata Serialization -/
 
 /-- Type alias for name index (Address → u64). -/
@@ -1436,8 +1513,10 @@ def Comm.commit (c : Comm) : Address := Address.blake3 (serCommTagged c)
 /-- The Ixon environment, containing all compiled constants.
     Mirrors Rust's `ix::ixon::env::Env` structure. -/
 structure Env where
-  /-- Alpha-invariant constants: Address → Constant -/
-  consts : Std.HashMap Address Constant := {}
+  /-- Alpha-invariant constants: Address → lazily-materialized constant.
+      Stored as serialized bytes ([`LazyConstant`]) and parsed on demand so a
+      freshly loaded env only pays for the constants it actually touches. -/
+  consts : Std.HashMap Address LazyConstant := {}
   /-- Named references: Ix.Name → Named (includes address + metadata) -/
   named : Std.HashMap Ix.Name Named := {}
   /-- Raw data blobs: Address → bytes -/
@@ -1452,13 +1531,13 @@ structure Env where
 
 namespace Env
 
-/-- Store a constant at the given address. -/
+/-- Store a constant at the given address. Caches the materialized value. -/
 def storeConst (env : Env) (addr : Address) (const : Constant) : Env :=
-  { env with consts := env.consts.insert addr const }
+  { env with consts := env.consts.insert addr (LazyConstant.ofConstant const) }
 
-/-- Get a constant by address. -/
+/-- Get a constant by address, materializing on demand. -/
 def getConst? (env : Env) (addr : Address) : Option Constant :=
-  env.consts.get? addr
+  (env.consts.get? addr).bind LazyConstant.get?
 
 /-- Register a name with full Named metadata. -/
 def registerName (env : Env) (name : Ix.Name) (named : Named) : Env :=
@@ -1630,7 +1709,8 @@ namespace Env
 /-- Convert Env with HashMaps to RawEnv with Arrays for FFI.
     Includes the full names table for round-trip fidelity. -/
 def toRawEnv (env : Env) : RawEnv := {
-  consts := env.consts.toArray.map fun (addr, const) => { addr, const }
+  consts := env.consts.toArray.map fun (addr, lc) =>
+    { addr, const := lc.get?.getD default }
   named := env.named.toArray.map fun (name, n) => { name, addr := n.addr, constMeta := n.constMeta }
   blobs := env.blobs.toArray.map fun (addr, bytes) => { addr, bytes }
   comms := env.comms.toArray.map fun (addr, comm) => { addr, comm }
@@ -1739,9 +1819,11 @@ def putEnv (env : Env) : PutM Unit := do
   -- exactly what `serConstant` produces).
   let consts := env.consts.toList.toArray.qsort fun a b => (compare a.1 b.1).isLT
   putTag0 ⟨consts.size.toUInt64⟩
-  for (addr, constant) in consts do
+  for (addr, lc) in consts do
     Serialize.put addr
-    let bytes := serConstant constant
+    -- The lazy entry already holds exactly `serConstant`'s output, so write
+    -- its bytes directly — no re-materialization or re-serialization.
+    let bytes := lc.rawBytes
     putTag0 ⟨bytes.size.toUInt64⟩
     putBytes bytes
 
@@ -1779,7 +1861,11 @@ def putEnv (env : Env) : PutM Unit := do
     Serialize.put addr
     putComm comm
 
-/-- Deserialize an Env from bytes. -/
+/-- Deserialize an Env from bytes (pure Lean, full metadata). Used for
+    round-trip (`deEnv`) on small/in-memory envs. The lazy/anon `.ixe` check
+    path does **not** go through here — it uses the Rust parser via
+    `deEnvAnon` / `rsDeEnvLazyFFI`, which handles every metadata variant and
+    returns zero-copy constant windows. -/
 def getEnv : GetM Env := do
   -- Header
   let tag ← getTag4
@@ -1810,8 +1896,7 @@ def getEnv : GetM Env := do
     let len := (← getTag0).size
     let bytes ← getBytes len.toNat
     match deConstant bytes with
-    | .ok constant =>
-      env := { env with consts := env.consts.insert addr constant }
+    | .ok constant => env := env.storeConst addr constant
     | .error e =>
       throw s!"Env.get: bad constant bytes for addr {reprStr (toString addr)}: {e}"
 
@@ -1875,7 +1960,7 @@ end Env
 /-- Serialize an Env to bytes. -/
 def serEnv (env : Env) : ByteArray := runPut (Env.putEnv env)
 
-/-- Deserialize an Env from bytes. -/
+/-- Deserialize an Env from bytes (full metadata, pure Lean). -/
 def deEnv (bytes : ByteArray) : Except String Env := runGet Env.getEnv bytes
 
 /-- Compute section sizes for debugging. Returns (blobs, consts, names, named, comms). -/
@@ -1893,9 +1978,9 @@ def envSectionSizes (env : Env) : Nat × Nat × Nat × Nat × Nat := Id.run do
   let constsBytes := runPut do
     let consts := env.consts.toList.toArray.qsort fun a b => (compare a.1 b.1).isLT
     putTag0 ⟨consts.size.toUInt64⟩
-    for (addr, constant) in consts do
+    for (addr, lc) in consts do
       Serialize.put addr
-      putConstant constant
+      putBytes lc.rawBytes
 
   -- Names section
   let namesBytes := runPut do
@@ -1945,9 +2030,86 @@ def rsSerEnv (env : Env) : ByteArray :=
 @[extern "rs_de_env"]
 opaque rsDeEnvFFI : @& ByteArray → Except String RawEnv
 
-/-- Deserialize bytes to an Ixon.Env using Rust. -/
+/-- Deserialize bytes to an Ixon.Env using Rust (full, eager materialization). -/
 def rsDeEnv (bytes : ByteArray) : Except String Env :=
   return (← rsDeEnvFFI bytes).toEnv
+
+/-! ### Lazy/anon deserialization (zero-copy `.ixe` load for the check path)
+
+The Rust side (`rs_de_env_lazy`) parses the env once — reusing the proven
+parser, so every metadata variant (e.g. `CallSite`) is handled — and returns:
+constants as `(addr, offset, len)` windows into the buffer we pass in,
+`name → addr`, per-`Defn` reducibility hints, and copied blobs. We then
+reconstruct an `Env` whose constants are byte-window `LazyConstant`s over that
+*same* buffer, so no constant body is copied across the FFI boundary and only
+the checked closure is ever materialized. This is the Lean counterpart of the
+Rust kernel's anon load (`get_anon`): lazy + metadata-light. (The `.ixe` is
+held resident via `readBinFile` rather than mmap'd; see `get_anon_mmap` for the
+mmap variant the native kernel uses.) -/
+
+/-- A constant as an offset window `[offset, offset+len)` into the source buffer. -/
+structure RawConstSlice where
+  addr : Address
+  offset : UInt64
+  len : UInt64
+  deriving Inhabited
+
+/-- A named entry reduced to `name → addr` plus an encoded reducibility hint
+    (`hintKind`: 0 = none, 1 = opaque, 2 = abbrev, 3 = regular `hintVal`). -/
+structure RawNamedLite where
+  name : Ix.Name
+  addr : Address
+  hintKind : UInt64
+  hintVal : UInt64
+  deriving Inhabited
+
+/-- Metadata-light env returned by `rs_de_env_lazy`. -/
+structure RawEnvLazy where
+  consts : Array RawConstSlice
+  named : Array RawNamedLite
+  blobs : Array RawBlob
+  deriving Inhabited
+
+/-- Decode an encoded reducibility hint into the `ConstantMeta` the check path
+    expects: a stripped `.defn` carrying just the hint (so `addEntries` finds it
+    via `.defn _ _ hints …`), or `.empty` for non-`Defn` entries. -/
+def RawNamedLite.toConstMeta (n : RawNamedLite) : ConstantMeta :=
+  let mkDefn (h : Lean.ReducibilityHints) : ConstantMeta :=
+    .defn default #[] h #[] #[] {} 0 0
+  match n.hintKind with
+  | 1 => mkDefn .opaque
+  | 2 => mkDefn .abbrev
+  | 3 => mkDefn (.regular n.hintVal.toUInt32)
+  | _ => .empty
+
+/-- Reconstruct an `Env` from a `RawEnvLazy` and the original buffer `buf`.
+    Constants become `LazyConstant.ofSlice buf offset len` — zero-copy windows
+    that share `buf`. `buf` MUST be the exact buffer passed to `rs_de_env_lazy`
+    (offsets are relative to it). -/
+def RawEnvLazy.toEnv (raw : RawEnvLazy) (buf : ByteArray) : Env := Id.run do
+  let mut env : Env := {}
+  for ⟨addr, offset, len⟩ in raw.consts do
+    env := { env with
+      consts := env.consts.insert addr
+        (LazyConstant.ofSlice buf offset.toNat len.toNat) }
+  for n in raw.named do
+    env := env.registerName n.name { addr := n.addr, constMeta := n.toConstMeta }
+  for ⟨addr, bytes⟩ in raw.blobs do
+    env := { env with blobs := env.blobs.insert addr bytes }
+  return env
+
+@[extern "rs_de_env_lazy"]
+opaque rsDeEnvLazyFFI : @& ByteArray → Except String RawEnvLazy
+
+/-- Lazy, zero-copy, metadata-light deserialization for the Aiur check path.
+    Constants are byte-window `LazyConstant`s into `bytes` (parsed on demand,
+    only for the checked closure); binder metadata is dropped, keeping just
+    `name → addr` and per-`Defn` hints. The returned env borrows `bytes` — keep
+    it reachable (the windows hold references, so it stays alive automatically).
+    This is the Lean counterpart of the Rust kernel's anon load (`get_anon`):
+    lazy + metadata-light, over a resident buffer. -/
+def deEnvAnon (bytes : ByteArray) : Except String Env :=
+  return (← rsDeEnvLazyFFI bytes).toEnv bytes
 
 /-- Anonymous-only deserialization: keep blobs + consts, parse-and-drop
     names/named/comms. Returns a `RawEnv` whose `named`/`names`/`comms`

--- a/Tests/Ix/Compile.lean
+++ b/Tests/Ix/Compile.lean
@@ -93,8 +93,8 @@ def compareEnvResults
       if leanAddr == rustAddr then
         matching := matching + 1
       else
-        let leanBytes := leanEnv.consts.get? leanAddr |>.map Ixon.ser |>.getD default
-        let rustBytes := rustEnv.consts.get? rustAddr |>.map Ixon.ser |>.getD default
+        let leanBytes := leanEnv.getConst? leanAddr |>.map Ixon.ser |>.getD default
+        let rustBytes := rustEnv.getConst? rustAddr |>.map Ixon.ser |>.getD default
         mismatched := mismatched.push ⟨name, leanAddr, rustAddr, false, leanBytes, rustBytes⟩
       -- Check metadata regardless of addr match
       let leanMeta := leanNamed.constMeta.exprMetaByType

--- a/Tests/Ix/IxVM.lean
+++ b/Tests/Ix/IxVM.lean
@@ -161,8 +161,9 @@ private def asTestCase (label : String) (witness : ClaimWitness) : AiurTestCase 
     satisfies `pred`, or fail with `IO.userError`. -/
 private def findConstWithOrThrow (ixonEnv : Ixon.Env) (label : String)
     (pred : Ixon.ConstantInfo → Bool) : IO (Address × Ixon.ConstantInfo) := do
-  for (addr, c) in ixonEnv.consts do
-    if pred c.info then return (addr, c.info)
+  for (addr, lc) in ixonEnv.consts do
+    if let some c := lc.get? then
+      if pred c.info then return (addr, c.info)
   throw <| IO.userError s!"no {label} const found in shared smoke env"
 
 /-- Single-entry HashMap for one `(root, tree)` pairing. -/

--- a/src/ffi/ixon/env.rs
+++ b/src/ffi/ixon/env.rs
@@ -4,16 +4,17 @@
 //! RawConst, RawNamed, RawBlob, RawComm.
 
 use crate::ix::address::Address;
-use crate::ix::env::Name;
+use crate::ix::env::{Name, ReducibilityHints};
 use crate::ix::ixon::comm::Comm;
 use crate::ix::ixon::constant::Constant as IxonConstant;
-use crate::ix::ixon::env::{Env as IxonEnv, Named as IxonNamed};
+use crate::ix::ixon::env::{Env as IxonEnv, LazyIndex, Named as IxonNamed};
 use crate::ix::ixon::merkle::merkle_root_canonical;
 use crate::ix::ixon::metadata::ConstantMeta;
 use crate::lean::{
   LeanIxName, LeanIxonComm, LeanIxonConstant, LeanIxonConstantMeta,
-  LeanIxonRawBlob, LeanIxonRawComm, LeanIxonRawConst, LeanIxonRawEnv,
-  LeanIxonRawNameEntry, LeanIxonRawNamed,
+  LeanIxonRawBlob, LeanIxonRawComm, LeanIxonRawConst, LeanIxonRawConstSlice,
+  LeanIxonRawEnv, LeanIxonRawEnvLazy, LeanIxonRawNameEntry, LeanIxonRawNamed,
+  LeanIxonRawNamedLite,
 };
 use lean_ffi::object::{
   LeanArray, LeanBorrowed, LeanByteArray, LeanExcept, LeanOwned, LeanRef,
@@ -473,5 +474,101 @@ pub extern "C" fn rs_de_env_anon(
       let msg = format!("rs_de_env_anon: {}", e);
       LeanExcept::error_string(&msg)
     },
+  }
+}
+
+// =============================================================================
+// rs_de_env_lazy: zero-copy, metadata-light deserialization for the Aiur
+// check path. Parses the env once in Rust (reusing the proven section parsers,
+// so every metadata variant — e.g. CallSite — is handled) and hands Lean only:
+//   - per-const (addr, offset, len) windows into the *same* buffer Lean passed
+//     in (no constant bytes copied across the boundary),
+//   - name -> addr,
+//   - per-Defn reducibility hints,
+//   - copied blobs.
+// Lean then stores byte-window `LazyConstant`s and materializes only the
+// closure it actually checks. See `Ix.Ixon.deEnvAnon`.
+// =============================================================================
+
+/// Encode an optional reducibility hint as `(kind, val)` for the FFI:
+/// `0` = none (not a Defn), `1` = Opaque, `2` = Abbrev, `3` = Regular(val).
+fn encode_hint(hint: &Option<ReducibilityHints>) -> (u64, u64) {
+  match hint {
+    None => (0, 0),
+    Some(ReducibilityHints::Opaque) => (1, 0),
+    Some(ReducibilityHints::Abbrev) => (2, 0),
+    Some(ReducibilityHints::Regular(n)) => (3, u64::from(*n)),
+  }
+}
+
+impl LeanIxonRawConstSlice<LeanOwned> {
+  /// Build `Ixon.RawConstSlice { addr, offset, len }`.
+  pub fn build(addr: &Address, offset: usize, len: usize) -> Self {
+    let ctor = LeanIxonRawConstSlice::alloc(0);
+    ctor.set_obj(0, LeanIxAddress::build(addr));
+    ctor.set_num_64(0, offset as u64);
+    ctor.set_num_64(1, len as u64);
+    ctor
+  }
+}
+
+impl LeanIxonRawNamedLite<LeanOwned> {
+  /// Build `Ixon.RawNamedLite { name, addr, hintKind, hintVal }`.
+  pub fn build(
+    cache: &mut LeanBuildCache,
+    name: &Name,
+    addr: &Address,
+    hint: &Option<ReducibilityHints>,
+  ) -> Self {
+    let (kind, val) = encode_hint(hint);
+    let ctor = LeanIxonRawNamedLite::alloc(0);
+    ctor.set_obj(0, LeanIxName::build(cache, name));
+    ctor.set_obj(1, LeanIxAddress::build(addr));
+    ctor.set_num_64(0, kind);
+    ctor.set_num_64(1, val);
+    ctor
+  }
+}
+
+/// Build a Lean `Ixon.RawEnvLazy` from a parsed [`LazyIndex`].
+fn build_raw_env_lazy(index: &LazyIndex) -> LeanIxonRawEnvLazy<LeanOwned> {
+  let mut cache = LeanBuildCache::new();
+
+  let consts_arr = LeanArray::alloc(index.consts.len());
+  for (i, c) in index.consts.iter().enumerate() {
+    consts_arr.set(i, LeanIxonRawConstSlice::build(&c.addr, c.offset, c.len));
+  }
+
+  let named_arr = LeanArray::alloc(index.named.len());
+  for (i, n) in index.named.iter().enumerate() {
+    named_arr.set(
+      i,
+      LeanIxonRawNamedLite::build(&mut cache, &n.name, &n.addr, &n.hint),
+    );
+  }
+
+  let blobs_arr = LeanArray::alloc(index.blobs.len());
+  for (i, (addr, bytes)) in index.blobs.iter().enumerate() {
+    blobs_arr.set(i, LeanIxonRawBlob::build_from_parts(addr, bytes));
+  }
+
+  let ctor = LeanIxonRawEnvLazy::alloc(0);
+  ctor.set_obj(0, consts_arr);
+  ctor.set_obj(1, named_arr);
+  ctor.set_obj(2, blobs_arr);
+  ctor
+}
+
+/// FFI: Deserialize ByteArray -> Except String Ixon.RawEnvLazy. Pure. The
+/// constants are returned as offset windows into the *input* buffer; the Lean
+/// side must reuse that same buffer when reconstructing the env.
+#[unsafe(no_mangle)]
+pub extern "C" fn rs_de_env_lazy(
+  obj: LeanByteArray<LeanBorrowed<'_>>,
+) -> LeanExcept<LeanOwned> {
+  let data = obj.as_bytes();
+  match crate::ix::ixon::env::Env::parse_lazy_index(data) {
+    Ok(index) => LeanExcept::ok(build_raw_env_lazy(&index)),
+    Err(e) => LeanExcept::error_string(&format!("rs_de_env_lazy: {e}")),
   }
 }

--- a/src/ix/ixon/env.rs
+++ b/src/ix/ixon/env.rs
@@ -61,6 +61,39 @@ pub struct AuxLayout {
   pub source_ctor_counts: Vec<usize>,
 }
 
+/// One constant in a [`LazyIndex`]: its content address plus the byte window
+/// `[offset, offset+len)` of its serialized Tag4 body within the source buffer.
+/// No bytes are copied — the consumer (the Lean lazy loader) slices its own
+/// copy of the buffer at these offsets.
+#[derive(Debug, Clone)]
+pub struct LazyConstSlice {
+  pub addr: Address,
+  pub offset: usize,
+  pub len: usize,
+}
+
+/// One named entry in a [`LazyIndex`]: just the `name → addr` mapping plus the
+/// per-`Defn` reducibility hint (the only metadata the typecheck circuit
+/// consumes). The heavy `ExprMetaArena` is parsed (to advance the cursor and
+/// handle every metadata variant, e.g. `CallSite`) but discarded.
+#[derive(Debug, Clone)]
+pub struct LazyNamed {
+  pub name: Name,
+  pub addr: Address,
+  pub hint: Option<ReducibilityHints>,
+}
+
+/// Result of [`Env::parse_lazy_index`]: a metadata-light, zero-copy view of an
+/// `.ixe` buffer suitable for the anon/lazy check path. Constants are byte
+/// windows (offsets), `named` is `name → addr` + hint, and `blobs` are copied
+/// (they are small and the kernel ingests their bytes directly).
+#[derive(Debug, Clone, Default)]
+pub struct LazyIndex {
+  pub consts: Vec<LazyConstSlice>,
+  pub named: Vec<LazyNamed>,
+  pub blobs: Vec<(Address, Vec<u8>)>,
+}
+
 /// The Ixon environment.
 ///
 /// Contains five maps:

--- a/src/ix/ixon/serialize.rs
+++ b/src/ix/ixon/serialize.rs
@@ -1088,7 +1088,7 @@ pub fn get_named_indexed(
 // ============================================================================
 
 use super::comm::Comm;
-use super::env::Env;
+use super::env::{Env, LazyConstSlice, LazyIndex, LazyNamed};
 use super::merkle::{merkle_root_canonical, zero_address};
 
 impl Env {
@@ -1448,6 +1448,127 @@ impl Env {
     }
 
     Ok(env)
+  }
+
+  /// Parse an `.ixe` buffer into a metadata-light, **zero-copy** index for the
+  /// anon/lazy check path (see [`LazyIndex`]). Mirrors [`Env::get`]'s section
+  /// walk and reuses the same battle-tested parsers (so every metadata variant
+  /// — e.g. `CallSite` — is handled), but:
+  ///
+  /// - constants are recorded as `(addr, offset, len)` windows into `data`
+  ///   rather than copied/stored, and their bodies are never parsed here;
+  /// - the `names` table and each `Named`'s `ExprMetaArena` are parsed only to
+  ///   advance the cursor and are then dropped, keeping just `name → addr` and
+  ///   the per-`Defn` reducibility hint;
+  /// - `comms` are skipped entirely.
+  ///
+  /// `data` must be the whole buffer (offsets are relative to its start). The
+  /// env-level merkle root over const addresses is still re-verified.
+  pub fn parse_lazy_index(data: &[u8]) -> Result<LazyIndex, String> {
+    let mut buf: &[u8] = data;
+
+    // Header: Tag4 (flag/variant) + canonical merkle root.
+    let tag = Tag4::get(&mut buf)?;
+    if tag.flag != Self::FLAG {
+      return Err(format!(
+        "parse_lazy_index: expected flag 0x{:X}, got 0x{:X}",
+        Self::FLAG,
+        tag.flag
+      ));
+    }
+    if tag.size != 0 {
+      return Err(format!(
+        "parse_lazy_index: expected Env variant 0, got {}",
+        tag.size
+      ));
+    }
+    let stored_root = get_address(&mut buf)?;
+
+    let mut index = LazyIndex::default();
+
+    // Section 1: Blobs (copied — small, and the kernel ingests their bytes).
+    let num_blobs = get_u64(&mut buf)?;
+    for _ in 0..num_blobs {
+      let addr = get_address(&mut buf)?;
+      let len = get_u64(&mut buf)? as usize;
+      if buf.len() < len {
+        return Err(format!(
+          "parse_lazy_index: need {} bytes for blob, have {}",
+          len,
+          buf.len()
+        ));
+      }
+      let (bytes, rest) = buf.split_at(len);
+      buf = rest;
+      index.blobs.push((addr, bytes.to_vec()));
+    }
+
+    // Section 2: Consts — record offset windows, never parse the bodies.
+    let num_consts = get_u64(&mut buf)?;
+    for _ in 0..num_consts {
+      let addr = get_address(&mut buf)?;
+      let len = Tag0::get(&mut buf)?.size as usize;
+      // Position of the body within `data` = bytes consumed so far.
+      let offset = data.len() - buf.len();
+      if buf.len() < len {
+        return Err(format!(
+          "parse_lazy_index: need {} bytes for constant, have {}",
+          len,
+          buf.len()
+        ));
+      }
+      buf = &buf[len..];
+      index.consts.push(LazyConstSlice { addr, offset, len });
+    }
+
+    // Section 3: Names — parsed to build the index for metadata decoding, then
+    // dropped (the check never consults the name component table).
+    let num_names = get_u64(&mut buf)?;
+    let mut names_lookup: FxHashMap<Address, Name> = FxHashMap::default();
+    let mut name_reverse_index: NameReverseIndex =
+      Vec::with_capacity(num_names as usize + 1);
+    let anon_addr = Address::from_blake3_hash(*Name::anon().get_hash());
+    names_lookup.insert(anon_addr, Name::anon());
+    for _ in 0..num_names {
+      let addr = get_address(&mut buf)?;
+      let name = get_name_component(&mut buf, &names_lookup)?;
+      name_reverse_index.push(addr.clone());
+      names_lookup.insert(addr, name);
+    }
+
+    // Section 4: Named — keep `name → addr` and the Defn reducibility hint; the
+    // full ConstantMeta (arena, CallSite, ...) is parsed then discarded.
+    let num_named = get_u64(&mut buf)?;
+    for _ in 0..num_named {
+      let name_addr = get_address(&mut buf)?;
+      let named = get_named_indexed(&mut buf, &name_reverse_index)?;
+      let name = names_lookup.get(&name_addr).cloned().ok_or_else(|| {
+        format!("parse_lazy_index: missing name for addr {:?}", name_addr)
+      })?;
+      let hint = match &named.meta.info {
+        super::metadata::ConstantMetaInfo::Def { hints, .. } => Some(*hints),
+        _ => None,
+      };
+      index.named.push(LazyNamed { name, addr: named.addr, hint });
+    }
+
+    // Section 5 (comms) is skipped: not needed by the check path.
+
+    // Re-verify the merkle root over const addresses (header integrity).
+    let mut const_addrs: Vec<Address> =
+      index.consts.iter().map(|c| c.addr.clone()).collect();
+    const_addrs.sort_unstable();
+    let computed_root =
+      merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
+    if computed_root != stored_root {
+      return Err(format!(
+        "parse_lazy_index: merkle root mismatch (stored={}, computed={})",
+        stored_root.hex(),
+        computed_root.hex(),
+      ));
+    }
+
+    Ok(index)
   }
 
   /// Anonymous-only deserialization: read the header + blobs +

--- a/src/lean.rs
+++ b/src/lean.rs
@@ -54,6 +54,12 @@ lean_ffi::lean_inductive! {
   LeanIxonRawNameEntry    [ { num_obj: 2 } ];
   LeanIxonRawEnv          [ { num_obj: 5 } ];
 
+  // Lazy/anon deserialization (`rs_de_env_lazy`): zero-copy const windows
+  // (addr + offset + len), name->addr + hint, and copied blobs.
+  LeanIxonRawConstSlice   [ { num_obj: 1, num_64: 2 } ];
+  LeanIxonRawNamedLite    [ { num_obj: 2, num_64: 2 } ];
+  LeanIxonRawEnvLazy      [ { num_obj: 3 } ];
+
   // --- Ixon multi-variant inductives ---
 
   LeanIxonUniv [


### PR DESCRIPTION
`ix check --ixe` deserialized the whole env eagerly: the Rust FFI materialized every constant and the Lean side built an object graph for all of them up front, even to check one lemma. On mathlib.ixe (2.97 GB) that was ~104 GB peak RSS / ~159 s just to load.

Make the Lean `Ixon.Env` constants lazy and load them without copying:

- `LazyConstant` is now an offset window `(buf, off, len)` into a shared backing buffer (+ optional materialized cache for the build path), parsed on demand. Only the checked closure is ever materialized.
- New `rs_de_env_lazy` FFI: `Env::parse_lazy_index` walks the env once (reusing the existing parser, so every metadata variant incl. `CallSite` is handled) and returns per-const `(addr, offset, len)` windows into the buffer Lean passed in, plus `name -> addr` and per-`Defn` reducibility hints. No constant body is parsed or copied at load time. `deEnvAnon` reconstructs an `Env` of byte-window `LazyConstant`s over that same buffer.
- This is anon-aligned with the circuit: binder metadata (the `ExprMetaArena`) is parsed-and-discarded, since the typecheck circuit only consumes anonymous constants, blobs, and the per-`Defn` hint. The CLI's `name -> addr` map is kept so targets can still be named.
- Pure-Lean `getEnv`/`deEnv`/`rsDeEnv` keep their full-metadata behavior for round-trip and the non-check loaders; only the check path (`CheckCmd`) switches to `deEnvAnon`.

Consumers updated for the lazy const type: closure walk, IOBuffer ingress (ships `rawBytes` windows directly), shard partitioning, decompile, and the compile/commit env builders.

Measured on mathlib.ixe (same file, same target): 104.5 GB -> 4.5 GB peak RSS, 159 s -> 13.5 s. Nothing in circuit changes: same closure bytes, same in-circuit blake3 verification, same proof.

Builds on the Rust kernel lazy deserialization from #415 