### PR TITLE
ci: Refactor `bench-pr.yml` for `actions/cache` token write access

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -114,6 +114,9 @@ jobs:
       full: ${{ steps.parse.outputs.full }}
       passthrough-env: ${{ steps.parse.outputs.passthrough-env }}
       config-summary: ${{ steps.parse.outputs.config-summary }}
+      # Set (with the step failing) when the !benchmark command was
+      # rejected; the failure comment quotes it.
+      parse-error: ${{ steps.parse.outputs.parse-error }}
     steps:
       # Everything downstream needs this job, so malformed inputs die here
       # (the checkout would take a bare "main" or a short SHA otherwise).
@@ -626,18 +629,41 @@ jobs:
           name: comment-body
           path: comment-body.md
 
-  # Post the assembled body. This is the ONLY job with access to the App
-  # token, and it runs no checkout and no repo-derived code — just an
-  # artifact download and two actions.
+  # Post the assembled body — or a red-X diagnostic when any stage failed
+  # (a rejected command or broken run must never end in silence on the
+  # PR). This is the ONLY job with access to the App token, and it runs
+  # no checkout and no repo-derived code — just an artifact download and
+  # two actions.
   comment:
-    needs: assemble
-    if: always() && needs.assemble.result == 'success'
+    needs: [build, compile, benchmark, assemble]
+    if: always() && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Download comment body
+        if: needs.assemble.result == 'success'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: comment-body
+      # Any failed stage prepends a red-X header (quoting the parse error
+      # when that's the cause) to the report — or replaces it when
+      # assemble produced none. A rejection-reddened cell still shows its
+      # tables below the header.
+      - name: Note failures
+        if: contains(needs.*.result, 'failure') || needs.assemble.result != 'success'
+        env:
+          PARSE_ERROR: ${{ needs.build.outputs.parse-error }}
+        run: |
+          {
+            echo "## ❌ benchmark run failed — [run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            if [ -n "$PARSE_ERROR" ]; then
+              echo
+              echo "> $PARSE_ERROR"
+            fi
+            echo
+            if [ -f comment-body.md ]; then cat comment-body.md; fi
+          } > body-with-header.md
+          mv body-with-header.md comment-body.md
       - name: Generate token to write PR comment
         id: app-token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -97,21 +97,6 @@ jobs:
             -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
             -f comment-body="$COMMENT_BODY"
 
-  setup:
-    name: Validate dispatch inputs
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      base-sha: ${{ inputs.base-sha }}
-      head-sha: ${{ inputs.head-sha }}
-    steps:
-      - name: Validate SHAs
-        env:
-          BASE: ${{ inputs.base-sha }}
-          HEAD: ${{ inputs.head-sha }}
-        run: |
-          [[ "$BASE" =~ ^[0-9a-f]{40}$ && "$HEAD" =~ ^[0-9a-f]{40}$ ]] \
-            || { echo "base-sha/head-sha must be full 40-hex SHAs" >&2; exit 1; }
   # Build the PR's `ix` + `bench-typecheck` once (they embed the IxVM kernel
   # and the Aiur prover), stage under ~/.local/bin, and cache by head SHA —
   # the matrix cells restore instead of re-running the full Lean build per
@@ -124,7 +109,7 @@ jobs:
   # the freshly built `ix bench ci parse` — the registry lives in Lean, so the
   # matrix can only exist post-build.
   build:
-    needs: setup
+    if: github.event_name == 'workflow_dispatch'
     runs-on: warp-ubuntu-latest-x64-32x
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
@@ -134,16 +119,25 @@ jobs:
       passthrough-env: ${{ steps.parse.outputs.passthrough-env }}
       config-summary: ${{ steps.parse.outputs.config-summary }}
     steps:
+      # Everything downstream needs this job, so malformed inputs die here
+      # (the checkout would take a bare "main" or a short SHA otherwise).
+      - name: Validate SHAs
+        env:
+          BASE: ${{ inputs.base-sha }}
+          HEAD: ${{ inputs.head-sha }}
+        run: |
+          [[ "$BASE" =~ ^[0-9a-f]{40}$ && "$HEAD" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "base-sha/head-sha must be full 40-hex SHAs" >&2; exit 1; }
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.setup.outputs.head-sha }}
+          ref: ${{ inputs.head-sha }}
           # The job builds and runs PR code; never leave the token in .git.
           persist-credentials: false
       - id: bins
         uses: actions/cache/restore@v5
         with:
           path: ~/.local/bin
