### PR TITLE
feat: Switch from Garnix to Cachix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
+# Trust the flake's nixConfig (the Cachix substituter) without prompting, so
+# the cache applies to every nix command in this shell, not just the devShell
+# build. Non-direnv users are unaffected: nix asks them before using it.
+export NIX_CONFIG="accept-flake-config = true"
 use flake

--- a/.github/actions/install-zisk/action.yml
+++ b/.github/actions/install-zisk/action.yml
@@ -52,8 +52,17 @@ runs:
     - name: Install Zisk toolchain (ziskup, pinned v1.0.0-alpha)
       shell: bash
       run: |
+        # ziskup's internal `cargo-zisk toolchain install` fetches the Zisk
+        # Rust toolchain from 0xPolygonHermez/rust `releases/latest`, which
+        # breaks whenever upstream publishes a release tag before uploading
+        # its assets. Tolerate that one failure (it is ziskup's last material
+        # step under --nokey) and redo the toolchain install pinned to the
+        # zisk-1.0.0 tag, matching the pinned cargo-zisk v1.0.0-alpha. The
+        # follow-up command still fails the job if ziskup died earlier (no
+        # cargo-zisk binary) or the pinned download itself breaks.
         curl -L https://raw.githubusercontent.com/0xPolygonHermez/zisk/main/ziskup/install.sh \
-          | bash -s -- --cpu --nokey -y --version 1.0.0-alpha --prefix "$HOME/.zisk"
+          | bash -s -- --cpu --nokey -y --version 1.0.0-alpha --prefix "$HOME/.zisk" || true
+        "$HOME/.zisk/bin/cargo-zisk" toolchain install --toolchain-version zisk-1.0.0
         echo "$HOME/.zisk/bin" >> "$GITHUB_PATH"
     # Pre-build the proofman C++ sys crate ALONE so its build script runs
     # exactly once before any parallel zisk-host build. zisk-host pulls

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v16
+        with:
+          name: argumentcomputer
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       # Ix CLI
       - run: nix build --print-build-logs --accept-flake-config
       - run: nix run .#ix -- --help
@@ -40,5 +44,9 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cachix/cachix-action@v16
+        with:
+          name: argumentcomputer
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       # Builds and runs tests using Lake as a Nix package
       - run: nix develop --accept-flake-config --command bash -c "lake build && lake test"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -58,5 +58,6 @@ jobs:
       - run: nix develop --accept-flake-config --command bash -c "lake build && lake test"
       # Realize the zkVM shells so they're verified and pushed to the cache,
       # and smoke-test each shell's toolchain entrypoint.
-      - run: nix develop --print-build-logs --accept-flake-config .#zisk --command cargo-zisk --version
-      - run: nix develop --print-build-logs --accept-flake-config .#sp1 --command cargo prove --version
+      # TODO: Re-enable once the zkVM shells build in CI.
+      # - run: nix develop --print-build-logs --accept-flake-config .#zisk --command cargo-zisk --version
+      # - run: nix develop --print-build-logs --accept-flake-config .#sp1 --command cargo prove --version

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,8 +31,14 @@ jobs:
       # Ix CLI
       - run: nix build --print-build-logs --accept-flake-config
       - run: nix run .#ix -- --help
-      # Ix tests
-      - run: nix run .#test --accept-flake-config
+      # One step per check for separate logs; the store is shared across
+      # steps, so nothing rebuilds.
+      - run: nix build --print-build-logs --accept-flake-config .#checks.x86_64-linux.clippy
+      - run: nix build --print-build-logs --accept-flake-config .#checks.x86_64-linux.nextest
+      - run: nix build --print-build-logs --accept-flake-config .#checks.x86_64-linux.ix-tests
+      # Catch-all: near-free after the steps above; fails if a check is added
+      # to the flake without a step here.
+      - run: nix flake check --accept-flake-config
 
   # Tests Nix devShell support on Ubuntu
   nix-devshell:
@@ -50,3 +56,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       # Builds and runs tests using Lake as a Nix package
       - run: nix develop --accept-flake-config --command bash -c "lake build && lake test"
+      # Realize the zkVM shells so they're verified and pushed to the cache,
+      # and smoke-test each shell's toolchain entrypoint.
+      - run: nix develop --print-build-logs --accept-flake-config .#zisk --command cargo-zisk --version
+      - run: nix develop --print-build-logs --accept-flake-config .#sp1 --command cargo prove --version

