### PR TITLE
zisk: update to Zisk v1.0.0-alpha (blake3-precompile branch)

### DIFF
--- a/.github/actions/install-sp1/action.yml
+++ b/.github/actions/install-sp1/action.yml
@@ -23,8 +23,15 @@ runs:
           libsecp256k1-dev libsodium-dev libpqxx-dev nasm libopenmpi-dev \
           openmpi-bin openmpi-common libclang-dev clang gcc-riscv64-unknown-elf \
           pkg-config libssl-dev
+    # sp1up resolves `releases/latest` (and downloads the toolchain) through
+    # api.github.com. Anonymous API calls share a 60/hr per-IP limit that hot
+    # runner IPs exhaust, failing the step with "Unable to access the latest
+    # release"; sp1up picks up GITHUB_TOKEN and authenticates every API call
+    # with it, switching to the token's own per-repo quota.
     - name: Install SP1 toolchain (sp1up, latest)
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         curl -L https://sp1up.succinct.xyz | bash
         ~/.sp1/bin/sp1up

--- a/.github/actions/install-zisk/action.yml
+++ b/.github/actions/install-zisk/action.yml
@@ -5,7 +5,7 @@ description: >-
   RUN the Zisk host. Execute needs the key too (zisk-host's `client.setup()`
   loads the circuit's const-tree files before either the execute or the prove
   branch), but BUILDING the host does not, so build-only callers skip the
-  ~3 GB download + const-tree regeneration. Assumes a Rust toolchain is
+  few-GB download + const-tree regeneration. Assumes a Rust toolchain is
   already set up.
 
 inputs:
@@ -36,12 +36,12 @@ runs:
           libsecp256k1-dev libsodium-dev libpqxx-dev nasm libopenmpi-dev \
           openmpi-bin openmpi-common libclang-dev clang gcc-riscv64-unknown-elf \
           pkg-config libssl-dev
-    # `--version 0.18.0` pins the toolchain to match our deps. Our host links the
-    # argumentcomputer/zisk `blake3-precompile` fork, which is based on v0.18.0
-    # (its cargo-zisk has `check-setup`, used below to regenerate the key's
-    # const-trees). Without the pin, ziskup installs `releases/latest`, which
-    # resolves to upstream `v1.0.0-alpha` — a different circuit whose cargo-zisk
-    # dropped the `check-setup` subcommand, breaking the key step. `--cpu` picks
+    # `--version 1.0.0-alpha` pins the toolchain to match our deps. Our host
+    # links the argumentcomputer/zisk `blake3-precompile` fork, which is now
+    # based on upstream v1.0.0-alpha (check-setup lives in the new
+    # `cargo-zisk-dev` binary, used below to regenerate the key's const-trees).
+    # Keep the pin anyway so a future upstream release can't silently change
+    # the toolchain under us. `--cpu` picks
     # the CPU build (no GPU on the runner) and `--nokey` skips ziskup's key
     # install — both avoid its interactive /dev/tty prompts. We keep `--nokey`
     # because the upstream `zisk-setup` bucket only carries the upstream circuit's
@@ -49,11 +49,11 @@ runs:
     # fork-matching key from our own S3 in the next step. `--prefix $HOME/.zisk`
     # pins the install where cargo-zisk's ZiskPaths fallback looks (the runner
     # sets XDG_CONFIG_HOME, which would otherwise relocate it).
-    - name: Install Zisk toolchain (ziskup, pinned v0.18.0)
+    - name: Install Zisk toolchain (ziskup, pinned v1.0.0-alpha)
       shell: bash
       run: |
         curl -L https://raw.githubusercontent.com/0xPolygonHermez/zisk/main/ziskup/install.sh \
-          | bash -s -- --cpu --nokey -y --version 0.18.0 --prefix "$HOME/.zisk"
+          | bash -s -- --cpu --nokey -y --version 1.0.0-alpha --prefix "$HOME/.zisk"
         echo "$HOME/.zisk/bin" >> "$GITHUB_PATH"
     # Pre-build the proofman C++ sys crate ALONE so its build script runs
     # exactly once before any parallel zisk-host build. zisk-host pulls
@@ -76,20 +76,22 @@ runs:
     # const-tree files. We host the fork-matching key in a public S3 bucket
     # WITHOUT the const-trees — exactly like Zisk's released
     # `zisk-provingkey-*.tar.gz` on `storage.googleapis.com/zisk-setup` — and
