### PR TITLE
bench: Add an Aiur recursive-verifier benchmark suite

### DIFF
--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -16,6 +16,12 @@ name: Benchmark main
 #   4. ooc-check    — restore that `.ixe` and run the out-of-circuit Rust kernel
 #                     (the same kernel, out-of-circuit and parallel — far faster)
 #                     over the whole env, tracking throughput.
+#   5. aiur-recursive — the aiur-recursive toy
+#                     (bench-recursive-verifier):
+#                     prove fixed tiny statements, run the in-circuit
+#                     multi-stark verifier over each proof, then prove THAT
+#                     execution — the end-to-end recursion cost. Env-independent
+#                     (no `.ixe`), so it needs only the staged binaries.
 # Each job reports to its own bencher testbed/workload so a threshold reset only
 # touches its own measures. `ix bench run` exits 3 when the kernel REJECTS a
 # constant — the red X lands on that step (no output scraping), while the clean
@@ -39,9 +45,10 @@ env:
   COMPILE_DIR: Benchmarks/Compile
 
 jobs:
-  # Build + stage the `ix` and `bench-typecheck` binaries once, then restore
-  # them on the matrix runners. `-Ctarget-cpu=native`: every job that RUNS
-  # these binaries must also be a warp host.
+  # Build + stage the `ix`, `bench-typecheck`, and `bench-recursive-verifier`
+  # binaries once, then restore them on the matrix runners.
+  # `-Ctarget-cpu=native`: every job that RUNS these binaries must also be a
+  # warp host.
   build:
     runs-on: warp-ubuntu-latest-x64-32x
     steps:
@@ -64,9 +71,9 @@ jobs:
       - run: |
           mkdir -p ~/.local/bin
           echo | lake run install            # copies ix -> ~/.local/bin/ix
-          lake build bench-typecheck
-          cp .lake/build/bin/bench-typecheck ~/.local/bin/bench-typecheck
-          chmod +x ~/.local/bin/bench-typecheck
+          lake build bench-typecheck bench-recursive-verifier
+          cp .lake/build/bin/bench-typecheck .lake/build/bin/bench-recursive-verifier ~/.local/bin/
+          chmod +x ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier
       - uses: actions/cache/save@v5
         with:
           path: ~/.local/bin
@@ -345,6 +352,86 @@ jobs:
             --threshold-measure throughput --threshold-test percentage
             --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary _
             --threshold-lower-boundary 0.10
