### PR TITLE
ci: Add `!benchmark` early feedback, improve Zisk build and plots

### DIFF
--- a/.github/actions/install-zisk/action.yml
+++ b/.github/actions/install-zisk/action.yml
@@ -90,17 +90,29 @@ runs:
     # instead of ~50 GB (the tarball also omits the `*_gpu` const variants the
     # first GPU prove would materialize — unused on this CPU runner). The
     # object name carries the fork rev so a circuit change can't silently
-    # reuse a stale key. Public bucket → plain curl, no AWS creds.
-    - name: Restore Zisk proving key (fork circuit) from S3
+    # reuse a stale key. `aws s3 cp` (multipart, no creds — public bucket)
+    # holds throughput steady where a single-stream `curl` swings by an
+    # order of magnitude; `curl` is the fallback for hosts without the AWS
+    # CLI. Deliberately NOT actions/cache'd: the runner fleet is AWS-hosted,
+    # so multipart S3 outruns the Actions cache service — and the tarball
+    # would crowd the repo's cache quota besides.
+    - name: Fetch proving key from S3, extract, regenerate const-trees
       if: inputs.proving-key == 'true'
       shell: bash
       run: |
+        object=zisk-provingkey-blake3-e4057c4c-cpu.tar.gz
+        tarball="${RUNNER_TEMP:-/tmp}/$object"
+        if command -v aws >/dev/null 2>&1; then
+          aws configure set default.s3.max_concurrent_requests 20
+          aws s3 cp --no-sign-request --region us-east-1 \
+            "s3://argument-zisk-setup/$object" "$tarball"
+        else
+          curl -fSL --retry 3 \
+            "https://argument-zisk-setup.s3.amazonaws.com/$object" -o "$tarball"
+        fi
         mkdir -p "$HOME/.zisk"
-        curl -fSL --retry 3 \
-          https://argument-zisk-setup.s3.amazonaws.com/zisk-provingkey-blake3-e4057c4c-cpu.tar.gz \
-          -o /tmp/zisk-provingkey.tar.gz
-        tar -C "$HOME/.zisk" -xzf /tmp/zisk-provingkey.tar.gz
-        rm -f /tmp/zisk-provingkey.tar.gz
-        # Regenerate the const-tree files omitted from the artifact (CPU build, so
-        # no --gpu). This is the "may take a while" step ziskup prints.
+        tar -C "$HOME/.zisk" -xzf "$tarball"
+        rm -f "$tarball"
+        # Regenerate the const-trees omitted from the artifact (CPU build →
+        # no --gpu). ziskup's "may take a while" step.
         cargo-zisk-dev check-setup --proving-key "$HOME/.zisk/provingKey" -a

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -673,13 +673,76 @@ jobs:
           name: comment-body
           path: comment-body.md
 
-  # Post the assembled body — or a red-X diagnostic when any stage failed
-  # (a rejected command or broken run must never end in silence on the
-  # PR). This is the ONLY job with access to the App token, and it runs
-  # no checkout and no repo-derived code — just an artifact download and
-  # two actions.
+  # Post the initial PR comment the instant the command is parsed: a red-X
+  # diagnostic if the parse/build failed (the same message the final comment
+  # would carry), otherwise a "running" placeholder so the commenter gets
+  # immediate feedback. The `comment` job edits THIS comment in place with
+  # the results at the end (its id is this job's output). Privileged (App
+  # token) like `comment`, and like it runs no checkout and no PR-derived
+  # code — only build's string outputs.
+  announce:
+    needs: build
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      comment-id: ${{ steps.post.outputs.comment-id }}
+    steps:
+      # PR-derived strings (parse-error, config-summary) arrive via env, not
+      # inline `${{ }}`; a quoted `echo "$VAR"` never re-evaluates the value,
+      # so a crafted summary can't inject shell (the rule the other jobs
+      # follow).
+      - name: Compose initial body
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          PARSE_ERROR: ${{ needs.build.outputs.parse-error }}
+          SUMMARY: ${{ needs.build.outputs.config-summary }}
+          HEAD_SHA: ${{ inputs.head-sha }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "$BUILD_RESULT" != success ]; then
+            {
+              echo "## ❌ benchmark run failed"
+              if [ -n "$PARSE_ERROR" ]; then
+                echo
+                echo "> $PARSE_ERROR"
+              fi
+              echo
+              echo "[Workflow logs]($RUN_URL)"
+            } > comment-body.md
+          else
+            {
+              echo "## ⏳ Benchmark running…"
+              echo
+              if [ -n "$SUMMARY" ]; then
+                echo "> $SUMMARY"
+                echo
+              fi
+              echo "Benchmarking \`${HEAD_SHA:0:7}\` — this comment will be replaced with the results when the run finishes."
+              echo
+              echo "[Watch progress]($RUN_URL)"
+            } > comment-body.md
+          fi
+      - name: Generate token to write PR comment
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.TOKEN_APP_ID }}
+          private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+      - name: Post initial comment
+        id: post
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          issue-number: ${{ inputs.pr }}
+          body-path: comment-body.md
+
+  # Edit the announce comment in place with the assembled body — or a red-X
+  # diagnostic when any stage failed (a rejected command or broken run must
+  # never end in silence on the PR). This job and `announce` are the only
+  # ones with the App token, and neither runs a checkout or repo-derived
+  # code — just an artifact download and two actions.
   comment:
-    needs: [build, compile, benchmark, assemble]
+    needs: [build, compile, benchmark, assemble, announce]
     if: always() && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -727,9 +790,15 @@ jobs:
           # takes either), so the existing secret works unchanged.
           client-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+      # `comment-id` edits the announce comment in place; `issue-number` is
+      # the fallback that creates a fresh comment if announce never posted
+      # one (empty id). `replace` overwrites the "running" placeholder rather
+      # than appending to it.
       - name: Post / update comment
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           issue-number: ${{ inputs.pr }}
+          comment-id: ${{ needs.announce.outputs.comment-id }}
+          edit-mode: replace
           body-path: comment-body.md

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -25,20 +25,24 @@
 # `aiur-recursive` runs the aiur-recursive toy (bench-recursive-verifier's
 # fixed configs — env-independent, so it always schedules exactly one cell
 # no matter what BENCH_ENVS says). The optional bare `execute` token flips
-# `aiur` to
-# execute-only (Phase 1, skipping the prove); bench-main runs both aiur
-# modes as separate cells on separate testbeds, so either kind of cell
-# fetches a cached main-side baseline from bencher. (aiur's third mode,
-# `recursive`, is local-only — `ix bench run --backend aiur --mode
-# recursive` — an IxVM-scale verifier execute needs >108 GB, beyond the
-# CI ceiling, so no comment token schedules it.)
+# `aiur` to execute-only (Phase 1, skipping the prove); bench-main runs
+# both aiur modes as separate cells on separate testbeds, so either kind
+# of cell fetches a cached main-side baseline from bencher. The bare
+# `recursive` token flips aiur to its recursive mode instead — an
+# unscheduled testbed with no bencher baseline (its main side is a base-SHA
+# run), and the verifier execute OOMs the standard CI host, so it's meant
+# for a bigger manual dispatch. The bare `fresh` token makes every cell
+# skip the bencher fetch and re-measure the main side with a base-SHA run
+# (nothing here uploads to bencher, so the canonical baseline is
+# untouched).
 #
 # Each matrix cell is one `ix bench run` per side, driven by the PR's `ix`
 # (`--repo` points it at the checkout to measure). main's numbers come from
 # bencher.dev (`ix bench fetch-main`); the workflow re-runs the base SHA
-# locally only when bencher can't supply them: the base SHA isn't ingested yet
+# locally only when bencher can't supply them — the base SHA isn't ingested yet
 # (freshly-pushed main whose CI is still running), or the PR's Vectors.csv
-# selects constants main was never benched on (constants the PR itself adds).
+# selects constants main was never benched on (constants the PR itself adds) —
+# or when the `fresh` token demands it.
 # Two-stage trigger: the issue_comment run only gates the commenter and
 # re-dispatches this same file as workflow_dispatch. GitHub classifies
 # issue_comment as a low-trust trigger with unconditionally READ-ONLY cache
@@ -127,6 +131,7 @@ jobs:
       envs: ${{ steps.parse.outputs.envs }}
       shard: ${{ steps.parse.outputs.shard }}
       full: ${{ steps.parse.outputs.full }}
+      fresh: ${{ steps.parse.outputs.fresh }}
       passthrough-env: ${{ steps.parse.outputs.passthrough-env }}
       config-summary: ${{ steps.parse.outputs.config-summary }}
       # Set (with the step failing) when the !benchmark command was
@@ -301,6 +306,7 @@ jobs:
       HEAD_SHA: ${{ inputs.head-sha }}
       SHARD: ${{ needs.build.outputs.shard }}
       FULL: ${{ needs.build.outputs.full }}
+      FRESH: ${{ needs.build.outputs.fresh }}
     steps:
       # PR checked out at the workspace root so the local install actions
       # resolve; base (bencher-miss fallback only) goes under base/.
@@ -430,6 +436,15 @@ jobs:
       - name: Fetch main from bencher
         id: bencher
         run: |
+          # The `fresh` token bypasses bencher entirely: same path as a full
+          # miss (exit 3) — no main.json, so the base run below supplies the
+          # whole main side. Nothing in this workflow uploads to bencher, so
+          # the canonical baseline is untouched.
+          if [ "$FRESH" = 1 ]; then
+            echo "source=base run @ ${BASE_SHA::7} (fresh — bencher bypassed)" >> "$GITHUB_OUTPUT"
+            echo "run-base=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # This cell's names = pr.json's row keys (empty when the PR run
           # produced nothing — fetch-main then exits 3 and the base run
           # supplies the whole main side).

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -126,6 +126,11 @@ structure BackendSpec where
   /-- `some reason` ⇒ `parse` skips the backend with the note in the
       config summary. -/
   disabled : Option String := none
+  /-- Modes present for local / on-demand `ix bench run --mode` only —
+      scheduled by no CI job (too heavy for the CI host), so they carry a
+      testbed for the compare surface but never upload to bencher and get
+      no dashboard plot. -/
+  unscheduled : List String := []
   /-- (mode, bencher testbed). -/
   testbeds : List (String × String)
   /-- (mode, compare-table columns), rendered in list order; the head is