-    # regenerate them here with `cargo-zisk check-setup -a`, which is how `ziskup`
-    # itself populates them. That keeps the artifact ~3 GB (gzip) instead of
-    # ~48 GB. The object name carries the fork rev so a circuit change can't
-    # silently reuse a stale key. Public bucket → plain curl, no AWS creds.
+    # regenerate them here with `cargo-zisk-dev check-setup -a`, which is how
+    # `ziskup` itself populates them. That keeps the artifact a few GB (gzip)
+    # instead of ~50 GB (the tarball also omits the `*_gpu` const variants the
+    # first GPU prove would materialize — unused on this CPU runner). The
+    # object name carries the fork rev so a circuit change can't silently
+    # reuse a stale key. Public bucket → plain curl, no AWS creds.
     - name: Restore Zisk proving key (fork circuit) from S3
       if: inputs.proving-key == 'true'
       shell: bash
       run: |
         mkdir -p "$HOME/.zisk"
         curl -fSL --retry 3 \
-          https://argument-zisk-setup.s3.amazonaws.com/zisk-provingkey-blake3-8f9e24d5-cpu.tar.gz \
+          https://argument-zisk-setup.s3.amazonaws.com/zisk-provingkey-blake3-e4057c4c-cpu.tar.gz \
           -o /tmp/zisk-provingkey.tar.gz
         tar -C "$HOME/.zisk" -xzf /tmp/zisk-provingkey.tar.gz
         rm -f /tmp/zisk-provingkey.tar.gz
         # Regenerate the const-tree files omitted from the artifact (CPU build, so
         # no --gpu). This is the "may take a while" step ziskup prints.
-        cargo-zisk check-setup --proving-key "$HOME/.zisk/provingKey" -a
+        cargo-zisk-dev check-setup --proving-key "$HOME/.zisk/provingKey" -a

