### PR TITLE
Ixon: compact index-keyed .ixe

### DIFF
--- a/Ix/Cli/CheckCmd.lean
+++ b/Ix/Cli/CheckCmd.lean
@@ -293,7 +293,9 @@ def forEachClaim
         let w ← mkWitness addr ixonEnv
         runOne claim none (.leanW w) label
       else
-        let envBytes := Ixon.serEnv ixonEnv
+        let envBytes ← match Ixon.serEnv ixonEnv with
+          | .error e => throw (IO.userError s!"serEnv failed for {label}: {e}")
+          | .ok b => pure b
         let envHandle ← match Aiur.EnvHandle.fromBytes envBytes with
           | .error e => throw (IO.userError s!"EnvHandle.fromBytes failed for {label}: {e}")
           | .ok h => pure h

--- a/Ix/CompileM.lean
+++ b/Ix/CompileM.lean
@@ -1622,10 +1622,16 @@ def compileEnv (env : Ix.Environment) (blocks : Ix.CondensedBlocks) (dbg : Bool 
   -- Merge name string blobs into the main blobs map
   let allBlobs := nameBlobs.fold (fun m k v => m.insert k v) compileEnv.blobs
 
-  -- Resolve per-name hints to each name's registered constant address
-  -- (the projection address for mutual-block members — exactly the
-  -- address the kernel looks hints up under). Alias collisions merge
-  -- order-independently, matching Rust `CompileState::finalize_hints`.
+  -- Resolve per-name hints into both channels (matching Rust
+  -- `CompileState::finalize_hints`): the EXACT value onto each Named
+  -- entry (decompile fidelity — alpha-identical definitions under
+  -- different names keep their own hints), and the per-address
+  -- `anonHints` advisory map keyed by each name's registered constant
+  -- address (the projection address for mutual-block members — exactly
+  -- the address the kernel looks hints up under), where alias
+  -- collisions merge order-independently.
+  let namedWithHints := compileEnv.nameToNamed.fold (init := {})
+    fun m name named => m.insert name { named with hints := defHints.get? name }
   let anonHints := compileEnv.nameToNamed.fold (init := {}) fun m name named =>
     match defHints.get? name with
     | some h => m.alter named.addr fun
@@ -1636,7 +1642,7 @@ def compileEnv (env : Ix.Environment) (blocks : Ix.CondensedBlocks) (dbg : Bool 
   let ixonEnv : Ixon.Env := {
     consts := compileEnv.constants.fold (init := {})
       fun m a c => m.insert a (Ixon.LazyConstant.ofConstant c)
-    named := compileEnv.nameToNamed
+    named := namedWithHints
     blobs := allBlobs
     names := namesMap
     comms := {}
@@ -1932,8 +1938,11 @@ def compileEnvParallel (env : Ix.Environment) (blocks : Ix.CondensedBlocks)
   if dbg then
     IO.println s!"  [Lean Compile] Blobs: {blockBlobCount} from blocks, {nameBlobCount} from names, {overlapCount} overlap, {finalBlobCount} final"
 
-  -- Resolve per-name hints to registered constant addresses (see the
-  -- serial driver / Rust `CompileState::finalize_hints`).
+  -- Resolve per-name hints into both channels (see the serial driver /
+  -- Rust `CompileState::finalize_hints`): exact per-Named + merged
+  -- per-address.
+  let namedWithHints := nameToNamed.fold (init := {})
+    fun m name named => m.insert name { named with hints := defHints.get? name }
   let anonHints := nameToNamed.fold (init := {}) fun m name named =>
     match defHints.get? name with
     | some h => m.alter named.addr fun
@@ -1944,7 +1953,7 @@ def compileEnvParallel (env : Ix.Environment) (blocks : Ix.CondensedBlocks)
   let ixonEnv : Ixon.Env := {
     consts := constants.fold (init := {})
       fun m a c => m.insert a (Ixon.LazyConstant.ofConstant c)
-    named := nameToNamed
+    named := namedWithHints
     blobs := allBlobs
     names := namesMap
     comms := {}

--- a/Ix/Ixon.lean
+++ b/Ix/Ixon.lean
@@ -540,6 +540,13 @@ structure Named where
   addr : Address
   constMeta : ConstantMeta := .empty
   original : Option (Address × ConstantMeta) := none
+  /-- EXACT per-name reducibility hints (`none` for constants that carry
+      none, e.g. theorems). Alpha-identical definitions under different
+      names share one constant address, so the per-address
+      `Env.anonHints` channel only holds a min-merged advisory winner —
+      this field is the faithful per-definition value, serialized in
+      each §5 entry's skippable header. Mirrors Rust `Named.hints`. -/
+  hints : Option Lean.ReducibilityHints := none
   deriving Inhabited, BEq, Repr
 
 /-- A cryptographic commitment -/
@@ -1168,18 +1175,43 @@ def getBinderInfo : GetM Lean.BinderInfo := do
   | 3 => pure .instImplicit
   | x => throw s!"invalid BinderInfo {x}"
 
-/-- Serialize ReducibilityHints. -/
-def putReducibilityHints : Lean.ReducibilityHints → PutM Unit
-  | .opaque => putU8 0
-  | .abbrev => putU8 1
-  | .regular n => do putU8 2; putTag0 ⟨n.toUInt64⟩
+/-- Serialize ReducibilityHints fused into a single Tag0 value:
+    0 = opaque, 1 = abbrev, h + 2 = regular h. The §3 wire form —
+    mirrors Rust `serialize.rs::fuse_hint`. -/
+def putFusedHint : Lean.ReducibilityHints → PutM Unit
+  | .opaque => putTag0 ⟨0⟩
+  | .abbrev => putTag0 ⟨1⟩
+  | .regular n => putTag0 ⟨n.toUInt64 + 2⟩
 
-def getReducibilityHints : GetM Lean.ReducibilityHints := do
-  match ← getU8 with
+def getFusedHint : GetM Lean.ReducibilityHints := do
+  match (← getTag0).size with
   | 0 => pure .opaque
   | 1 => pure .abbrev
-  | 2 => pure (.regular (← getTag0).size.toUInt32)
-  | x => throw s!"invalid ReducibilityHints {x}"
+  | v =>
+    let h := v - 2
+    if h > (0xFFFFFFFF : UInt64) then
+      throw s!"fused hint: Regular height {h} exceeds u32::MAX"
+    else pure (.regular h.toUInt32)
+
+/-- `putFusedHint` lifted over `Option`: 0 = none, otherwise the fused
+    value + 1 (some opaque = 1, some abbrev = 2, some (regular h) =
+    h + 3). The §5 per-name hint form; mirrors Rust `fuse_opt_hint`. -/
+def putFusedOptHint : Option Lean.ReducibilityHints → PutM Unit
+  | none => putTag0 ⟨0⟩
+  | some .opaque => putTag0 ⟨1⟩
+  | some .abbrev => putTag0 ⟨2⟩
+  | some (.regular n) => putTag0 ⟨n.toUInt64 + 3⟩
+
+def getFusedOptHint : GetM (Option Lean.ReducibilityHints) := do
+  match (← getTag0).size with
+  | 0 => pure none
+  | 1 => pure (some .opaque)
+  | 2 => pure (some .abbrev)
+  | v =>
+    let h := v - 3
+    if h > (0xFFFFFFFF : UInt64) then
+      throw s!"fused hint: Regular height {h} exceeds u32::MAX"
+    else pure (some (.regular h.toUInt32))
 
 /-- Order-independent merge for hint registration: alpha-equivalent
     definitions share one constant address but may carry different
@@ -1632,6 +1664,8 @@ structure RawNamed where
   name : Ix.Name
   addr : Address
   constMeta : ConstantMeta
+  /-- Per-name reducibility hints (mirrors `Named.hints`). -/
+  hints : Option Lean.ReducibilityHints := none
   deriving Repr, Inhabited, BEq
 
 /-- Raw FFI structure for a blob: Address → ByteArray.
@@ -1720,10 +1754,10 @@ def toEnv (raw : RawEnv) : Env := Id.run do
   -- and ensure all parent components are present for topological consistency.
   for ⟨_, name⟩ in raw.names do
     env := { env with names := addNameComponents env.names name }
-  for ⟨name, addr, constMeta⟩ in raw.named do
+  for ⟨name, addr, constMeta, hints⟩ in raw.named do
     -- Also add name components for indexed serialization
     env := { env with names := addNameComponents env.names name }
-    env := env.registerName name { addr, constMeta }
+    env := env.registerName name { addr, constMeta, hints }
   for ⟨addr, bytes⟩ in raw.blobs do
     env := { env with blobs := env.blobs.insert addr bytes }
   for ⟨addr, comm⟩ in raw.comms do
@@ -1746,7 +1780,8 @@ namespace Env
 def toRawEnv (env : Env) : RawEnv := {
   consts := env.consts.toArray.map fun (addr, lc) =>
     { addr, const := lc.get?.getD default }
-  named := env.named.toArray.map fun (name, n) => { name, addr := n.addr, constMeta := n.constMeta }
+  named := env.named.toArray.map fun (name, n) =>
+    { name, addr := n.addr, constMeta := n.constMeta, hints := n.hints }
   blobs := env.blobs.toArray.map fun (addr, bytes) => { addr, bytes }
   comms := env.comms.toArray.map fun (addr, comm) => { addr, comm }
   names := env.names.toArray.map fun (addr, name) => { addr, name }
@@ -1832,8 +1867,13 @@ partial def topologicalSortNames (names : Std.HashMap Address Ix.Name) : Array (
     visit name visited result
   result
 
-/-- Serialize an Env to bytes. -/
-def putEnv (env : Env) : PutM Unit := do
+/-- Serialize an Env to bytes.
+
+    Runs in `ExceptT String PutM`: the §3/§5 sections key their entries
+    by §2/§4 indices, so hints keyed outside `consts` or named entries
+    referencing unstored constants/names are unrepresentable and must
+    fail at write time (mirrors Rust `Env::put`). -/
+def putEnv (env : Env) : ExceptT String PutM Unit := do
   -- Header: Tag4 with flag=0xE, size=0 (Env variant)
   putTag4 ⟨FLAG, 0⟩
 
@@ -1884,16 +1924,30 @@ def putEnv (env : Env) : PutM Unit := do
     putTag0 ⟨bytes.size.toUInt64⟩
     putBytes bytes
 
+  -- Rank of each constant in §2's ascending-address order — §3 hint
+  -- entries and §5 named entries key their constants through it.
+  let constIdx : Std.HashMap Address UInt64 := consts.zipIdx.foldl
+    (fun acc ((addr, _), i) => acc.insert addr i.toUInt64) {}
+
   -- Section 3: anon_hints — the canonical hint channel for the
   -- anon/lazy readers, placed before the metadata sections so they can
   -- stop right after it. Serialized straight from `env.anonHints`, the
-  -- single home for hints. Matches Rust `Env::put`.
+  -- single home for hints, as delta-coded §2 ranks + fused hints (the
+  -- address sort is load-bearing: it makes the ranks strictly
+  -- ascending). Matches Rust `Env::put`.
   let hintPairs := env.anonHints.toList.toArray.qsort
     fun a b => (compare a.1 b.1).isLT
   putTag0 ⟨hintPairs.size.toUInt64⟩
+  let mut prevRank : UInt64 := 0 -- rank + 1 of the previous entry
   for (addr, hints) in hintPairs do
-    Serialize.put addr
-    putReducibilityHints hints
+    match constIdx.get? addr with
+    | none => throw s!"putEnv: anon_hints key {reprStr (toString addr)} not \
+                       present in consts — hints must be keyed by stored \
+                       constant addresses"
+    | some rank =>
+      putTag0 ⟨rank + 1 - prevRank⟩
+      putFusedHint hints
+      prevRank := rank + 1
 
   -- Section 4: Names (Address -> Name component)
   -- Topologically sorted so parents come before children, with ties broken by address
@@ -1906,21 +1960,38 @@ def putEnv (env : Env) : PutM Unit := do
     Serialize.put addr
     putNameComponent name
 
-  -- Section 5: Named (name Address -> Named with metadata)
+  -- Section 5: Named (name §4-index -> Named with metadata; the
+  -- entry's constant is a §2 rank). Entry order stays ascending name
+  -- hash. Each entry carries its EXACT per-name hint in the header,
+  -- then a length-prefixed metadata blob so hint scanners can skip the
+  -- bodies. `original` keeps a raw address: it can reference an
+  -- assumed constant that is NOT stored in §2 (prune cut bundles).
   let named := env.named.toList.toArray.qsort fun a b => (compare a.1 b.1).isLT
   putTag0 ⟨named.size.toUInt64⟩
   for (name, namedEntry) in named do
-    -- Use the name's stored hash, which matches how it was stored in env.names
-    Serialize.put name.getHash
-    Serialize.put namedEntry.addr
-    putConstantMetaIndexed namedEntry.constMeta nameIdx
-    -- Serialize original as Option: 0 = None, 1 = Some(addr, meta)
-    match namedEntry.original with
-    | none => putU8 0
-    | some (origAddr, origMeta) =>
-      putU8 1
-      Serialize.put origAddr
-      putConstantMetaIndexed origMeta nameIdx
+    -- The name's stored hash is bytewise its §4 component address.
+    match nameIdx.get? name.getHash with
+    | none => throw s!"putEnv: named key {reprStr (toString name.getHash)} \
+                       not present in the name table"
+    | some i => putTag0 ⟨i⟩
+    match constIdx.get? namedEntry.addr with
+    | none => throw s!"putEnv: named entry constant \
+                       {reprStr (toString namedEntry.addr)} not present in \
+                       consts — named entries must reference stored constants"
+    | some rank => putTag0 ⟨rank⟩
+    putFusedOptHint namedEntry.hints
+    -- Metadata blob: ConstantMeta + original as Option (0 = none,
+    -- 1 = some(addr, meta)), length-prefixed.
+    let blob := runPut do
+      putConstantMetaIndexed namedEntry.constMeta nameIdx
+      match namedEntry.original with
+      | none => putU8 0
+      | some (origAddr, origMeta) =>
+        putU8 1
+        Serialize.put origAddr
+        putConstantMetaIndexed origMeta nameIdx
+    putTag0 ⟨blob.size.toUInt64⟩
+    putBytes blob
 
   -- Section 6: Comms (Address -> Comm)
   let comms := env.comms.toList.toArray.qsort fun a b => (compare a.1 b.1).isLT
@@ -1983,14 +2054,21 @@ def getEnv : GetM Env := do
     env := { env with blobs := env.blobs.insert addr bytes }
 
   -- Section 2: Consts (length-prefixed; see putEnv for rationale).
-  -- Per-entry integrity: bytes must hash to the stored address.
+  -- Per-entry integrity: bytes must hash to the stored address. The
+  -- file order (strictly ascending addresses — enforced, since §3/§5
+  -- indices resolve against it) is retained as `constOrder`.
   let numConsts := (← getTag0).size
+  let mut constOrder : Array Address := #[]
   for _ in [:numConsts.toNat] do
     let addr ← Serialize.get
     let len := (← getTag0).size
     let bytes ← getBytes len.toNat
     if Address.blake3 bytes != addr then
       throw s!"Env.get: const bytes hash mismatch for {reprStr (toString addr)}"
+    if let some prev := constOrder.back? then
+      if !(compare prev addr).isLT then
+        throw "Env.get: §2 constants not in strictly ascending address order"
+    constOrder := constOrder.push addr
     match deConstant bytes with
     | .ok constant => env := env.storeConst addr constant
     | .error e =>
@@ -2001,12 +2079,27 @@ def getEnv : GetM Env := do
     if !env.consts.contains m then
       throw s!"Env.get: main {reprStr (toString m)} not present in consts"
 
-  -- Section 3: anon_hints
+  -- Section 3: anon_hints — delta-coded §2 ranks + fused hints.
   let numHints := (← getTag0).size
+  if numHints.toNat > constOrder.size then
+    throw s!"Env.get: hint count {numHints} exceeds const count \
+             {constOrder.size} — possibly a pre-compact-keys .ixe; \
+             recompile it"
+  let mut cursor : Nat := 0
   for _ in [:numHints.toNat] do
-    let addr : Address ← Serialize.get
-    let hints ← getReducibilityHints
+    let delta := (← getTag0).size
+    if delta == 0 then
+      throw "Env.get: zero hint index delta (§3 must be strictly \
+             ascending) — possibly a pre-compact-keys .ixe; recompile it"
+    let idx := cursor + delta.toNat - 1
+    let addr ← match constOrder[idx]? with
+      | some a => pure a
+      | none =>
+        throw s!"Env.get: hint index {idx} out of range ({constOrder.size} \
+                 consts) — possibly a pre-compact-keys .ixe; recompile it"
+    let hints ← getFusedHint
     env := { env with anonHints := env.anonHints.insert addr hints }
+    cursor := idx + 1
 
   -- Section 4: Names (build lookup table AND reverse index)
   let numNames := (← getTag0).size
@@ -2021,11 +2114,33 @@ def getEnv : GetM Env := do
     namesLookup := namesLookup.insert addr name
     env := { env with names := env.names.insert addr name }
 
-  -- Section 5: Named (name Address -> Named with metadata)
+  -- Section 5: Named (name §4-index -> Named with metadata; the
+  -- entry's constant is a §2 rank; the per-name hint sits in the
+  -- header before the length-prefixed metadata blob; `original` stays
+  -- a raw address)
   let numNamed := (← getTag0).size
   for _ in [:numNamed.toNat] do
-    let nameAddr ← Serialize.get
-    let constAddr : Address ← Serialize.get
+    let nameIdx := (← getTag0).size.toNat
+    let nameAddr ← match nameRev[nameIdx]? with
+      | some a => pure (a : Address)
+      | none =>
+        throw s!"Env.get: §5 name index {nameIdx} out of range \
+                 ({nameRev.size} names) — possibly a pre-compact-keys .ixe; \
+                 recompile it"
+    let constRank := (← getTag0).size.toNat
+    let constAddr ← match constOrder[constRank]? with
+      | some a => pure a
+      | none =>
+        throw s!"Env.get: §5 constant index {constRank} out of range \
+                 ({constOrder.size} consts) — possibly a pre-compact-keys \
+                 .ixe; recompile it"
+    let hints ← getFusedOptHint
+    let metaLen := (← getTag0).size.toNat
+    let stBefore ← get
+    if stBefore.bytes.size - stBefore.idx < metaLen then
+      throw s!"Env.get: §5 metadata blob needs {metaLen} bytes, have \
+               {stBefore.bytes.size - stBefore.idx} — possibly a \
+               pre-compact-keys .ixe; recompile it"
     let constMeta ← getConstantMetaIndexed nameRev
     -- Deserialize original as Option: 0 = None, 1 = Some(addr, meta)
     let origTag ← getU8
@@ -2036,9 +2151,14 @@ def getEnv : GetM Env := do
       let origMeta ← getConstantMetaIndexed nameRev
       pure (some (origAddr, origMeta))
     | x => throw s!"getEnv: Named.original: invalid tag {x}"
+    -- The header's length must frame exactly the parsed bytes.
+    let stAfter ← get
+    if stAfter.idx - stBefore.idx != metaLen then
+      throw s!"Env.get: §5 metadata blob length mismatch (header says \
+               {metaLen}, parsed {stAfter.idx - stBefore.idx})"
     match namesLookup.get? nameAddr with
     | some name =>
-      let namedEntry : Named := { addr := constAddr, constMeta, original }
+      let namedEntry : Named := { addr := constAddr, constMeta, original, hints }
       env := { env with
         named := env.named.insert name namedEntry
         addrToName := env.addrToName.insert constAddr name }
@@ -2052,12 +2172,11 @@ def getEnv : GetM Env := do
     let comm ← getComm
     env := { env with comms := env.comms.insert addr comm }
 
-  -- Verify the stored merkle root against the recomputed value. Empty
+  -- Verify the stored merkle root against the recomputed value —
+  -- `constOrder` is the §2 key set (ascending, enforced above). Empty
   -- const set → expected = zeroAddress.
-  let constAddrs : Array Address :=
-    (env.consts.toList.toArray.map (·.1))
   let computedRoot :=
-    (Ix.Merkle.merkleRootCanonical constAddrs).getD Ix.Merkle.zeroAddress
+    (Ix.Merkle.merkleRootCanonical constOrder).getD Ix.Merkle.zeroAddress
   if computedRoot != storedRoot then
     throw "Env.get: merkle root mismatch"
 
@@ -2072,8 +2191,14 @@ def getEnv : GetM Env := do
 
 end Env
 
-/-- Serialize an Env to bytes. -/
-def serEnv (env : Env) : ByteArray := runPut (Env.putEnv env)
+/-- Serialize an Env to bytes. Fails when the env is not
+    self-contained: §3 hints and §5 named entries are index-keyed on
+    the wire, so keys outside the stored consts/names are
+    unrepresentable (see `Env.putEnv`). -/
+def serEnv (env : Env) : Except String ByteArray :=
+  match (Env.putEnv env).run.run ByteArray.empty with
+  | (.ok _, bytes) => .ok bytes
+  | (.error e, _) => .error e
 
 /-- Deserialize an Env from bytes (full metadata, pure Lean). -/
 def deEnv (bytes : ByteArray) : Except String Env := runGet Env.getEnv bytes
@@ -2098,14 +2223,24 @@ def envSectionSizes (env : Env) : Nat × Nat × Nat × Nat × Nat × Nat := Id.r
       Serialize.put addr
       putBytes lc.rawBytes
 
-  -- anon_hints section (mirrors putEnv's derive-from-named rule)
+  -- anon_hints section: delta-coded §2 ranks + fused hints. The sort
+  -- is load-bearing (delta widths depend on it). Sizes assume a
+  -- well-formed env — an out-of-consts key falls back to rank 0 here
+  -- (diagnostics only; `serEnv` is where that is a hard error).
+  let sortedConstAddrs := (env.consts.toList.toArray.map (·.1)).qsort
+    fun a b => (compare a b).isLT
+  let constIdx : Std.HashMap Address UInt64 := sortedConstAddrs.zipIdx.foldl
+    (fun acc (addr, i) => acc.insert addr i.toUInt64) {}
   let hintsBytes := runPut do
     let hintPairs := env.anonHints.toList.toArray.qsort
       fun a b => (compare a.1 b.1).isLT
     putTag0 ⟨hintPairs.size.toUInt64⟩
+    let mut prevRank : UInt64 := 0
     for (addr, hints) in hintPairs do
-      Serialize.put addr
-      putReducibilityHints hints
+      let rank := constIdx.get? addr |>.getD 0
+      putTag0 ⟨rank + 1 - prevRank⟩
+      putFusedHint hints
+      prevRank := rank + 1
 
   -- Names section
   let namesBytes := runPut do
@@ -2115,7 +2250,10 @@ def envSectionSizes (env : Env) : Nat × Nat × Nat × Nat × Nat × Nat := Id.r
       Serialize.put addr
       Env.putNameComponent name
 
-  -- Named section
+  -- Named section (name §4-index + const §2 rank + fused hint +
+  -- length-prefixed metadata blob; absolute indices, so per-entry
+  -- sizes are iteration-order independent — never delta-code here).
+  -- Missing keys fall back to index 0 (diagnostics only).
   let namedBytes := runPut do
     let sortedNames := Env.topologicalSortNames env.names
     let nameIdx : NameIndex := sortedNames.zipIdx.foldl
@@ -2123,15 +2261,19 @@ def envSectionSizes (env : Env) : Nat × Nat × Nat × Nat × Nat × Nat := Id.r
     let named := env.named.toList.toArray.qsort fun a b => (compare a.1 b.1).isLT
     putTag0 ⟨named.size.toUInt64⟩
     for (name, namedEntry) in named do
-      Serialize.put name.getHash
-      Serialize.put namedEntry.addr
-      putConstantMetaIndexed namedEntry.constMeta nameIdx
-      match namedEntry.original with
-      | none => putU8 0
-      | some (origAddr, origMeta) =>
-        putU8 1
-        Serialize.put origAddr
-        putConstantMetaIndexed origMeta nameIdx
+      putTag0 ⟨nameIdx.get? name.getHash |>.getD 0⟩
+      putTag0 ⟨constIdx.get? namedEntry.addr |>.getD 0⟩
+      putFusedOptHint namedEntry.hints
+      let blob := runPut do
+        putConstantMetaIndexed namedEntry.constMeta nameIdx
+        match namedEntry.original with
+        | none => putU8 0
+        | some (origAddr, origMeta) =>
+          putU8 1
+          Serialize.put origAddr
+          putConstantMetaIndexed origMeta nameIdx
+      putTag0 ⟨blob.size.toUInt64⟩
+      putBytes blob
 
   -- Comms section
   let commsBytes := runPut do
@@ -2184,6 +2326,8 @@ structure RawConstSlice where
 structure RawNamedLite where
   name : Ix.Name
   addr : Address
+  /-- Per-name reducibility hints from the §5 entry header. -/
+  hints : Option Lean.ReducibilityHints := none
   deriving Inhabited
 
 /-- Metadata-light env returned by `rs_de_env_lazy`. Field order
@@ -2214,7 +2358,8 @@ def RawEnvLazy.toEnv (raw : RawEnvLazy) (buf : ByteArray) : Env := Id.run do
       consts := env.consts.insert addr
         (LazyConstant.ofSlice buf offset.toNat len.toNat) }
   for n in raw.named do
-    env := env.registerName n.name { addr := n.addr, constMeta := .empty }
+    env := env.registerName n.name
+      { addr := n.addr, constMeta := .empty, hints := n.hints }
   for ⟨addr, bytes⟩ in raw.blobs do
     env := { env with blobs := env.blobs.insert addr bytes }
   return env

--- a/Tests/FFI/Ixon.lean
+++ b/Tests/FFI/Ixon.lean
@@ -15,6 +15,15 @@ open Ix (DefKind DefinitionSafety QuotKind)
 
 namespace Tests.FFI.Ixon
 
+/-- `serEnv` for known-well-formed test fixtures: the env-construction
+    helpers in this file always store the referenced consts and name
+    components, so a serializer error here is a fixture bug — surface
+    it as a panic. -/
+def serEnv! (env : Env) : ByteArray :=
+  match Ixon.serEnv env with
+  | .ok bytes => bytes
+  | .error e => panic! s!"serEnv! failed on test fixture: {e}"
+
 /-! ## Ixon type roundtrip FFI declarations -/
 
 -- Simple enums (use lean_box/lean_unbox)
@@ -308,7 +317,7 @@ def envDiffTests : TestSeq :=
     return env
   let runDiff (a b : Env) (compareMeta : Bool := false) :
       Option Ixon.EnvDiff :=
-    (Ixon.rsDiffEnvs (serEnv a) (serEnv b) compareMeta).toOption
+    (Ixon.rsDiffEnvs (serEnv! a) (serEnv! b) compareMeta).toOption
   test "EnvDiff: self-diff empty (anon)"
     ((runDiff envBase envBase).any (·.isEmpty)) ++
   test "EnvDiff: self-diff empty (meta)"
@@ -388,8 +397,8 @@ def envDiffTests : TestSeq :=
       let dir ← IO.FS.createTempDir
       let pa := dir / "a.ixe"
       let pb := dir / "b.ixe"
-      let bytesA := serEnv envBase
-      let bytesB := serEnv envValueChanged
+      let bytesA := serEnv! envBase
+      let bytesB := serEnv! envValueChanged
       IO.FS.writeBinFile pa bytesA
       IO.FS.writeBinFile pb bytesB
       let r ← try
@@ -408,9 +417,12 @@ def envDiffTests : TestSeq :=
 /-- Self-diff over the pure-Lean writer's bytes must be empty in both
     modes (also exercises report marshaling on arbitrary inputs). -/
 def selfDiffEmpty (compareMeta : Bool) (env : RawEnv) : Bool :=
-  match Ixon.rsDiffEnvs (serEnv env.toEnv) (serEnv env.toEnv) compareMeta with
-  | .ok d => d.isEmpty
+  match Ixon.serEnv env.toEnv with
   | .error _ => false
+  | .ok bytes =>
+    match Ixon.rsDiffEnvs bytes bytes compareMeta with
+    | .ok d => d.isEmpty
+    | .error _ => false
 
 /-! ## Env pack FFI (`rs_pack_env`)
 
@@ -429,7 +441,7 @@ private def packFixture (env : Env) (mainName : String)
   let out := dir / "bundle.ixe"
   -- Every failure mode is caught into `.error`, so cleanup always runs.
   let result ← try
-    IO.FS.writeBinFile src (serEnv env)
+    IO.FS.writeBinFile src (serEnv! env)
     Ixon.rsPackEnv src.toString mainName assume out.toString anon false
     let bytes ← IO.FS.readBinFile out
     pure (Ixon.rsDeEnv bytes)
@@ -501,7 +513,7 @@ def envPackTests : TestSeq :=
       match ← packFixture src "bar" #[] with
       | .error e => pure (false, 0, 0, some e)
       | .ok b =>
-        match Ixon.rsDiffEnvs (serEnv src) (serEnv b) with
+        match Ixon.rsDiffEnvs (serEnv! src) (serEnv! b) with
         | .error e => pure (false, 0, 0, some s!"diff failed: {e}")
         | .ok d =>
           let ok := d.mainChanged == some (none, some barAddr)

--- a/Tests/FFI/Lifecycle.lean
+++ b/Tests/FFI/Lifecycle.lean
@@ -259,13 +259,18 @@ private def genSerdeRawEnv : Gen RawEnv := do
   -- Name entries for every address in the pool + every canonical const addr
   let names : Array RawNameEntry :=
     (pool.map fun (addr, name) => { addr, name }) ++ constNames
-  -- Named: pool addresses with empty metadata
+  -- Named: pool names over stored const addresses with empty metadata —
+  -- §5 keys each entry's constant by §2 rank, so the writers reject
+  -- named entries referencing anything outside `consts`.
   let numNamed ← Gen.choose Nat 0 3
   let mut named : Array RawNamed := #[]
-  for _ in [:numNamed] do
-    let idx ← Gen.choose Nat 0 (pool.size - 1)
-    let (addr, name) := pool[idx]!
-    named := named.push { name, addr, constMeta := .empty }
+  if consts.size > 0 then
+    for _ in [:numNamed] do
+      let idx ← Gen.choose Nat 0 (pool.size - 1)
+      let (_, name) := pool[idx]!
+      let cidx ← Gen.choose Nat 0 (consts.size - 1)
+      named := named.push
+        { name, addr := (consts[cidx]!).addr, constMeta := .empty }
   -- Blobs: content-addressed (the loaders verify blake3(bytes) == addr)
   let numBlobs ← Gen.choose Nat 0 3
   let mut blobs : Array RawBlob := #[]

--- a/Tests/Gen/Ixon.lean
+++ b/Tests/Gen/Ixon.lean
@@ -400,7 +400,11 @@ def genNamed : Gen Named := do
     (3, pure none),
     (1, (fun a m => some (a, m)) <$> genAddress <*> genConstantMeta),
   ]
-  return { addr, constMeta, original }
+  let hints ← frequency [
+    (1, pure none),
+    (2, some <$> genReducibilityHints),
+  ]
+  return { addr, constMeta, original, hints }
 
 /-- Generate a Comm. -/
 def genCommNew : Gen Comm :=
@@ -452,10 +456,13 @@ def genRawConst : Gen RawConst := do
   let c ← genConstant
   pure { addr := Address.blake3 (serConstant c), const := c }
 
-/-- Generate a RawNamed with empty metadata (matching Rust test generator).
-    Metadata addresses must reference valid names in env.names for indexed serialization. -/
+/-- Generate a standalone RawNamed with empty metadata. NOTE: its
+    `addr` is a random address, so it is NOT valid inside a RawEnv —
+    §5 keys the entry's constant by §2 rank and the writers reject
+    out-of-consts references. `genRawEnv` generates env-consistent
+    named entries itself. -/
 def genRawNamed : Gen RawNamed :=
-  RawNamed.mk <$> genIxName 3 <*> genAddress <*> pure .empty
+  RawNamed.mk <$> genIxName 3 <*> genAddress <*> pure .empty <*> pure none
 
 /-- Generate a RawBlob whose `addr` is the canonical content hash of
     `bytes`. Readers verify `Address.blake3 bytes == addr` per entry
@@ -473,11 +480,24 @@ def genRawNameEntry : Gen RawNameEntry :=
   RawNameEntry.mk <$> genAddress <*> genIxName 3
 
 /-- Generate a RawEnv with small arrays to avoid memory issues. `main`
-    (when present) references a generated const — writers/readers check
-    `main ∈ consts`. Assumptions and hint keys are opaque addresses. -/
+    (when present), named entries, and hint keys all reference
+    generated consts — the writers reject `main`/`named.addr`/hint
+    keys outside `consts` (§3/§5 are index-keyed). Assumptions stay
+    opaque addresses. -/
 def genRawEnv : Gen RawEnv := do
   let consts ← genSmallArray genRawConst
-  let named ← genSmallArray genRawNamed
+  let named ←
+    if consts.size > 0 then
+      genSmallArray do
+        let name ← genIxName 3
+        let i ← Gen.choose Nat 0 (consts.size - 1)
+        let addr := (consts[i % consts.size]!).addr
+        let hints ← frequency [
+          (1, pure none),
+          (2, some <$> genReducibilityHints),
+        ]
+        pure ({ name, addr, constMeta := .empty, hints } : RawNamed)
+    else pure #[]
   let blobs ← genSmallArray genRawBlob
   let comms ← genSmallArray genRawComm
   let names ← genSmallArray genRawNameEntry
@@ -492,8 +512,14 @@ def genRawEnv : Gen RawEnv := do
     else pure none
   let assumptionList ← genList genAddress
   let assumptions := assumptionList.toArray.qsort fun a b => (compare a b).isLT
-  let hintList ← genList (Prod.mk <$> genAddress <*> genReducibilityHints)
-  let anonHints := hintList.toArray.qsort fun a b => (compare a.1 b.1).isLT
+  let anonHints ←
+    if consts.size > 0 then do
+      let hintList ← genList do
+        let i ← Gen.choose Nat 0 (consts.size - 1)
+        let h ← genReducibilityHints
+        pure ((consts[i % consts.size]!).addr, h)
+      pure (hintList.toArray.qsort fun a b => (compare a.1 b.1).isLT)
+    else pure #[]
   pure { consts, named, blobs, comms, names, main, assumptions, anonHints }
 
 instance : Shrinkable RawConst where
@@ -517,14 +543,18 @@ instance : Shrinkable RawComm where
 
 instance : Shrinkable RawEnv where
   shrink env :=
-    -- Popping a const may orphan `main` (writers reject main ∉ consts),
-    -- so clear it when its target is dropped.
+    -- Popping a const may orphan `main` (writers reject main ∉ consts)
+    -- and any named entries / hints keyed to it (§3/§5 are
+    -- index-keyed) — drop those along with it.
     (if env.consts.size > 0 then
       let popped := env.consts.pop
       let main := match env.main with
         | some m => if popped.any (·.addr == m) then env.main else none
         | none => none
-      [{ env with consts := popped, main }]
+      let named := env.named.filter fun rn => popped.any (·.addr == rn.addr)
+      let anonHints :=
+        env.anonHints.filter fun (a, _) => popped.any (·.addr == a)
+      [{ env with consts := popped, main, named, anonHints }]
      else []) ++
     (if env.named.size > 0 then [{ env with named := env.named.pop }] else []) ++
     (if env.blobs.size > 0 then [{ env with blobs := env.blobs.pop }] else []) ++

--- a/Tests/Ix/Compile.lean
+++ b/Tests/Ix/Compile.lean
@@ -123,8 +123,8 @@ def compareEnvResults
   }
 
 /-- Serialize a Lean Ixon.Env to bytes -/
-def serializeEnv (env : Ixon.Env) : ByteArray :=
-  Ixon.serEnv env
+def serializeEnv (env : Ixon.Env) : IO ByteArray :=
+  IO.ofExcept (Ixon.serEnv env)
 
 /-! ## Integrated Test -/
 
@@ -338,7 +338,7 @@ def testCrossImpl : TestSeq :=
 
         let (leanBlobs, leanConsts, leanHints, leanNames, leanNamed, leanComms) := Ixon.envSectionSizes leanIxonEnv
         IO.println s!"[Step 4]   Lean sections: blobs={fmtBytes leanBlobs}, consts={fmtBytes leanConsts}, hints={fmtBytes leanHints}, names={fmtBytes leanNames}, named={fmtBytes leanNamed}, comms={fmtBytes leanComms}"
-        let leanEnvBytes := serializeEnv leanIxonEnv
+        let leanEnvBytes ← serializeEnv leanIxonEnv
         IO.println s!"[Step 4]   Lean env done: {fmtBytes leanEnvBytes.size}"
 
         IO.println s!"[Step 4]   Serializing Rust env ({phases.compileEnv.constCount} consts)..."
@@ -359,7 +359,7 @@ def testCrossImpl : TestSeq :=
 
         let (rustBlobs, rustConsts, rustHints, rustNames, rustNamed, rustComms) := Ixon.envSectionSizes phases.compileEnv
         IO.println s!"[Step 4]   Rust sections: blobs={fmtBytes rustBlobs}, consts={fmtBytes rustConsts}, hints={fmtBytes rustHints}, names={fmtBytes rustNames}, named={fmtBytes rustNamed}, comms={fmtBytes rustComms}"
-        let rustEnvBytes := serializeEnv phases.compileEnv
+        let rustEnvBytes ← serializeEnv phases.compileEnv
         IO.println s!"[Step 4]   Rust env done: {fmtBytes rustEnvBytes.size}"
         let serTime := (← IO.monoMsNow) - serStart
 

--- a/Tests/Ix/Compile/ValidateAux.lean
+++ b/Tests/Ix/Compile/ValidateAux.lean
@@ -66,6 +66,11 @@ def runCompileValidateAux (env : Lean.Environment) : IO UInt32 := do
   let prefixes := [
     `Tests.Ix.Compile.Mutual,
     `Tests.Ix.Compile.Canonicity,
+    -- IxVM ingress fixtures (Tests.Ix.IxVM) — nested/dedup shapes like
+    -- IxVMInd.DedupM (two nested occurrences of one external inductive
+    -- with distinct spec_params) that only otherwise compile under the
+    -- full-env `rust-compile` runner.
+    `IxVMInd,
     --`Init,
     --`_private.Init,
     --`State,

--- a/Tests/Ix/Ixon.lean
+++ b/Tests/Ix/Ixon.lean
@@ -37,12 +37,16 @@ def commSerde (c : Comm) : Bool :=
 
 def envSerde (raw : RawEnv) : Bool :=
   let env := raw.toEnv
-  let bytes1 := serEnv env
-  match deEnv bytes1 with
-  | .ok env' =>
-    let bytes2 := serEnv env'
-    bytes1 == bytes2  -- Byte-level equality after roundtrip
+  match serEnv env with
   | .error _ => false
+  | .ok bytes1 =>
+    match deEnv bytes1 with
+    | .ok env' =>
+      -- Byte-level equality after roundtrip
+      match serEnv env' with
+      | .ok bytes2 => bytes1 == bytes2
+      | .error _ => false
+    | .error _ => false
 
 /-!
 ## Unit Tests for New Format Types
@@ -143,12 +147,15 @@ def sharingUnits : TestSeq :=
 /-! ## Env Unit Tests -/
 
 def envSerdeUnit (env : Env) : Bool :=
-  let bytes1 := serEnv env
-  match deEnv bytes1 with
-  | .ok env' =>
-    let bytes2 := serEnv env'
-    bytes1 == bytes2
+  match serEnv env with
   | .error _ => false
+  | .ok bytes1 =>
+    match deEnv bytes1 with
+    | .ok env' =>
+      match serEnv env' with
+      | .ok bytes2 => bytes1 == bytes2
+      | .error _ => false
+    | .error _ => false
 
 def envUnitTests : TestSeq :=
   -- Test 1: Empty env
@@ -162,19 +169,34 @@ def envUnitTests : TestSeq :=
   let testName := Ix.Name.mkStr Ix.Name.mkAnon "test"
   let testNameAddr := testName.getHash
   let envWithName : Env := { names := ({} : Std.HashMap _ _).insert testNameAddr testName }
-  -- Test 4: Env with named entry and empty metadata
-  let constAddr := Address.blake3 (ByteArray.mk #[7, 8, 9])
+  -- Test 4: Env with named entry and empty metadata. §5 keys the
+  -- entry's constant by §2 rank, so the target must be a stored
+  -- constant (content-addressed — readers verify per entry).
+  let namedDef : Definition := {
+    kind := .defn, safety := .safe, lvls := 0, typ := .sort 0, value := .sort 0
+  }
+  let namedConst : Constant := {
+    info := .defn namedDef, sharing := #[], refs := #[], univs := #[]
+  }
+  let constAddr := Address.blake3 (serConstant namedConst)
   let envWithNamed : Env := Id.run do
     let mut env : Env := {}
+    env := env.storeConst constAddr namedConst
     env := { env with names := RawEnv.addNameComponents env.names testName }
     env := env.registerName testName { addr := constAddr, constMeta := .empty }
     return env
-  -- Test 5: Env with nested name and named entry
+  -- Test 5: Env with nested name and named entry, plus an `original`
+  -- edge whose address is deliberately NOT a stored constant — the §5
+  -- original address stays raw on the wire (it may reference an
+  -- assumed constant), so this must roundtrip.
   let nestedName := Ix.Name.mkStr (Ix.Name.mkNat testName 42) "bar"
   let envWithNestedName : Env := Id.run do
     let mut env : Env := {}
+    env := env.storeConst constAddr namedConst
     env := { env with names := RawEnv.addNameComponents env.names nestedName }
-    env := env.registerName nestedName { addr := constAddr, constMeta := .empty }
+    env := env.registerName nestedName
+      { addr := constAddr, constMeta := .empty,
+        original := some (Address.blake3 (ByteArray.mk #[99]), .empty) }
     return env
   -- Test 6: Env with blob and comm
   let secretAddr := Address.blake3 (ByteArray.mk #[10, 11, 12])
@@ -222,14 +244,17 @@ def constantSerializationMatches (c : Constant) : Bool :=
   rsEqConstantSerialization c (serConstant c)
 
 def envSerializationMatches (raw : RawEnv) : Bool :=
-  let env := raw.toEnv
-  rsEqEnvSerialization raw (serEnv env)
+  match serEnv raw.toEnv with
+  | .ok bytes => rsEqEnvSerialization raw bytes
+  | .error _ => false
 
 /-- Strict byte equality between the pure-Lean writer and the Rust
     writer over the same RawEnv (a stronger check than
     `rsEqEnvSerialization`'s content comparison). -/
 def envBytesMatchRust (raw : RawEnv) : Bool :=
-  serEnv raw.toEnv == rsSerEnvFFI raw
+  match serEnv raw.toEnv with
+  | .ok bytes => bytes == rsSerEnvFFI raw
+  | .error _ => false
 
 /-- Unit tests for Lean==Rust serialization comparison -/
 def envSerializationUnitTests : TestSeq :=
@@ -276,14 +301,31 @@ def envSerializationUnitTests : TestSeq :=
       Address.blake3 (ByteArray.mk #[43])],
     anonHints := #[(bundleConstAddr, .regular 5)]
   }
+  -- Test 6: Named entry + hints — the directed cross-language vector
+  -- for the index-keyed §5 (name §4-index + const §2 rank) and §3
+  -- (delta-coded ranks + fused hints). Unlike `RawEnv.toEnv`, the Rust
+  -- FFI side does not auto-add name components for named entries, so
+  -- `names` carries the leaf explicitly (ancestors are emitted by both
+  -- topological sorts from the parent chain).
+  let namedName := Ix.Name.mkStr Ix.Name.mkAnon "MyDef"
+  let namedRaw : RawEnv := {
+    consts := #[{ addr := bundleConstAddr, const := bundleConst }],
+    named := #[{ name := namedName, addr := bundleConstAddr,
+                 constMeta := .empty, hints := some (.regular 7) }],
+    blobs := #[], comms := #[],
+    names := #[{ addr := namedName.getHash, name := namedName }],
+    anonHints := #[(bundleConstAddr, .abbrev)]
+  }
   test "Empty env Lean==Rust" (envSerializationMatches emptyRaw) ++
   test "Blob env Lean==Rust" (envSerializationMatches blobRaw) ++
   test "Comm env Lean==Rust" (envSerializationMatches commRaw) ++
   test "Blob+Comm env Lean==Rust" (envSerializationMatches blobCommRaw) ++
   test "Bundle env Lean==Rust" (envSerializationMatches bundleRaw) ++
+  test "Named env Lean==Rust" (envSerializationMatches namedRaw) ++
   test "Empty env bytes Lean==Rust" (envBytesMatchRust emptyRaw) ++
   test "Blob env bytes Lean==Rust" (envBytesMatchRust blobRaw) ++
-  test "Bundle env bytes Lean==Rust" (envBytesMatchRust bundleRaw)
+  test "Bundle env bytes Lean==Rust" (envBytesMatchRust bundleRaw) ++
+  test "Named env bytes Lean==Rust" (envBytesMatchRust namedRaw)
 
 /-! ## Canonical env merkle root: Lean vs. Rust agreement -/
 

--- a/Tests/Ix/RustSerialize.lean
+++ b/Tests/Ix/RustSerialize.lean
@@ -38,7 +38,7 @@ def testRustSerdeRoundtrip : TestSeq :=
     -- Step 2: Canonical Lean serialization (deterministic, sorted by key)
     IO.println s!"[Step 2] Serializing with Lean (serEnv)..."
     let leanSerStart ← IO.monoMsNow
-    let leanBytes := Ixon.serEnv ixonEnv
+    let leanBytes ← IO.ofExcept (Ixon.serEnv ixonEnv)
     let leanSerTime := (← IO.monoMsNow) - leanSerStart
     IO.println s!"[Step 2]   {leanBytes.size} bytes in {leanSerTime}ms"
     IO.println ""
@@ -66,7 +66,7 @@ def testRustSerdeRoundtrip : TestSeq :=
     -- Step 5: Re-serialize the roundtripped env with Lean (deterministic)
     IO.println s!"[Step 5] Re-serializing roundtripped env with Lean..."
     let reserStart ← IO.monoMsNow
-    let roundtrippedBytes := Ixon.serEnv roundtrippedFromRust
+    let roundtrippedBytes ← IO.ofExcept (Ixon.serEnv roundtrippedFromRust)
     let reserTime := (← IO.monoMsNow) - reserStart
     IO.println s!"[Step 5]   {roundtrippedBytes.size} bytes in {reserTime}ms"
     IO.println ""

--- a/crates/compile/src/compile.rs
+++ b/crates/compile/src/compile.rs
@@ -274,16 +274,23 @@ impl CompileState {
   }
 
   /// Resolve the per-name hints recorded by `compile_definition` into
-  /// `env.anon_hints`, keyed by each name's registered constant address
-  /// (`Named.addr` — the projection address for mutual-block members,
-  /// i.e. exactly the address the kernel looks hints up under). Runs
-  /// once after the scheduler drains: addresses aren't final until the
-  /// `Named` entries are registered. Alias collisions resolve through
-  /// `Env::register_hint`'s order-independent merge.
+  /// the env. Runs once after the scheduler drains: addresses aren't
+  /// final until the `Named` entries are registered. Two channels:
+  ///
+  /// - `Named.hints` (exact, per name): alpha-identical definitions
+  ///   under different names share one constant address but may carry
+  ///   different hints; decompile reconstructs `DefinitionVal.hints`
+  ///   from here, so no merge may touch it.
+  /// - `env.anon_hints` (advisory, per constant address — `Named.addr`,
+  ///   the projection address for mutual-block members, i.e. exactly
+  ///   the address the anon-mode kernel looks hints up under). Alias
+  ///   collisions resolve through `Env::register_hint`'s
+  ///   order-independent merge.
   pub fn finalize_hints(&self) {
-    for entry in self.env.named.iter() {
-      if let Some(h) = self.def_hints.get(entry.key()) {
-        self.env.register_hint(entry.value().addr.clone(), *h.value());
+    for entry in self.def_hints.iter() {
+      if let Some(mut named) = self.env.named.get_mut(entry.key()) {
+        named.set_hints(Some(*entry.value()));
+        self.env.register_hint(named.addr.clone(), *entry.value());
       }
     }
   }

--- a/crates/compile/src/compile/aux_gen/nested.rs
+++ b/crates/compile/src/compile/aux_gen/nested.rs
@@ -641,13 +641,29 @@ pub fn sort_aux_by_partition_refinement(
   // `MutConst`s from one vector; source-original references inside aux
   // expressions intentionally remain external references and compare by
   // resolved content address.
+  //
+  // Each AUX member additionally carries a synthetic trailing "identity
+  // marker" ctor whose type is its `aux_to_nested` nested-app (block-param
+  // FVars abstracted to loose BVars by position). Two distinct nested
+  // occurrences of the same external inductive can instantiate to
+  // alpha-identical aux types+ctors when the distinguishing spec param is
+  // phantom in the external's constructors (e.g. `Bar2 M Nat` vs
+  // `Bar2 M Bool` where `Bar2.mk : α → Bar2 α β` never uses `β`) — the
+  // marker keeps such auxes in distinct canonical classes and orders them
+  // by spec-param content, while genuinely alias-collapsed occurrences
+  // (already deduped at creation by `aux_seen` post-`alias_to_rep`) are
+  // unaffected. The kernel's `canonical_aux_order` mirrors this marker.
+  let block_param_bvars: Vec<LeanExpr> = (0..expanded.block_param_fvars.len())
+    .map(|i| LeanExpr::bvar(Nat::from(i as u64)))
+    .collect();
   let all_mut_consts: Vec<MutConst> = expanded
     .types
     .iter()
-    .map(|mem| {
-      let ctor_names: Vec<Name> =
+    .enumerate()
+    .map(|(mi, mem)| {
+      let mut ctor_names: Vec<Name> =
         mem.ctors.iter().map(|c| c.name.clone()).collect();
-      let ctors: Vec<ConstructorVal> = mem
+      let mut ctors: Vec<ConstructorVal> = mem
         .ctors
         .iter()
         .enumerate()
@@ -664,6 +680,29 @@ pub fn sort_aux_by_partition_refinement(
           is_unsafe: false,
         })
         .collect();
+      if mi >= n_originals
+        && let Some(nested) = expanded.aux_to_nested.get(&mem.name)
+      {
+        let marker_typ = replace_params_expr(
+          nested,
+          &expanded.block_param_fvars,
+          &block_param_bvars,
+        );
+        let marker_name = Name::str(mem.name.clone(), "_nested_id".into());
+        ctors.push(ConstructorVal {
+          cnst: ConstantVal {
+            name: marker_name.clone(),
+            typ: marker_typ,
+            level_params: level_params.clone(),
+          },
+          induct: mem.name.clone(),
+          cidx: Nat::from(ctors.len() as u64),
+          num_params: Nat::from(mem.n_params as u64),
+          num_fields: Nat::from(0u64),
+          is_unsafe: false,
+        });
+        ctor_names.push(marker_name);
+      }
       MutConst::Indc(Ind {
         ind: InductiveVal {
           cnst: ConstantVal {
@@ -1166,11 +1205,22 @@ pub fn compute_aux_perm(
       if !orig_to_canon_names.contains_key(src_owner) {
         continue;
       }
+      let src_sig: Vec<String> =
+        normalized.iter().map(|e| e.pretty()).collect();
+      let canon_sigs: Vec<String> = canonical_signatures
+        .iter()
+        .map(|(head, specs)| {
+          let specs: Vec<String> = specs.iter().map(|e| e.pretty()).collect();
+          format!("{}[{}]", head.pretty(), specs.join(", "))
+        })
+        .collect();
       return Err(CompileError::InvalidMutualBlock {
         reason: format!(
-          "compute_aux_perm: no canonical match for in-SCC source aux #{j} owned by {} (head={})",
+          "compute_aux_perm: no canonical match for in-SCC source aux #{j} owned by {} (head={}); normalized source specs: [{}]; canonical signatures: {}",
           src_owner.pretty(),
           src_head.pretty(),
+          src_sig.join(", "),
+          canon_sigs.join(" · "),
         ),
       });
     };
@@ -2233,6 +2283,97 @@ mod tests {
   }
 
   // ---- expr_mentions_any_name ----
+
+  /// Two auxes whose instantiated views are alpha-identical — the
+  /// distinguishing spec param is phantom in the external's ctors, the
+  /// `IxVMInd.DedupM` shape (`Bar2 M Nat` vs `Bar2 M Bool` where
+  /// `Bar2.mk : α → Bar2 α β` never uses `β`) — must stay in DISTINCT
+  /// canonical classes: the identity-marker ctor carries
+  /// `aux_to_nested` into the compared data. Conversely, auxes with
+  /// equal nested identities still collapse (the alias-dedup net).
+  #[test]
+  fn sort_aux_distinguishes_phantom_spec_params() {
+    use crate::compile::CompileState;
+
+    let all0 = mk_name_for("M");
+    let nested_prefix = Name::str(all0.clone(), "_nested".to_string());
+    let aux_name =
+      |i: usize| Name::str(nested_prefix.clone(), format!("Bar2_{i}"));
+    let ty1 = LeanExpr::sort(LL::succ(LL::zero()));
+    let mk_orig = || ExpandedMember {
+      name: all0.clone(),
+      source_owner: all0.clone(),
+      typ: ty1.clone(),
+      ctors: vec![],
+      n_params: 0,
+      n_indices: 0,
+    };
+    // Aux views identical modulo the self-reference name: `mk : Nat → self`.
+    let mk_aux = |i: usize| ExpandedMember {
+      name: aux_name(i),
+      source_owner: all0.clone(),
+      typ: ty1.clone(),
+      ctors: vec![ExpandedCtor {
+        name: Name::str(aux_name(i), "mk".to_string()),
+        typ: LeanExpr::all(
+          mk_name_for("_"),
+          LeanExpr::cnst(mk_name_for("Nat"), vec![]),
+          LeanExpr::cnst(aux_name(i), vec![]),
+          ix_common::env::BinderInfo::Default,
+        ),
+        n_fields: 1,
+      }],
+      n_params: 0,
+      n_indices: 0,
+    };
+    let nested_id = |spec: &str| {
+      LeanExpr::app(
+        LeanExpr::cnst(mk_name_for("Bar2"), vec![]),
+        LeanExpr::cnst(mk_name_for(spec), vec![]),
+      )
+    };
+    let build = |spec2: &str| {
+      let mut aux_to_nested = FxHashMap::default();
+      aux_to_nested.insert(aux_name(1), nested_id("Nat"));
+      aux_to_nested.insert(aux_name(2), nested_id(spec2));
+      ExpandedBlock {
+        types: vec![mk_orig(), mk_aux(1), mk_aux(2)],
+        aux_to_nested,
+        aux_ctor_map: FxHashMap::default(),
+        block_param_fvars: vec![],
+        n_originals: 1,
+        level_params: vec![],
+      }
+    };
+    let stt = CompileState::new_empty();
+    // The structural comparator resolves external consts by compiled
+    // address; register the externals the fixtures reference.
+    for ext in ["Nat", "Bool", "Bar2"] {
+      stt.name_to_addr.insert(
+        mk_name_for(ext),
+        ix_common::address::Address::hash(ext.as_bytes()),
+      );
+    }
+
+    // Distinct nested identities → distinct canonical classes.
+    let mut expanded = build("Bool");
+    let perm = sort_aux_by_partition_refinement(&mut expanded, &stt).unwrap();
+    assert_eq!(perm.len(), 2);
+    assert_ne!(
+      perm[0], perm[1],
+      "phantom-spec-param auxes must not collapse (IxVMInd.DedupM shape)"
+    );
+    assert_eq!(expanded.types.len(), 3, "both auxes survive the sort");
+
+    // Equal nested identities → still one class (legitimate dedup).
+    let mut expanded = build("Nat");
+    let perm = sort_aux_by_partition_refinement(&mut expanded, &stt).unwrap();
+    assert_eq!(perm.len(), 2);
+    assert_eq!(
+      perm[0], perm[1],
+      "semantically equal nested identities still collapse"
+    );
+  }
 
   #[test]
   fn expr_mentions_any_name_none() {

--- a/crates/compile/src/decompile.rs
+++ b/crates/compile/src/decompile.rs
@@ -1546,16 +1546,17 @@ fn decompile_definition(
     },
     _ => vec![],
   };
-  // Hints live in `env.anon_hints`, keyed by the constant address the
-  // name resolves to (for aux originals, the canonical address — the
-  // original was compiled from the same Lean definition, so the hints
-  // coincide). Absent entry → `Opaque`, matching the compiler's
-  // treatment of theorems and opaques.
+  // Hints come from the per-name `Named.hints` channel — the exact
+  // value `finalize_hints` recorded for this name. The per-address
+  // `env.anon_hints` channel is unusable here: alpha-identical
+  // definitions under different names share one constant address, so
+  // it only holds a merged winner. Absent → `Opaque`, matching the
+  // compiler's treatment of theorems and opaques.
   let hints = stt
     .env
     .named
     .get(&name)
-    .and_then(|n| stt.env.anon_hints.get(&n.value().addr).map(|r| *r))
+    .and_then(|n| n.value().hints())
     .unwrap_or(ReducibilityHints::Opaque);
 
   let cnst = ConstantVal { name, level_params, typ };

--- a/crates/ffi/src/compile.rs
+++ b/crates/ffi/src/compile.rs
@@ -16,7 +16,7 @@ use crate::lean::{
   LeanIxonRawNameEntry, LeanIxonRawNamed,
 };
 use ix_common::address::Address;
-use ix_common::env::Name;
+use ix_common::env::{Name, ReducibilityHints};
 use ix_compile::compile::{
   CompileOptions, CompileState, compile_env_with_options,
 };
@@ -80,8 +80,9 @@ fn build_raw_named(
   name: &Name,
   addr: &Address,
   meta: &ConstantMeta,
+  hints: Option<ReducibilityHints>,
 ) -> LeanIxonRawNamed<LeanOwned> {
-  LeanIxonRawNamed::build_from_parts(cache, name, addr, meta)
+  LeanIxonRawNamed::build_from_parts(cache, name, addr, meta, hints)
 }
 
 /// Build RawBlob using type method.
@@ -399,7 +400,10 @@ pub extern "C" fn rs_compile_phases(
       .collect();
     let named_arr = LeanArray::alloc(named.len());
     for (i, (name, n)) in named.iter().enumerate() {
-      named_arr.set(i, build_raw_named(&mut cache, name, &n.addr, &n.meta()));
+      named_arr.set(
+        i,
+        build_raw_named(&mut cache, name, &n.addr, &n.meta(), n.hints()),
+      );
     }
 
     let blobs: Vec<_> = compile_stt
@@ -499,7 +503,10 @@ pub extern "C" fn rs_compile_env_to_ixon(
       .collect();
     let named_arr = LeanArray::alloc(named.len());
     for (i, (name, n)) in named.iter().enumerate() {
-      named_arr.set(i, build_raw_named(&mut cache, name, &n.addr, &n.meta()));
+      named_arr.set(
+        i,
+        build_raw_named(&mut cache, name, &n.addr, &n.meta(), n.hints()),
+      );
     }
 
     let blobs: Vec<_> = compile_stt

--- a/crates/ffi/src/lean.rs
+++ b/crates/ffi/src/lean.rs
@@ -44,11 +44,11 @@ lean_ffi::lean_inductive! {
   LeanIxonConstructorProj [ { num_obj: 1, num_64: 2 } ];
   LeanIxonRecursorProj    [ { num_obj: 1, num_64: 1 } ];
   LeanIxonDefinitionProj  [ { num_obj: 1, num_64: 1 } ];
-  LeanIxonNamed           [ { num_obj: 3 } ];
+  LeanIxonNamed           [ { num_obj: 4 } ];
   LeanIxonComm            [ { num_obj: 2 } ];
   LeanIxonConstant        [ { num_obj: 4 } ];
   LeanIxonRawConst        [ { num_obj: 2 } ];
-  LeanIxonRawNamed        [ { num_obj: 3 } ];
+  LeanIxonRawNamed        [ { num_obj: 4 } ];
   LeanIxonRawBlob         [ { num_obj: 2 } ];
   LeanIxonRawComm         [ { num_obj: 2 } ];
   LeanIxonRawNameEntry    [ { num_obj: 2 } ];
@@ -59,7 +59,7 @@ lean_ffi::lean_inductive! {
   // (addr + offset + len), name->addr, copied blobs, the bundle header
   // fields (main, assumptions), and the hints-section pairs.
   LeanIxonRawConstSlice   [ { num_obj: 1, num_64: 2 } ];
-  LeanIxonRawNamedLite    [ { num_obj: 2 } ];
+  LeanIxonRawNamedLite    [ { num_obj: 3 } ];
   LeanIxonRawEnvLazy      [ { num_obj: 6 } ];
 
   // Env diff report (`rs_diff_envs`). Slot counts MUST match the Lean

--- a/crates/ffi/src/lean_ixon/env.rs
+++ b/crates/ffi/src/lean_ixon/env.rs
@@ -64,7 +64,8 @@ impl<R: LeanRef> LeanIxonRawConst<R> {
 }
 
 // =============================================================================
-// RawNamed (name: Ix.Name, addr: Address, constMeta: ConstantMeta)
+// RawNamed (name: Ix.Name, addr: Address, constMeta: ConstantMeta,
+//           hints: Option ReducibilityHints)
 // =============================================================================
 
 /// Decoded Ixon.RawNamed
@@ -72,6 +73,31 @@ pub struct DecodedRawNamed {
   pub name: Name,
   pub addr: Address,
   pub const_meta: ConstantMeta,
+  pub hints: Option<ReducibilityHints>,
+}
+
+/// Build `Option Lean.ReducibilityHints` (scalar-optimized `none` or a
+/// boxed tag-1 ctor).
+pub(crate) fn build_opt_hints(hints: Option<ReducibilityHints>) -> LeanOwned {
+  match hints {
+    None => LeanOption::none().into(),
+    Some(h) => LeanOption::some(LeanIxReducibilityHints::build(&h)).into(),
+  }
+}
+
+/// Decode `Option Lean.ReducibilityHints` from an object slot.
+pub(crate) fn decode_opt_hints(
+  obj: LeanBorrowed<'_>,
+) -> Option<ReducibilityHints> {
+  if obj.is_scalar() {
+    return None;
+  }
+  let opt = obj.as_ctor();
+  match opt.tag() {
+    0 => None,
+    1 => Some(LeanIxReducibilityHints::new(opt.get(0).to_owned_ref()).decode()),
+    tag => panic!("Invalid Option tag for hints: {tag}"),
+  }
 }
 
 impl LeanIxonRawNamed<LeanOwned> {
@@ -81,6 +107,7 @@ impl LeanIxonRawNamed<LeanOwned> {
     ctor.set_obj(0, LeanIxName::build(cache, &rn.name));
     ctor.set_obj(1, LeanIxAddress::build(&rn.addr));
     ctor.set_obj(2, LeanIxonConstantMeta::build(&rn.const_meta));
+    ctor.set_obj(3, build_opt_hints(rn.hints));
     ctor
   }
 
@@ -90,11 +117,13 @@ impl LeanIxonRawNamed<LeanOwned> {
     name: &Name,
     addr: &Address,
     meta: &ConstantMeta,
+    hints: Option<ReducibilityHints>,
   ) -> Self {
     let ctor = LeanIxonRawNamed::alloc(0);
     ctor.set_obj(0, LeanIxName::build(cache, name));
     ctor.set_obj(1, LeanIxAddress::build(addr));
     ctor.set_obj(2, LeanIxonConstantMeta::build(meta));
+    ctor.set_obj(3, build_opt_hints(hints));
     ctor
   }
 }
@@ -108,6 +137,7 @@ impl<R: LeanRef> LeanIxonRawNamed<R> {
       addr: LeanIxAddress::from_borrowed(ctor.get(1).as_byte_array()).decode(),
       const_meta: LeanIxonConstantMeta::new(ctor.get(2).to_owned_ref())
         .decode(),
+      hints: decode_opt_hints(ctor.get(3)),
     }
   }
 }
@@ -419,7 +449,8 @@ pub fn decoded_to_ixon_env(decoded: &DecodedRawEnv) -> IxonEnv {
     env.store_name(rn.addr.clone(), rn.name.clone());
   }
   for rn in &decoded.named {
-    let named = IxonNamed::new(rn.addr.clone(), rn.const_meta.clone());
+    let mut named = IxonNamed::new(rn.addr.clone(), rn.const_meta.clone());
+    named.set_hints(rn.hints);
     env.register_name(rn.name.clone(), named);
   }
   for rb in &decoded.blobs {
@@ -462,6 +493,7 @@ pub fn ixon_env_to_decoded(env: &IxonEnv) -> Result<DecodedRawEnv, String> {
       name: e.key().clone(),
       addr: e.value().addr.clone(),
       const_meta: (*e.value().meta()).clone(),
+      hints: e.value().hints(),
     })
     .collect();
   let blobs = env
@@ -620,15 +652,17 @@ impl LeanIxonRawConstSlice<LeanOwned> {
 }
 
 impl LeanIxonRawNamedLite<LeanOwned> {
-  /// Build `Ixon.RawNamedLite { name, addr }`.
+  /// Build `Ixon.RawNamedLite { name, addr, hints }`.
   pub fn build(
     cache: &mut LeanBuildCache,
     name: &Name,
     addr: &Address,
+    hints: Option<ReducibilityHints>,
   ) -> Self {
     let ctor = LeanIxonRawNamedLite::alloc(0);
     ctor.set_obj(0, LeanIxName::build(cache, name));
     ctor.set_obj(1, LeanIxAddress::build(addr));
+    ctor.set_obj(2, build_opt_hints(hints));
     ctor
   }
 }
@@ -644,7 +678,10 @@ fn build_raw_env_lazy(index: &LazyIndex) -> LeanIxonRawEnvLazy<LeanOwned> {
 
   let named_arr = LeanArray::alloc(index.named.len());
   for (i, n) in index.named.iter().enumerate() {
-    named_arr.set(i, LeanIxonRawNamedLite::build(&mut cache, &n.name, &n.addr));
+    named_arr.set(
+      i,
+      LeanIxonRawNamedLite::build(&mut cache, &n.name, &n.addr, n.hints),
+    );
   }
 
   let blobs_arr = LeanArray::alloc(index.blobs.len());

--- a/crates/ffi/src/lean_ixon/meta.rs
+++ b/crates/ffi/src/lean_ixon/meta.rs
@@ -7,7 +7,7 @@ use crate::lean::{
   LeanIxonExprMetaData, LeanIxonNamed,
 };
 use ix_common::address::Address;
-use ix_common::env::BinderInfo;
+use ix_common::env::{BinderInfo, ReducibilityHints};
 use ixon::Comm;
 use ixon::env::Named;
 use ixon::metadata::{
@@ -625,15 +625,17 @@ impl<R: LeanRef> LeanIxonConstantMeta<R> {
 // =============================================================================
 
 impl LeanIxonNamed<LeanOwned> {
-  /// Build Ixon.Named { addr, constMeta, original }.
+  /// Build Ixon.Named { addr, constMeta, original, hints }.
   ///
   /// The third field encodes `Option (Address × ConstantMeta)` for
-  /// pre-aux_gen roundtrip fidelity (see `Ix/Ixon.lean` `structure Named`).
+  /// pre-aux_gen roundtrip fidelity and the fourth the per-name
+  /// reducibility hints (see `Ix/Ixon.lean` `structure Named`).
   /// Regression test: `Ixon.Named roundtrip` in `Tests/FFI/Ixon.lean`.
   pub fn build(
     addr: &Address,
     meta: &ConstantMeta,
     original: &Option<(Address, ConstantMeta)>,
+    hints: Option<ReducibilityHints>,
   ) -> Self {
     let original_obj: LeanOwned = match original {
       None => LeanOption::none().into(),
@@ -649,6 +651,7 @@ impl LeanIxonNamed<LeanOwned> {
     ctor.set_obj(0, LeanIxAddress::build(addr));
     ctor.set_obj(1, LeanIxonConstantMeta::build(meta));
     ctor.set_obj(2, original_obj);
+    ctor.set_obj(3, super::env::build_opt_hints(hints));
     ctor
   }
 }
@@ -680,7 +683,9 @@ impl<R: LeanRef> LeanIxonNamed<R> {
         tag => panic!("Invalid Option tag for Named.original: {tag}"),
       }
     };
+    let hints = super::env::decode_opt_hints(self.get_obj(3));
     let mut named = Named::new(addr, meta);
+    named.set_hints(hints);
     if let Some((orig_addr, orig_meta)) = original {
       named.set_original(orig_addr, orig_meta);
     }
@@ -773,5 +778,5 @@ pub extern "C" fn rs_roundtrip_ixon_named(
 ) -> LeanIxonNamed<LeanOwned> {
   let named = obj.decode();
   let original = named.original().map(|(a, m)| (a, (*m).clone()));
-  LeanIxonNamed::build(&named.addr, &named.meta(), &original)
+  LeanIxonNamed::build(&named.addr, &named.meta(), &original, named.hints())
 }

--- a/crates/ixon/src/diff.rs
+++ b/crates/ixon/src/diff.rs
@@ -744,6 +744,13 @@ fn classify_constants(
 /// Component labels for a same-addr metadata difference.
 fn meta_component_labels(a: &Named, b: &Named) -> Vec<String> {
   let mut out = Vec::new();
+  if a.hints() != b.hints() {
+    out.push(format!(
+      "hints({}→{})",
+      hint_label(a.hints().as_ref()),
+      hint_label(b.hints().as_ref())
+    ));
+  }
   let (am, bm) = (a.meta(), b.meta());
   if am.info != bm.info {
     let (ka, kb) = (am.info.kind_name(), bm.info.kind_name());

--- a/crates/ixon/src/env.rs
+++ b/crates/ixon/src/env.rs
@@ -61,6 +61,14 @@ impl MetaRepr {
 pub struct Named {
   /// Address of the constant (in consts map)
   pub addr: Address,
+  /// EXACT per-name reducibility hints (`None` for constants that carry
+  /// none, e.g. theorems). Needed because alpha-identical definitions
+  /// under different names share one constant address, so the
+  /// per-address [`Env::anon_hints`] channel only holds a min-merged
+  /// advisory winner (see [`Env::register_hint`]) — decompile
+  /// reconstructs `DefinitionVal.hints` from here. Serialized in each
+  /// §5 entry's skippable header, before the metadata blob.
+  hints: Option<ReducibilityHints>,
   /// Typed metadata for this constant (includes mutual context in `all`
   /// field). Private repr: structured, or demoted to serialized bytes —
   /// read through [`Self::meta`].
@@ -74,15 +82,31 @@ pub struct Named {
 
 impl Named {
   pub fn new(addr: Address, meta: ConstantMeta) -> Self {
-    Named { addr, meta: MetaRepr::structured(meta), original: None }
+    Named {
+      addr,
+      hints: None,
+      meta: MetaRepr::structured(meta),
+      original: None,
+    }
   }
 
   pub fn with_addr(addr: Address) -> Self {
     Named {
       addr,
+      hints: None,
       meta: MetaRepr::structured(ConstantMeta::default()),
       original: None,
     }
+  }
+
+  /// The per-name reducibility hints, if any.
+  pub fn hints(&self) -> Option<ReducibilityHints> {
+    self.hints
+  }
+
+  /// Set the per-name reducibility hints.
+  pub fn set_hints(&mut self, hints: Option<ReducibilityHints>) {
+    self.hints = hints;
   }
 
   /// The constant's metadata. Cheap (`Arc` clone) for structured
@@ -173,6 +197,10 @@ pub struct LazyConstSlice {
 pub struct LazyNamed {
   pub name: Name,
   pub addr: Address,
+  /// Per-name reducibility hints from the §5 entry header — carried so
+  /// [`Env::from_lazy_index`] envs match the full reader (the lazy
+  /// parser skips metadata bodies but reads entry headers).
+  pub hints: Option<ReducibilityHints>,
 }
 
 /// `IX_COMPILE_DEMOTE` (default **on**; set `0` to disable): store the
@@ -241,11 +269,13 @@ pub struct Env {
   pub comms: IxonMap<Address, Comm>,
   /// Reducibility hints, keyed by the constant's projection/standalone
   /// address (i.e. `Named.addr` — the address the kernel sees, **not**
-  /// the name-hash address). The SINGLE home for hints: the compiler
-  /// registers them here ([`Env::register_hint`]), every writer
-  /// serializes this map as the file's hints section, and every reader
-  /// populates it from that section. Hints do not appear in `Named`
-  /// metadata.
+  /// the name-hash address). This is the ANON channel: serialized as §3
+  /// (before the name/metadata sections) precisely so anon readers get
+  /// hints without touching metadata. Because alpha-equivalent
+  /// definitions share one constant address, alias collisions resolve
+  /// through [`Env::register_hint`]'s order-independent min-merge — the
+  /// map holds one advisory winner per address, NOT the exact
+  /// per-definition value (that lives in [`Self::name_hints`]).
   ///
   /// Ingress passes these hints through to `ingress_defn` so the
   /// kernel's lazy-delta tiebreak (`def_eq::def_rank_id`) sees
@@ -460,7 +490,9 @@ impl Env {
   #[cfg(not(target_arch = "riscv64"))]
   fn fill_from_lazy_index(mut env: Env, index: &LazyIndex) -> Env {
     for n in &index.named {
-      env.register_name(n.name.clone(), Named::with_addr(n.addr.clone()));
+      let mut named = Named::with_addr(n.addr.clone());
+      named.set_hints(n.hints);
+      env.register_name(n.name.clone(), named);
     }
     for (addr, hint) in &index.hints {
       env.anon_hints.insert(addr.clone(), *hint);
@@ -1033,13 +1065,18 @@ mod tests {
 
   #[test]
   fn demoted_named_roundtrips_and_serializes_identically() {
-    let addr = Address::hash(b"demoted-named-target");
+    // §5 keys the entry's constant by §2 rank, so the target must be a
+    // stored constant. The `original` address stays raw on the wire and
+    // may point anywhere — keep it at a junk address to pin that.
+    let target = dummy_constant();
+    let (addr, _) = target.commit();
+    let orig_addr = Address::hash(b"demoted-named-original");
     // Empty metadata: no name references, so `Env::put` needs no name
     // index entries. Name-ref-rich raw/indexed equivalence is covered
     // by `metadata::tests::test_constant_meta_indexed_roundtrip`.
     let meta = ConstantMeta::default();
     let mut structured = Named::new(addr.clone(), meta.clone());
-    structured.set_original(addr.clone(), meta.clone());
+    structured.set_original(orig_addr.clone(), meta.clone());
     let mut demoted = structured.clone();
     demoted.demote();
 
@@ -1056,7 +1093,10 @@ mod tests {
     // Envs whose named entries differ only in repr serialize identically.
     let mk_env = |named: &Named| {
       let env = Env::new();
-      env.register_name(n("target"), named.clone());
+      env.store_const(addr.clone(), target.clone());
+      let name = n("target");
+      env.store_name(Address::from_blake3_hash(*name.get_hash()), name.clone());
+      env.register_name(name, named.clone());
       let mut buf = Vec::new();
       env.put(&mut buf).unwrap();
       buf
@@ -1613,6 +1653,34 @@ mod tests {
     assert!(via_stream_cut.named.get(&bar).is_none());
     assert!(via_stream_cut.assumptions.contains(&b));
     assert_eq!(ser(&via_full_cut), ser(&via_stream_cut));
+  }
+
+  /// A cut bundle serializes a `Named.original` whose address is
+  /// assumed — NOT stored in §2 — which is exactly why the §5
+  /// `original` address stays raw on the wire (a §2 index cannot
+  /// represent it). Lock the roundtrip in.
+  #[test]
+  fn original_referencing_assumed_const_roundtrips() {
+    let (bytes, a, b, _) = streaming_prune_fixture();
+    let full = {
+      let mut cur = bytes.as_slice();
+      Env::get(&mut cur).unwrap()
+    };
+    let assumed: FxHashSet<Address> = [b.clone()].into_iter().collect();
+    let cut = full.prune_to_closure(&a, &assumed).unwrap();
+    assert!(cut.consts.get(&b).is_none(), "assumed const must not ride");
+
+    let mut buf = Vec::new();
+    cut.put(&mut buf).unwrap();
+    let back = {
+      let mut cur = buf.as_slice();
+      Env::get(&mut cur).unwrap()
+    };
+    assert!(back.consts.get(&b).is_none());
+    assert!(back.assumptions.contains(&b));
+    let foo_named = back.named.get(&n("Foo")).expect("Foo carried").clone();
+    let (orig_addr, _) = foo_named.original().expect("original carried");
+    assert_eq!(orig_addr, b, "original still points at the assumed const");
   }
 
   /// `prune_to_closure_anon` carries the value closure only: no names,

--- a/crates/ixon/src/metadata.rs
+++ b/crates/ixon/src/metadata.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use ix_common::address::Address;
-use ix_common::env::{self, BinderInfo, Name, ReducibilityHints};
+use ix_common::env::{self, BinderInfo, Name};
 
 use super::env::AuxLayout;
 use super::expr::Expr;
@@ -704,30 +704,9 @@ impl IxonByteSerde for BinderInfo {
   }
 }
 
-impl IxonByteSerde for ReducibilityHints {
-  fn put_ser(&self, buf: &mut Vec<u8>) {
-    match self {
-      Self::Opaque => put_u8(0, buf),
-      Self::Abbrev => put_u8(1, buf),
-      Self::Regular(x) => {
-        put_u8(2, buf);
-        Tag0::new(u64::from(*x)).put(buf);
-      },
-    }
-  }
-
-  fn get_ser(buf: &mut &[u8]) -> Result<Self, String> {
-    match get_u8(buf)? {
-      0 => Ok(Self::Opaque),
-      1 => Ok(Self::Abbrev),
-      2 => {
-        let tag = Tag0::get(buf)?;
-        Ok(Self::Regular(tag.size as u32))
-      },
-      x => Err(format!("ReducibilityHints::get: invalid {x}")),
-    }
-  }
-}
+// `ReducibilityHints` has no `IxonByteSerde` impl: its only wire home
+// is the env-level §3 section, which fuses the variant and height into
+// a single Tag0 value (see `serialize.rs::fuse_hint`).
 
 // ===========================================================================
 // Indexed serialization (Address -> u64 index)
@@ -1342,19 +1321,6 @@ mod tests {
       let mut buf = Vec::new();
       bi.put_ser(&mut buf);
       assert_eq!(BinderInfo::get_ser(&mut buf.as_slice()).unwrap(), bi);
-    }
-  }
-
-  #[test]
-  fn test_reducibility_hints_roundtrip() {
-    for h in [
-      ReducibilityHints::Opaque,
-      ReducibilityHints::Abbrev,
-      ReducibilityHints::Regular(42),
-    ] {
-      let mut buf = Vec::new();
-      h.put_ser(&mut buf);
-      assert_eq!(ReducibilityHints::get_ser(&mut buf.as_slice()).unwrap(), h);
     }
   }
 

--- a/crates/ixon/src/serialize.rs
+++ b/crates/ixon/src/serialize.rs
@@ -193,24 +193,105 @@ fn read_blob_section(
   Ok(blobs)
 }
 
+/// Appended to §3/§5 index-decode errors: the most likely cause of a
+/// mangled index section in an otherwise well-formed file is a
+/// pre-compact-keys `.ixe` (§3/§5 keys were raw 32-byte addresses
+/// before the index-keyed encoding).
+const PRE_COMPACT_KEYS: &str =
+  " — possibly a pre-compact-keys .ixe; recompile it";
+
+/// Fuse a `ReducibilityHints` into a single Tag0-encodable value:
+/// 0 = Opaque, 1 = Abbrev, h + 2 = Regular(h). Keeps the common
+/// small-height Regular case in one wire byte.
+fn fuse_hint(hint: &ReducibilityHints) -> u64 {
+  match hint {
+    ReducibilityHints::Opaque => 0,
+    ReducibilityHints::Abbrev => 1,
+    ReducibilityHints::Regular(h) => u64::from(*h) + 2,
+  }
+}
+
+/// Decoding counterpart of [`fuse_hint`].
+fn unfuse_hint(v: u64) -> Result<ReducibilityHints, String> {
+  match v {
+    0 => Ok(ReducibilityHints::Opaque),
+    1 => Ok(ReducibilityHints::Abbrev),
+    _ => u32::try_from(v - 2).map(ReducibilityHints::Regular).map_err(|_| {
+      format!("unfuse_hint: Regular height {} exceeds u32::MAX", v - 2)
+    }),
+  }
+}
+
+/// [`fuse_hint`] lifted over `Option`: 0 = None, otherwise
+/// `fuse_hint(h) + 1`. The §5 per-name hint form (`None` for
+/// hint-less constants like theorems).
+fn fuse_opt_hint(hint: Option<ReducibilityHints>) -> u64 {
+  match hint {
+    None => 0,
+    Some(h) => fuse_hint(&h) + 1,
+  }
+}
+
+/// Decoding counterpart of [`fuse_opt_hint`].
+fn unfuse_opt_hint(v: u64) -> Result<Option<ReducibilityHints>, String> {
+  match v {
+    0 => Ok(None),
+    _ => unfuse_hint(v - 1).map(Some),
+  }
+}
+
 /// Read the §3 `anon_hints` section (unconditional — every writer
-/// emits it, deriving the entries from Named metadata when the
-/// in-memory map is empty; see `Env::put`).
+/// emits it, straight from the `Env::anon_hints` map; see `Env::put`).
+///
+/// Entries are keyed by index into §2's ascending-address order,
+/// delta-coded (`idx_k = idx_{k-1} + delta_k` with `idx_{-1} = -1`);
+/// every delta must be ≥ 1, so the section is strictly ascending and
+/// duplicate-free by construction. `addr_at(i)` resolves an index to
+/// the i-th §2 address; the caller has just scanned §2, so the order
+/// is at hand in every reader.
 fn read_hints_section(
   buf: &mut &[u8],
+  consts_len: usize,
+  addr_at: impl Fn(usize) -> Address,
+  reader: &str,
 ) -> Result<Vec<(Address, ReducibilityHints)>, String> {
   let n = get_u64(buf)? as usize;
-  // Each hint entry needs at least addr (32) + one byte of hint.
-  if n > buf.len() / 33 {
+  if n > consts_len {
     return Err(format!(
-      "read_hints_section: hint count {n} exceeds remaining buffer"
+      "{reader}: hint count {n} exceeds const count \
+       {consts_len}{PRE_COMPACT_KEYS}"
     ));
   }
+  // Each hint entry needs at least two bytes (Tag0 delta + Tag0 hint).
+  if n > buf.len() / 2 {
+    return Err(format!("{reader}: hint count {n} exceeds remaining buffer"));
+  }
   let mut hints = Vec::with_capacity(n);
-  for _ in 0..n {
-    let addr = get_address(buf)?;
-    let hint = ReducibilityHints::get_ser(buf)?;
-    hints.push((addr, hint));
+  // Index of the next entry must be ≥ cursor (= previous index + 1).
+  let mut cursor: u64 = 0;
+  for k in 0..n {
+    let delta = get_u64(buf)?;
+    if delta == 0 {
+      return Err(format!(
+        "{reader}: hint entry {k} has zero index delta (§3 must be \
+         strictly ascending){PRE_COMPACT_KEYS}"
+      ));
+    }
+    let idx = cursor.checked_add(delta - 1).ok_or_else(|| {
+      format!(
+        "{reader}: hint entry {k} index delta overflows{PRE_COMPACT_KEYS}"
+      )
+    })?;
+    if idx >= consts_len as u64 {
+      return Err(format!(
+        "{reader}: hint entry {k} resolves to constant index {idx}, \
+         out of range ({consts_len} consts){PRE_COMPACT_KEYS}"
+      ));
+    }
+    let hint = unfuse_hint(get_u64(buf)?)
+      .map_err(|e| format!("{reader}: hint entry {k}: {e}"))?;
+    hints.push((addr_at(idx as usize), hint));
+    cursor = idx + 1;
   }
   Ok(hints)
 }
@@ -1179,33 +1260,96 @@ pub fn get_aux_layout(buf: &mut &[u8]) -> Result<AuxLayout, String> {
 pub fn put_named_indexed(
   named: &Named,
   idx: &NameIndex,
+  consts: &[Address],
+  scratch: &mut Vec<u8>,
   buf: &mut Vec<u8>,
 ) -> Result<(), String> {
-  put_address(&named.addr, buf);
-  // Demoted entries decode here and re-encode through the name index —
-  // the raw and indexed encodings share the wire format, differing only
-  // in how name references are written.
-  named.meta().put_with(NamePut::Indexed(idx), buf)?;
-  // Serialize original as Option: 0 = None, 1 = Some(addr, meta)
+  // The entry's constant is written as its rank in §2's ascending
+  // address order (`consts` is the writer's sorted const-address
+  // table). An address outside §2 is unrepresentable — reject at
+  // write time rather than emit a file every reader refuses.
+  let rank = consts.binary_search(&named.addr).map_err(|_| {
+    format!(
+      "put_named_indexed: constant {} not present in consts — named \
+       entries must reference stored constants",
+      named.addr.hex()
+    )
+  })?;
+  put_u64(rank as u64, buf);
+  // Per-name reducibility hints in the skippable entry header — the
+  // EXACT per-definition value (the §3 per-address channel min-merges
+  // alias collisions; see `Named::hints`).
+  put_u64(fuse_opt_hint(named.hints()), buf);
+  // Metadata blob, length-prefixed so scanners (`parse_lazy_index`,
+  // hint readers) can skip it without parsing. Demoted entries decode
+  // here and re-encode through the name index — the raw and indexed
+  // encodings share the wire format, differing only in how name
+  // references are written.
+  scratch.clear();
+  named.meta().put_with(NamePut::Indexed(idx), scratch)?;
+  // Serialize original as Option: 0 = None, 1 = Some(addr, meta). The
+  // original's address stays a raw 32 bytes: it can reference an
+  // assumed constant that is NOT stored in §2 (prune cut bundles), so
+  // a §2 index cannot represent it.
   match named.original() {
-    None => buf.push(0),
+    None => scratch.push(0),
     Some((addr, meta)) => {
-      buf.push(1);
-      put_address(&addr, buf);
-      meta.put_with(NamePut::Indexed(idx), buf)?;
+      scratch.push(1);
+      put_address(&addr, scratch);
+      meta.put_with(NamePut::Indexed(idx), scratch)?;
     },
   }
+  put_u64(scratch.len() as u64, buf);
+  buf.extend_from_slice(scratch);
   Ok(())
+}
+
+/// How §5 resolves its Tag0 constant indices back to addresses: from a
+/// plain address vector (the full readers' §2 scan order) or from the
+/// lazy index's §2 windows (cursor/lazy readers). Mirrors [`NameGet`].
+#[derive(Clone, Copy)]
+pub enum ConstGet<'a> {
+  Addrs(&'a [Address]),
+  Slices(&'a [LazyConstSlice]),
+}
+
+impl ConstGet<'_> {
+  fn addr(&self, i: usize, ctx: &str) -> Result<Address, String> {
+    let (addr, len) = match self {
+      ConstGet::Addrs(v) => (v.get(i).cloned(), v.len()),
+      ConstGet::Slices(v) => (v.get(i).map(|s| s.addr.clone()), v.len()),
+    };
+    addr.ok_or_else(|| {
+      format!(
+        "{ctx}: constant index {i} out of range ({len} \
+         consts){PRE_COMPACT_KEYS}"
+      )
+    })
+  }
 }
 
 /// Deserialize a Named entry with indexed metadata.
 pub fn get_named_indexed(
   buf: &mut &[u8],
   rev: &NameReverseIndex,
+  consts: ConstGet<'_>,
 ) -> Result<Named, String> {
-  let addr = get_address(buf)?;
+  let const_idx = get_u64(buf)? as usize;
+  let addr = consts.addr(const_idx, "get_named_indexed")?;
+  let hints = unfuse_opt_hint(get_u64(buf)?)
+    .map_err(|e| format!("get_named_indexed: {e}"))?;
+  let meta_len = get_u64(buf)? as usize;
+  if buf.len() < meta_len {
+    return Err(format!(
+      "get_named_indexed: metadata blob needs {meta_len} bytes, have \
+       {}{PRE_COMPACT_KEYS}",
+      buf.len()
+    ));
+  }
+  let before = buf.len();
   let meta = ConstantMeta::get_with(buf, NameGet::Indexed(rev))?;
   let mut named = Named::new(addr, meta);
+  named.set_hints(hints);
   match get_u8(buf)? {
     0 => {},
     1 => {
@@ -1214,6 +1358,15 @@ pub fn get_named_indexed(
       named.set_original(orig_addr, orig_meta);
     },
     x => return Err(format!("Named.original: invalid tag {x}")),
+  }
+  // The header's length must frame exactly the bytes the parsers
+  // consumed — a mismatch means a desynced or tampered entry.
+  let consumed = before - buf.len();
+  if consumed != meta_len {
+    return Err(format!(
+      "get_named_indexed: metadata blob length mismatch (header says \
+       {meta_len}, parsed {consumed}){PRE_COMPACT_KEYS}"
+    ));
   }
   Ok(named)
 }
@@ -1233,7 +1386,7 @@ pub fn get_named_indexed(
 pub struct NamedMetaCursor<'a> {
   buf: &'a [u8],
   remaining: u64,
-  rev: &'a NameReverseIndex,
+  index: &'a LazyIndex,
 }
 
 impl<'a> NamedMetaCursor<'a> {
@@ -1258,7 +1411,7 @@ impl<'a> NamedMetaCursor<'a> {
         index.named.len()
       ));
     }
-    Ok(NamedMetaCursor { buf, remaining, rev: &index.name_reverse_index })
+    Ok(NamedMetaCursor { buf, remaining, index })
   }
 
   /// Parse the next entry: `(name-component hash, Named)`; `None` once
@@ -1268,8 +1421,22 @@ impl<'a> NamedMetaCursor<'a> {
       return Ok(None);
     }
     self.remaining -= 1;
-    let name_addr = get_address(&mut self.buf)?;
-    let named = get_named_indexed(&mut self.buf, self.rev)?;
+    let name_idx = get_u64(&mut self.buf)? as usize;
+    let name_addr =
+      self.index.name_reverse_index.get(name_idx).cloned().ok_or_else(
+        || {
+          format!(
+            "NamedMetaCursor: §5 name index {name_idx} out of range ({} \
+           names){PRE_COMPACT_KEYS}",
+            self.index.name_reverse_index.len()
+          )
+        },
+      )?;
+    let named = get_named_indexed(
+      &mut self.buf,
+      &self.index.name_reverse_index,
+      ConstGet::Slices(&self.index.consts),
+    )?;
     Ok(Some((name_addr, named)))
   }
 }
@@ -1422,7 +1589,7 @@ impl Env {
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // Section 3: anon_hints (Address -> ReducibilityHints)
+    // Section 3: anon_hints (§2 index -> ReducibilityHints)
     //
     // The canonical hint channel, placed before the metadata sections
     // so `get_anon`/`get_anon_mmap` can stop right after it (they
@@ -1431,15 +1598,30 @@ impl Env {
     // (`Env::register_hint`) and readers fill the map from this very
     // section. Hints are performance-only advice and intentionally
     // NOT covered by the consts merkle root.
+    //
+    // Entries are keyed by rank in §2's ascending-address order,
+    // delta-coded against the previous entry (the address sort below
+    // is load-bearing: it makes the ranks strictly ascending), with
+    // the hint fused into one Tag0 value — 2-3 bytes per entry
+    // instead of a redundant 32-byte address.
     // ─────────────────────────────────────────────────────────────────────
     let sec_start = std::time::Instant::now();
     let mut hint_pairs: Vec<(Address, ReducibilityHints)> =
       self.anon_hints.iter().map(|e| (e.key().clone(), *e.value())).collect();
     hint_pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     put_u64(hint_pairs.len() as u64, buf);
+    let mut prev: u64 = 0; // rank + 1 of the previous entry
     for (addr, hints) in &hint_pairs {
-      put_address(addr, buf);
-      hints.put_ser(buf);
+      let rank = const_addrs.binary_search(addr).map_err(|_| {
+        format!(
+          "Env::put: anon_hints key {} not present in consts — hints \
+           must be keyed by stored constant addresses",
+          addr.hex()
+        )
+      })? as u64;
+      put_u64(rank + 1 - prev, buf);
+      put_u64(fuse_hint(hints), buf);
+      prev = rank + 1;
     }
     if !quiet {
       eprintln!(
@@ -1517,10 +1699,30 @@ impl Env {
     });
     let put_start = std::time::Instant::now();
     put_u64(named_keys.len() as u64, buf);
+    // Reusable scratch for the length-prefixed metadata blobs — keeps
+    // this loop's allocations per-entry-bounded (put's streaming-RAM
+    // property).
+    let mut named_scratch: Vec<u8> = Vec::new();
     for name in &named_keys {
       if let Some(entry) = self.named.get(name) {
-        put_bytes(name.get_hash().as_bytes(), buf);
-        put_named_indexed(entry.value(), &name_index, buf)?;
+        // The name key is written as its §4 topo-order index — the
+        // name-component address for a name is bytewise its hash.
+        let name_addr = Address::from_blake3_hash(*name.get_hash());
+        let name_idx =
+          name_index.get(&name_addr).copied().ok_or_else(|| {
+            format!(
+              "Env::put: named key {} not present in the name table",
+              name_addr.hex()
+            )
+          })?;
+        put_u64(name_idx, buf);
+        put_named_indexed(
+          entry.value(),
+          &name_index,
+          &const_addrs,
+          &mut named_scratch,
+          buf,
+        )?;
       }
     }
     if !quiet {
@@ -1658,14 +1860,24 @@ impl Env {
       }
     }
     // Section 3: anon_hints — the canonical hint channel, serialized
-    // straight from the map (see `Env::put`).
+    // straight from the map as delta-coded §2 ranks + fused hints
+    // (see `Env::put`; the address sort is load-bearing).
     let mut hint_pairs: Vec<(Address, ReducibilityHints)> =
       self.anon_hints.iter().map(|e| (e.key().clone(), *e.value())).collect();
     hint_pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     put_u64(hint_pairs.len() as u64, &mut buf);
+    let mut prev: u64 = 0; // rank + 1 of the previous entry
     for (addr, hints) in &hint_pairs {
-      put_address(addr, &mut buf);
-      hints.put_ser(&mut buf);
+      let rank = const_addrs.binary_search(addr).map_err(|_| {
+        format!(
+          "Env::put_file: anon_hints key {} not present in consts — \
+           hints must be keyed by stored constant addresses",
+          addr.hex()
+        )
+      })? as u64;
+      put_u64(rank + 1 - prev, &mut buf);
+      put_u64(fuse_hint(hints), &mut buf);
+      prev = rank + 1;
       emit!();
     }
 
@@ -1699,8 +1911,23 @@ impl Env {
         .map(|name| {
           let mut b = Vec::new();
           if let Some(entry) = self.named.get(name) {
-            put_bytes(name.get_hash().as_bytes(), &mut b);
-            put_named_indexed(entry.value(), &name_index, &mut b)?;
+            let name_addr = Address::from_blake3_hash(*name.get_hash());
+            let name_idx =
+              name_index.get(&name_addr).copied().ok_or_else(|| {
+                format!(
+                  "Env::put_file: named key {} not present in the name table",
+                  name_addr.hex()
+                )
+              })?;
+            put_u64(name_idx, &mut b);
+            let mut scratch = Vec::new();
+            put_named_indexed(
+              entry.value(),
+              &name_index,
+              &const_addrs,
+              &mut scratch,
+              &mut b,
+            )?;
           }
           Ok::<_, String>(b)
         })
@@ -1766,6 +1993,10 @@ impl Env {
 
     // Section 2: Consts (lazy: read length prefix, slice bytes, defer parse)
     let num_consts = get_u64(buf)?;
+    // §2 file order (ascending addresses, enforced below) — §3 hints
+    // and §5 named entries key their constants by index into it.
+    let mut consts_order: Vec<Address> =
+      Vec::with_capacity(capped_capacity(num_consts, buf));
     for i in 0..num_consts {
       let addr = get_address(buf)?;
       let len = Tag0::get(buf)?.size as usize;
@@ -1792,6 +2023,18 @@ impl Env {
           addr.hex()
         ));
       }
+      // §2 order is load-bearing for §3/§5 index resolution: writers
+      // emit ascending addresses; a permuted section would silently
+      // re-key every hint, so reject it outright.
+      if let Some(prev) = consts_order.last()
+        && *prev >= addr
+      {
+        return Err(format!(
+          "Env::get: §2 constants not in strictly ascending address \
+           order at idx {i}"
+        ));
+      }
+      consts_order.push(addr.clone());
       env
         .consts
         .insert(addr, crate::lazy::LazyConstant::from_bytes(bytes.into()));
@@ -1804,8 +2047,13 @@ impl Env {
       return Err(format!("Env::get: main {} not present in consts", m.hex()));
     }
 
-    // Section 3: anon_hints
-    for (addr, hints) in read_hints_section(buf)? {
+    // Section 3: anon_hints (§2-index keyed; resolved via consts_order)
+    for (addr, hints) in read_hints_section(
+      buf,
+      consts_order.len(),
+      |i| consts_order[i].clone(),
+      "Env::get",
+    )? {
       env.anon_hints.insert(addr, hints);
     }
 
@@ -1831,8 +2079,20 @@ impl Env {
     // Section 5: Named (use indexed deserialization for metadata)
     let num_named = get_u64(buf)?;
     for _ in 0..num_named {
-      let name_addr = get_address(buf)?;
-      let mut named = get_named_indexed(buf, &name_reverse_index)?;
+      let name_idx = get_u64(buf)? as usize;
+      let name_addr =
+        name_reverse_index.get(name_idx).cloned().ok_or_else(|| {
+          format!(
+            "Env::get: §5 name index {name_idx} out of range ({} \
+             names){PRE_COMPACT_KEYS}",
+            name_reverse_index.len()
+          )
+        })?;
+      let mut named = get_named_indexed(
+        buf,
+        &name_reverse_index,
+        ConstGet::Addrs(&consts_order),
+      )?;
       if demote_named {
         named.demote();
       }
@@ -1851,13 +2111,12 @@ impl Env {
     }
 
     // Verify the stored merkle root matches what we'd compute from
-    // env.consts. Empty const set → expected = zero_address().
-    // Rejects any tampering with the header.
-    let mut const_addrs: Vec<Address> =
-      env.consts.iter().map(|e| e.key().clone()).collect();
-    const_addrs.sort_unstable();
+    // the §2 addresses (already strictly ascending — enforced above,
+    // so `consts_order` is the sorted, duplicate-free key set). Empty
+    // const set → expected = zero_address(). Rejects any tampering
+    // with the header.
     let computed_root =
-      merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
+      merkle_root_canonical(&consts_order).unwrap_or_else(zero_address);
     if computed_root != stored_root {
       return Err(format!(
         "Env::get: merkle root mismatch (stored={}, computed={})",
@@ -1923,7 +2182,7 @@ impl Env {
 
     // Section 2: Consts — record offset windows, never parse the bodies.
     let num_consts = get_u64(&mut buf)?;
-    for _ in 0..num_consts {
+    for i in 0..num_consts {
       let addr = get_address(&mut buf)?;
       let len = Tag0::get(&mut buf)?.size as usize;
       // Position of the body within `data` = bytes consumed so far.
@@ -1936,12 +2195,28 @@ impl Env {
         ));
       }
       buf = &buf[len..];
+      // §2 order is load-bearing for §3/§5 index resolution (and for
+      // the sort-free merkle recompute below) — enforce it.
+      if let Some(prev) = index.consts.last()
+        && prev.addr >= addr
+      {
+        return Err(format!(
+          "parse_lazy_index: §2 constants not in strictly ascending \
+           address order at idx {i}"
+        ));
+      }
       index.consts.push(LazyConstSlice { addr, offset, len });
     }
 
-    // Section 3: anon_hints — kept verbatim on the index for
-    // full-reader parity.
-    index.hints = read_hints_section(&mut buf)?;
+    // Section 3: anon_hints — kept verbatim (resolved to addresses) on
+    // the index for full-reader parity. The §2 windows are the
+    // index→address table.
+    index.hints = read_hints_section(
+      &mut buf,
+      index.consts.len(),
+      |i| index.consts[i].addr.clone(),
+      "parse_lazy_index",
+    )?;
 
     // Section 4: Names — parsed to build the index for metadata
     // decoding. The reverse index is retained on the LazyIndex so §5
@@ -1968,12 +2243,38 @@ impl Env {
     index.named_section_offset = data.len() - buf.len();
     let num_named = get_u64(&mut buf)?;
     for _ in 0..num_named {
-      let name_addr = get_address(&mut buf)?;
-      let named = get_named_indexed(&mut buf, &index.name_reverse_index)?;
+      let name_idx = get_u64(&mut buf)? as usize;
+      let name_addr =
+        index.name_reverse_index.get(name_idx).cloned().ok_or_else(|| {
+          format!(
+            "parse_lazy_index: §5 name index {name_idx} out of range ({} \
+             names){PRE_COMPACT_KEYS}",
+            index.name_reverse_index.len()
+          )
+        })?;
+      // Entry header: const rank + per-name hint + metadata blob
+      // length. The blob is SKIPPED — this is the payoff of the
+      // length-prefixed layout: the lazy index never parses metadata
+      // arenas just to find entry boundaries. A `NamedMetaCursor`
+      // re-opened at `named_section_offset` parses them on demand.
+      let const_rank = get_u64(&mut buf)? as usize;
+      let addr =
+        ConstGet::Slices(&index.consts).addr(const_rank, "parse_lazy_index")?;
+      let hints = unfuse_opt_hint(get_u64(&mut buf)?)
+        .map_err(|e| format!("parse_lazy_index: {e}"))?;
+      let meta_len = get_u64(&mut buf)? as usize;
+      if buf.len() < meta_len {
+        return Err(format!(
+          "parse_lazy_index: §5 metadata blob needs {meta_len} bytes, \
+           have {}{PRE_COMPACT_KEYS}",
+          buf.len()
+        ));
+      }
+      buf = &buf[meta_len..];
       let name = names_lookup.get(&name_addr).cloned().ok_or_else(|| {
         format!("parse_lazy_index: missing name for addr {:?}", name_addr)
       })?;
-      index.named.push(LazyNamed { name, addr: named.addr });
+      index.named.push(LazyNamed { name, addr, hints });
     }
 
     // Section 6: Comms — carried verbatim (tiny; empty for
@@ -1995,10 +2296,11 @@ impl Env {
       ));
     }
 
-    // Re-verify the merkle root over const addresses (header integrity).
-    let mut const_addrs: Vec<Address> =
+    // Re-verify the merkle root over const addresses (header
+    // integrity). §2 ascending order was enforced during the scan, so
+    // the collected addresses are already the sorted key set.
+    let const_addrs: Vec<Address> =
       index.consts.iter().map(|c| c.addr.clone()).collect();
-    const_addrs.sort_unstable();
     let computed_root =
       merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
     if computed_root != stored_root {
@@ -2089,9 +2391,8 @@ impl Env {
   /// by design — only the full [`Env::get`] enforces EOF.
   ///
   /// Hints come straight from §3: the writer always emits that
-  /// section, deriving it from Named metadata when the in-memory map
-  /// is empty, so the historical read-time harvest from §Named is
-  /// gone.
+  /// section from the `anon_hints` map (its single home), so there is
+  /// no read-time harvest from §Named.
   ///
   /// Used by the anon-mode kernel path so a verifier holding only
   /// content addresses doesn't pay for metadata it will never consult.
@@ -2111,6 +2412,10 @@ impl Env {
 
     // Section 2: Consts (kept, lazy)
     let num_consts = get_u64(buf)?;
+    // §2 file order (ascending, enforced) — resolves §3 hint indices
+    // and doubles as the sorted key set for the merkle recompute.
+    let mut consts_order: Vec<Address> =
+      Vec::with_capacity(capped_capacity(num_consts, buf));
     for i in 0..num_consts {
       let addr = get_address(buf)?;
       let len = Tag0::get(buf)?.size as usize;
@@ -2131,6 +2436,15 @@ impl Env {
           addr.hex()
         ));
       }
+      if let Some(prev) = consts_order.last()
+        && *prev >= addr
+      {
+        return Err(format!(
+          "Env::get_anon: §2 constants not in strictly ascending \
+           address order at idx {i}"
+        ));
+      }
+      consts_order.push(addr.clone());
       env
         .consts
         .insert(addr, crate::lazy::LazyConstant::from_bytes(bytes.into()));
@@ -2151,19 +2465,21 @@ impl Env {
     // either way. Without them, every Definition is forced to
     // `Regular(0)` and the kernel can chew through `MAX_WHNF_FUEL` on
     // definitions Lean would have marked `Abbrev`/`Regular(h)`.
-    for (addr, hints) in read_hints_section(buf)? {
+    for (addr, hints) in read_hints_section(
+      buf,
+      consts_order.len(),
+      |i| consts_order[i].clone(),
+      "Env::get_anon",
+    )? {
       env.anon_hints.insert(addr, hints);
     }
 
     // Sections 4-6 (names / named / comms) are laid out after the
     // hints precisely so this reader can stop here.
 
-    // Verify merkle root over loaded consts.
-    let mut const_addrs: Vec<Address> =
-      env.consts.iter().map(|e| e.key().clone()).collect();
-    const_addrs.sort_unstable();
+    // Verify merkle root over the §2 addresses (ascending — enforced).
     let computed_root =
-      merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
+      merkle_root_canonical(&consts_order).unwrap_or_else(zero_address);
     if computed_root != stored_root {
       return Err(format!(
         "Env::get_anon: merkle root mismatch (stored={}, computed={})",
@@ -2261,6 +2577,10 @@ impl Env {
 
     // Section 2: Consts (mmap-backed lazy windows)
     let num_consts = get_u64(&mut buf)?;
+    // §2 file order (ascending, enforced) — resolves §3 hint indices
+    // and doubles as the sorted key set for the merkle recompute.
+    let mut consts_order: Vec<Address> =
+      Vec::with_capacity(capped_capacity(num_consts, buf));
     for i in 0..num_consts {
       let addr = get_address(&mut buf)?;
       let len = Tag0::get(&mut buf)?.size as usize;
@@ -2283,6 +2603,15 @@ impl Env {
           addr.hex()
         ));
       }
+      if let Some(prev) = consts_order.last()
+        && *prev >= addr
+      {
+        return Err(format!(
+          "Env::get_anon_mmap: §2 constants not in strictly ascending \
+           address order at idx {i}"
+        ));
+      }
+      consts_order.push(addr.clone());
       env.consts.insert(
         addr,
         crate::lazy::LazyConstant::from_mmap_slice(
@@ -2305,19 +2634,22 @@ impl Env {
     }
 
     // Section 3: anon_hints — see `get_anon` for the rationale.
-    for (addr, hints) in read_hints_section(&mut buf)? {
+    for (addr, hints) in read_hints_section(
+      &mut buf,
+      consts_order.len(),
+      |i| consts_order[i].clone(),
+      "Env::get_anon_mmap",
+    )? {
       env.anon_hints.insert(addr, hints);
     }
 
     // Sections 4-6 (names / named / comms) are laid out after the
     // hints precisely so this reader can stop here.
 
-    // Verify merkle root over loaded consts (same as get_anon).
-    let mut const_addrs: Vec<Address> =
-      env.consts.iter().map(|e| e.key().clone()).collect();
-    const_addrs.sort_unstable();
+    // Verify merkle root over the §2 addresses (ascending — enforced;
+    // same as get_anon).
     let computed_root =
-      merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
+      merkle_root_canonical(&consts_order).unwrap_or_else(zero_address);
     if computed_root != stored_root {
       return Err(format!(
         "Env::get_anon_mmap: merkle root mismatch (stored={}, computed={})",
@@ -2381,15 +2713,26 @@ impl Env {
     }
     let consts_size = buf.len() - before_consts;
 
-    // Section 3: anon_hints (serialized straight from the map)
+    // Section 3: anon_hints (serialized straight from the map). The
+    // address sort is load-bearing: §3 sizes are delta-coded §2 ranks,
+    // so an unsorted iteration would change (and corrupt) the deltas.
     let before_hints = buf.len();
     let mut hint_pairs: Vec<(Address, ReducibilityHints)> =
       self.anon_hints.iter().map(|e| (e.key().clone(), *e.value())).collect();
     hint_pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     put_u64(hint_pairs.len() as u64, &mut buf);
+    let mut prev: u64 = 0; // rank + 1 of the previous entry
     for (addr, hints) in &hint_pairs {
-      put_address(addr, &mut buf);
-      hints.put_ser(&mut buf);
+      let rank = const_addrs.binary_search(addr).map_err(|_| {
+        format!(
+          "Env::serialized_size_breakdown: anon_hints key {} not present \
+           in consts — hints must be keyed by stored constant addresses",
+          addr.hex()
+        )
+      })? as u64;
+      put_u64(rank + 1 - prev, &mut buf);
+      put_u64(fuse_hint(hints), &mut buf);
+      prev = rank + 1;
     }
     let hints_size = buf.len() - before_hints;
 
@@ -2405,12 +2748,29 @@ impl Env {
     }
     let names_size = buf.len() - before_names;
 
-    // Section 5: Named (use indexed serialization)
+    // Section 5: Named (use indexed serialization). Iteration order is
+    // fine for *sizes* only because both §5 indices are absolute — a
+    // delta-coded §5 would make per-entry sizes order-dependent.
     let before_named = buf.len();
     put_u64(self.named.len() as u64, &mut buf);
+    let mut named_scratch: Vec<u8> = Vec::new();
     for entry in self.named.iter() {
-      put_bytes(entry.key().get_hash().as_bytes(), &mut buf);
-      put_named_indexed(entry.value(), &name_index, &mut buf)?;
+      let name_addr = Address::from_blake3_hash(*entry.key().get_hash());
+      let name_idx = name_index.get(&name_addr).copied().ok_or_else(|| {
+        format!(
+          "Env::serialized_size_breakdown: named key {} not present in \
+           the name table",
+          name_addr.hex()
+        )
+      })?;
+      put_u64(name_idx, &mut buf);
+      put_named_indexed(
+        entry.value(),
+        &name_index,
+        &const_addrs,
+        &mut named_scratch,
+        &mut buf,
+      )?;
     }
     let named_size = buf.len() - before_named;
 
@@ -2670,6 +3030,18 @@ mod tests {
         if let Some((orig_addr, orig_meta)) = original {
           named.set_original(orig_addr, orig_meta);
         }
+        // Per-name hints ride the §5 entry header — exercise every
+        // variant including absent.
+        let hint_variant: u8 = Arbitrary::arbitrary(g);
+        match hint_variant % 4 {
+          0 => {},
+          1 => named.set_hints(Some(ReducibilityHints::Opaque)),
+          2 => named.set_hints(Some(ReducibilityHints::Abbrev)),
+          _ => {
+            let h: u32 = Arbitrary::arbitrary(g);
+            named.set_hints(Some(ReducibilityHints::Regular(h % 200)));
+          },
+        }
         env.named.insert(name, named);
       }
     }
@@ -2694,17 +3066,32 @@ mod tests {
       env.assumptions.insert(Address::arbitrary(g));
     }
 
-    // anon_hints (keyed by arbitrary addresses — the map is advisory
-    // and the hints section is serialized straight from it).
-    let num_hints = gen_range(g, 0..4);
-    for _ in 0..num_hints {
-      let variant: u8 = Arbitrary::arbitrary(g);
-      let hint = match variant % 3 {
-        0 => ReducibilityHints::Opaque,
-        1 => ReducibilityHints::Abbrev,
-        _ => ReducibilityHints::Regular(Arbitrary::arbitrary(g)),
-      };
-      env.anon_hints.insert(Address::arbitrary(g), hint);
+    // anon_hints — keyed by stored constant addresses: §3 writes each
+    // key as its §2 rank, so out-of-consts keys are a writer error.
+    // Regular heights span the fused-hint Tag0 1↔2-byte boundary
+    // (fused = h + 2 crosses 127 at h = 126).
+    if !const_addrs.is_empty() {
+      let num_hints = gen_range(g, 0..4);
+      for _ in 0..num_hints {
+        let variant: u8 = Arbitrary::arbitrary(g);
+        let hint = match variant % 3 {
+          0 => ReducibilityHints::Opaque,
+          1 => ReducibilityHints::Abbrev,
+          _ => {
+            let h: u32 = Arbitrary::arbitrary(g);
+            // Bias half the heights to the Tag0 1↔2-byte wire boundary
+            // (fused = h + 2 crosses 127 at h = 126); keep the rest
+            // full-range for the multi-byte Tag0 paths.
+            ReducibilityHints::Regular(if bool::arbitrary(g) {
+              h % 200
+            } else {
+              h
+            })
+          },
+        };
+        let idx = usize::arbitrary(g) % const_addrs.len();
+        env.anon_hints.insert(const_addrs[idx].clone(), hint);
+      }
     }
 
     env
@@ -2783,10 +3170,12 @@ mod tests {
           }
         }
 
-        // Check named content
+        // Check named content (addr + exact per-name hints)
         for entry in env.named.iter() {
           match recovered.named.get(entry.key()) {
-            Some(v) if v.addr == entry.value().addr => {},
+            Some(v)
+              if v.addr == entry.value().addr
+                && v.hints() == entry.value().hints() => {},
             _ => {
               eprintln!("named content mismatch for {:?}", entry.key());
               return false;
@@ -2805,8 +3194,8 @@ mod tests {
           }
         }
 
-        // Bundle fields + hints (gen_env metas are all Empty, so §3
-        // derivation contributes nothing and plain equality holds).
+        // Bundle fields + hints (§3 serializes the map verbatim, so
+        // plain equality holds after a roundtrip).
         if env.main != recovered.main {
           eprintln!("main mismatch: {:?} vs {:?}", env.main, recovered.main);
           return false;
@@ -3076,11 +3465,11 @@ mod tests {
     let a = store_canonical(&env, defn_const(vec![]));
     let b = store_canonical(&env, defn_const(vec![a.clone()]));
     // Populate metadata sections so we can verify they get dropped.
+    // §5 keys names by §4 index, so the component must be stored too.
     let blob_addr = env.store_blob(b"hello world".to_vec());
-    env.register_name(
-      Name::str(Name::anon(), "MyConst".to_string()),
-      Named::with_addr(a.clone()),
-    );
+    let name = Name::str(Name::anon(), "MyConst".to_string());
+    env.store_name(Address::from_blake3_hash(*name.get_hash()), name.clone());
+    env.register_name(name, Named::with_addr(a.clone()));
 
     let mut buf = Vec::new();
     env.put(&mut buf).unwrap();
@@ -3327,12 +3716,10 @@ mod tests {
       .expect("get_anon early-stops before the garbage");
   }
 
-  /// §3 is the canonical hint channel: with an empty `anon_hints` map
-  /// the writer derives the section from Named `Def` metadata, and an
-  /// env carrying the same hints explicitly serializes byte-identically.
-  /// The hints section round-trips through both the anon and full
-  /// readers, and `register_hint`'s merge is order-independent on
-  /// address collisions.
+  /// §3 is the canonical (and only) hint channel, serialized straight
+  /// from the `anon_hints` map. The hints section round-trips through
+  /// both the anon and full readers, and `register_hint`'s merge is
+  /// order-independent on address collisions.
   #[test]
   fn env_hints_roundtrip_and_merge_deterministic() {
     let env = Env::new();
@@ -3369,5 +3756,416 @@ mod tests {
       a.anon_hints.get(&ca).map(|r| *r),
       Some(ReducibilityHints::Abbrev)
     );
+  }
+
+  // ---------- Compact index-keyed §3/§5 tests ----------
+
+  #[test]
+  fn fused_hint_codec_roundtrip_and_bounds() {
+    use ReducibilityHints::*;
+    for h in [
+      Opaque,
+      Abbrev,
+      Regular(0),
+      Regular(125),
+      Regular(126),
+      Regular(u32::MAX),
+    ] {
+      assert_eq!(unfuse_hint(fuse_hint(&h)).unwrap(), h);
+    }
+    // Wire widths at the Tag0 1↔2-byte boundary: fused = h + 2.
+    let width = |h: &ReducibilityHints| {
+      let mut b = Vec::new();
+      put_u64(fuse_hint(h), &mut b);
+      b.len()
+    };
+    assert_eq!(width(&Regular(125)), 1, "fused 127 fits one byte");
+    assert_eq!(width(&Regular(126)), 2, "fused 128 needs the large form");
+    // Heights beyond u32 are malformed.
+    assert!(unfuse_hint(u64::from(u32::MAX) + 3).is_err());
+    assert!(unfuse_hint(u64::MAX).is_err());
+  }
+
+  /// Byte range of §3 (start of its count, end after its last entry),
+  /// computed by walking the prefix with the real parsers.
+  fn hints_section_bounds(buf: &[u8]) -> (usize, usize) {
+    let mut cur: &[u8] = buf;
+    read_env_header(&mut cur, "test").unwrap();
+    read_blob_section(&mut cur, "test").unwrap();
+    let n = get_u64(&mut cur).unwrap();
+    for _ in 0..n {
+      let _addr = get_address(&mut cur).unwrap();
+      let len = Tag0::get(&mut cur).unwrap().size as usize;
+      cur = &cur[len..];
+    }
+    let start = buf.len() - cur.len();
+    let m = get_u64(&mut cur).unwrap();
+    for _ in 0..m {
+      let _delta = get_u64(&mut cur).unwrap();
+      let _fused = get_u64(&mut cur).unwrap();
+    }
+    (start, buf.len() - cur.len())
+  }
+
+  /// Replace §3 with `custom` bytes (count + entries as given).
+  fn splice_hints(buf: &[u8], custom: &[u8]) -> Vec<u8> {
+    let (s, e) = hints_section_bounds(buf);
+    let mut out = buf[..s].to_vec();
+    out.extend_from_slice(custom);
+    out.extend_from_slice(&buf[e..]);
+    out
+  }
+
+  /// Assert every reader (full, anon, anon_mmap, lazy index) rejects
+  /// `buf` with an error containing all of `substrings`.
+  fn assert_all_readers_reject(buf: &[u8], substrings: &[&str]) {
+    use std::io::Write;
+    let mut errs: Vec<(&str, String)> = vec![
+      ("get", Env::get(&mut &buf[..]).expect_err("get accepted")),
+      (
+        "get_anon",
+        Env::get_anon(&mut &buf[..]).expect_err("get_anon accepted"),
+      ),
+      (
+        "parse_lazy_index",
+        Env::parse_lazy_index(buf).expect_err("parse_lazy_index accepted"),
+      ),
+    ];
+    let tmp = std::env::temp_dir()
+      .join(format!("ix_reject_{}.ixe", Address::hash(buf).hex()));
+    {
+      let mut f = std::fs::File::create(&tmp).unwrap();
+      f.write_all(buf).unwrap();
+    }
+    errs.push((
+      "get_anon_mmap",
+      Env::get_anon_mmap(&tmp).expect_err("get_anon_mmap accepted"),
+    ));
+    std::fs::remove_file(&tmp).ok();
+    for (reader, err) in errs {
+      for s in substrings {
+        assert!(err.contains(s), "{reader}: expected {s:?} in: {err}");
+      }
+    }
+  }
+
+  /// Two consts + two hints — the base fixture for §3 malformation.
+  fn two_hint_env_bytes() -> Vec<u8> {
+    let env = Env::new();
+    let a = store_canonical(&env, defn_const(vec![]));
+    let b = store_canonical(&env, defn_const(vec![a.clone()]));
+    env.register_hint(a, ReducibilityHints::Regular(7));
+    env.register_hint(b, ReducibilityHints::Abbrev);
+    let mut buf = Vec::new();
+    env.put(&mut buf).unwrap();
+    buf
+  }
+
+  #[test]
+  fn hints_zero_delta_rejected_by_all_readers() {
+    let buf = two_hint_env_bytes();
+    // count=2; first entry (delta 1 → idx 0), second entry delta 0.
+    let mut custom = Vec::new();
+    put_u64(2, &mut custom);
+    put_u64(1, &mut custom);
+    put_u64(fuse_hint(&ReducibilityHints::Regular(7)), &mut custom);
+    put_u64(0, &mut custom);
+    put_u64(1, &mut custom);
+    assert_all_readers_reject(
+      &splice_hints(&buf, &custom),
+      &["zero index delta", "pre-compact-keys"],
+    );
+  }
+
+  #[test]
+  fn hints_index_out_of_range_rejected_by_all_readers() {
+    let buf = two_hint_env_bytes();
+    // count=1; delta 3 → idx 2, but only 2 consts.
+    let mut custom = Vec::new();
+    put_u64(1, &mut custom);
+    put_u64(3, &mut custom);
+    put_u64(0, &mut custom);
+    assert_all_readers_reject(
+      &splice_hints(&buf, &custom),
+      &["out of range", "pre-compact-keys"],
+    );
+  }
+
+  #[test]
+  fn hints_count_above_const_count_rejected_by_all_readers() {
+    let buf = two_hint_env_bytes();
+    // count=3 > 2 consts — rejected before any entry is parsed.
+    let mut custom = Vec::new();
+    put_u64(3, &mut custom);
+    for _ in 0..3 {
+      put_u64(1, &mut custom);
+      put_u64(0, &mut custom);
+    }
+    assert_all_readers_reject(
+      &splice_hints(&buf, &custom),
+      &["hint count 3 exceeds const count 2", "pre-compact-keys"],
+    );
+  }
+
+  #[test]
+  fn hints_fused_overflow_rejected_by_all_readers() {
+    let buf = two_hint_env_bytes();
+    // count=1; valid delta, fused value above the Regular(u32) ceiling.
+    let mut custom = Vec::new();
+    put_u64(1, &mut custom);
+    put_u64(1, &mut custom);
+    put_u64(u64::from(u32::MAX) + 3, &mut custom);
+    assert_all_readers_reject(
+      &splice_hints(&buf, &custom),
+      &["exceeds u32::MAX"],
+    );
+  }
+
+  #[test]
+  fn old_format_hints_section_detected() {
+    let buf = two_hint_env_bytes();
+    // Simulate a pre-compact-keys §3: count=1, then a raw 32-byte
+    // address + tag byte + Tag0 height. The first address byte (0x00)
+    // parses as a zero delta, so every reader fails immediately with
+    // the recompile hint.
+    let mut custom = Vec::new();
+    put_u64(1, &mut custom);
+    custom.extend_from_slice(&[0u8; 32]);
+    custom.push(2);
+    Tag0::new(5).put(&mut custom);
+    assert_all_readers_reject(
+      &splice_hints(&buf, &custom),
+      &["pre-compact-keys", "recompile"],
+    );
+  }
+
+  #[test]
+  fn consts_out_of_order_rejected_by_all_readers() {
+    // The merkle root is order-independent (canonical over the key
+    // set), so a permuted §2 used to slip through — but §3/§5 indices
+    // resolve against file order, so readers must reject it.
+    let buf = two_hint_env_bytes();
+    // Locate the two §2 entries (addr + len tag + payload) and swap them.
+    let mut cur: &[u8] = &buf;
+    read_env_header(&mut cur, "test").unwrap();
+    read_blob_section(&mut cur, "test").unwrap();
+    let n = get_u64(&mut cur).unwrap();
+    assert_eq!(n, 2);
+    let first_start = buf.len() - cur.len();
+    let _addr = get_address(&mut cur).unwrap();
+    let len = Tag0::get(&mut cur).unwrap().size as usize;
+    cur = &cur[len..];
+    let second_start = buf.len() - cur.len();
+    let _addr = get_address(&mut cur).unwrap();
+    let len = Tag0::get(&mut cur).unwrap().size as usize;
+    cur = &cur[len..];
+    let second_end = buf.len() - cur.len();
+    let mut swapped = buf[..first_start].to_vec();
+    swapped.extend_from_slice(&buf[second_start..second_end]);
+    swapped.extend_from_slice(&buf[first_start..second_start]);
+    swapped.extend_from_slice(&buf[second_end..]);
+    assert_all_readers_reject(&swapped, &["strictly ascending"]);
+  }
+
+  #[test]
+  fn named_indices_out_of_range_rejected() {
+    // One named entry whose §5 name_idx / const_idx bytes get bumped
+    // out of range (both are single-byte Tag0 values in this env).
+    let env = Env::new();
+    let a = store_canonical(&env, defn_const(vec![]));
+    let name = n_test("Target");
+    env.store_name(Address::from_blake3_hash(*name.get_hash()), name.clone());
+    env.register_name(name, Named::with_addr(a));
+    let mut buf = Vec::new();
+    env.put(&mut buf).unwrap();
+
+    let index = Env::parse_lazy_index(&buf).unwrap();
+    let mut cur: &[u8] = &buf[index.named_section_offset..];
+    let count = get_u64(&mut cur).unwrap();
+    assert_eq!(count, 1);
+    let name_idx_off = buf.len() - cur.len();
+    let _name_idx = get_u64(&mut cur).unwrap();
+    let const_idx_off = buf.len() - cur.len();
+
+    // name_idx out of range: full + lazy readers reject...
+    let mut bad = buf.clone();
+    assert_eq!(bad[name_idx_off] & 0x80, 0, "expected small Tag0");
+    bad[name_idx_off] = 0x7F;
+    let err = Env::get(&mut bad.as_slice()).expect_err("get accepted");
+    assert!(err.contains("name index"), "got: {err}");
+    assert!(err.contains("pre-compact-keys"), "got: {err}");
+    let err =
+      Env::parse_lazy_index(&bad).expect_err("parse_lazy_index accepted");
+    assert!(err.contains("name index"), "got: {err}");
+    // ...and a cursor opened with a valid index over the bad buffer
+    // hits the same wall.
+    let mut cursor = NamedMetaCursor::open(&bad, &index).unwrap();
+    let err = cursor.next_entry().expect_err("cursor accepted");
+    assert!(err.contains("name index"), "got: {err}");
+
+    // const_idx out of range.
+    let mut bad = buf.clone();
+    assert_eq!(bad[const_idx_off] & 0x80, 0, "expected small Tag0");
+    bad[const_idx_off] = 0x7F;
+    let err = Env::get(&mut bad.as_slice()).expect_err("get accepted");
+    assert!(err.contains("constant index"), "got: {err}");
+    assert!(err.contains("pre-compact-keys"), "got: {err}");
+    let mut cursor = NamedMetaCursor::open(&bad, &index).unwrap();
+    let err = cursor.next_entry().expect_err("cursor accepted");
+    assert!(err.contains("constant index"), "got: {err}");
+  }
+
+  #[test]
+  fn writers_reject_hints_for_missing_consts() {
+    let env = Env::new();
+    store_canonical(&env, defn_const(vec![]));
+    env
+      .anon_hints
+      .insert(Address::hash(b"stray hint key"), ReducibilityHints::Abbrev);
+    let mut buf = Vec::new();
+    let err = env.put(&mut buf).expect_err("put accepted stray hint");
+    assert!(err.contains("not present in consts"), "got: {err}");
+    let tmp = std::env::temp_dir().join("ix_stray_hint_put_file_test.ixe");
+    let err = env.put_file(&tmp).expect_err("put_file accepted stray hint");
+    assert!(err.contains("not present in consts"), "got: {err}");
+    std::fs::remove_file(&tmp).ok();
+    let err = env
+      .serialized_size_breakdown()
+      .expect_err("breakdown accepted stray hint");
+    assert!(err.contains("not present in consts"), "got: {err}");
+  }
+
+  #[test]
+  fn writers_reject_named_for_missing_consts() {
+    let env = Env::new();
+    let name = n_test("Dangling");
+    env.store_name(Address::from_blake3_hash(*name.get_hash()), name.clone());
+    env.register_name(
+      name,
+      Named::with_addr(Address::hash(b"not a stored const")),
+    );
+    let mut buf = Vec::new();
+    let err = env.put(&mut buf).expect_err("put accepted dangling named");
+    assert!(err.contains("not present in consts"), "got: {err}");
+  }
+
+  #[test]
+  fn get_anon_hints_match_get_multi_entry() {
+    let env = Env::new();
+    let mut addrs = Vec::new();
+    for i in 0..5 {
+      addrs.push(store_canonical(&env, defn_const_discriminator(vec![], i)));
+    }
+    env.register_hint(addrs[0].clone(), ReducibilityHints::Opaque);
+    env.register_hint(addrs[2].clone(), ReducibilityHints::Regular(200));
+    env.register_hint(addrs[4].clone(), ReducibilityHints::Abbrev);
+    let mut buf = Vec::new();
+    env.put(&mut buf).unwrap();
+    let full = Env::get(&mut buf.as_slice()).unwrap();
+    let anon = Env::get_anon(&mut buf.as_slice()).unwrap();
+    assert_eq!(full.anon_hints.len(), 3);
+    assert_eq!(anon.anon_hints.len(), 3);
+    for e in full.anon_hints.iter() {
+      assert_eq!(anon.anon_hints.get(e.key()).map(|r| *r), Some(*e.value()));
+    }
+  }
+
+  fn n_test(s: &str) -> Name {
+    Name::str(Name::anon(), s.to_string())
+  }
+
+  /// THE alias regression (validate-aux's 222 decompile mismatches):
+  /// alpha-identical definitions under different names share one
+  /// constant address, so the per-address §3 channel min-merges their
+  /// hints — but the per-name §5 channel must preserve each name's
+  /// EXACT hint through a roundtrip.
+  #[test]
+  fn aliased_names_keep_exact_hints() {
+    let env = Env::new();
+    let shared = store_canonical(&env, defn_const(vec![]));
+    for (name, hint) in [
+      ("SlowAlias", ReducibilityHints::Regular(9)),
+      ("FastAlias", ReducibilityHints::Abbrev),
+    ] {
+      let name = n_test(name);
+      env.store_name(Address::from_blake3_hash(*name.get_hash()), name.clone());
+      let mut named = Named::with_addr(shared.clone());
+      named.set_hints(Some(hint));
+      env.register_name(name, named);
+      // The per-address channel merges (order-independently).
+      env.register_hint(shared.clone(), hint);
+    }
+
+    let mut buf = Vec::new();
+    env.put(&mut buf).unwrap();
+    let back = Env::get(&mut buf.as_slice()).unwrap();
+    assert_eq!(
+      back.named.get(&n_test("SlowAlias")).unwrap().hints(),
+      Some(ReducibilityHints::Regular(9)),
+      "losing alias keeps its exact per-name hint"
+    );
+    assert_eq!(
+      back.named.get(&n_test("FastAlias")).unwrap().hints(),
+      Some(ReducibilityHints::Abbrev)
+    );
+    // §3 holds the merged advisory winner (Abbrev < Regular).
+    assert_eq!(
+      back.anon_hints.get(&shared).map(|r| *r),
+      Some(ReducibilityHints::Abbrev)
+    );
+
+    // The lazy index reads §5 headers without parsing metadata bodies —
+    // per-name hints must match the full reader.
+    let index = Env::parse_lazy_index(&buf).unwrap();
+    let lazy = Env::from_lazy_index(&index, &buf).unwrap();
+    for name in ["SlowAlias", "FastAlias"] {
+      assert_eq!(
+        lazy.named.get(&n_test(name)).unwrap().hints(),
+        back.named.get(&n_test(name)).unwrap().hints(),
+        "lazy/full hint parity for {name}"
+      );
+    }
+  }
+
+  /// §5 entries are length-prefixed; a header length that disagrees
+  /// with the parsed size (or overruns the buffer) is rejected.
+  #[test]
+  fn named_meta_len_mismatch_rejected() {
+    let env = Env::new();
+    let a = store_canonical(&env, defn_const(vec![]));
+    let name = n_test("Target");
+    env.store_name(Address::from_blake3_hash(*name.get_hash()), name.clone());
+    env.register_name(name, Named::with_addr(a));
+    let mut buf = Vec::new();
+    env.put(&mut buf).unwrap();
+
+    // Locate the first entry's meta_len byte: after the §5 count,
+    // name_idx, const_idx, and fused hint (all 1-byte Tag0s here).
+    let index = Env::parse_lazy_index(&buf).unwrap();
+    let mut cur: &[u8] = &buf[index.named_section_offset..];
+    let _count = get_u64(&mut cur).unwrap();
+    let _name_idx = get_u64(&mut cur).unwrap();
+    let _const_idx = get_u64(&mut cur).unwrap();
+    let _hint = get_u64(&mut cur).unwrap();
+    let len_off = buf.len() - cur.len();
+    assert_eq!(buf[len_off] & 0x80, 0, "expected small Tag0 meta_len");
+
+    // Shrink the length: parsers consume more than the header says.
+    let mut bad = buf.clone();
+    bad[len_off] -= 1;
+    let err = Env::get(&mut bad.as_slice()).expect_err("get accepted");
+    assert!(err.contains("length mismatch"), "got: {err}");
+
+    // Grow the length past the remaining buffer: bounds check fires.
+    let mut bad = buf.clone();
+    bad[len_off] = 0x7F;
+    let err = Env::get(&mut bad.as_slice()).expect_err("get accepted");
+    assert!(
+      err.contains("length mismatch") || err.contains("needs"),
+      "got: {err}"
+    );
+    let err =
+      Env::parse_lazy_index(&bad).expect_err("parse_lazy_index accepted");
+    assert!(err.contains("needs"), "got: {err}");
   }
 }

--- a/crates/ixvm-codegen/src/env_handle.rs
+++ b/crates/ixvm-codegen/src/env_handle.rs
@@ -7,9 +7,9 @@
 //! the env is parsed exactly once instead of every call.
 //!
 //! `anon_hints` (`Defn` reducibility hints) come from the `.ixe` §3
-//! hints section, which every writer emits (deriving it from Named
-//! metadata when the in-memory map is empty) — both readers used here
-//! populate the map directly, so no post-decode harvest is needed.
+//! hints section, which every writer emits straight from the
+//! `Env::anon_hints` map — both readers used here populate the map
+//! directly, so no post-decode harvest is needed.
 
 use ixon::Env;
 

--- a/crates/kernel/src/inductive.rs
+++ b/crates/kernel/src/inductive.rs
@@ -1277,6 +1277,45 @@ impl<M: KernelMode> TypeChecker<'_, M> {
         aux_ctor_kids.push(aux_ctor_kid);
       }
 
+      // Synthetic trailing "identity marker" ctor carrying the aux's
+      // nested-occurrence identity (`Ext spec_params`, pre-rewrite: NOT
+      // passed through `replace_aux_refs_for_sort`, or it would become
+      // the self-reference and lose the distinction). Two nested
+      // occurrences of one external inductive can instantiate to
+      // alpha-identical views when the distinguishing spec param is
+      // phantom in the external's constructors — the marker keeps them
+      // in distinct classes and orders them by spec-param content
+      // (external consts by address, block params by index), mirroring
+      // the compile-side marker in `sort_aux_by_partition_refinement`.
+      // Genuinely alpha-collapsed occurrences have address-equal spec
+      // params, so their markers compare equal and still collapse.
+      {
+        let mut marker_ty = self
+          .intern(KExpr::cnst(member.id.clone(), member.occurrence_us.clone()));
+        for sp in member.spec_params.iter() {
+          marker_ty = self.intern(KExpr::app(marker_ty, sp.clone()));
+        }
+        let mut mh = blake3::Hasher::new();
+        mh.update(b"AUX_MARKER_VIEW");
+        mh.update(aux_addr.as_bytes());
+        let marker_addr = Address::from_blake3_hash(mh.finalize());
+        let marker_kid =
+          KId::new(marker_addr.clone(), M::meta_field(Name::anon()));
+        let marker_ctor = KConst::Ctor {
+          name: M::meta_field(Name::anon()),
+          level_params: M::meta_field(vec![]),
+          is_unsafe: false,
+          lvls: block_us.len() as u64,
+          induct: aux_id.clone(),
+          cidx: aux_ctor_kids.len() as u64,
+          params: n_block_params,
+          fields: 0,
+          ty: marker_ty,
+        };
+        all_ctor_lookup.insert(marker_addr, marker_ctor);
+        aux_ctor_kids.push(marker_kid);
+      }
+
       let aux_indc = KConst::Indc {
         name: M::meta_field(seed_name),
         level_params: M::meta_field(vec![]),

--- a/docs/Ixon.md
+++ b/docs/Ixon.md
@@ -783,7 +783,7 @@ pub enum NameData {
 }
 ```
 
-**Name serialization** (component form, for Env section 3):
+**Name serialization** (component form, for Env section 4):
 ```
 Tag (1 byte): 0 = Anonymous, 1 = Str, 2 = Num
 + (if Str/Num) parent_address (32 bytes)
@@ -857,19 +857,34 @@ directly into a [`LazyConstant`](../crates/ixon/src/lazy.rs) without
 parsing its Tag4 envelope, deferring full deserialization until first
 access.
 
-**Section 3: Reducibility hints** (Address → ReducibilityHints)
+**Section 3: Reducibility hints** (§2 index → ReducibilityHints)
 ```
-count (Tag0)
-[Address (32 bytes) + ReducibilityHints]*
+count (Tag0)                          -- must be ≤ the §2 count
+[index_delta (Tag0) + fused_hint (Tag0)]*
 ```
 
-The canonical (and only) hint channel, keyed by constant address and
-sorted ascending. Hints never appear in `ConstantMeta`: the compiler
-registers each definition's hints into `Env::anon_hints`
-(`Env::register_hint`, an order-independent merge on alias
-collisions), writers serialize that map here, and readers load it
-back. Hints are performance-only advice (the `Regular(0)` fallback is
-always correct) and are intentionally outside the consts merkle root.
+The **anon hint channel** — merged advisory hints per constant
+address, for readers that never see names (`get_anon`/`get_anon_mmap`,
+the anon-mode kernel, `--anon` bundles). Entries are keyed by **index
+into §2's ascending-address order**, delta-coded: the k-th entry's
+constant index is `idx_k = idx_{k-1} + delta_k` with `idx_{-1} = -1`
+(so the first delta stores `index + 1`). Every delta must be ≥ 1,
+which makes the section strictly ascending and duplicate-free by
+construction; an index ≥ the §2 count is malformed. The hint fuses
+variant and height into one Tag0 value: `0` = Opaque, `1` = Abbrev,
+`h + 2` = Regular(h) with `h : u32`. A typical entry is 2-3 bytes
+(previously a 32-byte address + 1-3 bytes).
+
+Hints never appear in `ConstantMeta`. Because anonymization conflates
+alpha-identical definitions (many names, one address), this per-address
+map holds one **min-merged winner** per constant
+(`Env::register_hint`, order-independent under
+`Opaque < Abbrev < Regular(h)`) — fine for the kernel's def-eq unfold
+ordering, which is all this channel feeds. The EXACT per-definition
+hints live per name in §5 entry headers. Hints keyed by an address not
+stored in §2 are unrepresentable — writers reject such envs. Hints are
+performance-only advice (the `Regular(0)` fallback is always correct)
+and are intentionally outside the consts merkle root.
 
 **Section 4: Names** (Address → NameComponent, topologically sorted)
 ```
@@ -877,11 +892,43 @@ count (Tag0)
 [Address (32 bytes) + NameComponent]*
 ```
 
-**Section 5: Named** (Name Address → Named with indexed metadata)
+**Section 5: Named** (name §4-index → Named with indexed metadata)
 ```
 count (Tag0)
-[NameAddress (32 bytes) + ConstAddress (32 bytes) + ConstantMeta]*
+[ name_idx  (Tag0)         -- absolute index into §4's topo order
+  const_idx (Tag0)         -- absolute index into §2's ascending order
+  hint      (Tag0)         -- fused option: 0 = none, 1 = Opaque,
+                              2 = Abbrev, h+3 = Regular(h)
+  meta_len  (Tag0)         -- byte length of the metadata blob below
+  ConstantMeta             -- name references are §4 indices
+  original: 0x00 | 0x01 + Address (32 bytes) + ConstantMeta ]*
+                           -- ConstantMeta + original span meta_len bytes
 ```
+
+Entries stay sorted by ascending name hash (the diff meta sweep
+merge-joins two files' §5 sections on it), so `name_idx` values are
+not monotonic — both indices are absolute, not delta-coded.
+
+`hint` is the **exact per-name reducibility hint** (`none` for
+theorems etc.). It lives here — not in §3 — because alpha-identical
+definitions under different names share one §2 constant, so the
+per-address §3 channel can only hold a min-merged advisory winner;
+faithful decompilation needs the per-definition value. The hint sits
+in the entry header, before the length-prefixed metadata blob, so a
+reader can scan every `name → hint` pair while skipping the blobs
+outright (`meta_len` bytes each) — `parse_lazy_index` does exactly
+that instead of parsing and discarding each metadata arena. Full
+readers parse the blob and reject entries whose parsed size disagrees
+with `meta_len`.
+
+The `original` address (aux_gen provenance) stays a **raw 32 bytes**:
+a prune cut can carry a `Named` whose original references an *assumed*
+constant that is not stored in §2, which a §2 index cannot represent.
+
+Because §2 order is load-bearing for §3/§5 index resolution, every
+reader enforces strictly ascending §2 addresses during its scan (this
+also makes the collected §2 key list directly usable for the merkle
+recompute, with no re-sort).
 
 **Section 6: Commitments** (Address → Comm)
 ```
@@ -905,8 +952,10 @@ Mathlib-scale env drops from ~3-4 GB (structured + metadata) to ~1 GB
 
 Exposed to Lean via `rs_de_env_anon` (`Ix.Ixon.rsDeEnvAnon`);
 `Env::get_anon_mmap` is the zero-copy mmap sibling and
-`Env::parse_lazy_index` the zero-copy index variant (reads through §5,
-skipping only comms).
+`Env::parse_lazy_index` the zero-copy index variant (walks every
+section, but reads only the §5 entry headers — name index, const
+rank, hint — and seeks past each `meta_len`-framed metadata blob, so
+no metadata arena is ever parsed).
 
 ### Bundles: pinning a single value
 

--- a/docs/ix_canonicity.md
+++ b/docs/ix_canonicity.md
@@ -236,7 +236,7 @@ Everything needed to round-trip back to a source-faithful Lean
 | Call-site source/canonical metadata     | `ExprMetaData::CallSite { entries, canon_meta }`     |
 | Level-parameter names                   | `ConstantMetaInfo::*.lvls`                           |
 | `InductiveVal.all` (Lean source order)  | `ConstantMetaInfo::{Def,Indc,Rec}.all`               |
-| `ReducibilityHints`                     | `ConstantMetaInfo::Def.hints`                        |
+| `ReducibilityHints`                     | `Named.hints` (`.ixe` §5 header, exact per name) + merged `Env::anon_hints` (§3) |
 | Original pre-aux_gen form               | `Named.original = Some((addr, meta))`                |
 | Aux-name permutation (nested)           | `stt.aux_perms` in-memory → `ConstantMetaInfo::Muts.aux_layout` on disk — §10.2 |
 | Docstrings                              | planned: `ConstantMeta.doc_string: Option<Address>`  |


### PR DESCRIPTION
§3 (reducibility hints) and §5 (named metadata) keyed their entries by raw 32-byte addresses that are fully redundant — every §3 key is an address already listed in §2, and every §5 entry repeats a §4 name hash plus a §2 const address. This PR replaces them with Tag0 varint indices, the same move §5 metadata already makes for name references:

- §3: Tag0(index_delta) + Tag0(fused_hint) against §2's ascending-address order (0=Opaque, 1=Abbrev, h+2=Regular(h)) — 2–3 bytes per entry instead of 33–36. Strictly-positive deltas double as the sort/dedup validation.
- §5: name → §4 topo-index, constant → §2 rank (absolute; entry order stays name-hash-sorted for the diff merge-join). original keeps a raw address since a prune cut can reference an assumed constant absent from §2.
- Writers hard-error on hint keys / named entries referencing unstored constants (previously write-OK-read-fail); Lean serEnv is now Except-returning. Readers enforce strictly ascending §2 order, which the indices depend on and which makes the §2 scan double as the sorted merkle key set.
- Lazy paths are untouched: get_anon/get_anon_mmap still stop after §3; parse_lazy_index, NamedMetaCursor, streaming prune, and ix diff --meta stay O(1)-per-entry.

Saves ~56 MB on a mathlib env (~10× shrink of both sections' fixed key costs; proportionally much more on thin ix pack bundles).

Breaking: in-place format change with no version byte (matching the pre-bundle precedent) — existing .ixe files must be recompiled. New readers reject old files with "possibly a pre-compact-ke unaffected (envs are compiled and consumed within a
run).

Rust and Lean writers verified byte-identical (put_file_yte-equality vectors including a new named-entry + hintscase); new tests cover malformed deltas, out-of-range int bytes, and writer key errors.

---

Also in this PR: Compile: keep phantom-spec-param nested auxes distinct in the canonical sort

While testing, lake test -- rust-compile surfaced a pre-existing compiler bug (independent of the format work): sort_aux_by_partition_refinement compared only the instantiated aux types and constructors, so two nested occurrences of one external inductive whose distinguishing spec param is phantom in the external's constructors — the IxVMInd.DedupM fixture shape, Bar2 M Nat vs Bar2 M Bool with Bar2.mk : α → Bar2 α β — produced alpha-identical views and collapsed into one canonical class. compute_aux_perm then (correctly) found no canonical match for the losing source aux and failed the whole block. The sort's doc comment always claimed the nested identity was part of the compared data; it wasn't.

Fix: each aux's sort view carries a trailing synthetic identity-marker ctor holding its aux_to_nested nested-app (block params abstracted to positional bvars). Distinct identities split and order canonically by spec-param content address; genuinely alias-collapsed occurrences (address-equal specs) still dedup; already-distinct auxes are unaffected since the marker is compared last. The kernel's canonical_aux_order mirrors the marker on its synthetic views (ext head + spec_params, pre-rewrite) so both reconstructions stay in lockstep, and compute_aux_perm's no-match error now prints the normalized source specs against every canonical signature.

Coverage: validate-aux now permanently seeds the IxVMInd fixtures (previously these shapes only compiled under the full-env rust-compile runner), plus a unit test pinning split-vs-collapse behavior. lake test -- rust-compile passes end-to-end: all blocks compile, and the full-env re-decompile reports 0 mismatches over 201,979 constants — which also exercises the per-name hints fix at scale.