### PR TITLE
ci: Fix `!benchmark BENCH_ENVS=Lean,FLT`

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -4,7 +4,8 @@
 #   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute]
 #     (sp1 is disabled in the registry (Ix/Cli/BenchCmd.lean) — the parser skips it
 #      with a note in the config summary)
-#   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (default InitStd; case-insensitive)
+#   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (default InitStd; case-insensitive;
+#                                  #  compile-only requests may name any registry env, e.g. Lean/FLT)
 #   BENCH_FULL=1                   # run the full curated set, not just primary
 #   BENCH_SHARD=1                  # restrict to the multi-shard target constants
 #   BENCH_PHASES=1                 # add per-constant phase drill-downs to the comment
@@ -238,7 +239,8 @@ jobs:
           auto-config: false
           build: false
           use-github-cache: false
-          use-mathlib-cache: ${{ matrix.env == 'Mathlib' && 'true' || 'false' }}
+          # Mathlib oleans for every env that imports Mathlib (FLT does).
+          use-mathlib-cache: ${{ (matrix.env == 'Mathlib' || matrix.env == 'FLT') && 'true' || 'false' }}
       # The measured `ix compile` resolves the env's imports from the
       # subpackage's oleans — bench-main builds the same target before its
       # measured compile.
@@ -502,19 +504,22 @@ jobs:
           build: true
           build-args: "ix bench-typecheck"
           use-github-cache: false
-      # Base-side `ix compile` of the Mathlib env resolves imports from the
-      # base tree's Benchmarks/Compile subpackage — mathlib lives there, not
-      # in the root workspace, so the cache fetch can't ride the build
-      # action above.
+      # Base-side `ix compile` of a mathlib-importing env (Mathlib, FLT)
+      # resolves imports from the base tree's Benchmarks/Compile subpackage —
+      # mathlib lives there, not in the root workspace, so the cache fetch
+      # can't ride the build action above. Compile cells need this even with
+      # cached binaries: the compile backend always compiles (`--ixe` is
+      # ignored by design), while a prover cell with cached binaries rides
+      # the restored `.ixe` and skips the compile entirely.
       - name: Fetch base Mathlib oleans
         if: >-
           steps.bencher.outputs.run-base == 'true' &&
-          steps.base-src.outputs.cached != 'true' &&
-          matrix.cell.env == 'Mathlib'
+          (matrix.cell.env == 'Mathlib' || matrix.cell.env == 'FLT') &&
+          (matrix.cell.backend == 'compile' || steps.base-src.outputs.cached != 'true')
         working-directory: base/Benchmarks/Compile
         run: |
           lake exe cache get
-          lake build CompileMathlib
+          lake build Compile${{ matrix.cell.env }}
       # NOTE: the PR's `ix bench` orchestrates the base run (--repo base); the
       # MEASURED tools resolve from base/.lake/build/bin. When a PR changes
       # the benchmark CLIs themselves, the base tools may reject the new

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -606,7 +606,9 @@ def parseError (msg : String) : IO UInt32 := do
 
       !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute]
                  [KEY=VALUE …]
-      BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd)
+      BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd;
+                                    compile-only requests may name any
+                                    registry env, e.g. Lean or FLT)
       BENCH_FULL=1                 (full curated set, not just primary)
       BENCH_SHARD=1                (only the multi-shard target constants)
       BENCH_PHASES=1 / RUST_LOG=… / WITHOUT_VK_VERIFICATION=… /
@@ -702,13 +704,20 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
           let tok := tok.trimAscii.toString
           match Ix.Cli.BenchCmd.findEnv tok with
           | some e =>
-            if !e.benched then
-              return ← parseError s!"env `{e.name}` is not benched in CI \
-                (benched: {", ".intercalate benchedEnvNames})"
+            -- `compile` measures any registry env (its row is env-keyed;
+            -- no curated constants involved). Every other backend selects
+            -- constants from Vectors.csv, which only covers the benched
+            -- envs — so an unbenched env needs a compile-only request.
+            if !e.benched && backends.any (·.name != "compile") then
+              return ← parseError s!"env `{e.name}` is only available for a \
+                compile-only `!benchmark compile` (the other backends need \
+                curated constants; benched: \
+                {", ".intercalate benchedEnvNames})"
             if !envs.contains e.name then envs := envs.push e.name
           | none =>
             return ← parseError s!"unknown env `{tok}` in BENCH_ENVS \
-              (benched: {", ".intercalate benchedEnvNames})"
+              (registry: \
+              {", ".intercalate (Ix.Cli.BenchCmd.envSpecs.map (·.name))})"
       | "BENCH_SHARD" => if val == "1" then shard := "1"
       | "BENCH_FULL" => if val == "1" then full := "1"
       | k =>

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -174,6 +174,11 @@ structure CompareArgs where
       `BENCH_PHASES=1`) — the spans are noisy and dynamically named, so
       the default table stays at the headline measures. -/
   phases : Bool := false