--- a/README.md
+++ b/README.md
@@ -409,18 +409,19 @@ Non-Nix users: install Zisk manually per the
    export CUDA_CACHE_MAXSIZE=4294967296   # 4 GB
    ```
 
-   **Warm-batch proving and cold-start.** The first GPU proof on a machine
-   pays a large one-time cold-start: the proving kernels are JIT-compiled
-   (PTX→SASS), almost entirely inside `GENERATING_INNER_PROOFS`. Measured on an
-   RTX PRO 6000, a `nataddcomm.ixe` proof takes **~126 s cold vs ~12 s warm**
-   (the inner-proof phase alone drops from ~123 s to ~9 s; EXECUTE and
-   `CALCULATING_CONTRIBUTIONS` are unchanged). Two things reuse that work:
-   `--ixe` is repeatable, so passing several inputs proves them in one process
-   and pays the cold-start once for the whole batch; and the JIT output is
-   cached on disk (`CUDA_CACHE_MAXSIZE` above), so even a *fresh* process stays
-   warm — the ~12 s figure above is a separate process from the cold run. So a
-   single small one-off proof looks slow (it eats the cold-start); amortize by
-   batching, or just disregard it. By default proving is stateful with no
+   **Warm-batch proving and cold-start.** On the Zisk v0.18 branch the first
+   GPU proof on a machine paid a large one-time JIT cold-start (PTX→SASS,
+   ~126 s cold vs ~12 s warm for `nataddcomm.ixe` on an RTX PRO 6000). At
+   Zisk v1.0.0-alpha that per-process JIT penalty is gone: cold ≈ warm, both
+   **~17.6-17.9 s** for the same `nataddcomm.ixe` proof on the same GPU
+   (inner-proof phase ~14 s — note that is slower than v0.18's ~9 s warm
+   figure; upstream prover/recursion changes, not the blake3 port). The one
+   remaining true first-run cost is one-time and on-disk, not per-process:
+   the first GPU prove against a freshly generated proving key materializes
+   ~40 GB of `*_gpu` const/consttree variants under `~/.zisk/provingKey`.
+   `--ixe` is still repeatable, so several inputs can be proved in one warm
+   process. Keeping `CUDA_CACHE_MAXSIZE` pinned (above) remains harmless but
+   is no longer load-bearing. By default proving is stateful with no
    checkpointing — if a run is killed it loses in-flight shard proofs and
    restarts from the first shard; use a proof store (`--store-dir`, see
    *Sharding large environments* below) to make a sharded run resumable.
@@ -472,7 +473,7 @@ Non-Nix users: install Zisk manually per the
    [installation docs](https://0xpolygonhermez.github.io/zisk/getting_started/installation.html).
 
    **Heap cap.** The Zisk zkVM has a hard 512 MB RAM cap
-   ([`RAM_SIZE`](https://github.com/0xPolygonHermez/zisk/blob/v0.17.0/core/src/mem.rs#L111)),
+   ([`RAM_SIZE`](https://github.com/0xPolygonHermez/zisk/blob/v1.0.0-alpha/core/src/mem.rs#L111)),
    of which ~510 MB is usable heap, and isn't configurable without
    rebuilding the proving setup. Envs whose deserialized in-memory
    representation exceeds that won't fit (full `TutorialDefs.lean` pulls in

--- a/docs/zisk-cycle-cost-model.md
+++ b/docs/zisk-cycle-cost-model.md
@@ -8,6 +8,12 @@ prove within the RAM cap while minimizing the number of pieces.
 Measured on an RTX PRO 6000 (250 GiB host). Inputs, scripts, and raw data:
 `~/benchdata/prof/`.
 
+> **Version note.** All numbers below were measured on the Zisk v0.18-based
+> `blake3-precompile` branch. On the v1.0.0-alpha port the cycle counts drift
+> slightly from upstream zisklib/ROM changes (e.g. `nataddcomm.ixe`:
+> 53,239,676 → 53,860,206 STEPS, ~+1.2%); the model's structure and
+> coefficients remain a good approximation but have not been re-fit.
+
 ---
 
 ## Background

--- a/zisk/Cargo.lock
+++ b/zisk/Cargo.lock
@@ -512,12 +512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arraydeque"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,15 +525,15 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asm-runner"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "libc",
  "mem-common",
  "mem-planner-cpp",
  "named-sem",
- "proofman-common",
+ "proofman-util",
  "rayon",
  "thiserror 2.0.18",
  "tracing",
@@ -587,28 +581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +596,16 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
 
 [[package]]
 name = "auto_impl"
@@ -828,9 +810,6 @@ name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "bitvec"
@@ -874,6 +853,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -1025,8 +1016,8 @@ dependencies = [
 
 [[package]]
 name = "circuit"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "clang-sys"
@@ -1114,26 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "config"
-version = "0.15.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
-dependencies = [
- "async-trait",
- "convert_case 0.6.0",
- "json5",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde-untagged",
- "serde_core",
- "serde_json",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.3",
- "yaml-rust2",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,26 +1121,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "const_format"
@@ -1205,15 +1156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 dependencies = [
  "custom_derive",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1392,9 +1334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "curves"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "fields",
  "num-bigint",
@@ -1459,11 +1411,10 @@ dependencies = [
 
 [[package]]
 name = "data-bus"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "zisk-common",
- "zisk-core",
 ]
 
 [[package]]
@@ -1571,7 +1522,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case 0.10.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -1643,15 +1594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1715,15 +1657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,17 +1692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,20 +1702,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "evmap"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
-dependencies = [
- "hashbag",
- "left-right",
- "smallvec",
-]
-
-[[package]]
 name = "executor"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1801,10 +1712,9 @@ dependencies = [
  "crossbeam",
  "data-bus",
  "fields",
- "itertools 0.14.0",
  "mem-common",
- "mem-planner-cpp",
  "named-sem",
+ "paste",
  "pil-std-lib",
  "precomp-arith-eq",
  "precomp-arith-eq-384",
@@ -1813,7 +1723,7 @@ dependencies = [
  "precomp-blake3f",
  "precomp-dma",
  "precomp-keccakf",
- "precomp-poseidon2",
+ "precomp-poseidon",
  "precomp-sha256f",
  "precompiles-common",
  "precompiles-hints",
@@ -1823,10 +1733,10 @@ dependencies = [
  "rayon",
  "sm-arith",
  "sm-binary",
- "sm-frequent-ops",
  "sm-main",
  "sm-mem",
  "sm-rom",
+ "thiserror 2.0.18",
  "tracing",
  "witness",
  "zisk-common",
@@ -1887,8 +1797,8 @@ dependencies = [
 
 [[package]]
 name = "fields"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -2173,12 +2083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbag"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,15 +2100,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -2212,15 +2107,6 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2320,12 +2206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,23 +2237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,16 +2255,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2581,12 +2441,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,17 +2607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,25 +2673,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "left-right"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
-dependencies = [
- "crossbeam-utils",
- "loom",
- "slab",
-]
-
-[[package]]
 name = "lib-c"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
-
-[[package]]
-name = "lib-float"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "libc"
@@ -2998,19 +2825,13 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mem-common"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "clap",
  "fields",
- "num-bigint",
- "num-traits",
- "proofman-common",
- "proofman-macros",
- "proofman-util",
  "rayon",
  "static_assertions",
- "tracing",
  "zisk-common",
  "zisk-core",
  "zisk-pil",
@@ -3018,8 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "mem-planner-cpp"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "mem-common",
  "proofman-common",
@@ -3042,56 +2863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "metrics"
-version = "0.24.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
-dependencies = [
- "portable-atomic",
- "rapidhash",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
-dependencies = [
- "base64",
- "evmap",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "indexmap",
- "ipnet",
- "metrics",
- "metrics-util",
- "quanta",
- "rustls",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.16.1",
- "metrics",
- "quanta",
- "rand 0.9.4",
- "rand_xoshiro",
- "rapidhash",
- "sketches-ddsketch",
 ]
 
 [[package]]
@@ -3209,12 +2980,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3240,6 +3034,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3336,16 +3152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,12 +3215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,39 +3241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,8 +3253,8 @@ dependencies = [
 
 [[package]]
 name = "pil-std-lib"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "colored",
  "fields",
@@ -3547,12 +3314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,8 +3339,8 @@ dependencies = [
 
 [[package]]
 name = "precomp-arith-eq"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
@@ -3589,7 +3350,6 @@ dependencies = [
  "fields",
  "lazy_static",
  "lib-c",
- "mem-common",
  "num-bigint",
  "num-traits",
  "path-clean",
@@ -3597,36 +3357,26 @@ dependencies = [
  "precompiles-common",
  "precompiles-helpers",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
  "regex",
  "rustfmt-wrapper",
- "serde",
- "serde_json",
- "sm-mem",
  "tracing",
- "typenum",
- "witness",
  "zisk-common",
  "zisk-core",
  "zisk-pil",
+ "ziskemu",
 ]
 
 [[package]]
 name = "precomp-arith-eq-384"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
  "ark-ff 0.5.0",
- "ark-secp256k1",
- "ark-std 0.5.0",
  "fields",
  "lazy_static",
- "lib-c",
- "mem-common",
  "num-bigint",
  "num-traits",
  "path-clean",
@@ -3635,16 +3385,10 @@ dependencies = [
  "precompiles-common",
  "precompiles-helpers",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "regex",
  "rustfmt-wrapper",
- "serde",
- "serde_json",
  "tracing",
- "typenum",
- "witness",
  "zisk-common",
  "zisk-core",
  "zisk-pil",
@@ -3652,20 +3396,16 @@ dependencies = [
 
 [[package]]
 name = "precomp-big-int"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "generic-array",
  "lib-c",
- "mem-common",
  "pil-std-lib",
  "precompiles-common",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "sm-mem",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -3674,18 +3414,15 @@ dependencies = [
 
 [[package]]
 name = "precomp-blake2"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "mem-common",
  "pil-std-lib",
  "precompiles-common",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "sm-mem",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -3694,19 +3431,16 @@ dependencies = [
 
 [[package]]
 name = "precomp-blake3f"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "mem-common",
  "pil-std-lib",
  "precompiles-common",
  "precompiles-helpers",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "sm-mem",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -3715,22 +3449,16 @@ dependencies = [
 
 [[package]]
 name = "precomp-dma"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "generic-array",
- "lib-c",
- "mem-common",
  "pil-std-lib",
  "precompiles-common",
  "precompiles-helpers",
- "proofman",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "sm-mem",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -3739,8 +3467,8 @@ dependencies = [
 
 [[package]]
 name = "precomp-keccakf"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "circuit",
  "fields",
@@ -3749,7 +3477,6 @@ dependencies = [
  "precompiles-common",
  "precompiles-helpers",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
  "tiny-keccak",
@@ -3760,20 +3487,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomp-poseidon2"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+name = "precomp-poseidon"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "mem-common",
  "pil-std-lib",
  "precompiles-common",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "sha2",
- "sm-mem",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -3782,18 +3505,15 @@ dependencies = [
 
 [[package]]
 name = "precomp-sha256f"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "mem-common",
  "pil-std-lib",
  "precompiles-common",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
- "sm-mem",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -3802,8 +3522,8 @@ dependencies = [
 
 [[package]]
 name = "precompiles-common"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
  "mem-common",
@@ -3814,15 +3534,14 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff 0.5.0",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-std 0.5.0",
  "cfg-if",
  "circuit",
  "crunchy",
@@ -3833,13 +3552,11 @@ dependencies = [
 
 [[package]]
 name = "precompiles-hints"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "borsh",
- "lib-c",
- "precompiles-helpers",
  "rayon",
  "rustls",
  "tracing",
@@ -3911,8 +3628,8 @@ dependencies = [
 
 [[package]]
 name = "proofman"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "bincode",
  "blake3",
@@ -3945,8 +3662,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-common"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "bincode",
  "borsh",
@@ -3976,8 +3693,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-hints"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "fields",
  "itoa",
@@ -3989,8 +3706,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-macros"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3999,8 +3716,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-starks-lib-c"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "crossbeam-channel",
  "tracing",
@@ -4008,8 +3725,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-util"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "bincode",
  "colored",
@@ -4019,12 +3736,13 @@ dependencies = [
 
 [[package]]
 name = "proofman-verifier"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "bincode",
  "fields",
  "num-traits",
+ "rayon",
  "serde",
  "tracing",
 ]
@@ -4119,21 +3837,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -4297,30 +4000,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -4407,47 +4092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4482,8 +4126,8 @@ dependencies = [
 
 [[package]]
 name = "riscv"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "rlp"
@@ -4497,12 +4141,11 @@ dependencies = [
 
 [[package]]
 name = "rom-setup"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "blake3",
- "colored",
  "fields",
  "proofman-common",
  "sm-rom",
@@ -4510,20 +4153,6 @@ dependencies = [
  "zisk-common",
  "zisk-core",
  "zisk-pil",
-]
-
-[[package]]
-name = "ron"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
-dependencies = [
- "bitflags",
- "once_cell",
- "serde",
- "serde_derive",
- "typeid",
- "unicode-ident",
 ]
 
 [[package]]
@@ -4559,16 +4188,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -4621,7 +4240,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 1.0.69",
- "toml 0.8.23",
+ "toml",
  "toolchain_find",
 ]
 
@@ -4883,18 +4502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
-]
-
-[[package]]
 name = "serde_arrays"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,27 +4550,6 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 
@@ -5032,26 +4618,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5059,30 +4625,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signal-hook-tokio"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
-dependencies = [
- "futures-core",
- "libc",
- "signal-hook 0.3.18",
- "tokio",
-]
-
-[[package]]
-name = "signal-hook-tokio"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e513e435a8898a0002270f29d0a708b7879708fb5c4d00e46983ca2d2d378cf0"
-dependencies = [
- "futures-core",
- "libc",
- "signal-hook 0.4.4",
- "tokio",
 ]
 
 [[package]]
@@ -5108,12 +4650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
-name = "sketches-ddsketch"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5121,19 +4657,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sm-arith"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "num-bigint",
  "pil-std-lib",
  "proofman-common",
- "proofman-macros",
- "proofman-util",
  "rayon",
  "sm-binary",
  "sm-frequent-ops",
- "static_assertions",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -5142,15 +4674,12 @@ dependencies = [
 
 [[package]]
 name = "sm-binary"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
- "num-bigint",
  "pil-std-lib",
  "proofman-common",
- "proofman-macros",
- "proofman-util",
  "rayon",
  "sm-frequent-ops",
  "static_assertions",
@@ -5162,33 +4691,27 @@ dependencies = [
 
 [[package]]
 name = "sm-frequent-ops"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "clap",
  "fields",
- "num-bigint",
  "proofman-common",
- "proofman-util",
- "rayon",
  "static_assertions",
- "tracing",
  "zisk-core",
 ]
 
 [[package]]
 name = "sm-main"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
  "mem-common",
- "num-bigint",
  "pil-std-lib",
  "proofman-common",
- "proofman-macros",
- "proofman-util",
  "rayon",
+ "thiserror 2.0.18",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -5198,20 +4721,17 @@ dependencies = [
 
 [[package]]
 name = "sm-mem"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
+ "env",
  "fields",
  "mem-common",
- "num-bigint",
- "num-traits",
  "pil-std-lib",
  "proofman-common",
- "proofman-macros",
  "proofman-util",
  "rayon",
  "tracing",
- "witness",
  "zisk-common",
  "zisk-core",
  "zisk-pil",
@@ -5219,17 +4739,15 @@ dependencies = [
 
 [[package]]
 name = "sm-rom"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
- "anyhow",
  "asm-runner",
  "fields",
- "itertools 0.14.0",
+ "mem-common",
  "proofman-common",
- "proofman-macros",
- "proofman-util",
  "rayon",
+ "thiserror 2.0.18",
  "tracing",
  "zisk-common",
  "zisk-core",
@@ -5356,9 +4874,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -5478,6 +4993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5573,16 +5097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5591,7 +5105,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -5614,22 +5127,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
+ "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5658,7 +5158,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned 0.6.9",
+ "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -5733,19 +5233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-health"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
-dependencies = [
- "prost",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-prost",
-]
-
-[[package]]
 name = "tonic-prost"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5802,24 +5289,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -5945,12 +5414,6 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -6178,16 +5641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,19 +5695,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6264,16 +5704,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver 1.0.28",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -6291,15 +5721,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6796,8 +6217,8 @@ dependencies = [
 
 [[package]]
 name = "witness"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "colored",
  "fields",
@@ -6839,17 +6260,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "yaml-rust2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
-dependencies = [
- "arraydeque",
- "encoding_rs",
- "hashlink",
 ]
 
 [[package]]
@@ -6987,51 +6397,28 @@ dependencies = [
 
 [[package]]
 name = "zisk-build"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "blake3",
  "cargo_metadata",
  "clap",
  "rom-setup",
- "tracing",
  "vergen-git2",
-]
-
-[[package]]
-name = "zisk-cluster-api"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
-dependencies = [
- "anyhow",
- "chrono",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tracing",
- "uuid",
- "zisk-cluster-common",
 ]
 
 [[package]]
 name = "zisk-cluster-common"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "borsh",
  "chrono",
  "proofman",
  "proofman-common",
- "proofman-util",
  "serde",
- "serde_json",
- "thiserror 2.0.18",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -7041,80 +6428,38 @@ dependencies = [
 
 [[package]]
 name = "zisk-common"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "alloy-sol-types",
- "anyhow",
  "bincode",
+ "clap",
  "dirs",
  "fields",
- "libc",
+ "paste",
  "proofman",
  "proofman-common",
- "proofman-util",
  "proofman-verifier",
- "quinn",
- "rcgen",
- "rustls",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
- "tracing-subscriber",
  "zisk-core",
+ "zisk-definitions",
+ "zisk-stream",
  "zisk-verifier",
 ]
 
 [[package]]
-name = "zisk-coordinator"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
-dependencies = [
- "anyhow",
- "async-stream",
- "bincode",
- "blake3",
- "chrono",
- "clap",
- "colored",
- "config",
- "futures",
- "futures-util",
- "hex",
- "humantime",
- "metrics",
- "proofman",
- "proofman-util",
- "prost-types",
- "reqwest",
- "serde",
- "serde_json",
- "signal-hook 0.3.18",
- "signal-hook-tokio 0.3.1",
- "thiserror 2.0.18",
- "tokio",
- "tonic",
- "tracing",
- "uuid",
- "witness",
- "zisk-cluster-api",
- "zisk-cluster-common",
- "zisk-common",
-]
-
-[[package]]
 name = "zisk-coordinator-api"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "chrono",
  "prost",
  "prost-types",
- "tokio",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -7124,8 +6469,8 @@ dependencies = [
 
 [[package]]
 name = "zisk-coordinator-client"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7139,69 +6484,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "zisk-coordinator-server"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "blake3",
- "chrono",
- "clap",
- "config",
- "futures",
- "hex",
- "metrics",
- "metrics-exporter-prometheus",
- "prost",
- "prost-types",
- "serde",
- "serde_json",
- "signal-hook 0.4.4",
- "signal-hook-tokio 0.4.0",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tonic",
- "tonic-health",
- "tonic-prost",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "uuid",
- "zisk-cluster-api",
- "zisk-cluster-common",
- "zisk-common",
- "zisk-coordinator",
- "zisk-coordinator-api",
-]
-
-[[package]]
 name = "zisk-core"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "elf",
  "fields",
  "lib-c",
- "lib-float",
  "paste",
  "precompiles-helpers",
  "rayon",
  "riscv",
- "serde",
  "sha2",
  "tiny-keccak",
  "zisk-definitions",
- "ziskos-hints",
+ "ziskos",
 ]
 
 [[package]]
 name = "zisk-definitions"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "zisk-host"
@@ -7222,26 +6525,36 @@ dependencies = [
 
 [[package]]
 name = "zisk-pil"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "fields",
  "proofman-common",
  "proofman-macros",
- "rayon",
  "serde",
  "serde_arrays",
 ]
 
 [[package]]
+name = "zisk-program-macros"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
+dependencies = [
+ "blake3",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zisk-prover-backend"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "alloy-sol-types",
  "anyhow",
  "asm-runner",
- "bincode",
  "blake3",
  "borsh",
  "colored",
@@ -7254,54 +6567,60 @@ dependencies = [
  "proofman-verifier",
  "rom-setup",
  "serde",
- "sha2",
  "tracing",
  "zisk-cluster-common",
  "zisk-common",
  "zisk-core",
+ "zisk-pil",
+ "zisk-program-macros",
  "ziskemu",
 ]
 
 [[package]]
 name = "zisk-sdk"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
- "alloy-sol-types",
- "anyhow",
  "bincode",
- "bytes",
- "colored",
- "fields",
- "futures",
  "proofman-common",
  "rom-setup",
  "serde",
+ "thiserror 2.0.18",
  "tokio",
- "tonic",
- "tracing",
  "uuid",
  "zisk-build",
- "zisk-cluster-common",
  "zisk-common",
  "zisk-coordinator-api",
  "zisk-coordinator-client",
- "zisk-coordinator-server",
  "zisk-prover-backend",
 ]
 
 [[package]]
+name = "zisk-stream"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
+dependencies = [
+ "libc",
+ "quinn",
+ "rcgen",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "zisk-verifier"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskemu"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "clap",
  "data-bus",
@@ -7311,16 +6630,15 @@ dependencies = [
  "memmap2",
  "num-format",
  "object",
- "proofman-common",
  "rayon",
  "regex",
  "riscv",
  "serde_json",
  "sm-arith",
  "sm-binary",
- "symbolic-common",
  "symbolic-demangle",
  "sysinfo 0.38.4",
+ "time",
  "vergen-git2",
  "zisk-common",
  "zisk-core",
@@ -7329,9 +6647,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ziskos"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
+dependencies = [
+ "anyhow",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "aurora-engine-modexp",
+ "bincode",
+ "blst",
+ "bytes",
+ "cfg-if",
+ "ctor",
+ "fields",
+ "getrandom 0.2.17",
+ "lazy_static",
+ "lib-c",
+ "libc",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "precompiles-helpers",
+ "rand 0.8.6",
+ "ripemd",
+ "secp256k1",
+ "serde",
+ "sha2",
+ "tiny-keccak",
+ "tokio",
+ "zisk-definitions",
+ "zisk-stream",
+ "zisk-verifier",
+ "zkvm-interface",
+]
+
+[[package]]
 name = "ziskos-hints"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7356,8 +6714,8 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "bindgen 0.72.1",
 ]

--- a/zisk/Cargo.toml
+++ b/zisk/Cargo.toml
@@ -8,14 +8,15 @@ resolver = "2"
 
 [workspace.dependencies]
 # argumentcomputer/zisk fork — the `blake3-precompile` branch adds a Blake3
-# compression precompile on top of upstream Zisk v0.18.0 (proofman v0.18.0).
+# compression precompile on top of upstream Zisk v1.0.0-alpha (proofman
+# v1.0.0-alpha).
 # The guest reaches the precompile via `ziskos::zisklib::blake3` or,
 # transparently, through the `blake3` shim crate (see `zisk/guest/Cargo.toml`).
 zisk-sdk = { git = "https://github.com/argumentcomputer/zisk.git", branch = "blake3-precompile" }
 ziskos = { git = "https://github.com/argumentcomputer/zisk.git", branch = "blake3-precompile" }
 
 # No local-path patch: the host builds zisk-sdk directly from the
-# `blake3-precompile` branch above (now that v0.18.0 + the blake3 shim are
-# pushed). To iterate against a local checkout instead, re-add:
+# `blake3-precompile` branch above. To iterate against a local checkout
+# instead, re-add:
 #   [patch."https://github.com/argumentcomputer/zisk.git"]
 #   zisk-sdk = { path = "/path/to/zisk/sdk" }

--- a/zisk/agg-guest/Cargo.lock
+++ b/zisk/agg-guest/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blake3"
 version = "1.8.4"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "arrayvec",
  "ziskos",
@@ -326,8 +326,8 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "clang-sys"
@@ -461,8 +461,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fields"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -617,8 +617,8 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "libc"
@@ -808,15 +808,14 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-std",
  "cfg-if",
  "circuit",
  "crunchy",
@@ -846,8 +845,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-verifier"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "fields",
  "num-traits",
@@ -1087,15 +1086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,21 +1217,21 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "zisk-verifier"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1265,7 +1255,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2",
- "spin",
  "tiny-keccak",
  "zisk-definitions",
  "zisk-verifier",
@@ -1274,8 +1263,8 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "bindgen",
 ]

--- a/zisk/agg-guest/src/main.rs
+++ b/zisk/agg-guest/src/main.rs
@@ -49,7 +49,8 @@
 //!   - [76..108) combined assumptions root (mode 1: post-discharge)
 //!   - [108..112) num_proofs           (checked_count)
 //!
-//! v0.18 proof word layout (as `&[u64]`):
+//! Zisk proof word layout (as `&[u64]`; unchanged v0.18 → v1.0.0-alpha,
+//! re-verified against v1.0.0-alpha leaf proofs):
 //!   [minimal(1)][n_publics(1)][program_vk(4)][zisk_publics(64)][proof…][vk(4)]
 //! so program_vk = words[2..6]; the leaf's committed publics occupy the
 //! zisk_publics region (one u32 slot per word, low 32 bits) starting at

--- a/zisk/guest/Cargo.lock
+++ b/zisk/guest/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 [[package]]
 name = "blake3"
 version = "1.8.4"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "arrayvec",
  "ziskos",
@@ -332,8 +332,8 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "circuit"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "clang-sys"
@@ -502,8 +502,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fields"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "cfg-if",
  "num-bigint",
@@ -684,8 +684,8 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-c"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "libc"
@@ -881,15 +881,14 @@ dependencies = [
 
 [[package]]
 name = "precompiles-helpers"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "ark-std",
  "cfg-if",
  "circuit",
  "crunchy",
@@ -919,8 +918,8 @@ dependencies = [
 
 [[package]]
 name = "proofman-verifier"
-version = "0.18.0"
-source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v0.18.0#42ad4d02da3d3b6238ac126ead82a8814f3fd426"
+version = "1.0.0-alpha"
+source = "git+https://github.com/0xPolygonHermez/pil2-proofman.git?tag=v1.0.0-alpha#4f2a34ac686c788ad66a1a8ea0a17a016319e65b"
 dependencies = [
  "fields",
  "num-traits",
@@ -1179,15 +1178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "svgbobdoc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,8 +1338,8 @@ dependencies = [
 
 [[package]]
 name = "zisk-definitions"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 
 [[package]]
 name = "zisk-guest"
@@ -1364,16 +1354,16 @@ dependencies = [
 
 [[package]]
 name = "zisk-verifier"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "proofman-verifier",
 ]
 
 [[package]]
 name = "ziskos"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1400,7 +1390,6 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2",
- "spin",
  "tiny-keccak",
  "zisk-definitions",
  "zisk-verifier",
@@ -1409,8 +1398,8 @@ dependencies = [
 
 [[package]]
 name = "zkvm-interface"
-version = "0.18.0"
-source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#8f9e24d562cf7ec4069506d5c0189bf7fe711fb5"
+version = "1.0.0-alpha"
+source = "git+https://github.com/argumentcomputer/zisk.git?branch=blake3-precompile#e4057c4cd6daaa29ea54f283ff27818acc9be8b2"
 dependencies = [
  "bindgen",
 ]

--- a/zisk/guest/Cargo.toml
+++ b/zisk/guest/Cargo.toml
@@ -12,7 +12,7 @@ ix-common = { path = "../../crates/common" }
 # `log::info!` — none of it is reachable from a Zisk guest (no stderr) and
 # the formatting machinery was ~45-55 % of cycles in the profile.
 log = { version = "0.4", features = ["max_level_off"] }
-# argumentcomputer/zisk fork — `blake3-precompile-v0.17` exposes the Blake3
+# argumentcomputer/zisk fork — the `blake3-precompile` branch exposes the Blake3
 # compression precompile via `ziskos::zisklib::blake3`, plus a `name = "blake3"`
 # drop-in crate at `ziskos/blake3/` which the `[patch.crates-io]` below routes
 # every `blake3::Hasher` / `blake3::hash` call through.

--- a/zisk/host/src/main.rs
+++ b/zisk/host/src/main.rs
@@ -569,7 +569,8 @@ fn leaf_assumptions(
   out
 }
 
-/// Extract a proof's 32-byte program vk: v0.18 lays the proof out as u64
+/// Extract a proof's 32-byte program vk: Zisk (v0.18 and v1.0.0-alpha
+/// alike) lays the proof out as u64
 /// words `[minimal(1)][n_publics(1)][program_vk(4)]…`, so the program vk is
 /// bytes `[16..48)` (words 2..6). Used both to derive the allowed-vk set the
 /// agg guest pins against and to key the proof store.
@@ -809,7 +810,7 @@ fn build_client(gpu: bool, asm: bool) -> Result<EmbeddedClient> {
   if gpu {
     builder = builder.gpu();
   }
-  builder.build()
+  Ok(builder.build()?)
 }
 
 /// Check a single constant chosen by Lean NAME (one iteration of `--consts`).


### PR DESCRIPTION
The argumentcomputer/zisk blake3-precompile branch is now the v1.0.0-alpha port (e4057c4cd; the old v0.18 tip is archived as blake3-precompile-v0.18). Relock host/guest/agg-guest against it.

Host code: EmbeddedClientBuilder::build() returns SdkError at v1.0.0-alpha instead of anyhow::Error — coerce at the one call site. The Zisk proof word layout ([minimal][n_publics][program_vk(4)][zisk_publics(64)]...) is unchanged; comments updated after re-verifying against v1.0.0-alpha leaf proofs (program_vk extraction + agg-guest in-guest verification both pass).