+
+  # The aiur-recursive toy cell (`ix bench run --backend
+  # aiur-recursive`):
+  # bench-recursive-verifier proves each fixed config's tiny statement, runs
+  # the in-circuit multi-stark verifier over the proof, then proves that
+  # execution — uploading the recursion-cost trend to its own testbed.
+  # Env-independent: no `.ixe`, no compile job — just the staged binaries
+  # and the toolchain (libleanshared). A config whose outer prove exceeds
+  # the watchdog ceiling lands as a `status: oom` row that bmf drops,
+  # keeping that row off bencher.
+  aiur-recursive:
+    name: aiur-recursive-prove
+    needs: build
+    runs-on: warp-ubuntu-latest-x64-32x
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/cache/restore@v5
+        with:
+          path: ~/.local/bin
+          key: bench-bins-${{ github.sha }}
+      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          use-github-cache: false
+      - name: Run aiur-recursive benchmark
+        run: ix bench run --backend aiur-recursive --out bench.json
+      - name: Convert to Bencher Metric Format
+        id: bmf
+        if: ${{ !cancelled() }}
+        run: |
+          ix bench bmf --in bench.json --out aiur-recursive-bmf.json
+          cat aiur-recursive-bmf.json
+      # recursive-fft-cost drifts ~±15% run-to-run (the parallel prover
+      # emits byte-different valid proofs, so the verifier authenticates
+      # different Merkle paths), hence the loose 25% bound; the proof
+      # sizes are structural (fixed query count and path depth) and ride
+      # the tight 5% bound like aiur's; wall-clock/RAM ride the standard
+      # 10% percentage bounds.
+      - uses: ./.github/actions/bencher-track
+        if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
+        with:
+          testbed: aiur-recursive-x64-32x
+          workload: aiur-recursive
+          file: aiur-recursive-bmf.json
+          key: ${{ secrets.BENCHER_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          thresholds: |
+            --threshold-measure recursive-fft-cost --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.25
+            --threshold-lower-boundary _
+            --threshold-measure recursive-execute-time --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
+            --threshold-measure recursive-prove-time --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
+            --threshold-measure recursive-verify-time --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
+            --threshold-measure recursive-peak-rss --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
+            --threshold-measure recursive-proof-size --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
+            --threshold-lower-boundary _
+            --threshold-measure prove-time --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
+            --threshold-measure proof-size --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
+            --threshold-lower-boundary _
+            --threshold-measure verify-time --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
+            --threshold-measure peak-rss --threshold-test percentage
+            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
+            --threshold-lower-boundary _
 
   # Execute the same constants through the zkVM hosts and track cycles /
   # execute-time / throughput / peak-rss (and shards / max-shard-cycles

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,7 +1,7 @@
 # `!benchmark` PR command: run the curated constant set (Benchmarks/Vectors.csv)
 # through chosen prover backend(s) and post a main-vs-PR comparison table.
 #
-#   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute]
+#   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all) [execute]
 #     (sp1 is disabled in the registry (Ix/Cli/BenchCmd.lean) — the parser skips it
 #      with a note in the config summary)
 #   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (default InitStd; case-insensitive;
@@ -20,10 +20,16 @@
 # Phase-1 columns `fft-cost` / `execute-time` measured en route; `zisk` /
 # `sp1` / `ooc` run `execute`; `compile` runs `ix compile <env>.lean →
 # <env>.ixe` (the same cell bench-main.yml uploads under testbed
-# `ix-compile-*`). The optional bare `execute` token flips `aiur` to
+# `ix-compile-*`); `aiur-recursive` runs the aiur-recursive toy
+# (bench-recursive-verifier's fixed configs — env-independent, so it
+# always schedules exactly one cell no matter what BENCH_ENVS says).
+# The optional bare `execute` token flips `aiur` to
 # execute-only (Phase 1, skipping the prove); bench-main runs both aiur
 # modes as separate cells on separate testbeds, so either kind of cell
-# fetches a cached main-side baseline from bencher.
+# fetches a cached main-side baseline from bencher. (aiur's third mode,
+# `recursive`, is local-only — `ix bench run --backend aiur --mode
+# recursive` — an IxVM-scale verifier execute needs >108 GB, beyond the
+# CI ceiling, so no comment token schedules it.)
 #
 # Each matrix cell is one `ix bench run` per side, driven by the PR's `ix`
 # (`--repo` points it at the checkout to measure). main's numbers come from
@@ -99,7 +105,8 @@ jobs:
             -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
             -f comment-body="$COMMENT_BODY"
 
-  # Build the PR's `ix` + `bench-typecheck` once (they embed the IxVM kernel
+  # Build the PR's `ix` + `bench-typecheck` + `bench-recursive-verifier`
+  # once (they embed the IxVM kernel
   # and the Aiur prover), stage under ~/.local/bin, and cache by head SHA —
   # the matrix cells restore instead of re-running the full Lean build per
   # cell, and re-running !benchmark on the same commit skips the build
@@ -160,13 +167,13 @@ jobs:
         with:
           auto-config: false
           build: ${{ steps.bins.outputs.cache-hit != 'true' }}
-          build-args: "ix bench-typecheck"
+          build-args: "ix bench-typecheck bench-recursive-verifier"
           use-github-cache: false
       - if: steps.bins.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.local/bin
-          cp .lake/build/bin/ix .lake/build/bin/bench-typecheck ~/.local/bin/
-          chmod +x ~/.local/bin/ix ~/.local/bin/bench-typecheck
+          cp .lake/build/bin/ix .lake/build/bin/bench-typecheck .lake/build/bin/bench-recursive-verifier ~/.local/bin/
+          chmod +x ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier
       - if: steps.bins.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
@@ -324,7 +331,7 @@ jobs:
           fail-on-cache-miss: true
       - run: |
           mkdir -p .lake/build/bin
-          mv ~/.local/bin/ix ~/.local/bin/bench-typecheck .lake/build/bin/
+          mv ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier .lake/build/bin/
           echo "$PWD/.lake/build/bin" >> "$GITHUB_PATH"
       # Toolchain provisioning only (no package build, no mathlib cache):
       # the restored binaries link against the toolchain's libleanshared.
@@ -455,7 +462,10 @@ jobs:
       # bench-main.yml's build/compile jobs already cached the base SHA's
       # binaries and `.ixe` on the push to main — restore both before paying
       # for a from-scratch base build.
-      - name: Restore base binaries (bench-main build cache)
+      # The bench-bins-<sha> key family has two producers: bench-main's build
+      # job (main commits) and this workflow's own build job (any PR head that
+      # ran !benchmark) — a stacked-PR base hits the latter.
+      - name: Restore base binaries (bench-bins cache)
         if: steps.bencher.outputs.run-base == 'true'
         id: base-bins
         uses: actions/cache/restore@v5
@@ -489,20 +499,21 @@ jobs:
              && cmp -s lean-toolchain base/lean-toolchain; then
             if [ "$BENV" != Mathlib ] || [ "${{ steps.base-ixe.outputs.cache-hit }}" = true ]; then
               mkdir -p base/.lake/build/bin
-              mv ~/.local/bin/ix ~/.local/bin/bench-typecheck base/.lake/build/bin/ 2>/dev/null || true
-              [ -x base/.lake/build/bin/ix ] && [ -x base/.lake/build/bin/bench-typecheck ] && cached=true
+              mv ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier base/.lake/build/bin/ 2>/dev/null || true
+              [ -x base/.lake/build/bin/ix ] && [ -x base/.lake/build/bin/bench-typecheck ] \
+                && [ -x base/.lake/build/bin/bench-recursive-verifier ] && cached=true
             fi
           fi
           echo "cached=$cached" >> "$GITHUB_OUTPUT"
-          echo "base binaries: $([ "$cached" = true ] && echo restored from bench-main cache || echo building from source)"
-      - name: Build base (ix, bench-typecheck)
+          echo "base binaries: $([ "$cached" = true ] && echo restored from cache || echo building from source)"
+      - name: Build base (ix, bench-typecheck, bench-recursive-verifier)
         if: steps.bencher.outputs.run-base == 'true' && steps.base-src.outputs.cached != 'true'
         uses: leanprover/lean-action@v1
         with:
           lake-package-directory: base
           auto-config: false
           build: true
-          build-args: "ix bench-typecheck"
+          build-args: "ix bench-typecheck bench-recursive-verifier"
           use-github-cache: false
       # Base-side `ix compile` of a mathlib-importing env (Mathlib, FLT)
       # resolves imports from the base tree's Benchmarks/Compile subpackage —

--- a/.github/workflows/bencher-thresholds-reset.yml
+++ b/.github/workflows/bencher-thresholds-reset.yml
@@ -22,7 +22,7 @@ name: Bencher thresholds reset
 #     cancel by removing it before merge. Naming convention: one label per token,
 #     `bencher-thresholds-reset:<token>` where <token> is a workload (a backend
 #     testbed in Ix/Cli/BenchCmd.lean (backendSpecs) minus its runner-arch suffix:
-#     `ix-compile`, `aiur-check-execute`, `aiur-check-prove`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
+#     `ix-compile`, `aiur-check-execute`, `aiur-check-prove`, `aiur-check-recursive`, `recursive`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
 #     `all` (the merge step expands an `all` label into every workload). Labeling
 #     requires Triage+, so PR authors from forks cannot self-queue a reset. The
 #     label shares the command/workflow name; the ref it moves is
@@ -44,7 +44,7 @@ on:
         # GitHub requires literal choice options, so this list stays static:
         # keep it (and the jobs' valid= lists below) in sync with the
         # backend testbeds in Ix/Cli/BenchCmd.lean (backendSpecs).
-        options: [ix-compile, aiur-check-execute, aiur-check-prove, zisk-check-execute, sp1-check-execute, ooc-check, all]
+        options: [ix-compile, aiur-check-execute, aiur-check-prove, aiur-check-recursive, recursive, zisk-check-execute, sp1-check-execute, ooc-check, all]
       sha:
         description: "Commit to anchor to (default: HEAD)"
         required: false
@@ -77,7 +77,7 @@ jobs:
           # (backendSpecs) minus the runner-arch suffix. Static because this
           # job runs on a cheap runner with no built `ix`; keep in sync when
           # adding a backend.
-          valid="aiur-check-execute aiur-check-prove ix-compile ooc-check sp1-check-execute zisk-check-execute"
+          valid="aiur-check-execute aiur-check-prove aiur-check-recursive ix-compile ooc-check recursive sp1-check-execute zisk-check-execute"
           if [ "$EVENT" = workflow_dispatch ]; then
             # Reset the chosen workload(s) at the given commit; no PR scan.
             sha="${INPUT_SHA:-$HEAD_SHA}"
@@ -133,7 +133,7 @@ jobs:
           # which the merge job expands into every workload). Same static
           # list as the reset job; keep both in sync with backendSpecs in
           # Ix/Cli/BenchCmd.lean.
-          valid="aiur-check-execute aiur-check-prove ix-compile ooc-check sp1-check-execute zisk-check-execute"
+          valid="aiur-check-execute aiur-check-prove aiur-check-recursive ix-compile ooc-check recursive sp1-check-execute zisk-check-execute"
           accepted="$valid all"
           # Parse the workload token(s) after the command, lowercased.
           workloads=$(printf '%s' "$BODY" \

--- a/.github/workflows/bencher-thresholds-reset.yml
+++ b/.github/workflows/bencher-thresholds-reset.yml
@@ -22,7 +22,7 @@ name: Bencher thresholds reset
 #     cancel by removing it before merge. Naming convention: one label per token,
 #     `bencher-thresholds-reset:<token>` where <token> is a workload (a backend
 #     testbed in Ix/Cli/BenchCmd.lean (backendSpecs) minus its runner-arch suffix:
-#     `ix-compile`, `aiur-check-execute`, `aiur-check-prove`, `aiur-check-recursive`, `recursive`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
+#     `ix-compile`, `aiur-check-execute`, `aiur-check-prove`, `aiur-check-recursive`, `aiur-recursive`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
 #     `all` (the merge step expands an `all` label into every workload). Labeling
 #     requires Triage+, so PR authors from forks cannot self-queue a reset. The
 #     label shares the command/workflow name; the ref it moves is
@@ -44,7 +44,7 @@ on:
         # GitHub requires literal choice options, so this list stays static:
         # keep it (and the jobs' valid= lists below) in sync with the
         # backend testbeds in Ix/Cli/BenchCmd.lean (backendSpecs).
-        options: [ix-compile, aiur-check-execute, aiur-check-prove, aiur-check-recursive, recursive, zisk-check-execute, sp1-check-execute, ooc-check, all]
+        options: [ix-compile, aiur-check-execute, aiur-check-prove, aiur-check-recursive, aiur-recursive, zisk-check-execute, sp1-check-execute, ooc-check, all]
       sha:
         description: "Commit to anchor to (default: HEAD)"
         required: false
@@ -77,7 +77,7 @@ jobs:
           # (backendSpecs) minus the runner-arch suffix. Static because this
           # job runs on a cheap runner with no built `ix`; keep in sync when
           # adding a backend.
-          valid="aiur-check-execute aiur-check-prove aiur-check-recursive ix-compile ooc-check recursive sp1-check-execute zisk-check-execute"
+          valid="aiur-check-execute aiur-check-prove aiur-check-recursive aiur-recursive ix-compile ooc-check sp1-check-execute zisk-check-execute"
           if [ "$EVENT" = workflow_dispatch ]; then
             # Reset the chosen workload(s) at the given commit; no PR scan.
             sha="${INPUT_SHA:-$HEAD_SHA}"
@@ -133,7 +133,7 @@ jobs:
           # which the merge job expands into every workload). Same static
           # list as the reset job; keep both in sync with backendSpecs in
           # Ix/Cli/BenchCmd.lean.
-          valid="aiur-check-execute aiur-check-prove aiur-check-recursive ix-compile ooc-check recursive sp1-check-execute zisk-check-execute"
+          valid="aiur-check-execute aiur-check-prove aiur-check-recursive aiur-recursive ix-compile ooc-check sp1-check-execute zisk-check-execute"
           accepted="$valid all"
           # Parse the workload token(s) after the command, lowercased.
           workloads=$(printf '%s' "$BODY" \

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -28,7 +28,8 @@ lake exe bench-recursive-verifier --execute-only  # skip the outer prove (FFT/ex
   --json <path>    write a benchmark results row (Ix.Benchmark.Results); the
                    row lands after the verifier execute and is refined after
                    the outer prove, so a kill mid-prove keeps the execute
-                   metrics. `ix bench run --backend recursive` drives this.
+                   metrics. `ix bench run --backend aiur-recursive`
+                   drives this.
   --json-name <n>  row key (default: the inner entrypoint name)
   --texray         tracing-texray timeline + RAM; with --json, spans also land
                    at `<json>.spans` for the CI drill-down

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -1,0 +1,195 @@
+import Ix.Aiur.Meta
+import Ix.Aiur.Protocol
+import Ix.Aiur.Compiler
+import Ix.Aiur.Statistics
+import Ix.MultiStark
+import Ix.TracingTexray
+import Ix.Benchmark.Results
+
+open Aiur
+
+/-!
+# Recursive-verifier cost benchmark
+
+Proves a tiny fixed statement with the multi-stark backend, runs the in-circuit
+recursive verifier (`verify_multi_stark_proof`) over that proof, then proves
+and verifies THAT execution — the end-to-end recursion step. Mirrors the setup
+of `Tests/MultiStark.lean::endToEndSuite`, but measures cost instead of
+asserting accept/reject.
+
+```
+lake exe bench-recursive-verifier                 # factorial(5), q=3, blowup 2
+lake exe bench-recursive-verifier --execute-only  # skip the outer prove (FFT/exec only)
+
+  --trivial        square(5) instead of factorial(5) — the per-statement floor
+  --queries N      FRI query count        (default 3)
+  --blowup N       log2 blowup            (default 2)
+  --pow N          commit PoW bits        (default 20)
+  --json <path>    write a benchmark results row (Ix.Benchmark.Results); the
+                   row lands after the verifier execute and is refined after
+                   the outer prove, so a kill mid-prove keeps the execute
+                   metrics. `ix bench run --backend recursive` drives this.
+  --json-name <n>  row key (default: the inner entrypoint name)
+  --texray         tracing-texray timeline + RAM; with --json, spans also land
+                   at `<json>.spans` for the CI drill-down
+```
+
+Row metrics: `prove-time`/`proof-size`/`verify-time` (the INNER statement),
+`peak-rss` (inner-prove window), `recursive-execute-time`/`recursive-fft-cost` (the
+verifier's execution and its in-circuit cost — the recursion-cost proxy), and
+`recursive-prove-time`/`recursive-peak-rss`/`recursive-proof-size`/
+`recursive-verify-time` (the outer prove — the headline recursion metrics).
+
+Determinism note: the multi-stark prover is **non-deterministic under `parallel`**
+(the same statement yields byte-different valid proofs run-to-run), so the
+verifier authenticates slightly different Merkle paths and its FFT drifts ~±15%.
+Aiur *execution* FFT is deterministic; pin the inner proof with
+`RAYON_NUM_THREADS=1` for exactly reproducible numbers.
+-/
+
+def factorialProgram : Source.Toplevel := ⟦
+  pub fn factorial(n: G) -> G {
+    match n {
+      0 => 1,
+      _ => n * factorial(n - 1),
+    }
+  }
+⟧
+
+/-- The most trivial provable statement (`--trivial`): one non-recursive
+function, no memory — the floor of the verifier's per-statement cost. -/
+def squareProgram : Source.Toplevel := ⟦
+  pub fn square(n: G) -> G {
+    n * n
+  }
+⟧
+
+/-- `--queries N`-style overrides for parameter sweeps (e.g. pairing a run
+against a config another commit could complete); defaults are the standard
+recursion-tuned set. -/
+def argNat (args : List String) (flag : String) (dflt : Nat) : Nat :=
+  match args.dropWhile (· != flag) with
+  | _ :: v :: _ => v.toNat?.getD dflt
+  | _ => dflt
+
+def argStr (args : List String) (flag : String) : Option String :=
+  match args.dropWhile (· != flag) with
+  | _ :: v :: _ => some v
+  | _ => none
+
+def recCommitParams (args : List String) : Aiur.CommitmentParameters :=
+  { logBlowup := argNat args "--blowup" 2, capHeight := 0 }
+def innerFri (args : List String) : Aiur.FriParameters :=
+  { logFinalPolyLen := argNat args "--final-poly" 0, maxLogArity := 1,
+    numQueries := argNat args "--queries" 3,
+    commitProofOfWorkBits := argNat args "--pow" 20, queryProofOfWorkBits := 0 }
+
+def secs (t0 t1 : Nat) : Float := (Float.ofNat (t1 - t0)) / 1e9
+
+open Ix.Benchmark.Results in
+def main (args : List String) : IO UInt32 := do
+  let doProve := !args.contains "--execute-only"
+  let recCommitParams := recCommitParams args
+  let innerFri := innerFri args
+  let jsonOut := argStr args "--json"
+  IO.println s!"params: logBlowup={recCommitParams.logBlowup} \
+    numQueries={innerFri.numQueries} finalPoly={innerFri.logFinalPolyLen} \
+    pow={innerFri.commitProofOfWorkBits}"
+  -- Inner proof: factorial(5) (or `square(5)` under --trivial) under the
+  -- multi-stark backend.
+  let (program, entry) :=
+    if args.contains "--trivial" then (squareProgram, `square)
+    else (factorialProgram, `factorial)
+  let rowName := (argStr args "--json-name").getD entry.toString
+  -- Same texray/sampler arrangement as bench-typecheck: the RSS sampler
+  -- always runs (peak-rss windows), the timeline only under --texray, and
+  -- with --json too the spans stream to `<json>.spans`.
+  TracingTexray.startSampler
+  if args.contains "--texray" then
+    TracingTexray.init {}
+    if let some path := jsonOut then TracingTexray.jsonSink s!"{path}.spans"
+  let writeRow' := fun (fields : List (String × Lean.Json)) =>
+    match jsonOut with
+    | some path => writeRow path rowName "ok" fields
+    | none => pure ()
+  let facCompiled ← match program.compile with
+    | .ok c => pure c
+    | .error e => IO.eprintln s!"inner compile failed: {e}"; return 1
+  let facSystem := AiurSystem.build facCompiled.bytecode recCommitParams
+  let facIdx := facCompiled.getFuncIdx entry |>.get!
+  IO.println s!"proving inner {entry}(5)…"
+  TracingTexray.resetPeakTreeRss
+  let it0 ← IO.monoNanosNow
+  let (claim, proof, _) := facSystem.prove innerFri facIdx #[Aiur.G.ofNat 5] default
+  let proofBytes := proof.toBytes
+  let it1 ← IO.monoNanosNow
+  let innerOk := facSystem.verify innerFri claim proof matches .ok _
+  let it2 ← IO.monoNanosNow
+  let innerPeak ← TracingTexray.peakTreeRssBytes
+  IO.println s!"inner PROVE: {secs it0 it1} s, \
+    proof {proofBytes.size} bytes; inner VERIFY: \
+    {secs it1 it2} s ({if innerOk then "ok" else "FAILED"})"
+  if !innerOk then
+    IO.eprintln "inner proof failed to verify"
+    return 1
+  -- Proof (advice, channel 0), vk (channel 1), claims (channel 2), plus the
+  -- Keccak-bound vk/claims digests and FRI params as public input.
+  let claimBytes := MultiStark.serializeClaims #[claim]
+  let (pubInput, io) := MultiStark.verifierInput proofBytes facSystem.vkBytes
+    claimBytes recCommitParams innerFri
+  -- Compile the verifier toplevel and run it over the proof.
+  let vTop ← match MultiStark.multiStark with
+    | .ok t => pure t
+    | .error e => IO.eprintln s!"verifier merge failed: {e}"; return 1
+  let vCompiled ← match vTop.compile with
+    | .ok c => pure c
+    | .error e => IO.eprintln s!"verifier compile failed: {e}"; return 1
+  let vIdx := vCompiled.getFuncIdx `verify_multi_stark_proof |>.get!
+  IO.println "executing verify_multi_stark_proof…"
+  let e0 ← IO.monoNanosNow
+  match vCompiled.bytecode.execute vIdx pubInput io with
+  | .error e => IO.eprintln s!"verifier execution REJECTED: {e}"; return 1
+  | .ok (_, _, qc) =>
+    let e1 ← IO.monoNanosNow
+    let stats := Aiur.computeStats vCompiled qc
+    IO.println s!"verifier accepted, execute {secs e0 e1} s"
+    IO.println s!"\n=== recursive verifier in-circuit cost ==="
+    IO.println s!"totalFftCost = {stats.totalFftCost}"
+    IO.println "\n=== per-circuit breakdown (top FFT contributors) ==="
+    Aiur.printStats stats
+    -- The execute-side row lands before the outer prove, so an OOM kill
+    -- there still leaves these metrics on disk (the orchestrator merges
+    -- `status: oom` in over them).
+    let baseFields : List (String × Lean.Json) :=
+      [ ("prove-time", jsonRound 6 (secs it0 it1))
+      , ("proof-size", Lean.toJson proofBytes.size)
+      , ("verify-time", jsonRound 6 (secs it1 it2))
+      , ("peak-rss", Lean.toJson innerPeak)
+      , ("recursive-execute-time", jsonRound 6 (secs e0 e1))
+      , ("recursive-fft-cost", jsonRound 0 stats.totalFftCost) ]
+    writeRow' baseFields
+    if !doProve then
+      return 0
+    -- PROVE the verifier execution (multi-stark): the recursion step itself.
+    IO.println "\n=== PROVING the verifier (multi-stark) ==="
+    let vSystem := AiurSystem.build vCompiled.bytecode recCommitParams
+    TracingTexray.resetPeakTreeRss
+    let t0 ← IO.monoNanosNow
+    let (vclaim, vproof, _) := vSystem.prove innerFri vIdx pubInput io
+    let nbytes := vproof.toBytes.size  -- force the (lazy, pure) prove to run
+    let t1 ← IO.monoNanosNow
+    let outerPeak ← TracingTexray.peakTreeRssBytes
+    let outerOk := vSystem.verify innerFri vclaim vproof matches .ok _
+    let t2 ← IO.monoNanosNow
+    IO.println s!"verifier PROVE time: {secs t0 t1} s, proof {nbytes} bytes"
+    IO.println s!"verifier proof VERIFY time: \
+      {secs t1 t2} s ({if outerOk then "ok" else "FAILED"})"
+    if !outerOk then
+      IO.eprintln "outer proof failed to verify"
+      return 1
+    writeRow' <| baseFields ++
+      [ ("recursive-prove-time", jsonRound 6 (secs t0 t1))
+      , ("recursive-peak-rss", Lean.toJson outerPeak)
+      , ("recursive-proof-size", Lean.toJson nbytes)
+      , ("recursive-verify-time", jsonRound 6 (secs t1 t2)) ]
+    return 0

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -58,9 +58,9 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  parameters (`recursiveFriParameters`), so recursive rows are
                  NOT comparable to the standard prove cell — they land on
                  their own testbed (`ix bench run --backend aiur --mode
-                 recursive`), which stays empty while the IxVM-scale cell
-                 OOMs (>108 GB in the verifier execute today; the kill lands
-                 as a `status: oom` row that bmf drops). With --texray, both
+                 recursive`). An IxVM-scale verifier execute needs >108 GB,
+                 so a watchdog kill landing as a `status: oom` row (dropped
+                 by bmf) is the expected shape there. With --texray, both
                  proves stream the same `stark/...` span names, so the summed
                  `phase-stark-*` fields cover the pair. Conflicts with
                  --execute-only.

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -3,6 +3,7 @@ import Ix.IxVM
 import Ix.Aiur.Protocol
 import Ix.Aiur.Compiler
 import Ix.Aiur.Statistics
+import Ix.MultiStark
 import Ix.TracingTexray
 import Ix.Benchmark.Bench
 import Ix.Benchmark.Results
@@ -47,6 +48,22 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  <path>.spans (JSON Lines) for the CI drill-down. Off by default.
   --execute-only run only Phase 1 (constants / fft-cost / execute-time) and skip
                  proving — the fast `execute`-mode signal.
+  --recursive    after each constant's prove, run the in-circuit multi-stark
+                 verifier (`verify_multi_stark_proof`) over the fresh proof:
+                 execute it (`recursive-execute-time`, `recursive-fft-cost` — the
+                 recursion-cost proxy), then prove that execution end-to-end
+                 (`recursive-prove-time`, `recursive-peak-rss`,
+                 `recursive-proof-size`, `recursive-verify-time`). The whole
+                 system, inner prove included, switches to the recursion-tuned
+                 parameters (`recursiveFriParameters`), so recursive rows are
+                 NOT comparable to the standard prove cell — they land on
+                 their own testbed (`ix bench run --backend aiur --mode
+                 recursive`), which stays empty while the IxVM-scale cell
+                 OOMs (>108 GB in the verifier execute today; the kill lands
+                 as a `status: oom` row that bmf drops). With --texray, both
+                 proves stream the same `stark/...` span names, so the summed
+                 `phase-stark-*` fields cover the pair. Conflicts with
+                 --execute-only.
 ```
 
 For each constant the harness STARK-checks `Ix.Claim.check addr none` (the full
@@ -62,6 +79,9 @@ transitive typecheck) in two phases:
    against proof size or verification cost, so all three are tracked. With
    texray on, each prove emits a per-span timeline (`aiur/execute`,
    `aiur/witness`, `stark/...`) with RAM Δ/peak to stderr.
+3. **Recursive** (`--recursive` only, right after each constant's prove): feed
+   the fresh proof + vk + claims to `verify_multi_stark_proof`, execute it,
+   then prove the verifier execution — the end-to-end recursion cost.
 
 When `--json` is set the file is rewritten after every prove, so an external
 `timeout` still leaves a complete file of the results collected so far (cheapest
@@ -71,7 +91,9 @@ limit; bound a run with an external `timeout` if needed.
 
 The JSON is a flat shape (`{ "<name>": { "constants": …, "fft-cost": …,
 "execute-time": …, "prove-time": …, "proof-size": …, "verify-time": …,
-"throughput": …, "peak-rss": … } }`). `peak-rss` and `throughput` are
+"throughput": …, "peak-rss": …, and with --recursive also "recursive-execute-time": …,
+"recursive-fft-cost": …, "recursive-prove-time": …, "recursive-peak-rss": …,
+"recursive-proof-size": …, "recursive-verify-time": … } }`). `peak-rss` and `throughput` are
 phase-scoped by MODE: an `--execute-only` row carries the Phase-1 RSS
 high-water and constants/sec over the execute; a prove row carries the
 prover's high-water and constants/sec over the prove (with `prove-time`,
@@ -92,6 +114,26 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
+  commitProofOfWorkBits := 20
+  queryProofOfWorkBits := 0
+}
+
+/-- Recursion-tuned commitment parameters for `--recursive`, matching
+    `bench-recursive-verifier`'s defaults. -/
+def recursiveCommitmentParameters : Aiur.CommitmentParameters := {
+  logBlowup := 2
+  capHeight := 0
+}
+
+/-- Recursion-tuned FRI parameters: the in-circuit verifier's cost scales with
+    the inner proof's query count, so the recursion configuration trades
+    queries (3, not 100) for blowup and commit proof-of-work. `--recursive`
+    runs the WHOLE system — the inner prove included — under these, so its
+    rows are not comparable to the standard `prove` cell's. -/
+def recursiveFriParameters : Aiur.FriParameters := {
+  logFinalPolyLen := 0
+  maxLogArity := 1
+  numQueries := 3
   commitProofOfWorkBits := 20
   queryProofOfWorkBits := 0
 }
@@ -126,6 +168,25 @@ structure Result where
       prover would dwarf an execute peak, so the modes never share a row —
       or a testbed). -/
   executePeakRss : Option Nat := none
+  /-- Wall time of executing the in-circuit multi-stark verifier over this
+      constant's fresh proof (`--recursive` only). -/
+  recursiveExecuteSec : Option Float := none
+  /-- That execution's own in-circuit FFT cost — the deterministic proxy for
+      what proving the verifier costs. Drifts ~±15% run-to-run: the parallel
+      prover emits byte-different valid proofs, so the verifier authenticates
+      different Merkle paths (pin with `RAYON_NUM_THREADS=1`). -/
+  recursiveFftCost : Option Float := none
+  /-- Wall time of PROVING the verifier execution — the end-to-end recursion
+      cost. -/
+  recursiveProveSec : Option Float := none
+  /-- The outer (recursion) prove's RSS high-water (windowed like `peakRss`;
+      the outer prove dwarfs the verifier execution, so one field serves). -/
+  recursivePeakRss : Option Nat := none
+  /-- Serialized outer proof size in bytes. -/
+  recursiveProofSize : Option Nat := none
+  /-- Wall time of `AiurSystem.verify` over the outer proof; `none` if that
+      verification failed (reported loudly). -/
+  recursiveVerifySec : Option Float := none
   deriving Inhabited
 
 /-- A `Json` number with at most `d` decimal places, rendered decimally.