--- a/README.md
+++ b/README.md
@@ -606,6 +606,6 @@ Non-Nix users: install Zisk manually per the
 
 Build and run the Ix CLI with `nix build` and `nix run`.
 
-This will prompt you to optionally enable the Garnix cache, which can also be done by passing `--accept-flake-config` to the Nix command. Then when building, you should see `copying path '/nix/store/<...>' from https://cache.garnix.io`
+This will prompt you to optionally enable the Cachix binary cache, which can also be done by passing `--accept-flake-config` to the Nix command. Then when building, you should see `copying path '/nix/store/<...>' from https://argumentcomputer.cachix.org`
 
 To build and run the test suite, run `nix build .#test` and `nix run .#test`.

--- a/README.md
+++ b/README.md
@@ -214,15 +214,8 @@ The Ix kernel typechecker has an SP1 guest at `sp1/guest/` driven by a host at
 serialized `Ixon.Env`, then feed that file to the SP1 host to either execute or
 prove the typecheck.
 
-**Nix users only:** enter the SP1 dev shell first to pick up `cargo-prove` and
-the succinct Rust toolchain:
-
-```
-nix develop .#sp1
-```
-
-Non-Nix users: install the SP1 toolchain manually per the
-[SP1 docs](https://docs.succinct.xyz/docs/sp1/getting-started/install).
+Install the SP1 toolchain (`cargo-prove` and the succinct Rust toolchain) per
+the [SP1 docs](https://docs.succinct.xyz/docs/sp1/getting-started/install).
 
 1. **Compile a `.ixe` from a Lean file.** `ix compile` takes the Lean source
    as a positional argument and writes the serialized `Ixon.Env`; `--out` sets
@@ -331,14 +324,8 @@ host at `zisk/host/`. The workflow mirrors the SP1 one — first compile a Lean
 program to a `.ixe`, then feed it to the Zisk host to either execute or prove
 the typecheck.
 
-**Nix users only:** enter the Zisk dev shell first to pick up `cargo-zisk`,
-`ziskemu`, and the RISC-V toolchain needed to build the guest:
-
-```
-nix develop .#zisk
-```
-
-Non-Nix users: install Zisk manually per the
+Install Zisk (`cargo-zisk`, `ziskemu`, and the RISC-V toolchain needed to
+build the guest) per the
 [Zisk install docs](https://0xpolygonhermez.github.io/zisk/getting_started/installation.html).
 
 1. **Compile a `.ixe` from a Lean file.** Same as for SP1:
@@ -393,8 +380,7 @@ Non-Nix users: install Zisk manually per the
    ```
 
    Requires a CUDA-capable GPU and the matching CUDA runtime libraries
-   visible to the linker (`LD_LIBRARY_PATH`). The Nix `.#zisk` shell wires
-   these up automatically; for non-Nix setups follow the
+   visible to the linker (`LD_LIBRARY_PATH`); follow the
    [Zisk install docs](https://0xpolygonhermez.github.io/zisk/getting_started/installation.html).
 
    **CUDA JIT cache (`CUDA_CACHE_MAXSIZE`).** The driver caches compiled

--- a/flake.nix
+++ b/flake.nix
@@ -314,11 +314,12 @@
             ];
           };
 
+          # TODO: Re-enable the zkVM shells once they build in CI.
           # Zisk shell for `zisk-guest/` (cargo-zisk, ziskemu, RISC-V toolchain).
           # Kept separate from `default`: merging cross-pollinates NIX_CFLAGS_COMPILE
           # between zisk.nix's and this flake's nixpkgs, which breaks bindgen on
           # `lean.h`.
-          devShells.zisk = zisk.devShells.${system}.default;
+          # devShells.zisk = zisk.devShells.${system}.default;
 
           # SP1 shell for `sp1/host` + `sp1/guest`: host Rust toolchain plus
           # cargo-prove and the succinct Rust toolchain (~/.sp1) from sp1.nix.
@@ -326,18 +327,18 @@
           # toolchain when `RUSTUP_TOOLCHAIN=succinct` (set by `sp1-build`); the
           # plain host rustc doesn't know `riscv64im-succinct-zkvm-elf`.
           # `sp1-prover-types`'s build script needs `protoc`.
-          devShells.sp1 = pkgs.mkShell {
-            name = "sp1";
-            inputsFrom = [ sp1.devShells.${system}.default ];
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-            packages = with pkgs; [
-              pkg-config
-              openssl
-              protobuf
-              clang
-              (sp1.packages.${system}.rustup-shim.override { inherit rustToolchain; })
-            ];
-          };
+          # devShells.sp1 = pkgs.mkShell {
+          #   name = "sp1";
+          #   inputsFrom = [ sp1.devShells.${system}.default ];
+          #   LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          #   packages = with pkgs; [
+          #     pkg-config
+          #     openssl
+          #     protobuf
+          #     clang
+          #     (sp1.packages.${system}.rustup-shim.override { inherit rustToolchain; })
+          #   ];
+          # };
 
           formatter = pkgs.alejandra;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,10 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://cache.garnix.io"
+      "https://argumentcomputer.cachix.org"
     ];
     extra-trusted-public-keys = [
-      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+      "argumentcomputer.cachix.org-1:ovhbTx1V56BYDerOWInQvXKXl68LlhNwEA+n7EWk1m4="
     ];
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -101,14 +101,26 @@
                 pkgs.libiconv
               ];
           };