+  /-- What one table row is, for the header and summary: `constant` on
+      the per-constant backends, `env` on compile (whose rows are
+      env-keyed), `env/constant` on ooc (which mixes an env row with
+      per-constant rows). -/
+  rowNoun : String := "constant"
 
 def renderCompare (a : CompareArgs) : String := Id.run do
   let names := (rowNames a.mainRows ++ rowNames a.prRows).foldl
@@ -192,7 +197,7 @@ def renderCompare (a : CompareArgs) : String := Id.run do
     | none, some _ => false
     | none, none => x < y
 
-  let mut head := #["constant"]
+  let mut head := #[a.rowNoun]
   for m in a.metrics do
     head := head ++ #[s!"{metricLabel m} (main)", s!"{metricLabel m} (PR)", "Δ%"]
   let mut lines := #[
@@ -234,8 +239,11 @@ def renderCompare (a : CompareArgs) : String := Id.run do
           else if bad < -a.threshold then
             delta := delta ++ " 🟢"; rowImproved := true
       cells := cells ++ #[renderSide mainStatus mv, renderSide prStatus pv, delta]
+    -- Independent tallies: a row can regress on one metric and improve
+    -- on another (compile-time up, peak-ram down), and the summary must
+    -- not hide either side.
     if rowRegressed then regressed := regressed + 1
-    else if rowImproved then improved := improved + 1
+    if rowImproved then improved := improved + 1
     lines := lines.push ("| " ++ " | ".intercalate cells.toList ++ " |")
 
   let mut out := #[a.title, ""] ++ lines ++ #[""]
@@ -245,8 +253,11 @@ def renderCompare (a : CompareArgs) : String := Id.run do
     out := out.push s!"❌ **`{n}` FAILED TO TYPECHECK on the {side} side** — \
       the kernel rejected it; see the logs."
   if !failures.isEmpty then out := out.push ""
-  out := out.push s!"_{names.size} constants · {regressed} regressed · \
-    {improved} improved (|Δ| > {fmtF a.threshold 1}% on any metric)._"
+  let plural := fun (n : Nat) (noun : String) =>
+    s!"{n} {noun}{if n == 1 then "" else "s"}"
+  out := out.push s!"_{plural names.size a.rowNoun} · {regressed} with \
+    regressions · {improved} with improvements \
+    (|Δ| > {fmtF a.threshold 1}% on any metric)._"
   -- One side empty while the other measured is almost always a broken side
   -- (e.g. the base-run fallback hit a base binary that predates a flag),
   -- not a real all-regressed/all-new comparison — flag it briefly instead
@@ -326,6 +337,10 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     prRows := ← readRows prPath
     metrics, threshold, title
     phases := ((← IO.getEnv "BENCH_PHASES").getD "0") == "1"
+    rowNoun :=
+      if backend == "compile" then "env"
+      else if backend == "ooc" then "env/constant"
+      else "constant"
   }
   match p.flag? "out" with
   | some f => IO.FS.writeFile (f.as! String) (table ++ "\n")

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -154,7 +154,9 @@ breakdowns. bench-main's compile job pre-cuts these artifacts
 
 ```
 !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute] [KEY=VALUE …]
-BENCH_ENVS=InitStd,Mathlib     # default InitStd (case-insensitive)
+BENCH_ENVS=InitStd,Mathlib     # default InitStd (case-insensitive); a
+                               # compile-only request may name any registry
+                               # env (Lean, FLT compile fine, just unbenched)
 BENCH_FULL=1                   # full curated set, not just primary
 BENCH_SHARD=1                  # only the multi-shard target constants
 BENCH_PHASES=1                 # add the per-constant phase drill-downs


### PR DESCRIPTION
## `!benchmark` follow-ups: compile-only envs and a better summary line

Two fixes for the `!benchmark` PR comment, following up on #483.

**Compile-only requests accept any registry env.** `BENCH_ENVS` rejected everything outside the benched set (`InitStd`, `Mathlib`), but that gate only matters for backends that select curated constants from `Vectors.csv`. The `compile` backend measures the env-keyed row directly — and bench-main already tracks all four envs' compile cells on bencher — so `!benchmark compile BENCH_ENVS=Lean,FLT` now works. An unbenched env combined with any other backend still rejects, with the reason spelled out. `bench-pr.yml` provisions mathlib oleans for FLT wherever it did for Mathlib (both import Mathlib), and the base-side olean fetch now also covers compile cells with cached binaries — the compile backend always recompiles, so restored binaries alone never sufficed there (a latent gap for base-run `compile · Mathlib` as well).

**The summary line stops lying about mixed results.**
`_1 constants · 1 regressed · 0 improved_` had two problems on compile tables: the rows are envs, not constants (and `constants` is also a metric column in the same table), and a row that regressed on one metric while improving on another counted only as regressed. The row noun is now backend-aware (`env` / `constant` / `env/constant` for ooc), pluralized, and the tallies are independent:

```
_1 env · 1 with regressions · 1 with improvements (|Δ| > 3.0% on any metric)._
```