@@ -143,12 +148,14 @@ def backendSpecs : List BackendSpec := [
   -- recursion-tuned FRI parameters, so even its shared-name metrics
   -- (prove-time, peak-rss) are not comparable to the prove cell's. An
   -- IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling; the
-  -- kill lands as a `status: oom` row that bmf drops, which is why no CI
-  -- job schedules this testbed.
+  -- kill lands as a `status: oom` row that bmf drops, which is why it's
+  -- marked `unscheduled`: a testbed for local `--mode recursive` runs only —
+  -- never uploaded to bencher, never plotted.
   { name := "aiur", defaultMode := "prove",
     testbeds := [("prove", "aiur-check-prove-x64-32x"),
                  ("execute", "aiur-check-execute-x64-32x"),
                  ("recursive", "aiur-check-recursive-x64-32x")],
+    unscheduled := ["recursive"],
     metrics := [("prove", ["prove-time", "throughput", "peak-rss",
                            "execute-time", "verify-time", "proof-size",
                            "fft-cost"]),

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -12,8 +12,8 @@
   is re-asserted); a stale one is deleted and recreated (the plot PATCH
   endpoint only takes index/title/window, not dimensions). Unrecognized
   titles are untouched, so hand-pinned plots survive. A registry benchmark
-  bencher hasn't seen yet (first upload still pending) is skipped with a
-  warning and picked up on the next sync.
+  — or a whole testbed — bencher hasn't seen yet (first upload still
+  pending) is skipped with a warning and picked up on the next sync.
 
   The sync also asserts every measure's canonical units (`unitsFor`) —
   bencher auto-creates measures with placeholder units on first upload,
@@ -301,8 +301,13 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut desired : Array DesiredPlot := #[]
   for spec in specs do
     let workload := workloadOf spec.testbed
+    -- A registry testbed bencher hasn't seen yet (its bench-main cell isn't
+    -- scheduled — e.g. the aiur `recursive` mode, whose outer prove doesn't
+    -- fit the CI host, so nothing ever uploads to it) has no plots to sync:
+    -- warn and skip it, like a not-yet-uploaded benchmark, instead of
+    -- failing the whole run. Picked up on a later sync once data lands.
     let some testbedUuid := findUuid testbeds "slug" spec.testbed
-      | p.printError s!"error: no testbed slug '{spec.testbed}'"; return 1
+      | IO.eprintln s!"warn: testbed '{spec.testbed}' not on bencher yet — skipped"; continue
     -- Benchmark names → UUIDs, dropping the not-yet-uploaded ones loudly.
     let mut benchUuids : Array String := #[]
     for n in spec.benchmarks do

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -1,8 +1,9 @@
 /-
   `ix bench plots`: sync the bencher.dev dashboard plots to the benchmark
   registry — one plot per (testbed, measure) that bench-main.yml tracks,
-  with one line per benchmark row uploaded there, plus the cross-kernel
-  input-constants overlay. The spec derives from the registry
+  with one line per benchmark row uploaded there, plus two cross-cutting
+  plots: the shared input-constants trend and the Zisk-shards-per-heavy-
+  primary trend. The spec derives from the registry
   (`Ix.Cli.BenchCmd`) + `Vectors.csv`, so nothing is hand-listed, and
   every join is on the bencher SLUG (the row-key identity uploads use;
   display names are console-editable and never consulted).
