### PR TITLE
ci: Fix `bench-pr.yml`

### DIFF
--- a/.github/actions/bencher-track/action.yml
+++ b/.github/actions/bencher-track/action.yml
@@ -1,18 +1,19 @@
 name: Track benchmarks on bencher
 description: >-
   Run `bencher run` for the `ix` project. Every measure's baseline is windowed
-  to the data points recorded since the workload's `bencher-thresholds-reset-<workload>`
-  tag, so a toolchain bump (or any permanent shift) is recalibrated by moving
-  that one tag — via the !bencher-thresholds-reset PR comment or the
-  bencher-thresholds-reset workflow. The calling job must check out with
-  fetch-depth: 0 and fetch-tags: true (the tag is read here).
+  to the data points recorded since the workload's
+  `refs/bencher/<workload>` anchor ref, so a toolchain bump
+  (or any permanent shift) is recalibrated by moving that one ref — via the
+  !bencher-thresholds-reset PR comment or the bencher-thresholds-reset
+  workflow. The ref lives outside refs/tags (fetched here directly), so it
+  never decorates `git log` and callers need no fetch-depth/fetch-tags.
 
 inputs:
   testbed:
     description: Bencher testbed slug.
     required: true
   workload:
-    description: Workload key for the `bencher-thresholds-reset-<workload>` tag (the backend testbed minus its runner-arch suffix, e.g. zisk-check-execute).
+    description: Workload key for the `refs/bencher/<workload>` anchor (the backend testbed minus its runner-arch suffix, e.g. zisk-check-execute).
     required: true
   file:
     description: Bencher Metric Format JSON file to upload.
@@ -45,16 +46,21 @@ runs:
         THRESHOLDS: ${{ inputs.thresholds }}
       run: |
         # Baseline window: data points for this benchmark since the workload's
-        # `bencher-thresholds-reset-<workload>` tag (moved on a toolchain bump or any
-        # permanent shift). The same window applies to every measure. We count
-        # actual data points, not commits, so the baseline never reaches past
-        # the anchor (a failed run produces no metric, so a commit count would
-        # overshoot). The matrix uploads one report per benchmark, so count this
-        # benchmark's reports (its name is the upload's top-level key). The ix
-        # project is public, so no token is needed. With no tag yet, fall back
-        # to Bencher's 64-point window.
+        # `refs/bencher/<workload>` anchor ref (moved on a
+        # toolchain bump or any permanent shift). A custom namespace, NOT
+        # refs/tags: these are CI plumbing, and tags would decorate every
+        # user's bare `git log` at the anchor commit. The same window applies
+        # to every measure. We count actual data points, not commits, so the
+        # baseline never reaches past the anchor (a failed run produces no
+        # metric, so a commit count would overshoot). The matrix uploads one
+        # report per benchmark, so count this benchmark's reports (its name
+        # is the upload's top-level key). The ix project is public, so no
+        # token is needed. With no anchor yet, fall back to Bencher's
+        # 64-point window.
         sample=64
-        if reset_epoch=$(git log -1 --format=%ct "bencher-thresholds-reset-$WORKLOAD" 2>/dev/null); then
+        git fetch --quiet --no-tags origin \
+          "+refs/bencher/*:refs/bencher/*" 2>/dev/null || true
+        if reset_epoch=$(git log -1 --format=%ct "refs/bencher/$WORKLOAD" 2>/dev/null); then
           bench=$(jq -r '[keys[]][0]' "$FILE")
           sample=$(curl -fsS "https://api.bencher.dev/v0/projects/ix/reports?branch=${GITHUB_REF_NAME}&testbed=${TESTBED}&start_time=$((reset_epoch * 1000))&per_page=255" \
             | jq --arg b "$bench" '[.[] | select([.results[]?[]?.benchmark.name] | index($b))] | length')

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -138,9 +138,6 @@ jobs:
           # - { env: FC, cache_pkg: formal_conjectures, mathlib: true }
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true   # bencher-track reads the bencher-thresholds-reset tag
       - uses: actions/cache/restore@v5
         with:
           path: ~/.local/bin
@@ -264,9 +261,6 @@ jobs:
         mode: [execute, prove]
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0     # full history for the baseline-anchor lookup
-          fetch-tags: true   # bencher-track reads the bencher-thresholds-reset tag
       - uses: actions/cache/restore@v5
         with:
           path: ~/.local/bin