-          cargoArtifacts = craneLib.buildDepsOnly craneArgs;
+          # Build dependencies once with every feature enabled so the `net`
+          # stack (tokio/iroh) is compiled and cached here, then shared by the
+          # package builds and the all-features clippy check instead of being
+          # rebuilt per consumer.
+          cargoArtifacts = craneLib.buildDepsOnly (
+            craneArgs
+            // {
+              cargoExtraArgs = "--locked --all-features";
+            }
+          );
 
-          # Test build: parallel + test-ffi (only used by ixTest)
-          rustPkg = craneLib.buildPackage (
+          # Test build: parallel + test-ffi (only used by ixTest).
+          # doCheck = false: the `nextest` check is the single place cargo
+          # tests run, so package builds only compile.
+          rustPkgTest = craneLib.buildPackage (
             craneArgs
             // {
               inherit cargoArtifacts;
               cargoExtraArgs = "--locked --features parallel,test-ffi";
+              doCheck = false;
             }
           );
 
@@ -118,13 +130,40 @@
             // {
               inherit cargoArtifacts;
               cargoExtraArgs = "--locked --features parallel";
+              doCheck = false;
+            }
+          );
+
+          # Net build for the `ix` CLI (`ix serve` / `ix connect` iroh stack),
+          # mirroring the lakefile's `ix_rs_net` target, which skips `net` on
+          # macOS.
+          rustPkgNet = craneLib.buildPackage (
+            craneArgs
+            // {
+              inherit cargoArtifacts;
+              cargoExtraArgs =
+                "--locked --features parallel"
+                + pkgs.lib.optionalString (!pkgs.stdenv.isDarwin) ",net";
+              doCheck = false;
             }
           );
 
           # Lake package
           lake2nix = pkgs.callPackage lean4-nix.lake { };