@@ -78,13 +79,14 @@ def plotTitle (workload measure : String) : String :=
 /-- Tracked but not plotted solo. The two aiur cells re-measure each
     other's deterministic Phase-1 numbers as a redundancy check — one
     trend line each is enough ("Aiur Execute Time" from the execute cell,
-    "Aiur FFT Cost" from the prove cell). Zisk `shards` is a PR-comment
-    column only ("Zisk Cycles" / max-shard-cycles carry the sharding
-    trend), and zisk `constants` charts on the cross-kernel overlay below
-    instead of alone. `ix-decompile` reuses the compile cell's `.ixe`, so
-    its `file-size` / `constants` duplicate "Ix Environment Size" / "Ix
-    Input Constants" exactly — the decompile cell tracks only its own
-    decompile-time / throughput / peak-rss trends. -/
+    "Aiur FFT Cost" from the prove cell). Zisk `shards` is charted below
+    over the heavy-tier primaries alone (light constants are pinned at a
+    single shard, a flat line at 1), not over the full set here; zisk
+    `constants` charts on the input-constants plot below instead of alone.
+    `ix-decompile` reuses the compile cell's `.ixe`, so its `file-size` /
+    `constants` duplicate "Ix Environment Size" / "Ix Input Constants"
+    exactly — the decompile cell tracks only its own decompile-time /
+    throughput / peak-rss trends. -/
 def plotSkips : List (String × String) :=
   [("aiur-check-prove", "execute-time"), ("aiur-check-execute", "fft-cost"),
    ("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),
@@ -272,7 +274,8 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
   if !dryRun && (← IO.getEnv "BENCHER_API_KEY").isNone then
     p.printError "error: set BENCHER_API_KEY (or pass --dry-run)"
     return 2
-  let specs := plotSpecs (BenchCmd.parseVectorsCsv (← IO.FS.readFile csv))
+  let rows := BenchCmd.parseVectorsCsv (← IO.FS.readFile csv)
+  let specs := plotSpecs rows
 
   let branches ← fetchAll project "branch"
   let testbeds ← fetchAll project "testbed"
@@ -324,26 +327,45 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
         { title := plotTitle workload measure, testbeds := #[testbedUuid],
           benchmarks := benchUuids, measure := measureUuid }
 
-  -- Cross-kernel input-constants overlay: aiur and zisk both report the
-  -- named constants of the checked closure — the pre-shard input set,
-  -- unaffected by anon-work dedup or shard partitioning — so the paired
-  -- lines must coincide. Separation on this chart means the kernels'
-  -- counts drifted apart (a coverage bug tripwire), on top of the count
-  -- trend itself. Zisk lines render once its host uploads `constants`.
+  -- Input-constants trend over the primary set. aiur and zisk report the
+  -- SAME named-constant count for each checked closure (the pre-shard input
+  -- set, unaffected by anon-work dedup or shard partitioning), so the count
+  -- is shared: sourcing it from both testbeds drew every constant twice.
+  -- aiur-check-prove is the single source (it always uploads `constants`),
+  -- so each primary is one line.
   let overlay : Option DesiredPlot := do
     let aiurTb ← findUuid testbeds "slug" "aiur-check-prove-x64-32x"
-    let ziskTb ← findUuid testbeds "slug" "zisk-check-execute-x64-32x"
     let consts ← findUuid measures "slug" "constants"
     let primaries ← (specs.find? (·.testbed == "aiur-check-prove-x64-32x")).map
       (·.benchmarks.filterMap (findUuid benchmarks "name" ·))
     return { title := "Aiur/Zisk Input Constants",
-             testbeds := #[aiurTb, ziskTb], benchmarks := primaries,
+             testbeds := #[aiurTb], benchmarks := primaries,
              measure := consts }
   match overlay with
   | some d => desired := desired.push d
   | none => do
     IO.eprintln
-      "warn: input-constants overlay skipped (missing testbed or measure)"
+      "warn: input-constants plot skipped (missing testbed or measure)"
+
+  -- Zisk shards over time, one line per HEAVY-tier primary — the constants
+  -- whose closure is cut into a multi-shard partition. Light constants run
+  -- as a single shard (a flat line at 1), so they're left out; the full-set
+  -- `shards` plot stays in `plotSkips`.
+  let ziskShards : Option DesiredPlot := do
+    let ziskTb ← findUuid testbeds "slug" "zisk-check-execute-x64-32x"
+    let shardsM ← findUuid measures "slug" "shards"
+    let benched := (BenchCmd.envSpecs.filter (·.benched)).map (·.name)
+    let heavy := benched.foldl (init := (#[] : Array String)) fun acc env =>
+      acc ++ (BenchCmd.selectNames rows env "execute"
+        (full := false) (tier := "heavy") (shardOnly := false)).map (·.name)
+    return { title := "Zisk Shards", testbeds := #[ziskTb],
+             benchmarks := heavy.filterMap (findUuid benchmarks "name" ·),
+             measure := shardsM }
+  match ziskShards with
+  | some d => desired := desired.push d
+  | none => do
+    IO.eprintln
+      "warn: Zisk shards plot skipped (missing testbed or measure)"
 
   for d in desired do
     match ← syncPlot project dryRun window xAxis branchUuid plots idx d with
@@ -361,7 +383,7 @@ end Ix.Cli.BenchPlots
 open Ix.Cli.BenchPlots in
 def benchPlotsCmd : Cli.Cmd := `[Cli|
   plots VIA runPlotsCmd;
-  "Sync the bencher.dev dashboard plots to the registry: one plot per tracked (testbed, measure) plus the cross-kernel input-constants overlay. Needs the bencher CLI; writes need BENCHER_API_KEY (plot create/delete permission)."
+  "Sync the bencher.dev dashboard plots to the registry: one plot per tracked (testbed, measure) plus the shared input-constants and Zisk heavy-shards plots. Needs the bencher CLI; writes need BENCHER_API_KEY (plot create/delete permission)."
 
   FLAGS:
     "dry-run";         "Print the create/replace/keep decisions without writing (no key needed)"

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -126,8 +126,7 @@ def unitsFor (slug : String) : Option String :=
     ooc); unranked workloads (a future backend) sort last. -/
 def workloadOrder : List String :=
   ["ix-compile", "ix-decompile", "aiur-check-prove", "aiur-check-execute",
-   "aiur-check-recursive", "aiur-recursive", "zisk-check-execute",
-   "ooc-check"]
+   "aiur-recursive", "zisk-check-execute", "ooc-check"]
 
 structure PlotSpec where
   testbed : String
@@ -148,6 +147,9 @@ def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
   for b in BenchCmd.backendSpecs do
     if b.disabled.isSome then continue
     for (mode, testbed) in b.testbeds do
+      -- On-demand modes (e.g. aiur `recursive`) upload nothing, so there's
+      -- nothing to plot — the registry marks them explicitly.
+      if b.unscheduled.contains mode then continue
       let names : Array String := Id.run do
         if b.name == "compile" then
           return (BenchCmd.envSpecs.map (·.name)).toArray

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -616,7 +616,7 @@ def parseError (msg : String) : IO UInt32 := do
     BENCH_ENVS, rejects the command — exit 2 and a `parse-error` output):
 
       !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all)
-                 [execute] [KEY=VALUE …]
+                 [execute | recursive] [KEY=VALUE …]
       BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd;
                                     compile-only requests may name any
                                     registry env, e.g. Lean or FLT)
@@ -638,8 +638,12 @@ def parseError (msg : String) : IO UInt32 := do
     command, like a typo'd backend.
 
     The bare `execute` token flips a backend with an execute metrics entry
-    to execute-only — a real switch only for aiur, whose two modes store on
-    separate testbeds, so either kind of cell finds a cached baseline. -/
+    to execute-only — a real switch only for aiur, whose modes store on
+    separate testbeds, so either kind of cell finds a cached baseline.
+    `recursive` likewise flips aiur to its recursive mode; that testbed is
+    `unscheduled`, so the cell has no bencher baseline (its main side comes
+    from a base-SHA run) and the verifier execute OOMs on the 128 GB CI
+    host — reserved for a bigger manual dispatch. -/
 def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let body ← match p.flag? "comment" with
     | some f => pure (f.as! String)
@@ -659,9 +663,13 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut backends : Array Ix.Cli.BenchCmd.BackendSpec := #[]
   let mut skipped : Array Ix.Cli.BenchCmd.BackendSpec := #[]
   let mut executeFlag := false
+  let mut recursiveFlag := false
   for t in toks.map (·.toLower) do
     if t == "execute" then
       executeFlag := true
+      continue
+    if t == "recursive" then
+      recursiveFlag := true
       continue
     let requested := if t == "all"
       then Ix.Cli.BenchCmd.backendSpecs
@@ -673,7 +681,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       return ← parseError s!"unknown token `{t}` in the benchmark command \
         (expected a backend — \
         {", ".intercalate (Ix.Cli.BenchCmd.backendSpecs.map (·.name))} — \
-        or `all` / `execute`)"
+        or `all` / `execute` / `recursive`)"
     for b in requested do
       if b.disabled.isSome then
         if skipped.all (·.name != b.name) then skipped := skipped.push b
@@ -746,7 +754,8 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   if envs.isEmpty then envs := #["InitStd"]
 
   let modeFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>
-    if executeFlag && !(b.metricsFor "execute").isEmpty then "execute"
+    if recursiveFlag && !(b.metricsFor "recursive").isEmpty then "recursive"
+    else if executeFlag && !(b.metricsFor "execute").isEmpty then "execute"
     else b.defaultMode
   let mut cells : Array Json := #[]
   for b in backends do

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -616,7 +616,7 @@ def parseError (msg : String) : IO UInt32 := do
     BENCH_ENVS, rejects the command — exit 2 and a `parse-error` output):
 
       !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all)
-                 [execute | recursive] [KEY=VALUE …]
+                 [execute | recursive] [fresh] [KEY=VALUE …]
       BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd;
                                     compile-only requests may name any
                                     registry env, e.g. Lean or FLT)
@@ -643,7 +643,13 @@ def parseError (msg : String) : IO UInt32 := do
     `recursive` likewise flips aiur to its recursive mode; that testbed is
     `unscheduled`, so the cell has no bencher baseline (its main side comes
     from a base-SHA run) and the verifier execute OOMs on the 128 GB CI
-    host — reserved for a bigger manual dispatch. -/
+    host — reserved for a bigger manual dispatch.
+
+    The bare `fresh` token makes every cell bypass its bencher baseline and
+    re-measure the main side with a base-SHA run — for when the published
+    baseline is suspect (corrupted upload, stale toolchain). The comparison
+    prints in the comment only; PR runs never upload to bencher, so the
+    canonical baseline is untouched. -/
 def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let body ← match p.flag? "comment" with
     | some f => pure (f.as! String)
@@ -664,12 +670,16 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut skipped : Array Ix.Cli.BenchCmd.BackendSpec := #[]
   let mut executeFlag := false
   let mut recursiveFlag := false
+  let mut freshFlag := false
   for t in toks.map (·.toLower) do
     if t == "execute" then
       executeFlag := true
       continue
     if t == "recursive" then
       recursiveFlag := true
+      continue
+    if t == "fresh" then
+      freshFlag := true
       continue
     let requested := if t == "all"
       then Ix.Cli.BenchCmd.backendSpecs
@@ -681,7 +691,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       return ← parseError s!"unknown token `{t}` in the benchmark command \
         (expected a backend — \
         {", ".intercalate (Ix.Cli.BenchCmd.backendSpecs.map (·.name))} — \
-        or `all` / `execute` / `recursive`)"
+        or `all` / `execute` / `recursive` / `fresh`)"
     for b in requested do
       if b.disabled.isSome then
         if skipped.all (·.name != b.name) then skipped := skipped.push b
@@ -779,6 +789,8 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       if b.testbeds.length > 1 then s!"{b.name}={modeFor b}" else b.name)).toList
   let mut summary := s!"backends: `{modes}` · envs: `{",".intercalate envs.toList}` · \
     set: `{if full == "1" then "full" else "primary"}` · shard: `{shard}`"
+  if freshFlag then
+    summary := summary ++ " · baseline: `fresh` (base-SHA run, bencher bypassed)"
   for b in skipped do
     summary := summary ++
       s!" · skipped `{b.name}` ({b.disabled.getD "disabled in the registry"})"
@@ -794,6 +806,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
     h.putStr <| s!"matrix={(Json.arr cells).compress}\n"
       ++ s!"envs={(Json.arr (envs.map Json.str)).compress}\n"
       ++ s!"shard={shard}\nfull={full}\n"
+      ++ s!"fresh={if freshFlag then 1 else 0}\n"
       ++ s!"config-summary={summary}\n"
       ++ "passthrough-env<<PTENV\n"
       ++ "\n".intercalate passthrough.toList

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -32,6 +32,9 @@ import Ix.Common
 import Ix.Meta
 import Ix.IxVM
 
+/-- Runs the full compile → serialize → decompile roundtrip over the given
+    constants and returns the number of failures (0 = clean): decompile
+    mismatches, or a non-zero constant count if a phase aborted. -/
 @[extern "rs_tmp_decode_const_map"]
 opaque tmpDecodeConstMap : @& List (Lean.Name × Lean.ConstantInfo) → USize
 
@@ -131,8 +134,11 @@ def main (args : List String) : IO UInt32 := do
   if args.contains "rust-compile" then
     let env ← get_env!
     IO.println s!"Loaded environment with {env.constants.toList.length} constants"
-    let result := tmpDecodeConstMap env.constants.toList
-    IO.println s!"Rust compiled: {result}"
+    let failures := tmpDecodeConstMap env.constants.toList
+    if failures != 0 then
+      IO.eprintln s!"[rust-compile] FAILED: {failures} compile/decompile roundtrip failure(s)"
+      return 1
+    IO.println "[rust-compile] OK: compile → decompile roundtrip clean"
     return 0
 
   -- Special case: cli tests have their own runner

--- a/crates/ffi/src/lean_env.rs
+++ b/crates/ffi/src/lean_env.rs
@@ -1744,14 +1744,12 @@ extern "C" fn rs_tmp_decode_const_map(
           .insert(entry.key().clone(), entry.value().addr.clone());
       }
       match decompile_env(&fresh_stt) {
-        Ok(dstt2) => {
-          match check_decompile(env.as_ref(), &fresh_stt, &dstt2) {
-            Ok(c) => failures += c.mismatches + c.missing,
-            Err(e) => {
-              eprintln!("[rust-compile] Phase 6 check FAILED: {e:?}");
-              failures += 1;
-            },
-          }
+        Ok(dstt2) => match check_decompile(env.as_ref(), &fresh_stt, &dstt2) {
+          Ok(c) => failures += c.mismatches + c.missing,
+          Err(e) => {
+            eprintln!("[rust-compile] Phase 6 check FAILED: {e:?}");
+            failures += 1;
+          },
         },
         Err(e) => {
           eprintln!("[rust-compile] Phase 6 re-decompile FAILED: {e:?}");

--- a/crates/ffi/src/lean_env.rs
+++ b/crates/ffi/src/lean_env.rs
@@ -1690,10 +1690,19 @@ extern "C" fn rs_tmp_decode_const_map(
     dstt.env.len()
   );
 
-  // Phase 3: Check roundtrip
+  // Phase 3: Check roundtrip. `failures` accumulates roundtrip breakage
+  // here and in Phase 6; the function returns it, so a non-zero total fails
+  // the Lean `rust-compile` test. (Fatal phase aborts above return `n`,
+  // which is likewise non-zero — an abort is also a failure.)
   eprintln!("[rust-compile] Phase 3: Checking decompile roundtrip...");
   let t2 = std::time::Instant::now();
-  let _ = check_decompile(env.as_ref(), &stt, &dstt);
+  let mut failures = match check_decompile(env.as_ref(), &stt, &dstt) {
+    Ok(c) => c.mismatches + c.missing,
+    Err(e) => {
+      eprintln!("[rust-compile] Phase 3 check FAILED: {e:?}");
+      1
+    },
+  };
   eprintln!(
     "[rust-compile] Phase 3 done in {:.2}s",
     t2.elapsed().as_secs_f32()
@@ -1736,7 +1745,13 @@ extern "C" fn rs_tmp_decode_const_map(
       }
       match decompile_env(&fresh_stt) {
         Ok(dstt2) => {
-          let _ = check_decompile(env.as_ref(), &fresh_stt, &dstt2);
+          match check_decompile(env.as_ref(), &fresh_stt, &dstt2) {
+            Ok(c) => failures += c.mismatches + c.missing,
+            Err(e) => {
+              eprintln!("[rust-compile] Phase 6 check FAILED: {e:?}");
+              failures += 1;
+            },
+          }
         },
         Err(e) => {
           eprintln!("[rust-compile] Phase 6 re-decompile FAILED: {e:?}");
@@ -1755,10 +1770,10 @@ extern "C" fn rs_tmp_decode_const_map(
   );
 
   eprintln!(
-    "[rust-compile] All phases complete. Total: {:.2}s",
+    "[rust-compile] All phases complete. Total: {:.2}s ({failures} roundtrip failure(s))",
     t0.elapsed().as_secs_f32()
   );
-  n
+  failures
 }
 
 // ============================================================================

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -96,7 +96,7 @@ a PR tree and compare them — exactly what the PR workflow does.
 
 | backend | what it measures | tool |
 |---|---|---|
-| `aiur`    | Aiur STARK check, one bench-main cell per mode on its own testbed: prove — the real-workload simulation (prove-time, proof-size, verify-time, peak-rss, plus fft-cost / execute-time from its own Phase 1) — and execute, the fast Phase-1-only signal (fft-cost, execute-time, throughput, peak-rss). `!benchmark aiur [execute]` picks the mode. A third mode, recursive (`bench-typecheck --recursive`), additionally executes AND proves the in-circuit multi-stark verifier over each fresh proof — the whole system runs under recursion-tuned FRI parameters, so its rows land on their own testbed (`aiur-check-recursive`) and are not comparable to the prove cell's. Local-only (`ix bench run --backend aiur --mode recursive`): an IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling, so no CI job or comment token schedules it | `bench-typecheck` |
+| `aiur`    | Aiur STARK check, one bench-main cell per mode on its own testbed: prove — the real-workload simulation (prove-time, proof-size, verify-time, peak-rss, plus fft-cost / execute-time from its own Phase 1) — and execute, the fast Phase-1-only signal (fft-cost, execute-time, throughput, peak-rss). `!benchmark aiur [execute]` picks the mode. A third mode, recursive (`bench-typecheck --recursive`), additionally executes AND proves the in-circuit multi-stark verifier over each fresh proof — the whole system runs under recursion-tuned FRI parameters, so its rows land on their own testbed (`aiur-check-recursive`) and are not comparable to the prove cell's. Unscheduled (an IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling, so no CI job runs it and nothing uploads to its testbed): run it locally (`ix bench run --backend aiur --mode recursive`) or request it on demand with `!benchmark aiur recursive` — on the standard CI host the OOM renders as an empty table, so the token is meant for a bigger manual dispatch | `bench-typecheck` |
 | `aiur-recursive` | the aiur-recursive toy: prove a fixed tiny statement per config, both at the ~100-query soundness level (`square-q100-b1`, the lighter trivial-statement end; `factorial-q100-b2`, the heavier recursive one), run the in-circuit multi-stark verifier over the proof (recursive-execute-time, recursive-fft-cost — the recursion-cost proxy), then prove that execution end-to-end (recursive-prove-time, recursive-peak-rss, recursive-proof-size, recursive-verify-time). Env-independent: fixed configs instead of `Vectors.csv` constants, no `.ixe`, always exactly one cell regardless of `BENCH_ENVS` | `bench-recursive-verifier` |
 | `zisk`    | ZisK VM execute: cycles, execute-time, throughput, peak-rss, constants (pre-shard closure count, same universe as aiur's), shards (1 when unsharded) | `zisk-host` |
 | `sp1`     | SP1 VM execute (currently disabled in the registry) | `sp1-host` |
@@ -168,7 +168,7 @@ breakdowns. bench-main's compile job pre-cuts these artifacts
 
 ```
 !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [decompile] [aiur-recursive] | all)
-           [execute] [KEY=VALUE …]
+           [execute | recursive] [fresh] [KEY=VALUE …]
 BENCH_ENVS=InitStd,Mathlib     # default InitStd (case-insensitive); a
                                # compile-only request may name any registry
                                # env (Lean, FLT compile fine, just unbenched)
@@ -189,7 +189,13 @@ input box can't hold newlines:
 Parsed by `ix bench ci parse` in the PR build job, right after the `ix`
 binary exists — the registry lives in Lean, so nothing pre-build reads it
 (and no Python remains). Mode defaults per backend from the registry; the
-bare `execute` token flips `aiur` to Phase-1 only.
+bare `execute` token flips `aiur` to Phase-1 only, and `recursive` to its
+recursive mode (unscheduled testbed, so no bencher baseline; OOMs the
+standard CI host — meant for a bigger manual dispatch). The bare `fresh`
+token makes every cell bypass its bencher baseline and re-measure the main
+side with a base-SHA run — for when the published baseline is suspect. PR
+runs never upload to bencher, so the comparison prints in the comment and
+the canonical baseline is untouched.
 
 ## CI shape
 


### PR DESCRIPTION
# bench/ci: plot fixes, early `!benchmark` comment, fast Zisk key fetch, roundtrip gating

A batch of independent CI/bench fixes that accumulated while working on the
benchmark dashboard, the Zisk install path, and the compile/decompile test
surface. Each is its own commit.

## 1. `ix bench plots`: skip a testbed bencher hasn't seen yet (`70e9aa5`)

`ix bench plots` resolved every registry testbed against bencher's testbed
list and treated a missing one as fatal (`return 1`), so a registry testbed
with no uploads yet aborted the whole sync (`error: no testbed slug
'aiur-check-recursive-x64-32x'`). Now a not-yet-seen testbed is a **warn +
skip**, mirroring how a not-yet-uploaded *benchmark* is already handled — a
general safety net for testbeds mid-rollout.

## 2. Zisk-shards plot, single-source constants plot, early `!benchmark` comment (`d556051`)

- **New "Zisk Shards" plot** over the heavy-tier primaries only (`shards` is
  already uploaded per-constant and thresholded; light constants are pinned
  at a single shard, so they're excluded).
- **Fix the Aiur/Zisk input-constants plot drawing every constant twice.**
  The count is shared across the kernels, so sourcing it from both testbeds
  double-plotted each constant; now sourced from `aiur-check-prove` alone.
- **`!benchmark` posts a comment as soon as the command parses** — a red-X on
  parse/build failure, else a "⏳ running" placeholder — then the final
  `comment` job edits that same comment in place with the results. A new
  `announce` job posts it; privileged like the `comment` job it feeds (it
  holds the App token), but it runs no checkout and no PR-derived code.

> The `!benchmark` change only takes effect once on `main` (the workflow file
> always runs from the default branch), so it won't be exercised by a
> `!benchmark` on this PR.

## 3. Fetch the Zisk proving key with multipart `aws s3 cp` (`42b70a0`)

`install-zisk` fetched the \~3 GB fork-matching proving key with a
single-stream `curl`, whose throughput swings \~3–16 MB/s and made the step
run **3–18 min** — the dominant CI-time variance in the Zisk jobs. Now it's
fetched with `aws s3 cp` (multipart, `--no-sign-request`, 20 concurrent
requests), falling back to `curl` on hosts without the AWS CLI. The
const-tree regeneration still runs each time (\~1 min).

Deliberately **not** cached with `actions/cache`: the warp runners are
AWS-hosted, so multipart S3 pulled the 3.2 GiB tarball in \~15 s
(\~225 MiB/s) on this PR's CI, while a measured cache hit restored the same
artifact in \~64 s (\~43 MB/s — the cache service's ceiling; an earlier
revision of this branch tried it). Skipping the cache also avoids a 2.7 GB
entry crowding the `bench-ixe` / rust caches under the repo's quota.

## 4. aiur `recursive` mode: on-demand marker + `!benchmark recursive` token (`0ec3f4e`)

The aiur `recursive` mode's testbed (`aiur-check-recursive-x64-32x`) is
scheduled by no CI job — its verifier execute needs >108 GB, past the 128 GB
CI host — yet it sat in the registry like a tracked testbed (the source of
the change-1 skip). A new `BackendSpec.unscheduled` field (aiur:
`["recursive"]`) marks such modes explicitly: `ix bench plots` skips them by
design (nothing uploads → nothing to plot), while they stay runnable via
local `ix bench run --mode recursive`. A `recursive` `!benchmark` token
(mirroring `execute`) lets a PR request the mode on demand; on the CI host it
OOMs to an empty table (no bencher baseline → base-SHA run) — usable on a
bigger manual dispatch.

## 5. `rust-compile` test fails on roundtrip mismatches (`a6d3033`)

The `rust-compile` diagnostic (`lake test -- rust-compile`) runs the full
compile → serialize → decompile roundtrip and printed `check_decompile`'s
mismatch counts, but **discarded the result** (`let _ = check_decompile(...)`)
and returned the constant count, so Lean always exited 0 — a real mismatch or
a fatal phase abort passed silently. Now Phase 3 and Phase 6 mismatches (+
`missing`) accumulate into a failure count that the FFI returns and the Lean
runner exits 1 on; fatal aborts already returned a non-zero count. This makes
the test gate-worthy.

One known gap in the gate's coverage: `check_decompile` iterates the
*decompiled* env, so its counts cover hash mismatches and extra constants;
constants *dropped* from the decompiled env (present in the original, absent
after roundtrip) are still only logged. Counting those needs an aux_gen-aware
original-side sweep — left for a follow-up.

## 6. `!benchmark fresh`: bypass the bencher baseline (`30cdcaf`)

A new bare `fresh` token makes every cell skip the `ix bench fetch-main`
bencher lookup and re-measure the main side with a base-SHA run — the same
path a full bencher miss (exit 3) already takes — for when the published
baseline is suspect (corrupted upload, stale toolchain). The comparison
prints in the PR comment only: bench-pr.yml never uploads to bencher, so the
canonical baseline is untouched. The config summary and the table's
main-source footer both say when `fresh` was in effect. Also catches the
bench-pr.yml header and the `docs/benchmarking.md` grammar up with the
`recursive` token from commit 4, which they still contradicted.

## Verification

- `Ix/Cli/BenchPlots.lean`, `BenchCmd.lean`, `BenchReport.lean` build
  (`lake build`).
- `ix-ffi` (with `test-ffi`) passes `cargo check`.
- Workflow/action YAML reviewed by hand (no `actionlint` in the env).
- Local timing/RAM of the two compile/decompile tests (to size a possible CI
  addition): `rust-compile` ≈ 110 s / **21.7 GiB** peak (213,960 constants,
  0 mismatches); `validate-aux` ≈ 15 s / **2.1 GiB** peak (0 failures).
  `rust-compile`'s peak exceeds `ubuntu-latest` (\~16 GiB) → needs a warp
  runner; both are Lean-driven `lake test`, so they'd belong in the
  `lean-test` job, not the cargo `rust-test` job. Wiring them into `ci.yml`
  is **not** in this PR.