-          key: bench-bins-${{ needs.setup.outputs.head-sha }}
+          key: bench-bins-${{ inputs.head-sha }}
       - if: steps.bins.outputs.cache-hit != 'true'
         uses: actions-rust-lang/setup-rust-toolchain@v1
       # `.cargo/config.toml` sets `-Ctarget-cpu=native`; log the build CPU so a
@@ -172,7 +166,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.local/bin
-          key: bench-bins-${{ needs.setup.outputs.head-sha }}
+          key: bench-bins-${{ inputs.head-sha }}
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       # Parse the !benchmark command from an env var (never
       # inline-interpolated); unknown tokens fall off the allowlist.
@@ -188,7 +182,7 @@ jobs:
   # requesting the compile backend never compiles the env twice.
   compile:
     name: compile-${{ matrix.env }}
-    needs: [setup, build]
+    needs: build
     if: needs.build.outputs.envs != '[]'
     runs-on: warp-ubuntu-latest-x64-32x
     timeout-minutes: 120
@@ -200,7 +194,7 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.setup.outputs.head-sha }}
+          ref: ${{ inputs.head-sha }}
           # The job runs PR code; never leave the token in .git.
           persist-credentials: false
       # Re-running !benchmark on the same commit: the .ixe is already
@@ -210,14 +204,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ matrix.env }}.ixe
-          key: bench-pr-ixe-${{ needs.setup.outputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}
           lookup-only: true
       - name: Restore PR binaries
         if: steps.pr-ixe.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v5
         with:
           path: ~/.local/bin
-          key: bench-bins-${{ needs.setup.outputs.head-sha }}
+          key: bench-bins-${{ inputs.head-sha }}
           fail-on-cache-miss: true
       - if: steps.pr-ixe.outputs.cache-hit != 'true'
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -238,7 +232,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ${{ matrix.env }}.ixe
-          key: bench-pr-ixe-${{ needs.setup.outputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}
       # The measured row: the compile cell reuses it as its PR side (same
       # runner class, same binaries, same command it would run itself).
       - name: Publish compile row
@@ -246,13 +240,13 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: compile.json
-          key: bench-pr-row-${{ needs.setup.outputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
 
   benchmark:
     # Explicit name: the default would append EVERY matrix value (backend,
     # env, mode, runner, label); the label already is the cell id.
     name: ${{ matrix.cell.label }}
-    needs: [setup, build, compile]
+    needs: [build, compile]
     # A compile failure stops the cells (they would just re-fail the same
     # compile lazily); the skipped case can't arise (envs is never empty)
     # but is tolerated for robustness.
@@ -270,8 +264,8 @@ jobs:
       BENV: ${{ matrix.cell.env }}
       MODE: ${{ matrix.cell.mode }}
       LABEL: ${{ matrix.cell.label }}
-      BASE_SHA: ${{ needs.setup.outputs.base-sha }}
-      HEAD_SHA: ${{ needs.setup.outputs.head-sha }}
+      BASE_SHA: ${{ inputs.base-sha }}
+      HEAD_SHA: ${{ inputs.head-sha }}
       SHARD: ${{ needs.build.outputs.shard }}
       FULL: ${{ needs.build.outputs.full }}
     steps:
@@ -586,10 +580,10 @@ jobs:
   # artifact and never touches PR code (CodeQL: untrusted checkout /
   # execution in a privileged workflow).
   assemble:
-    needs: [setup, build, benchmark]
+    needs: [build, benchmark]
     # Assemble even when benchmark cells failed (the tables carry the ❌
     # rows); the build job must have produced the binaries.
-    if: always() && needs.setup.result == 'success' && needs.build.result == 'success'
+    if: always() && needs.build.result == 'success'
     # `bench report` is a pure-Lean subcommand (AVX-512 lives only in the
     # binary's Rust objects, which it never executes) — cheap host is fine.
     # Move to a warp host if `ix` startup or this subcommand ever touches
@@ -600,12 +594,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ needs.setup.outputs.head-sha }}
+          ref: ${{ inputs.head-sha }}
           persist-credentials: false
       - uses: actions/cache/restore@v5
         with:
           path: ~/.local/bin
-          key: bench-bins-${{ needs.setup.outputs.head-sha }}
+          key: bench-bins-${{ inputs.head-sha }}
           fail-on-cache-miss: true
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       # Provision the toolchain so `ix` finds libleanshared (no package build).
@@ -623,7 +617,7 @@ jobs:
       - name: Build comment body
         env:
           SUMMARY: ${{ needs.build.outputs.config-summary }}
-          HEAD_SHA: ${{ needs.setup.outputs.head-sha }}
+          HEAD_SHA: ${{ inputs.head-sha }}
         run: |
           mkdir -p tables   # absent when no cell uploaded a table
           ix bench report \
@@ -640,7 +634,7 @@ jobs:
   # token, and it runs no checkout and no repo-derived code — just an
   # artifact download and two actions.
   comment:
-    needs: [setup, assemble]
+    needs: assemble
     if: always() && needs.assemble.result == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -655,13 +655,15 @@ jobs:
           PARSE_ERROR: ${{ needs.build.outputs.parse-error }}
         run: |
           {
-            echo "## ❌ benchmark run failed — [run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo "## ❌ benchmark run failed"
             if [ -n "$PARSE_ERROR" ]; then
               echo
               echo "> $PARSE_ERROR"
             fi
             echo
             if [ -f comment-body.md ]; then cat comment-body.md; fi
+            echo
+            echo "[Workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > body-with-header.md
           mv body-with-header.md comment-body.md
       - name: Generate token to write PR comment

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -61,14 +61,6 @@ permissions:
   issues: read
   pull-requests: read
 
-concurrency:
-  # The event name keeps the relay run and the benchmark run it dispatches
-  # in separate groups — sharing one, the freshly-queued child cancels its
-  # in-flight parent. Within each kind, a re-comment on the same PR still
-  # cancels the previous run.
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.pr || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   dispatch:
     name: Relay !benchmark comment

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -62,7 +62,11 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pr || github.event.issue.number }}
+  # The event name keeps the relay run and the benchmark run it dispatches
+  # in separate groups — sharing one, the freshly-queued child cancels its
+  # in-flight parent. Within each kind, a re-comment on the same PR still
+  # cancels the previous run.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.pr || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -54,7 +54,7 @@ on:
         description: The !benchmark command line(s)
         required: true
 
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Benchmark PR #{0}', inputs.pr) || 'Relay benchmark comment' }}
+run-name: "${{ github.event_name == 'workflow_dispatch' && format('Benchmark PR #{0}', inputs.pr) || 'Relay benchmark comment' }}"
 
 permissions:
   contents: read

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -25,11 +25,36 @@
 # locally only when bencher can't supply them: the base SHA isn't ingested yet
 # (freshly-pushed main whose CI is still running), or the PR's Vectors.csv
 # selects constants main was never benched on (constants the PR itself adds).
+# Two-stage trigger: the issue_comment run only gates the commenter and
+# re-dispatches this same file as workflow_dispatch. GitHub classifies
+# issue_comment as a low-trust trigger with unconditionally READ-ONLY cache
+# access in the default branch's scope (anti-cache-poisoning; no token
+# permission can override it), so every cache save in a comment-triggered
+# run fails with "token has no writable scopes". workflow_dispatch is on
+# the trusted-trigger allowlist, so the dispatched run's cache saves work
+# with an ordinary read-only token. The commenter gate (org MEMBER/OWNER)
+# lives in the dispatch job; manual dispatch needs repo write access.
 name: Benchmark pull requests
 
 on:
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number (for the result comment)
+        required: true
+      base-sha:
+        description: Full base SHA to compare against
+        required: true
+      head-sha:
+        description: Full head SHA to benchmark
+        required: true
+      comment-body:
+        description: The !benchmark command line(s)
+        required: true
+
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Benchmark PR #{0}', inputs.pr) || 'Relay benchmark comment' }}
 
 permissions:
   contents: read
@@ -37,33 +62,56 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ inputs.pr || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
-  setup:
-    name: Parse !benchmark comment
+  dispatch:
+    name: Relay !benchmark comment
     if: >-
+      github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       github.event.issue.state == 'open' &&
       contains(github.event.comment.body, '!benchmark') &&
       (github.event.comment.author_association == 'MEMBER' ||
        github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
-    outputs:
-      base-sha: ${{ steps.shas.outputs.base }}
-      head-sha: ${{ steps.shas.outputs.head }}
+    permissions:
+      actions: write
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v6
       # issue_comment doesn't carry the PR's base/head; this action looks
       # them up.
       - uses: xt0rted/pull-request-comment-branch@v3
         id: comment-branch
-      - name: Resolve base/head SHAs
-        id: shas
+      - name: Dispatch the trusted run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          echo "base=${{ steps.comment-branch.outputs.base_sha }}" >> "$GITHUB_OUTPUT"
-          echo "head=${{ steps.comment-branch.outputs.head_sha }}" >> "$GITHUB_OUTPUT"
+          gh workflow run bench-pr.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "${{ github.event.repository.default_branch }}" \
+            -f pr="${{ github.event.issue.number }}" \
+            -f base-sha="${{ steps.comment-branch.outputs.base_sha }}" \
+            -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
+            -f comment-body="$COMMENT_BODY"
+
+  setup:
+    name: Validate dispatch inputs
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      base-sha: ${{ inputs.base-sha }}
+      head-sha: ${{ inputs.head-sha }}
+    steps:
+      - name: Validate SHAs
+        env:
+          BASE: ${{ inputs.base-sha }}
+          HEAD: ${{ inputs.head-sha }}
+        run: |
+          [[ "$BASE" =~ ^[0-9a-f]{40}$ && "$HEAD" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "base-sha/head-sha must be full 40-hex SHAs" >&2; exit 1; }
   # Build the PR's `ix` + `bench-typecheck` once (they embed the IxVM kernel
   # and the Aiur prover), stage under ~/.local/bin, and cache by head SHA —
   # the matrix cells restore instead of re-running the full Lean build per
@@ -78,14 +126,6 @@ jobs:
   build:
     needs: setup
     runs-on: warp-ubuntu-latest-x64-32x
-    # The cache service refuses writes from a wholly read-only token
-    # ("cache write denied: token has no writable scopes"), and this job
-    # saves the bench-bins cache — actions:write makes the token writable.
-    # Granted per-job so the workflow default stays read-only (the
-    # privileged comment job must not inherit it).
-    permissions:
-      contents: read
-      actions: write
     outputs:
       matrix: ${{ steps.parse.outputs.matrix }}
       envs: ${{ steps.parse.outputs.envs }}
@@ -139,7 +179,7 @@ jobs:
       - name: Parse command
         id: parse
         env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_BODY: ${{ inputs.comment-body }}
         run: ix bench ci parse
 
   # ONE measured `ix compile` per requested env, before the cells: it
@@ -151,10 +191,6 @@ jobs:
     needs: [setup, build]
     if: needs.build.outputs.envs != '[]'
     runs-on: warp-ubuntu-latest-x64-32x
-    # Saves the .ixe + compile-row caches (see build for why actions:write).
-    permissions:
-      contents: read
-      actions: write
     timeout-minutes: 120
     strategy:
       fail-fast: false
@@ -217,11 +253,6 @@ jobs:
     # env, mode, runner, label); the label already is the cell id.
     name: ${{ matrix.cell.label }}
     needs: [setup, build, compile]
-    # Saves the .ixe fallback + rust-cache entries (see build for why
-    # actions:write).
-    permissions:
-      contents: read
-      actions: write
     # A compile failure stops the cells (they would just re-fail the same
     # compile lazily); the skipped case can't arise (envs is never empty)
     # but is tolerated for robustness.
@@ -553,7 +584,7 @@ jobs:
   # PR-built `ix bench report`), so it must never share a job with the App
   # token — the posting job below only downloads the finished body as an
   # artifact and never touches PR code (CodeQL: untrusted checkout /
-  # execution in a privileged issue_comment workflow).
+  # execution in a privileged workflow).
   assemble:
     needs: [setup, build, benchmark]
     # Assemble even when benchmark cells failed (the tables carry the ❌
@@ -629,5 +660,5 @@ jobs:
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
-          issue-number: ${{ github.event.issue.number }}
+          issue-number: ${{ inputs.pr }}
           body-path: comment-body.md

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -556,6 +556,17 @@ def runMatrixCmd (p : Cli.Parsed) : IO UInt32 := do
     the workflows' job matrices, meaningless locally. -/
 def ciRunner : String := "warp-ubuntu-latest-x64-32x"
 
+/-- Reject the `!benchmark` command: stderr for the log, and a
+    `parse-error` step output so the workflow's failure comment can quote
+    the reason instead of pointing at the run log. Exit 2 (usage). -/
+def parseError (msg : String) : IO UInt32 := do
+  IO.eprintln s!"error: {msg}"
+  if let some outPath := ← IO.getEnv "GITHUB_OUTPUT" then
+    let h ← IO.FS.Handle.mk outPath IO.FS.Mode.append
+    h.putStr s!"parse-error={msg}\n"
+    h.flush
+  return 2
+
 /-- Parse a `!benchmark` command into the cells it schedules — locally a
     dry-run preview (`ix bench ci parse --comment "!benchmark aiur"` prints
     the summary and cell list), in CI the matrix generator. The text comes
@@ -564,7 +575,8 @@ def ciRunner : String := "warp-ubuntu-latest-x64-32x"
     `$GITHUB_OUTPUT` is set, the machine outputs (matrix, flags, summary,
     passthrough env) are appended there in Actions format.
 
-    Grammar (unknown tokens fall off the allowlist):
+    Grammar (an unknown command-line token, or an unknown/unbenched env in
+    BENCH_ENVS, rejects the command — exit 2 and a `parse-error` output):
 
       !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute]
       BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd)
@@ -590,19 +602,31 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut skipped : Array Ix.Cli.BenchCmd.BackendSpec := #[]
   let mut executeFlag := false
   for t in toks.map (·.toLower) do
+    if t == "execute" then
+      executeFlag := true
+      continue
     let requested := if t == "all"
       then Ix.Cli.BenchCmd.backendSpecs
       else (Ix.Cli.BenchCmd.findBackend t).toList
+    -- Everything after `!benchmark` on the command line must parse: a
+    -- typo'd backend silently running the default would report numbers
+    -- the commenter never asked for.
+    if requested.isEmpty then
+      return ← parseError s!"unknown token `{t}` in the benchmark command \
+        (expected a backend — \
+        {", ".intercalate (Ix.Cli.BenchCmd.backendSpecs.map (·.name))} — \
+        or `all` / `execute`)"
     for b in requested do
       if b.disabled.isSome then
         if skipped.all (·.name != b.name) then skipped := skipped.push b
       else if backends.all (·.name != b.name) then
         backends := backends.push b
-    if t == "execute" then executeFlag := true
   if backends.isEmpty then
     backends := (Ix.Cli.BenchCmd.findBackend "aiur").toList.toArray
 
   -- KEY=VALUE config lines below the command line.
+  let benchedEnvNames :=
+    (Ix.Cli.BenchCmd.envSpecs.filter (·.benched)).map (·.name)
   let mut envs : Array String := #[]
   let mut shard := "0"
   let mut full := "0"
@@ -619,10 +643,20 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       let val := "=".intercalate rest |>.trimAscii.toString
       match key.trimAscii.toString with
       | "BENCH_ENVS" =>
+        -- A recognized key makes intent unambiguous, so its VALUE must
+        -- parse fully too (unknown bare keys stay ignored — comments
+        -- contain prose, and prose contains `=`).
         for tok in val.splitOn "," do
-          if let some e := Ix.Cli.BenchCmd.findEnv tok.trimAscii.toString then
-            if e.benched && !envs.contains e.name then
-              envs := envs.push e.name
+          let tok := tok.trimAscii.toString
+          match Ix.Cli.BenchCmd.findEnv tok with
+          | some e =>
+            if !e.benched then
+              return ← parseError s!"env `{e.name}` is not benched in CI \
+                (benched: {", ".intercalate benchedEnvNames})"
+            if !envs.contains e.name then envs := envs.push e.name
+          | none =>
+            return ← parseError s!"unknown env `{tok}` in BENCH_ENVS \
+              (benched: {", ".intercalate benchedEnvNames})"
       | "BENCH_SHARD" => if val == "1" then shard := "1"
       | "BENCH_FULL" => if val == "1" then full := "1"
       | k =>


### PR DESCRIPTION
Workflows triggered by `issue_comment` have read-only tokens for the `actions/cache` action, which reads a job-level `ACTIONS_RUNTIME_TOKEN` that can't be overridden. To work around this, we now have the `issue_comment` workflow run the `gh workflow` CLI to run a separate `workflow_dispatch` trigger that then runs the PR benchmark and has write access to the GitHub cache.

Other changes:
- Adds error handling to surface parse or benchmark errors by a PR comment with a failure message and link to the log.
- Removes concurrency keys so that jobs can run in parallel and don't get cancelled by subsequent `!benchmark` comments

Successful tests: https://github.com/samuelburnham/ix/pull/1#issuecomment-4931400189