@@ -181,6 +242,25 @@ def Result.toJsonEntry (executeOnly : Bool) (r : Result) : String × Json :=
     let fields := match r.verifySec with
       | some v => fields ++ [ ("verify-time", jsonRound 6 v) ]
       | none => fields
+    -- The recursion metrics (--recursive), in measurement order; the
+    -- execute-side pair lands before the outer prove runs, so an OOM'd
+    -- outer prove still leaves them on disk.
+    let fields := match r.recursiveExecuteSec, r.recursiveFftCost with
+      | some s, some c => fields ++ [ ("recursive-execute-time", jsonRound 6 s)
+                                    , ("recursive-fft-cost", jsonRound 0 c) ]
+      | _, _ => fields
+    let fields := match r.recursiveProveSec with
+      | some s => fields ++ [ ("recursive-prove-time", jsonRound 6 s) ]
+      | none => fields
+    let fields := match r.recursivePeakRss with
+      | some n => fields ++ [ ("recursive-peak-rss", Lean.toJson n) ]
+      | none => fields
+    let fields := match r.recursiveProofSize with
+      | some n => fields ++ [ ("recursive-proof-size", Lean.toJson n) ]
+      | none => fields
+    let fields := match r.recursiveVerifySec with
+      | some v => fields ++ [ ("recursive-verify-time", jsonRound 6 v) ]
+      | none => fields
     (r.name, Json.mkObj fields)
 
 /-- Time a thunk, returning its value and the elapsed seconds. The result is