+          # Restrict the Lake build inputs to Lean-relevant files so edits to
+          # unrelated files (flake.nix, CI, docs) don't invalidate the whole
+          # Lean build. The Rust side gets the same via cleanCargoSource.
+          leanSrc = pkgs.lib.fileset.toSource {
+            root = ./.;
+            fileset = pkgs.lib.fileset.unions [
+              ./lakefile.lean
+              ./lake-manifest.json
+              ./lean-toolchain
+              (pkgs.lib.fileset.fileFilter (f: f.hasExt "lean") ./.)
+            ];
+          };
           lakeDeps = lake2nix.buildDeps {
-            src = ./.;
+            src = leanSrc;
             depOverrideDeriv = {
               Blake3 = blake3-lean.packages.${system}.rust;
             };
@@ -132,7 +171,7 @@
           # Shared Lake build args: patches out the Cargo build (Crane handles it)
           mkLakeBuildArgs = rustLib: {
             inherit lakeDeps;
-            src = ./.;
+            src = leanSrc;
             # Don't build the `ix_rs` static lib with Lake, since we build it with Crane
             postPatch = ''
               substituteInPlace lakefile.lean --replace-fail 'proc { cmd := "cargo"' '--proc { cmd := "cargo"'
@@ -151,8 +190,10 @@
 
           # Release build args (no test-ffi symbols)
           lakeBuildArgs = mkLakeBuildArgs rustPkgRelease;
+          # CLI build args (net symbols for `ix serve` / `ix connect`)
+          lakeNetBuildArgs = mkLakeBuildArgs rustPkgNet;
           # Test build args (includes test-ffi symbols)
-          lakeTestBuildArgs = mkLakeBuildArgs rustPkg;
+          lakeTestBuildArgs = mkLakeBuildArgs rustPkgTest;
 
           ixLib = lake2nix.mkPackage (
             lakeBuildArgs
@@ -180,7 +221,18 @@
                   --set LEAN_PATH "${drv}/.lake/build/lib/lean:${leanPath}"
               done
             '';
-          ixCLI = wrapBin (lake2nix.mkPackage (lakeBinArgs // { name = "ix"; }));
+          # The CLI links rustPkgNet (lakefile: `ix` uses `ix_rs_net`), reusing
+          # ixLib's oleans.
+          ixCLI = wrapBin (
+            lake2nix.mkPackage (
+              lakeNetBuildArgs
+              // {
+                lakeArtifacts = ixLib;
+                installArtifacts = true;
+                name = "ix";
+              }
+            )
+          );
           # Test binary links rustPkg (with test-ffi) instead of rustPkgRelease
           ixTest = wrapBin (
             lake2nix.mkPackage (
@@ -211,10 +263,40 @@
           packages = {
             default = ixLib;
             ix = ixCLI;
-            test = ixTest;
             zkv-prover = ZKVotingProver // {
               meta.mainProgram = "Apps-ZKVoting-Prover";
             };
+          };
+
+          checks = {
+            # Lint the host workspace; warnings are errors.
+            clippy = craneLib.cargoClippy (
+              craneArgs
+              // {
+                inherit cargoArtifacts;
+                cargoExtraArgs = "--locked --all-features";
+                cargoClippyExtraArgs = "--all-targets -- -D warnings";
+              }
+            );
+            # Rust unit tests across the host workspace.
+            nextest = craneLib.cargoNextest (
+              craneArgs
+              // {
+                inherit cargoArtifacts;
+                cargoExtraArgs = "--locked --workspace";
+                cargoNextestExtraArgs = "--profile ci --run-ignored all";
+              }
+            );
+            # Lean test suite. The suite reads fixtures and writes scratch
+            # files by paths relative to the working dir, so run it from a
+            # writable copy of the source tree, as if from a checkout.
+            ix-tests = pkgs.runCommand "ix-tests" { } ''
+              cp -r ${./.} src
+              chmod -R u+w src
+              cd src
+              ${ixTest}/bin/IxTests
+              touch $out
+            '';
           };
 
           # Lean + Rust shell for host development (`cargo build`, `lake build`).

--- a/zisk/agg-guest/build.rs
+++ b/zisk/agg-guest/build.rs
@@ -1,0 +1,13 @@
+// Same explicit linker script as the main guest — `ziskos::_start` needs the
+// Zisk memory-layout symbols and the zisk-1.0.0 toolchain doesn't embed the
+// script. Shares `zisk/guest/zisk.ld` so the layout can't drift between the
+// two guests; see that guest's build.rs for details.
+fn main() {
+  if std::env::var("TARGET").as_deref() == Ok("riscv64ima-zisk-zkvm-elf") {
+    println!(
+      "cargo:rustc-link-arg=-T{}/../guest/zisk.ld",
+      std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    );
+  }
+  println!("cargo:rerun-if-changed=../guest/zisk.ld");
+}

--- a/zisk/guest/build.rs
+++ b/zisk/guest/build.rs
@@ -1,0 +1,16 @@
+// The Zisk memory-layout linker script (`zisk.ld`, vendored verbatim from
+// 0xPolygonHermez/rust `compiler/rustc_target/src/spec/targets/
+// riscv64ima_zisk_zkvm_elf_linker_script.ld`) defines `_global_pointer`,
+// `_init_stack_top`, and the `_kernel_heap_*` symbols that `ziskos::_start`
+// and its allocators reference. The zisk-1.0.0 toolchain release dropped the
+// script embedded in the target spec, so the guest passes it explicitly;
+// drop this (and `zisk.ld`) once a pinned toolchain ships it again.
+fn main() {
+  if std::env::var("TARGET").as_deref() == Ok("riscv64ima-zisk-zkvm-elf") {
+    println!(
+      "cargo:rustc-link-arg=-T{}/zisk.ld",
+      std::env::var("CARGO_MANIFEST_DIR").unwrap()
+    );
+  }
+  println!("cargo:rerun-if-changed=zisk.ld");
+}

--- a/zisk/guest/zisk.ld
+++ b/zisk/guest/zisk.ld
@@ -1,0 +1,81 @@
+OUTPUT_FORMAT("elf64-littleriscv")
+OUTPUT_ARCH("riscv")
+ENTRY(_start)
+
+MEMORY {
+  rom   (xa) : ORIGIN = 0x80000000, LENGTH = 0x10000000
+  ram   (wxa) : ORIGIN = 0xa0020000, LENGTH = 0x1FFE0000
+}
+
+PHDRS {
+  text PT_LOAD FLAGS(5);
+  rodata PT_LOAD FLAGS(4);
+  data PT_LOAD FLAGS(6);
+  bss PT_LOAD FLAGS(6);
+  output_data PT_LOAD FLAGS(6);
+}
+
+_stack_size           = 0x400000;  /* 4 MB reserved */
+_output_data_size     = 0x10000;   /* 64 KB reserved */
+_float_ram_data_size  = 0x10000;   /* 64 KB reserved */
+
+/*
+
+0xA0000000  ┌────────────────────┐
+            │ .general_registers │  64 KB reserved (NOLOAD)
+            │  0x10000 bytes     │  _general_registers_start / _end
+0xA0010000  ├────────────────────┤
+            │ .float_registers   │  64 KB reserved (NOLOAD)
+            │  0x10000 bytes     │  _float_registers_start / _end
+0xA001FFFF  └────────────────────┘ ← _kernel_heap_top
+0xA0020000  ┌────────────────────┐
+            │ .output_data       │  64 KB reserved (NOLOAD)
+            │  0x10000 bytes     │  _output_data_start / _end
+0xA0030000  ├────────────────────┤
+            │   .data            │
+            │   .bss             │
+            ├────────────────────┤ ← _bss_end
+            │   stack ↑ 4MB      │
+            ├────────────────────┤ ← _init_stack_top = _kernel_heap_bottom
+            │   heap ↓           │
+            │                    │
+0xBFFEFFFF  │                    │
+0xBFFF0000  ├────────────────────┤ ← _kernel_heap_top 
+            │ float ram          │
+0xC0000000  └────────────────────┘ 
+
+*/
+
+SECTIONS
+{
+  .text : { *(.text.init) *(.text .text.*)} >rom AT>rom :text
+
+  . = ALIGN(8);
+  PROVIDE(_global_pointer = .);
+  .rodata : { *(.rodata .rodata.*)} >rom AT>rom :rodata
+
+  /* reserved space for output data */
+
+  .output_data (NOLOAD) : {
+    PROVIDE(_output_data_start = .);
+    . = . + _output_data_size; 
+    PROVIDE(_output_data_end = .);
+  } >ram AT>ram :output_data
+
+  .data : { *(.data .data.* .sdata .sdata.*) } >ram AT>ram :data
+
+  .bss : {
+    PROVIDE(_bss_start = .);
+    *(.bss .bss.*);
+    PROVIDE(_bss_end = .); # ... and one at the end
+  } >ram AT>ram :bss
+
+  . = ALIGN(8);
+  PROVIDE(_init_stack_top = . + _stack_size); # reserve 4M bytes for the initialisation stack
+
+  PROVIDE(_kernel_heap_bottom = _init_stack_top);
+  PROVIDE(_kernel_heap_top = ORIGIN(ram) + LENGTH(ram) - _float_ram_data_size);
+  PROVIDE(_kernel_heap_size = _kernel_heap_top - _kernel_heap_bottom);
+
+  _end = .;
+}


### PR DESCRIPTION
Garnix is shutting down, so this PR switches back to Cachix and improves Nix test coverage with flake checks (clippy, Rust tests, and Lean tests), which are now fully cached and will only run when the source changes. This means the Nix CI job time is now usually under 3 minutes.

Fixes an issue with Zisk `install-action`, and comments out Zisk/SP1 dev shells for now as they are not working.