@@ -379,9 +373,6 @@ jobs:
         cell: ${{ fromJson(needs.plan.outputs.zkvm-cells) }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true   # bencher-track reads the bencher-thresholds-reset tag
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-workspaces: ${{ matrix.cell.backend }}
@@ -479,9 +470,6 @@ jobs:
         bench: ${{ fromJson(needs.plan.outputs.bench-envs) }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true   # bencher-track reads the bencher-thresholds-reset tag
       - uses: actions/cache/restore@v5
         with:
           path: ~/.local/bin

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -78,6 +78,14 @@ jobs:
   build:
     needs: setup
     runs-on: warp-ubuntu-latest-x64-32x
+    # The cache service refuses writes from a wholly read-only token
+    # ("cache write denied: token has no writable scopes"), and this job
+    # saves the bench-bins cache — actions:write makes the token writable.
+    # Granted per-job so the workflow default stays read-only (the
+    # privileged comment job must not inherit it).
+    permissions:
+      contents: read
+      actions: write
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
       envs: ${{ steps.parse.outputs.envs }}
@@ -143,6 +151,10 @@ jobs:
     needs: [setup, build]
     if: needs.build.outputs.envs != '[]'
     runs-on: warp-ubuntu-latest-x64-32x
+    # Saves the .ixe + compile-row caches (see build for why actions:write).
+    permissions:
+      contents: read
+      actions: write
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -205,6 +217,11 @@ jobs:
     # env, mode, runner, label); the label already is the cell id.
     name: ${{ matrix.cell.label }}
     needs: [setup, build, compile]
+    # Saves the .ixe fallback + rust-cache entries (see build for why
+    # actions:write).
+    permissions:
+      contents: read
+      actions: write
     # A compile failure stops the cells (they would just re-fail the same
     # compile lazily); the skipped case can't arise (envs is never empty)
     # but is tolerated for robustness.

--- a/.github/workflows/bencher-thresholds-reset.yml
+++ b/.github/workflows/bencher-thresholds-reset.yml
@@ -1,7 +1,10 @@
 name: Bencher thresholds reset
 
-# Move `bencher-thresholds-reset-<workload>` tag(s) so bencher-track re-windows those
-# measures from a chosen commit — after a toolchain bump or any permanent shift.
+# Move `refs/bencher/<workload>` anchor ref(s) so bencher-track re-windows
+# those measures from a chosen commit — after a toolchain bump or any
+# permanent shift. A custom ref namespace, NOT refs/tags: the anchors are CI
+# plumbing, and tags would decorate every user's bare `git log` at the
+# anchor commit (and be fetched by every clone).
 # Other workloads are unaffected; historical data stays in Bencher, only the
 # alert baseline is re-anchored. Two ways to trigger:
 #
@@ -10,7 +13,7 @@ name: Bencher thresholds reset
 #     command. It records each valid workload as a `bencher-thresholds-reset:<workload>`
 #     PR label and replies to confirm (or warns on an unknown/missing workload,
 #     catching a typo immediately). On merge, the `reset` job simply reads those
-#     labels from the event payload — no re-parsing — and anchors the tags at the
+#     labels from the event payload — no re-parsing — and anchors the refs at the
 #     merge commit. The label is the shared flag between the two events, and is
 #     human-visible/cancelable (remove the label to cancel a queued reset).
 #   - Manual label (no comment needed): the merge step honors any
@@ -22,8 +25,8 @@ name: Bencher thresholds reset
 #     `ix-compile`, `aiur-check-execute`, `aiur-check-prove`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
 #     `all` (the merge step expands an `all` label into every workload). Labeling
 #     requires Triage+, so PR authors from forks cannot self-queue a reset. The
-#     label shares the command/workflow name; the git tag it moves is the same
-#     stem with a dash: `bencher-thresholds-reset-<workload>`.
+#     label shares the command/workflow name; the ref it moves is
+#     `refs/bencher/<workload>`.
 #   - workflow_dispatch: reset the chosen workload at a given commit (default
 #     HEAD); does not read PR contents. For ad-hoc or bootstrap resets.
 #
@@ -94,14 +97,14 @@ jobs:
           done_list=""
           for w in $workloads; do
             case " $valid " in *" $w "*) ;; *) echo "skip unknown workload: $w"; continue ;; esac
-            tag="bencher-thresholds-reset-$w"
-            echo "Anchoring $tag -> $sha"
-            # Update the tag if it exists, else create it. (Checking first avoids
+            ref="bencher/$w"
+            echo "Anchoring refs/$ref -> $sha"
+            # Update the ref if it exists, else create it. (Checking first avoids
             # the spurious 422 a PATCH-then-POST logs on first creation.)
-            if gh api --silent "repos/$REPO/git/refs/tags/$tag" 2>/dev/null; then
-              gh api --silent -X PATCH "repos/$REPO/git/refs/tags/$tag" -f sha="$sha" -F force=true
+            if gh api --silent "repos/$REPO/git/ref/$ref" 2>/dev/null; then
+              gh api --silent -X PATCH "repos/$REPO/git/refs/$ref" -f sha="$sha" -F force=true
             else
-              gh api --silent -X POST "repos/$REPO/git/refs" -f ref="refs/tags/$tag" -f sha="$sha"
+              gh api --silent -X POST "repos/$REPO/git/refs" -f ref="refs/$ref" -f sha="$sha"
             fi
             done_list="$done_list $w"
           done


### PR DESCRIPTION
- Fixes token permissions to allow cached Lean binaries between jobs
- Moves `bencher-thresholds-reset` Git tags to the `refs/bencher` namespace so that they don't pollute `git log`