@@ -210,6 +290,12 @@ def runTypecheckCmd (p : Cli.Parsed) : IO UInt32 := do
   -- Execute-only: run just Phase 1 (constants / fft-cost / execute-time) and
   -- skip the Phase 2 prove loop.
   let executeOnly := p.hasFlag "execute-only"
+  -- Recursive: after each constant's prove, execute AND prove the in-circuit
+  -- multi-stark verifier over the fresh proof (Phase 3).
+  let recursive := p.hasFlag "recursive"
+  if recursive && executeOnly then
+    IO.eprintln "error: --recursive measures the prove path; drop --execute-only"
+    return Ix.Benchmark.Results.exitUsage
   -- Off by default; CI passes --texray explicitly.
   let useTexray := p.hasFlag "texray"
   -- Start the process-tree RSS sampler so each Result's peak-rss reflects the
@@ -233,7 +319,26 @@ def runTypecheckCmd (p : Cli.Parsed) : IO UInt32 := do
   let entrypoint := if skipDeps then `verify_const else `verify_claim
   let some funIdx := compiled.getFuncIdx entrypoint
     | throw (IO.userError s!"{entrypoint} entrypoint missing")
-  let aiurSystem := Aiur.AiurSystem.build compiled.bytecode commitmentParameters
+  -- Recursive mode runs the WHOLE system — the inner prove included — under
+  -- the recursion-tuned parameters, so the verifier's query loop stays
+  -- tractable (cost scales with numQueries).
+  let (commitParams, friParams) :=
+    if recursive then (recursiveCommitmentParameters, recursiveFriParameters)
+    else (commitmentParameters, friParameters)
+  let aiurSystem := Aiur.AiurSystem.build compiled.bytecode commitParams
+  -- The recursive-verifier context, compiled and built ONCE: the verifier
+  -- toplevel is constant-independent, and its prover system (same recursion
+  -- parameters) is reused for every constant's outer prove.
+  let vCtx : Option (Aiur.CompiledToplevel × Aiur.Bytecode.FunIdx × Aiur.AiurSystem) ←
+    if !recursive then pure none else do
+      let .ok vTop := MultiStark.multiStark
+        | throw (IO.userError "Merging multi-stark verifier failed")
+      let .ok vCompiled := vTop.compile
+        | throw (IO.userError "Compilation of multi-stark verifier failed")
+      let some vIdx := vCompiled.getFuncIdx `verify_multi_stark_proof
+        | throw (IO.userError "verify_multi_stark_proof entrypoint missing")
+      pure (some (vCompiled, vIdx,
+        Aiur.AiurSystem.build vCompiled.bytecode commitParams))
 
   -- Load the serialized env lazily (the `ix check --ixe` path, #445): byte-window
   -- constants over the backing buffer, so only the checked closure is ever
@@ -347,11 +452,11 @@ def runTypecheckCmd (p : Cli.Parsed) : IO UInt32 := do
         if skipDeps then
           let witness := IxVM.ClaimHarness.buildVerifyConst ixonEnv addr
           let (claim, proof, ioBuf) :=
-            aiurSystem.proveIxVM friParameters funIdx witness.input witness.inputIOBuffer
+            aiurSystem.proveIxVM friParams funIdx witness.input witness.inputIOBuffer
           (.ok (claim, proof, ioBuf) :
             Except String (Array Aiur.G × Aiur.Proof × Aiur.IOBuffer))
         else
-          match aiurSystem.proveAddrWithEnv friParameters funIdx envHandle addr.hash with
+          match aiurSystem.proveAddrWithEnv friParams funIdx envHandle addr.hash with
           | .error e => .error e
           | .ok (claimBytes, proof, ioBuf) =>
             -- The envHandle path returns the SERIALIZED `Ix.Claim`; rebuild
@@ -367,20 +472,72 @@ def runTypecheckCmd (p : Cli.Parsed) : IO UInt32 := do
       | .ok (claim, proof, _ioBuf) =>
         spent := spent + proveSec
         let peak ← TracingTexray.peakTreeRssBytes
-        let proofSize := (Aiur.Proof.toBytes proof).size
+        let proofBytes := Aiur.Proof.toBytes proof
         let (verifyRes, verifySec) ← timed fun _ =>
-          aiurSystem.verify friParameters claim proof
+          aiurSystem.verify friParams claim proof
         let verifySec? ← match verifyRes with
           | .ok () => pure (some verifySec)
           | .error e =>
             IO.eprintln s!"  verify {r.name} FAILED: {e}"
             pure none
         IO.println s!"  {r.name}: prove={proveSec}s verify={verifySec}s \
-          proof={proofSize} bytes (cumulative {spent}s)"
+          proof={proofBytes.size} bytes (cumulative {spent}s)"
         ordered := ordered.set! i
           ({ r with proveSec := some proveSec, peakRss := some peak
-                  , proofSize := some proofSize, verifySec := verifySec? }, addr)
+                  , proofSize := some proofBytes.size, verifySec := verifySec? }, addr)
         writeJson (ordered.map (·.1))
+        -- Phase 3 (--recursive): the in-circuit verifier over the fresh
+        -- proof — execute it (recursive-execute-time / recursive-fft-cost), then prove
+        -- that execution (recursive-prove-time / recursive-peak-rss /
+        -- recursive-proof-size / recursive-verify-time). A reject on the execute
+        -- is a correctness alarm, reported loudly with the recursive fields
+        -- left absent — never a benchmark datum.
+        if let some (vCompiled, vIdx, vSystem) := vCtx then
+          IO.println s!"  [{i + 1}/{ordered.size}] recursively verifying {r.name} …"
+          (← IO.getStdout).flush
+          let claimBytes := MultiStark.serializeClaims #[claim]
+          let (pubInput, io) := MultiStark.verifierInput proofBytes
+            aiurSystem.vkBytes claimBytes commitParams friParams
+          let (rvRes, rvSec) ← timed fun _ =>
+            vCompiled.bytecode.execute vIdx pubInput io
+          match rvRes with
+          | .error e =>
+            IO.eprintln s!"  ❌ recursive verifier REJECTED {r.name}'s proof: {e}"
+          | .ok (_, _, qc) =>
+            let rvStats := Aiur.computeStats vCompiled qc
+            IO.println s!"  {r.name}: recursive={rvSec}s \
+              recursive-fft-cost={rvStats.totalFftCost}"
+            let (row, _) := ordered[i]!
+            ordered := ordered.set! i
+              ({ row with recursiveExecuteSec := some rvSec
+                        , recursiveFftCost := some rvStats.totalFftCost }, addr)
+            -- Flush the execute-side pair before the outer prove: an OOM
+            -- there keeps them, and the announce (flushed) names the
+            -- constant that died.
+            writeJson (ordered.map (·.1))
+            IO.println s!"  [{i + 1}/{ordered.size}] proving the verifier over {r.name} …"
+            (← IO.getStdout).flush
+            TracingTexray.resetPeakTreeRss
+            let ((rvClaim, rvProof, _), rvProveSec) ← timed fun _ =>
+              vSystem.prove friParams vIdx pubInput io
+            let rvPeak ← TracingTexray.peakTreeRssBytes
+            let rvProofBytes := Aiur.Proof.toBytes rvProof
+            let (rvVerifyRes, rvVerifySec) ← timed fun _ =>
+              vSystem.verify friParams rvClaim rvProof
+            let rvVerifySec? ← match rvVerifyRes with
+              | .ok () => pure (some rvVerifySec)
+              | .error e =>
+                IO.eprintln s!"  outer verify {r.name} FAILED: {e}"
+                pure none
+            IO.println s!"  {r.name}: recursive-prove={rvProveSec}s \
+              recursive-verify={rvVerifySec}s outer proof={rvProofBytes.size} bytes"
+            let (row, _) := ordered[i]!
+            ordered := ordered.set! i
+              ({ row with recursiveProveSec := some rvProveSec
+                        , recursivePeakRss := some rvPeak
+                        , recursiveProofSize := some rvProofBytes.size
+                        , recursiveVerifySec := rvVerifySec? }, addr)
+            writeJson (ordered.map (·.1))
     catch e =>
       IO.eprintln s!"  prove {r.name} threw: {e}"
 
@@ -400,6 +557,7 @@ def typecheckCmd : Cli.Cmd := `[Cli|
     "json"      : String; "Write per-constant results JSON to this path. Off by default; normal CLI usage prints only the human-readable summary."
     "skip-deps";          "Check only each target itself (verify_const, trusting its deps) instead of re-checking its whole transitive closure (verify_claim). Same flag as `zisk-host --skip-deps`."
     "execute-only";       "Execute only (Phase 1: constants / fft-cost / execute-time) and skip proving. The fast per-PR `execute`-mode signal."
+    "recursive";          "After each prove, execute and then prove the in-circuit multi-stark verifier over the fresh proof (the recursive-* metrics; see the module docstring). Uses recursion-tuned FRI parameters. Conflicts with --execute-only."
     texray;               "Enable the tracing-texray timeline + RAM breakdown (per-prove spans on stderr). Combined with --json, per-phase span timings are additionally written to `<json>.spans` as JSON Lines for the CI drill-down. Off by default."
 
 ]

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -78,7 +78,8 @@ def selectNames (rows : Array VectorRow) (env : String) (mode : String)
     Array VectorRow := Id.run do
   let effTier :=
     if tier != "" then tier
-    else if mode == "prove" && full then "cheap" else "all"
+    else if (mode == "prove" || mode == "recursive") && full then "cheap"
+    else "all"
   rows.filter fun r =>
     r.env == env
     && (full || r.primary)
@@ -136,15 +137,38 @@ structure BackendSpec where
 def backendSpecs : List BackendSpec := [
   -- prove is aiur's default: the real-workload simulation (it measures
   -- Phase 1 — execute-time, fft-cost — inside the same process en route).
-  -- execute is the fast Phase-1-only signal.
+  -- execute is the fast Phase-1-only signal. recursive layers the in-circuit
+  -- multi-stark verifier on prove: execute it over each fresh proof, then
+  -- prove that execution — the recursion cell. It runs under the
+  -- recursion-tuned FRI parameters, so even its shared-name metrics
+  -- (prove-time, peak-rss) are not comparable to the prove cell's. At IxVM
+  -- scale the cell is expected to OOM today (>108 GB in the verifier
+  -- execute); the kill lands as a `status: oom` row that bmf drops, so the
+  -- testbed simply stays empty until recursion fits.
   { name := "aiur", defaultMode := "prove",
     testbeds := [("prove", "aiur-check-prove-x64-32x"),
-                 ("execute", "aiur-check-execute-x64-32x")],
+                 ("execute", "aiur-check-execute-x64-32x"),
+                 ("recursive", "aiur-check-recursive-x64-32x")],
     metrics := [("prove", ["prove-time", "throughput", "peak-rss",
                            "execute-time", "verify-time", "proof-size",
                            "fft-cost"]),
                 ("execute", ["execute-time", "throughput", "peak-rss",
-                             "fft-cost"])] },
+                             "fft-cost"]),
+                ("recursive", ["recursive-prove-time", "recursive-peak-rss",
+                               "recursive-proof-size", "recursive-verify-time",
+                               "recursive-execute-time", "recursive-fft-cost",
+                               "prove-time", "proof-size"])] },
+  -- The recursive-verifier toy (bench-recursive-verifier): fixed tiny
+  -- statements (`recursiveConfigs`), proving the in-circuit multi-stark
+  -- verifier end-to-end. Env-independent: the cell ignores --env and never
+  -- needs an .ixe. Unlike the aiur recursive mode above, the floor config
+  -- completes on a 128 GB host, so this testbed gets real rows.
+  { name := "recursive", defaultMode := "prove",
+    testbeds := [("prove", "recursive-x64-32x")],
+    metrics := [("prove", ["recursive-prove-time", "recursive-peak-rss",
+                           "recursive-proof-size", "recursive-verify-time",
+                           "recursive-execute-time", "recursive-fft-cost",
+                           "prove-time", "proof-size"])] },
   { name := "zisk", defaultMode := "execute",
     testbeds := [("execute", "zisk-check-execute-x64-32x")],
     metrics := [("execute", ["execute-time", "throughput", "peak-rss",
@@ -165,6 +189,16 @@ def backendSpecs : List BackendSpec := [
 
 def findBackend (name : String) : Option BackendSpec :=
   backendSpecs.find? (·.name == name)
+
+/-- The `recursive` backend's rows: (row name, bench-recursive-verifier
+    config args). Fixed configs rather than `Vectors.csv` constants — the
+    toy proves the same tiny statements everywhere: `square-q1-b1` is the
+    floor config (completes at ~80 GB under Keccak; ~2.6 GB under Blake3)
+    and `factorial-q3-b2` the recursion-tuned default. -/
+def recursiveConfigs : List (String × Array String) := [
+  ("square-q1-b1", #["--trivial", "--queries", "1", "--blowup", "1"]),
+  ("factorial-q3-b2", #[])
+]
 
 def BackendSpec.testbedFor (b : BackendSpec) (mode : String) : Option String :=
   (b.testbeds.find? (·.1 == mode)).map (·.2)
@@ -437,7 +471,11 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
         (rows.find? (fun r => r.name == n && r.env == env)).getD
           { name := n, env, tier := "cheap", shardTarget := false, primary := false }
   let names := selected.map (·.name)
-  IO.eprintln s!"[bench] cell {backend}-{env}-{mode}: {names.size} constant(s)"
+  match backend with
+  | "recursive" =>
+    IO.eprintln s!"[bench] cell {backend}-{mode}: {recursiveConfigs.length} config(s)"
+  | _ =>
+    IO.eprintln s!"[bench] cell {backend}-{env}-{mode}: {names.size} constant(s)"
 
   -- Fresh accumulator per run.
   if ← FilePath.pathExists out then IO.FS.removeFile out
@@ -475,12 +513,28 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
   | "aiur" =>
     let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))
     let bt ← resolveBin repo "bench-typecheck"
-    let modeArgs := if mode == "execute" then #["--execute-only"] else #[]
-    let doneKey := if mode == "prove" then "prove-time" else "execute-time"
+    let modeArgs := match mode with
+      | "execute" => #["--execute-only"]
+      | "recursive" => #["--recursive"]
+      | _ => #[]
+    let doneKey := match mode with
+      | "execute" => "execute-time"
+      | "recursive" => "recursive-prove-time"
+      | _ => "prove-time"
     runPerConstant out names doneKey fun name =>
       runGuarded watchdog ceilingGb bt
         (#["--ixe", ixe, "--consts", name, "--json", out, "--texray"]
           ++ modeArgs)
+  | "recursive" =>
+    -- Fixed-config rows; no env, no .ixe. One process per config under the
+    -- watchdog, self-reporting through the rows contract like every other
+    -- per-row backend.
+    let brv ← resolveBin repo "bench-recursive-verifier"
+    runPerConstant out (recursiveConfigs.map (·.1)).toArray "recursive-prove-time"
+      fun name =>
+        let cfgArgs := ((recursiveConfigs.find? (·.1 == name)).map (·.2)).getD #[]
+        runGuarded watchdog ceilingGb brv
+          (cfgArgs ++ #["--json", out, "--json-name", name, "--texray"])
   | "zisk" | "sp1" =>
     if mode != "execute" then
       p.printError s!"error: {backend} supports only execute mode"
@@ -532,6 +586,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
   let expected := match backend with
     | "compile" => #[info.name]
     | "ooc" => #[info.name] ++ names
+    | "recursive" => (recursiveConfigs.map (·.1)).toArray
     | _ => names
   let code ← gate out expected
   if code == 0 || code == exitRejected then
@@ -576,7 +631,7 @@ def benchRunCmd : Cli.Cmd := `[Cli|
   FLAGS:
     backend      : String; "aiur | zisk | sp1 | ooc | compile"
     env          : String; "Benchmark env from the registry (default: InitStd)"
-    mode         : String; "prove | execute (default: the backend's defaultMode)"
+    mode         : String; "prove | execute | recursive (default: the backend's defaultMode)"
     out          : String; "Benchmark results JSON output path (default: bench.json)"
     repo         : String; "Checkout to benchmark: tools resolve from <repo>/.lake/build/bin first, then PATH (default: .)"
     csv          : String; "Vectors path (default: <repo>/Benchmarks/Vectors.csv)"

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -141,10 +141,10 @@ def backendSpecs : List BackendSpec := [
   -- multi-stark verifier on prove: execute it over each fresh proof, then
   -- prove that execution — the recursion cell. It runs under the
   -- recursion-tuned FRI parameters, so even its shared-name metrics
-  -- (prove-time, peak-rss) are not comparable to the prove cell's. At IxVM
-  -- scale the cell is expected to OOM today (>108 GB in the verifier
-  -- execute); the kill lands as a `status: oom` row that bmf drops, so the
-  -- testbed simply stays empty until recursion fits.
+  -- (prove-time, peak-rss) are not comparable to the prove cell's. An
+  -- IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling; the
+  -- kill lands as a `status: oom` row that bmf drops, which is why no CI
+  -- job schedules this testbed.
   { name := "aiur", defaultMode := "prove",
     testbeds := [("prove", "aiur-check-prove-x64-32x"),
                  ("execute", "aiur-check-execute-x64-32x"),
@@ -158,17 +158,18 @@ def backendSpecs : List BackendSpec := [
                                "recursive-proof-size", "recursive-verify-time",
                                "recursive-execute-time", "recursive-fft-cost",
                                "prove-time", "proof-size"])] },
-  -- The recursive-verifier toy (bench-recursive-verifier): fixed tiny
+  -- The aiur-recursive toy (bench-recursive-verifier): fixed tiny
   -- statements (`recursiveConfigs`), proving the in-circuit multi-stark
   -- verifier end-to-end. Env-independent: the cell ignores --env and never
-  -- needs an .ixe. Unlike the aiur recursive mode above, the floor config
-  -- completes on a 128 GB host, so this testbed gets real rows.
-  { name := "recursive", defaultMode := "prove",
-    testbeds := [("prove", "recursive-x64-32x")],
+  -- needs an .ixe. Unlike the aiur recursive mode above, the floor
+  -- config's outer prove fits a 128 GB host, so CI schedules this testbed.
+  { name := "aiur-recursive", defaultMode := "prove",
+    testbeds := [("prove", "aiur-recursive-x64-32x")],
     metrics := [("prove", ["recursive-prove-time", "recursive-peak-rss",
                            "recursive-proof-size", "recursive-verify-time",
                            "recursive-execute-time", "recursive-fft-cost",
-                           "prove-time", "proof-size"])] },
+                           "prove-time", "proof-size", "verify-time",
+                           "peak-rss"])] },
   { name := "zisk", defaultMode := "execute",
     testbeds := [("execute", "zisk-check-execute-x64-32x")],
     metrics := [("execute", ["execute-time", "throughput", "peak-rss",
@@ -472,7 +473,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
           { name := n, env, tier := "cheap", shardTarget := false, primary := false }
   let names := selected.map (·.name)
   match backend with
-  | "recursive" =>
+  | "aiur-recursive" =>
     IO.eprintln s!"[bench] cell {backend}-{mode}: {recursiveConfigs.length} config(s)"
   | _ =>
     IO.eprintln s!"[bench] cell {backend}-{env}-{mode}: {names.size} constant(s)"
@@ -525,7 +526,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
       runGuarded watchdog ceilingGb bt
         (#["--ixe", ixe, "--consts", name, "--json", out, "--texray"]
           ++ modeArgs)
-  | "recursive" =>
+  | "aiur-recursive" =>
     -- Fixed-config rows; no env, no .ixe. One process per config under the
     -- watchdog, self-reporting through the rows contract like every other
     -- per-row backend.
@@ -586,7 +587,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
   let expected := match backend with
     | "compile" => #[info.name]
     | "ooc" => #[info.name] ++ names
-    | "recursive" => (recursiveConfigs.map (·.1)).toArray
+    | "aiur-recursive" => (recursiveConfigs.map (·.1)).toArray
     | _ => names
   let code ← gate out expected
   if code == 0 || code == exitRejected then
@@ -629,7 +630,7 @@ def benchRunCmd : Cli.Cmd := `[Cli|
   "Run one benchmark cell (backend × env × mode), writing benchmark results JSON. Exits 0 on success (rows saved as the local baseline), 3 when the kernel rejected any constant, 1 when no rows were produced."
 
   FLAGS:
-    backend      : String; "aiur | zisk | sp1 | ooc | compile"
+    backend      : String; "aiur | zisk | sp1 | ooc | compile | aiur-recursive"
     env          : String; "Benchmark env from the registry (default: InitStd)"
     mode         : String; "prove | execute | recursive (default: the backend's defaultMode)"
     out          : String; "Benchmark results JSON output path (default: bench.json)"

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -116,7 +116,8 @@ def unitsFor (slug : String) : Option String :=
     ooc); unranked workloads (a future backend) sort last. -/
 def workloadOrder : List String :=
   ["ix-compile", "aiur-check-prove", "aiur-check-execute",
-   "aiur-check-recursive", "recursive", "zisk-check-execute", "ooc-check"]
+   "aiur-check-recursive", "aiur-recursive", "zisk-check-execute",
+   "ooc-check"]
 
 structure PlotSpec where
   testbed : String
@@ -139,7 +140,7 @@ def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
       let names : Array String := Id.run do
         if b.name == "compile" then
           return (BenchCmd.envSpecs.map (·.name)).toArray
-        if b.name == "recursive" then
+        if b.name == "aiur-recursive" then
           return (BenchCmd.recursiveConfigs.map (·.1)).toArray
         let mut ns : Array String := #[]
         for env in benched do

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -104,13 +104,19 @@ def unitsFor (slug : String) : Option String :=
    ("max-shard-cycles", "cycles"),
    ("shards", "shards"),
    ("fft-cost", "FFTs"),
+   ("recursive-execute-time", "seconds (s)"),
+   ("recursive-prove-time", "seconds (s)"),
+   ("recursive-verify-time", "seconds (s)"),
+   ("recursive-peak-rss", "bytes (B)"),
+   ("recursive-proof-size", "bytes (B)"),
+   ("recursive-fft-cost", "FFTs"),
    ("throughput", "constants / second")].lookup slug
 
 /-- Dashboard group order (compile first, then aiur prove/execute, zisk,
     ooc); unranked workloads (a future backend) sort last. -/
 def workloadOrder : List String :=
   ["ix-compile", "aiur-check-prove", "aiur-check-execute",
-   "zisk-check-execute", "ooc-check"]
+   "aiur-check-recursive", "recursive", "zisk-check-execute", "ooc-check"]
 
 structure PlotSpec where
   testbed : String
@@ -133,6 +139,8 @@ def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
       let names : Array String := Id.run do
         if b.name == "compile" then
           return (BenchCmd.envSpecs.map (·.name)).toArray
+        if b.name == "recursive" then
+          return (BenchCmd.recursiveConfigs.map (·.1)).toArray
         let mut ns : Array String := #[]
         for env in benched do
           if b.name == "ooc" then ns := ns.push env

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -32,9 +32,13 @@ namespace Ix.Cli.BenchReport
 /-! ## Metric formatting -/
 
 /-- Per-metric formatting kind. Metric names are the results-JSON keys the
-    tools emit (see the registry in Ix.Cli.BenchCmd). Unknown metrics fall through to a
-    generic decimal rendering. -/
+    tools emit (see the registry in Ix.Cli.BenchCmd). A `recursive-` metric
+    formats like its inner counterpart (`recursive-peak-rss` like
+    `peak-rss`, …). Unknown metrics fall through to a generic decimal
+    rendering. -/
 def metricKind (metric : String) : String :=
+  let metric := if metric.startsWith "recursive-"
+    then (metric.drop "recursive-".length).toString else metric
   if ["peak-rss", "file-size", "proof-size"].contains metric
   then "bytes"
   else if metric.startsWith "phase-" then "seconds"
@@ -48,11 +52,14 @@ def metricKind (metric : String) : String :=
 /-- Display label for a metric column. Keys stay the bencher measure slugs
     (renaming one would orphan its threshold/history); only the table
     rendering differs. `file-size` is the serialized `.ixe` env — bencher
-    plots it as "Environment Size"; `peak-rss` reads better as plain RAM. -/
+    plots it as "Environment Size"; `peak-rss` reads better as plain RAM,
+    in every slug that embeds it (`recursive-peak-rss` → …-peak-ram);
+    `throughput` carries its unit here because the cells print bare
+    magnitudes (matching `unitsFor`'s "constants / second" on bencher). -/
 def metricLabel (metric : String) : String :=
   if metric == "file-size" then "env-size"
-  else if metric == "peak-rss" then "peak-ram"
-  else metric
+  else if metric == "throughput" then "throughput (const/s)"
+  else metric.replace "peak-rss" "peak-ram"
 
 /-- Group a digit string by thousands: `"105492"` → `"105,492"`. -/
 private def commafy (s : String) : String := Id.run do
@@ -340,6 +347,7 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     rowNoun :=
       if backend == "compile" then "env"
       else if backend == "ooc" then "env/constant"
+      else if backend == "aiur-recursive" then "proof"
       else "constant"
   }
   match p.flag? "out" with
@@ -566,7 +574,10 @@ def runMatrixCmd (p : Cli.Parsed) : IO UInt32 := do
     let mut cells : Array Json := #[]
     for b in Ix.Cli.BenchCmd.backendSpecs do
       if b.disabled.isSome then continue
-      for env in benched do
+      -- The aiur-recursive backend is env-independent (fixed toy
+      -- statements, no `.ixe`): one cell, not one per env.
+      let envsFor := if b.name == "aiur-recursive" then benched.take 1 else benched
+      for env in envsFor do
         cells := cells.push <| Json.mkObj
           [("backend", Json.str b.name), ("env", Json.str env),
            ("mode", Json.str b.defaultMode)]
@@ -604,8 +615,8 @@ def parseError (msg : String) : IO UInt32 := do
     Grammar (an unknown command-line token, or an unknown/unbenched env in
     BENCH_ENVS, rejects the command — exit 2 and a `parse-error` output):
 
-      !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute]
-                 [KEY=VALUE …]
+      !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all)
+                 [execute] [KEY=VALUE …]
       BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd;
                                     compile-only requests may name any
                                     registry env, e.g. Lean or FLT)
@@ -739,7 +750,13 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
     else b.defaultMode
   let mut cells : Array Json := #[]
   for b in backends do
-    for e in envs do
+    -- The aiur-recursive backend is env-independent (fixed toy
+    -- statements, no `.ixe`): one cell no matter how many envs BENCH_ENVS
+    -- lists. The env kept is the first requested one, so the cell's `.ixe`
+    -- restore (an unconditional workflow step) still finds a compiled
+    -- artifact.
+    let cellEnvs := if b.name == "aiur-recursive" then envs.take 1 else envs
+    for e in cellEnvs do
       cells := cells.push <| Json.mkObj
         [("backend", Json.str b.name), ("env", Json.str e),
          ("mode", Json.str (modeFor b)),

--- a/Ix/MultiStark.lean
+++ b/Ix/MultiStark.lean
@@ -1,5 +1,7 @@
 module
 public import Ix.Aiur.Meta
+public import Ix.Aiur.Protocol
+public import Ix.Keccak
 public import Ix.IxVM.Core
 public import Ix.IxVM.ByteStream
 public import Ix.MultiStark.Goldilocks
@@ -83,6 +85,43 @@ def multiStark : Except Aiur.Global Aiur.Source.Toplevel := do
   let t ← t.merge pcs
   let t ← t.merge verifier
   t.merge entrypoints
+
+/-! ## Lean-side input assembly
+
+Callers of `verify_multi_stark_proof` (tests, benchmarks) must reproduce the
+verifier's wire formats byte-for-byte — the vk and claims are keccak-256
+digest-bound. These helpers are that recipe's single home. -/
+
+/-- The 8 little-endian bytes of `n` as a `u64`. -/
+def u64le (n : Nat) : Array UInt8 :=
+  (Array.range 8).map (fun i => UInt8.ofNat ((n >>> (8 * i)) % 256))
+
+/-- Serialize public claims to `read_claims`'s wire format (which is also what
+the prover's Fiat-Shamir transcript observes): a length-prefixed list of
+length-prefixed claims, every word a little-endian `u64`. -/
+def serializeClaims (claims : Array (Array Aiur.G)) : ByteArray := Id.run do
+  let mut out : Array UInt8 := u64le claims.size
+  for c in claims do
+    out := out ++ u64le c.size
+    for g in c do
+      out := out ++ u64le g.val.toNat
+  return ⟨out⟩
+
+/-- Assemble `verify_multi_stark_proof`'s inputs from the serialized proof, vk
+(`AiurSystem.vkBytes`), and claims (`serializeClaims`): the public input (vk
+digest ++ claims digest ++ the variable FRI parameters) and the IO buffer
+(channel 0 = proof advice, 1 = vk, 2 = claims, each under key `[0]`). -/
+def verifierInput (proofBytes vkBytes claimBytes : ByteArray)
+    (commitParams : Aiur.CommitmentParameters) (friParams : Aiur.FriParameters) :
+    Array Aiur.G × Aiur.IOBuffer :=
+  let gs := fun (b : ByteArray) => b.data.map Aiur.G.ofUInt8
+  let digestGs := fun (b : ByteArray) => gs (Keccak.hash b)
+  let pubInput := digestGs vkBytes ++ digestGs claimBytes ++
+    #[.ofNat friParams.numQueries, .ofNat friParams.commitProofOfWorkBits,
+      .ofNat commitParams.logBlowup]
+  let io := (((default : Aiur.IOBuffer).extend 0 #[.ofNat 0] (gs proofBytes)).extend
+    1 #[.ofNat 0] (gs vkBytes)).extend 2 #[.ofNat 0] (gs claimBytes)
+  (pubInput, io)
 
 /-- The verifier toplevel PLUS its self-test entrypoints
 (`Ix/MultiStark/Tests.lean`). Kept separate from `multiStark` because every

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -77,6 +77,15 @@ ix bench fetch-main --sha $(git merge-base origin/main HEAD) \
   --backend aiur --mode prove --consts Nat.add_comm --out main.json
 ix bench compare --backend aiur --env InitStd --mode prove \
   --main main.json --pr .lake/benches/aiur-InitStd-prove.json
+
+# The recursion cell — fixed toy statements, no env or .ixe needed:
+ix bench run --backend aiur-recursive
+
+# Recursion layered on a real constant (recursion-tuned FRI parameters;
+# an IxVM-scale verifier execute exceeds 100 GB, so cap the watchdog and
+# expect the honest oom row on anything big):
+ix bench run --backend aiur --env InitStd --mode recursive \
+  --consts Nat.add_comm --ixe InitStd.ixe --ceiling-gb 50
 ```
 
 `--repo <dir>` points the run at another checkout: the *measured* tools
@@ -87,15 +96,19 @@ a PR tree and compare them — exactly what the PR workflow does.
 
 | backend | what it measures | tool |
 |---|---|---|
-| `aiur`    | Aiur STARK check, one bench-main cell per mode on its own testbed: prove — the real-workload simulation (prove-time, proof-size, verify-time, peak-rss, plus fft-cost / execute-time from its own Phase 1) — and execute, the fast Phase-1-only signal (fft-cost, execute-time, throughput, peak-rss). `!benchmark aiur [execute]` picks the mode | `bench-typecheck` |
+| `aiur`    | Aiur STARK check, one bench-main cell per mode on its own testbed: prove — the real-workload simulation (prove-time, proof-size, verify-time, peak-rss, plus fft-cost / execute-time from its own Phase 1) — and execute, the fast Phase-1-only signal (fft-cost, execute-time, throughput, peak-rss). `!benchmark aiur [execute]` picks the mode. A third mode, recursive (`bench-typecheck --recursive`), additionally executes AND proves the in-circuit multi-stark verifier over each fresh proof — the whole system runs under recursion-tuned FRI parameters, so its rows land on their own testbed (`aiur-check-recursive`) and are not comparable to the prove cell's. Local-only (`ix bench run --backend aiur --mode recursive`): an IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling, so no CI job or comment token schedules it | `bench-typecheck` |
+| `aiur-recursive` | the aiur-recursive toy: prove a fixed tiny statement per config (`square-q1-b1`, the per-statement floor; `factorial-q3-b2`, the recursion-tuned default), run the in-circuit multi-stark verifier over the proof (recursive-execute-time, recursive-fft-cost — the recursion-cost proxy), then prove that execution end-to-end (recursive-prove-time, recursive-peak-rss, recursive-proof-size, recursive-verify-time). Env-independent: fixed configs instead of `Vectors.csv` constants, no `.ixe`, always exactly one cell regardless of `BENCH_ENVS` | `bench-recursive-verifier` |
 | `zisk`    | ZisK VM execute: cycles, execute-time, throughput, peak-rss, constants (pre-shard closure count, same universe as aiur's), shards (1 when unsharded) | `zisk-host` |
 | `sp1`     | SP1 VM execute (currently disabled in the registry) | `sp1-host` |
 | `ooc`     | out-of-circuit Rust kernel: whole-env row + one full-closure row per primary (`check-time` wraps only the check — the env loads once, outside every row's timed window) | `ix check-rs --json` |
 | `compile` | `ix compile <env>.lean → <env>.ixe`: compile-time, file-size, constants, throughput | `ix compile --json` |
 
-All tools take the same `--consts`/`--consts-file` grammar and emit the same
-rows. The ooc and zkVM cells share per-constant **full-closure** scope, so
-their delta isolates in-circuit vs out-of-circuit overhead.
+All tools emit the same rows, and all the constant-driven ones take the same
+`--consts`/`--consts-file` grammar (`bench-recursive-verifier` instead takes
+its config as flags — `--trivial`, `--queries`, `--blowup` — with the row
+name supplied via `--json-name`). The ooc and zkVM cells share per-constant
+**full-closure** scope, so their delta isolates in-circuit vs out-of-circuit
+overhead.
 
 With `--texray`, tools write per-phase span timings (`aiur/prove_ixvm`,
 `aiur/witness`, `stark/*`, `zisk/execute`, …) to `<json>.spans`. The
@@ -153,7 +166,8 @@ breakdowns. bench-main's compile job pre-cuts these artifacts
 ## `!benchmark` grammar
 
 ```
-!benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all) [execute] [KEY=VALUE …]
+!benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all) [execute]
+           [KEY=VALUE …]
 BENCH_ENVS=InitStd,Mathlib     # default InitStd (case-insensitive); a
                                # compile-only request may name any registry
                                # env (Lean, FLT compile fine, just unbenched)
@@ -183,7 +197,9 @@ SHA) → `plan` (`ix bench ci matrix` → job matrices) + `compile` (per env:
 `ix bench run --backend compile`, cache the `.ixe` + pre-cut zisk shards) →
 `aiur` (execute + prove cells) / `zkvm-execute` / `ooc-check` (each: restore caches, one
 `ix bench run … --ixe`, `ix bench bmf`, upload via
-`.github/actions/bencher-track`). A kernel rejection exits 3 and reddens the
+`.github/actions/bencher-track`) / `aiur-recursive` (same shape, but needing only
+the staged binaries — no `.ixe`, so it waits on `build` alone). A kernel
+rejection exits 3 and reddens the
 run step while the clean rows still upload.
 
 **Dashboard plots**: `ix bench plots` pins one plot per (testbed, measure)
@@ -218,3 +234,10 @@ write token, running no PR code).
   re-enable it there and it returns to the matrices and the parser.
 - **Non-`main` base branches** — `fetch-main` queries `branch=main`; a PR
   against another base always pays the local base run.
+- **aiur recursive in CI** — `bench-typecheck --recursive` layers the
+  in-circuit multi-stark verifier on real constants, but an IxVM-scale
+  verifier execute needs >108 GB, beyond the CI ceiling, so the
+  `aiur-check-recursive` testbed is registered but unscheduled: no
+  bench-main job and no `!benchmark` token (the `aiur-recursive` token is
+  the toy backend). Run it locally with
+  `ix bench run --backend aiur --mode recursive`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -122,6 +122,10 @@ lean_exe «bench-typecheck» where
   root := `Benchmarks.Typecheck
   supportInterpreter := true
 
+lean_exe «bench-recursive-verifier» where
+  root := `Benchmarks.RecursiveVerifier
+  supportInterpreter := true
+
 end Benchmarks
 
 section IxApplications


### PR DESCRIPTION
Two new benchmarks that measure recursion end-to-end: prove a statement, run the in-circuit multi-stark verifier over that proof, then prove and verify THAT execution. One of them runs in CI on every push to main and on demand from a PR comment.

## The two benchmarks

- **`bench-recursive-verifier`** (backend `aiur-recursive`) proves a couple of fixed tiny statements and recurses over each proof. `square-q1-b1` is the floor: the cheapest provable statement at the cheapest FRI settings, and its outer prove completes on a 128 GB host (~80 GB under Keccak). `factorial-q3-b2` is the recursion-tuned default (~8.4e10 fft, ~200 GB-class — expected to OOM, recorded honestly as a `status: oom` row that never reaches bencher). It needs no compiled environment, writes its results row incrementally (`--json`/`--json-name`/`--texray`), and flushes the verifier-execution metrics before the outer prove starts, so a run killed mid-prove still keeps `recursive-execute-time` and `recursive-fft-cost`.
- **`bench-typecheck --recursive`** layers the same recursion step on the real IxVM typecheck benchmark: after proving each constant, it executes and then proves the verifier over that fresh proof. The whole run uses recursion-tuned FRI parameters (3 queries, blowup 2), so its numbers are not comparable to the normal prove benchmark. Executing the verifier over an IxVM-scale proof needs >108 GB — more than the CI machines have — so this one is local-only: `ix bench run --backend aiur --mode recursive`. Its bencher testbed (`aiur-check-recursive-x64-32x`) exists but nothing uploads to it.

Both tools assemble the verifier's input (proof, vk, claims, keccak digests) the same way, via the shared helpers in `Ix/MultiStark.lean` (`serializeClaims`, `verifierInput`) — one home for the wire format.

## CI

- **`!benchmark aiur-recursive`** (also part of `all`) runs the toy benchmark on a PR and posts the usual main-vs-PR table. It ignores `BENCH_ENVS` — the benchmark doesn't depend on an environment, so the parser schedules it exactly once. The bare word `recursive` is rejected with a hint, kept free for a future aiur mode token.
- **bench-main.yml** gets an `aiur-recursive` job that uploads the trend to bencher. Thresholds: 25% on `recursive-fft-cost` (the parallel prover emits byte-different valid proofs, so the verifier authenticates different Merkle paths and its FFT count drifts ~±15% run to run; pin with `RAYON_NUM_THREADS=1`), 10% on times and RAM, 5% on proof sizes.
- **The new binary is built and cached together with `ix` and `bench-typecheck`** in both workflows — including the base side of a PR comparison, so the "main" column always comes from the base commit's own binary rather than silently reusing the PR's (which would make every delta look like ~0).
- **bencher names**: testbed `aiur-recursive-x64-32x`, workload/reset-token `aiur-recursive`, benchmark rows `square-q1-b1` and `factorial-q3-b2`. Every measure the tool emits is registered — the recursion measures plus the inner statement's `prove-time`, `proof-size`, `verify-time`, `peak-rss` — so each gets a table column, a threshold, a dashboard plot, and its canonical units.
- **Table polish**: the `recursive-*` measures print human-readably like their inner counterparts (`80.00 GiB`, `40m 12.5s`), everything RAM displays as `peak-ram`, `throughput` names its unit once in the column header (`const/s`), and the summary line counts this benchmark's rows as proofs.

## Measured

On this (Keccak) verifier the floor is ~3.2e10 fft for a 12 KB inner proof — the cost is hash-dominated (the sponge's bit-level plumbing is ~84% of it), which is what the Blake3 migration attacks.

## After merge

The first bench-main run creates the bencher testbed; run the plots sync afterward (`bencher-plots.yml` dispatch, or `ix bench plots` with `BENCHER_API_KEY`) to pin the new plots and units.
