### PR TITLE
Aiur inlined function calls (`@fn(args)`) + blake3 G-function cleanup

### DIFF
--- a/Ix/Aiur/Compiler.lean
+++ b/Ix/Aiur/Compiler.lean
@@ -112,6 +112,7 @@ def Bytecode.Toplevel.needsCircuit (t : Bytecode.Toplevel) : Array Bool := Id.ru
 
 /-- Full compilation pipeline. -/
 def Source.Toplevel.compile (t : Source.Toplevel) : Except String CompiledToplevel := do
+  let t ← t.inlineCalls
   let typedDecls ← t.checkAndSimplify.mapError toString
   let concDecls ← typedDecls.concretize.mapError toString
   let (bytecodeRaw, preNameMap) ← concDecls.toBytecode
@@ -129,13 +130,14 @@ def Source.Toplevel.compile (t : Source.Toplevel) : Except String CompiledToplev
 `needsCircuit`, the field-setter `mapIdx`, the name-map `fold`, and the
 terminating `pure` — are all total). -/
 theorem Source.Toplevel.compile_ok_of_stages
-    {t : Source.Toplevel} {typedDecls concDecls bytecodeRaw preNameMap}
-    (hts : t.checkAndSimplify = .ok typedDecls)
+    {t inlined : Source.Toplevel} {typedDecls concDecls bytecodeRaw preNameMap}
+    (hinline : t.inlineCalls = .ok inlined)
+    (hts : inlined.checkAndSimplify = .ok typedDecls)
     (hconc : typedDecls.concretize = .ok concDecls)
     (hbc : concDecls.toBytecode = .ok (bytecodeRaw, preNameMap)) :
     ∃ ct, t.compile = .ok ct := by
-  simp only [Source.Toplevel.compile, hts, hconc, hbc, Except.mapError, bind,
-             Except.bind, pure, Except.pure]
+  simp only [Source.Toplevel.compile, hinline, hts, hconc, hbc, Except.mapError,
+             bind, Except.bind, pure, Except.pure]
   exact ⟨_, rfl⟩
 
 /-- Inverse of `compile_ok_of_stages`: unpack a successful `compile` into
@@ -144,27 +146,28 @@ lemmas through the composition. -/
 theorem Source.Toplevel.compile_stages_of_ok
     {t : Source.Toplevel} {ct : CompiledToplevel}
     (_hct : t.compile = .ok ct) :
-    ∃ typedDecls concDecls bytecodeRaw preNameMap,
-      t.checkAndSimplify = .ok typedDecls ∧
+    ∃ inlined typedDecls concDecls bytecodeRaw preNameMap,
+      t.inlineCalls = .ok inlined ∧
+      inlined.checkAndSimplify = .ok typedDecls ∧
       typedDecls.concretize = .ok concDecls ∧
       concDecls.toBytecode = .ok (bytecodeRaw, preNameMap) := by
   -- Case on each stage result; `mapError` on `.ok` is definitionally `.ok`.
-  cases hts : t.checkAndSimplify with
-  | error e => simp [Source.Toplevel.compile, hts, bind, Except.bind, Except.mapError] at _hct
-  | ok typedDecls =>
-    cases hconc : typedDecls.concretize with
-    | error e =>
-      simp [Source.Toplevel.compile, hts, hconc, bind, Except.bind, Except.mapError] at _hct
-    | ok concDecls =>
-      cases hbc : concDecls.toBytecode with
+  cases hinline : t.inlineCalls with
+  | error e => simp [Source.Toplevel.compile, hinline, bind, Except.bind] at _hct
+  | ok inlined =>
+    cases hts : inlined.checkAndSimplify with
+    | error e => simp [Source.Toplevel.compile, hinline, hts, bind, Except.bind, Except.mapError] at _hct
+    | ok typedDecls =>
+      cases hconc : typedDecls.concretize with
       | error e =>
-        simp [Source.Toplevel.compile, hts, hconc, hbc, bind, Except.bind, Except.mapError] at _hct
-      | ok bc =>
-        obtain ⟨bytecodeRaw, preNameMap⟩ := bc
-        -- `checkAndSimplify`/`concretize` are unfolded; `toBytecode` is not
-        -- (private module), so the first two equalities reduce to `rfl` but
-        -- the third still mentions `concDecls.toBytecode` — supply `hbc`.
-        exact ⟨typedDecls, concDecls, bytecodeRaw, preNameMap, rfl, hconc, hbc⟩
+        simp [Source.Toplevel.compile, hinline, hts, hconc, bind, Except.bind, Except.mapError] at _hct
+      | ok concDecls =>
+        cases hbc : concDecls.toBytecode with
+        | error e =>
+          simp [Source.Toplevel.compile, hinline, hts, hconc, hbc, bind, Except.bind, Except.mapError] at _hct
+        | ok bc =>
+          obtain ⟨bytecodeRaw, preNameMap⟩ := bc
+          exact ⟨inlined, typedDecls, concDecls, bytecodeRaw, preNameMap, rfl, hts, hconc, hbc⟩
 
 -- Compile post-conditions moved to `Proofs/StructCompatible.lean`.
 

--- a/Ix/Aiur/Compiler/Check.lean
+++ b/Ix/Aiur/Compiler/Check.lean
@@ -622,7 +622,14 @@ def inferTerm (t : Term) : CheckM Typed.Term := match t with
     match typOpt with
     | some (typ, escapes) => pure (Typed.Term.match typ escapes term' branches')
     | none => throw .emptyMatch
-  | .app func args u => do
+  | .app func args mode => do
+    -- `.inlined` is eliminated by `Toplevel.inlineCalls` before checking;
+    -- reaching it here means the pass was skipped. Downstream stages carry
+    -- only the unconstrained flag.
+    let u : Bool ← match mode with
+      | .normal => pure false
+      | .unconstrained => pure true
+      | .inlined => throw (.cannotApply func)
     let ctx ← read
     -- Local function lookup (only for unqualified names); returns
     -- `some (.ok …)` on hit, `some (.error …)` on wrong-type local, `none` to

--- a/Ix/Aiur/Meta.lean
+++ b/Ix/Aiur/Meta.lean
@@ -156,6 +156,10 @@ syntax ("." noWs)? ident "(" ")"                                              : 
 syntax ("." noWs)? ident "(" aiur_trm (", " aiur_trm)* ")"                  : aiur_trm
 syntax "#" noWs ("." noWs)? ident "(" ")"                                     : aiur_trm
 syntax "#" noWs ("." noWs)? ident "(" aiur_trm (", " aiur_trm)* ")"         : aiur_trm
+-- Inlined call: `@fn(args)` splices `fn`'s body into the caller at compile
+-- time (no separate circuit). Callee must not be inline-recursive.
+syntax "@" noWs ("." noWs)? ident "(" ")"                                     : aiur_trm
+syntax "@" noWs ("." noWs)? ident "(" aiur_trm (", " aiur_trm)* ")"         : aiur_trm
 syntax ident "‹" aiur_typ (", " aiur_typ)* "›" "(" ")"                      : aiur_trm
 syntax ident "‹" aiur_typ (", " aiur_typ)* "›" "(" aiur_trm
        (", " aiur_trm)* ")"                                                  : aiur_trm
@@ -266,16 +270,22 @@ partial def elabTrm : ElabStxCat `aiur_trm
     | .str .anonymous _ => pure ()
     | _ => logWarningAt f "empty parentheses are not needed; use the name without parentheses"
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, toExpr false]
+    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, mkConst ``Source.CallMode.normal]
   | `(aiur_trm| $[.]?$f:ident ($a:aiur_trm $[, $as:aiur_trm]*)) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, toExpr false]
+    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, mkConst ``Source.CallMode.normal]
   | `(aiur_trm| #$[.]?$f:ident()) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, toExpr true]
+    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, mkConst ``Source.CallMode.unconstrained]
   | `(aiur_trm| #$[.]?$f:ident($a:aiur_trm $[, $as:aiur_trm]*)) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, toExpr true]
+    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, mkConst ``Source.CallMode.unconstrained]
+  | `(aiur_trm| @$[.]?$f:ident()) => do
+    let g ← mkAppM ``Global.mk #[toExpr f.getId]
+    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, mkConst ``Source.CallMode.inlined]
+  | `(aiur_trm| @$[.]?$f:ident($a:aiur_trm $[, $as:aiur_trm]*)) => do
+    let g ← mkAppM ``Global.mk #[toExpr f.getId]
+    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, mkConst ``Source.CallMode.inlined]
   | `(aiur_trm| $a:aiur_trm + $b:aiur_trm) => do
     mkAppM ``Source.Term.add #[← elabTrm a, ← elabTrm b]
   | `(aiur_trm| $a:aiur_trm - $b:aiur_trm) => do
@@ -355,29 +365,29 @@ partial def elabTrm : ElabStxCat `aiur_trm
   -- Template function calls: explicit type args are dropped (inferred)
   | `(aiur_trm| $f:ident‹$_:aiur_typ $[, $_:aiur_typ]*›()) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, toExpr false]
+    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, mkConst ``Source.CallMode.normal]
   | `(aiur_trm| $f:ident‹$_:aiur_typ $[, $_:aiur_typ]*›
                  ($a:aiur_trm $[, $as:aiur_trm]*)) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, toExpr false]
+    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, mkConst ``Source.CallMode.normal]
   | `(aiur_trm| #$f:ident‹$_:aiur_typ $[, $_:aiur_typ]*›()) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, toExpr true]
+    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, mkConst ``Source.CallMode.unconstrained]
   | `(aiur_trm| #$f:ident‹$_:aiur_typ $[, $_:aiur_typ]*›
                  ($a:aiur_trm $[, $as:aiur_trm]*)) => do
     let g ← mkAppM ``Global.mk #[toExpr f.getId]
-    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, toExpr true]
+    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, mkConst ``Source.CallMode.unconstrained]
   -- Template constructor calls
   | `(aiur_trm| $tmpl:ident‹$_:aiur_typ $[, $_:aiur_typ]*›.$ctor:ident()) => do
     logWarningAt ctor "empty parentheses are not needed; use the name without parentheses"
     let name := tmpl.getId ++ ctor.getId
     let g ← mkAppM ``Global.mk #[toExpr name]
-    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, toExpr false]
+    mkAppM ``Source.Term.app #[g, ← elabEmptyList ``Source.Term, mkConst ``Source.CallMode.normal]
   | `(aiur_trm| $tmpl:ident‹$_:aiur_typ $[, $_:aiur_typ]*›.$ctor:ident
                  ($a:aiur_trm $[, $as:aiur_trm]*)) => do
     let name := tmpl.getId ++ ctor.getId
     let g ← mkAppM ``Global.mk #[toExpr name]
-    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, toExpr false]
+    mkAppM ``Source.Term.app #[g, ← elabList a as elabTrm ``Source.Term, mkConst ``Source.CallMode.normal]
   | `(aiur_trm| fold($i .. $j, $init, |$acc, @$v| $body)) => do
     let i := i.getNat
     let j := j.getNat

--- a/Ix/Aiur/Stages/Source.lean
+++ b/Ix/Aiur/Stages/Source.lean
@@ -374,6 +374,21 @@ inductive Pattern
 
 namespace Source
 
+/-- How a function application is compiled.
+* `normal` — a constrained circuit call (its own circuit, a lookup, and
+  output columns at the call site).
+* `unconstrained` — a call whose callee is trusted (no lookup / circuit
+  constraint); the old `unconstrained := true`.
+* `inlined` — the callee's body is spliced into the caller at compile
+  time (no separate circuit, no interface columns). Eliminated by
+  `Toplevel.inlineCalls` before typechecking; forbidden for callees that
+  are (transitively) inline-recursive. -/
+inductive CallMode
+  | normal
+  | unconstrained
+  | inlined
+  deriving Repr, BEq, Hashable, Inhabited, DecidableEq
+
 /-- Stage 1 term language. `tuple` and `array` are direct constructors (no `Data`
 mutual child); cf. `Ix/Aiur/Term.lean` which nested them under `.data`. -/
 inductive Term
@@ -386,7 +401,7 @@ inductive Term
   | ret : Term → Term
   | let : Pattern → Term → Term → Term
   | match : Term → List (Pattern × Term) → Term
-  | app : Global → List Term → (unconstrained : Bool) → Term
+  | app : Global → List Term → (mode : CallMode) → Term
   | add : Term → Term → Term
   | sub : Term → Term → Term
   | mul : Term → Term → Term
@@ -538,6 +553,487 @@ where
         globals := globals.insert n
         result := result.push item
     pure (globals, result)
+
+/-- Rename every local bound in a pattern to a fresh `.str "inl#N"` name,
+extending `subst` for the pattern's scope and advancing the fresh counter.
+-/
+def Pattern.freshen (cnt : Nat) (subst : Std.HashMap Local Local) :
+    Pattern → Nat × Std.HashMap Local Local × Pattern
+  | .var x =>
+    let x' : Local := .str s!"inl#{cnt}"
+    (cnt + 1, subst.insert x x', .var x')
+  | .wildcard => (cnt, subst, .wildcard)
+  | .field g => (cnt, subst, .field g)
+  | .ref g ps =>
+    let (cnt, subst, ps') := ps.attach.foldl (init := (cnt, subst, ([] : List Pattern)))
+      fun (cnt, subst, acc) ⟨p, _⟩ =>
+        let (cnt, subst, p') := Pattern.freshen cnt subst p
+        (cnt, subst, acc ++ [p'])
+    (cnt, subst, .ref g ps')
+  | .tuple ps =>
+    let (cnt, subst, ps') := ps.attach.foldl (init := (cnt, subst, (#[] : Array Pattern)))
+      fun (cnt, subst, acc) ⟨p, _⟩ =>
+        let (cnt, subst, p') := Pattern.freshen cnt subst p
+        (cnt, subst, acc.push p')
+    (cnt, subst, .tuple ps')
+  | .array ps =>
+    let (cnt, subst, ps') := ps.attach.foldl (init := (cnt, subst, (#[] : Array Pattern)))
+      fun (cnt, subst, acc) ⟨p, _⟩ =>
+        let (cnt, subst, p') := Pattern.freshen cnt subst p
+        (cnt, subst, acc.push p')
+    (cnt, subst, .array ps')
+  | .or p q =>
+    let (cnt, subst, p') := Pattern.freshen cnt subst p
+    let (cnt, subst, q') := Pattern.freshen cnt subst q
+    (cnt, subst, .or p' q')
+  | .pointer p =>
+    let (cnt, subst, p') := Pattern.freshen cnt subst p
+    (cnt, subst, .pointer p')
+termination_by p => sizeOf p
+decreasing_by
+  all_goals first
+    | decreasing_tactic
+    | (have := Array.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+    | (have := List.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+
+/-- Consistently α-rename the locals bound inside `t` to fresh names,
+following `subst` for the currently-renamed variables. Used before
+splicing an inlined body so its locals cannot collide with the caller's
+(the `Simple` pass floats nested `let`s outward, which would otherwise
+capture reused names). Only bound occurrences are rewritten; free
+variables that are the callee's inputs are handled by `subst` seeded at
+the call site. -/
+def Term.freshen (cnt : Nat) (subst : Std.HashMap Local Local) :
+    Term → Nat × Term :=
+  fun t =>
+  match t with
+  | .var x => (cnt, .var (subst.getD x x))
+  | .unit | .ref _ | .field _ | .u8Lit _ => (cnt, t)
+  | .let p v b =>
+    let (cnt, v') := Term.freshen cnt subst v
+    let (cnt, subst', p') := Pattern.freshen cnt subst p
+    let (cnt, b') := Term.freshen cnt subst' b
+    (cnt, .let p' v' b')
+  | .match s arms =>
+    let (cnt, s') := Term.freshen cnt subst s
+    let (cnt, arms') := arms.attach.foldl (init := (cnt, ([] : List (Pattern × Term))))
+      fun (cnt, acc) ⟨(p, a), _⟩ =>
+        let (cnt, subst', p') := Pattern.freshen cnt subst p
+        let (cnt, a') := Term.freshen cnt subst' a
+        (cnt, acc ++ [(p', a')])
+    (cnt, .match s' arms')
+  | .tuple ts =>
+    let (cnt, ts') := ts.attach.foldl (init := (cnt, #[])) fun (cnt, acc) ⟨x, _⟩ =>
+      let (cnt, x') := Term.freshen cnt subst x; (cnt, acc.push x')
+    (cnt, .tuple ts')
+  | .array ts =>
+    let (cnt, ts') := ts.attach.foldl (init := (cnt, #[])) fun (cnt, acc) ⟨x, _⟩ =>
+      let (cnt, x') := Term.freshen cnt subst x; (cnt, acc.push x')
+    (cnt, .array ts')
+  | .app g args mode =>
+    let (cnt, args') := args.attach.foldl (init := (cnt, ([] : List Term))) fun (cnt, acc) ⟨x, _⟩ =>
+      let (cnt, x') := Term.freshen cnt subst x; (cnt, acc ++ [x'])
+    (cnt, .app g args' mode)
+  | .ret a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .ret a')
+  | .add a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .add a' b')
+  | .sub a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .sub a' b')
+  | .mul a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .mul a' b')
+  | .eqZero a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .eqZero a')
+  | .proj a n => let (cnt, a') := Term.freshen cnt subst a; (cnt, .proj a' n)
+  | .get a n => let (cnt, a') := Term.freshen cnt subst a; (cnt, .get a' n)
+  | .slice a i j => let (cnt, a') := Term.freshen cnt subst a; (cnt, .slice a' i j)
+  | .set a n v => let (cnt, a') := Term.freshen cnt subst a; let (cnt, v') := Term.freshen cnt subst v; (cnt, .set a' n v')
+  | .store a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .store a')
+  | .load a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .load a')
+  | .ptrVal a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .ptrVal a')
+  | .ann τ a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .ann τ a')
+  | .assertEq a b c =>
+    let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; let (cnt, c') := Term.freshen cnt subst c
+    (cnt, .assertEq a' b' c')
+  | .ioGetInfo c k => let (cnt, c') := Term.freshen cnt subst c; let (cnt, k') := Term.freshen cnt subst k; (cnt, .ioGetInfo c' k')
+  | .ioSetInfo c k i l rv =>
+    let (cnt, c') := Term.freshen cnt subst c; let (cnt, k') := Term.freshen cnt subst k; let (cnt, i') := Term.freshen cnt subst i
+    let (cnt, l') := Term.freshen cnt subst l; let (cnt, rv') := Term.freshen cnt subst rv
+    (cnt, .ioSetInfo c' k' i' l' rv')
+  | .ioRead c i n => let (cnt, c') := Term.freshen cnt subst c; let (cnt, i') := Term.freshen cnt subst i; (cnt, .ioRead c' i' n)
+  | .ioWrite c d rv =>
+    let (cnt, c') := Term.freshen cnt subst c; let (cnt, d') := Term.freshen cnt subst d; let (cnt, rv') := Term.freshen cnt subst rv
+    (cnt, .ioWrite c' d' rv')
+  | .u8BitDecomposition a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .u8BitDecomposition a')
+  | .u8ShiftLeft a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .u8ShiftLeft a')
+  | .u8ShiftRight a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .u8ShiftRight a')
+  | .u8Xor a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8Xor a' b')
+  | .u8Add a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8Add a' b')
+  | .u8Mul a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8Mul a' b')
+  | .u8Sub a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8Sub a' b')
+  | .u8And a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8And a' b')
+  | .u8Or a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8Or a' b')
+  | .u8LessThan a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8LessThan a' b')
+  | .u32LessThan a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u32LessThan a' b')
+  | .u8ChainRotr7 a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8ChainRotr7 a' b')
+  | .u8ChainRotr4 a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8ChainRotr4 a' b')
+  | .unconstrainedBigUintDivMod a b =>
+    let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .unconstrainedBigUintDivMod a' b')
+  | .u8RangeCheck a b => let (cnt, a') := Term.freshen cnt subst a; let (cnt, b') := Term.freshen cnt subst b; (cnt, .u8RangeCheck a' b')
+  | .toField a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .toField a')
+  | .u8FromFieldUnsafe a => let (cnt, a') := Term.freshen cnt subst a; (cnt, .u8FromFieldUnsafe a')
+  | .debug s o a =>
+    let (cnt, o') := match o with
+      | none => (cnt, none)
+      | some x => let (cnt, x') := Term.freshen cnt subst x; (cnt, some x')
+    let (cnt, a') := Term.freshen cnt subst a
+    (cnt, .debug s o' a')
+termination_by t => sizeOf t
+decreasing_by
+  all_goals first
+    | decreasing_tactic
+    | (have := Array.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+    | (have := List.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+
+/-- Peel the leading `let` bindings off a term: returns the binding frames
+(outermost first) and the non-`let` core. -/
+def Term.peelLets : Term → List (Pattern × Term) × Term
+  | .let p v b => let (fs, c) := Term.peelLets b; ((p, v) :: fs, c)
+  | t => ([], t)
+
+/-- Wrap `body` in a chain of `let` frames (first frame outermost). -/
+def Term.wrapLets : List (Pattern × Term) → Term → Term
+  | [], body => body
+  | (p, v) :: fs, body => .let p v (Term.wrapLets fs body)
+
+/-- Every `.inlined` call site in `t`, as `(callee, argCount)` pairs. Drives
+both validation (callee exists, arity matches) and the inline-dependency
+graph the bottom-up expansion is ordered by. -/
+def Term.inlineCallSites : Term → List (Global × Nat)
+  | .app g args .inlined =>
+    args.attach.foldl (fun acc ⟨a, _⟩ => acc ++ a.inlineCallSites) [(g, args.length)]
+  | .app _ args _ =>
+    args.attach.foldl (fun acc ⟨a, _⟩ => acc ++ a.inlineCallSites) []
+  | .unit | .var _ | .ref _ | .field _ | .u8Lit _ => []
+  | .tuple ts | .array ts =>
+    ts.attach.foldl (fun acc ⟨a, _⟩ => acc ++ a.inlineCallSites) []
+  | .match s arms =>
+    arms.attach.foldl (fun acc ⟨(_, a), _⟩ => acc ++ a.inlineCallSites) s.inlineCallSites
+  | .let _ v b => v.inlineCallSites ++ b.inlineCallSites
+  | .add a b | .sub a b | .mul a b | .set a _ b
+  | .u8Xor a b | .u8Add a b | .u8Mul a b | .u8Sub a b | .u8And a b | .u8Or a b
+  | .u8LessThan a b | .u32LessThan a b | .u8ChainRotr7 a b | .u8ChainRotr4 a b
+  | .unconstrainedBigUintDivMod a b | .u8RangeCheck a b | .ioGetInfo a b =>
+    a.inlineCallSites ++ b.inlineCallSites
+  | .assertEq a b c | .ioWrite a b c => a.inlineCallSites ++ b.inlineCallSites ++ c.inlineCallSites
+  | .ioSetInfo c k i l rv =>
+    c.inlineCallSites ++ k.inlineCallSites ++ i.inlineCallSites ++ l.inlineCallSites ++ rv.inlineCallSites
+  | .ioRead a b _ => a.inlineCallSites ++ b.inlineCallSites
+  | .ret a | .eqZero a | .proj a _ | .get a _ | .slice a _ _ | .store a | .load a
+  | .ptrVal a | .ann _ a | .u8BitDecomposition a | .u8ShiftLeft a | .u8ShiftRight a
+  | .toField a | .u8FromFieldUnsafe a => a.inlineCallSites
+  | .debug _ o a => (match o with | none => [] | some x => x.inlineCallSites) ++ a.inlineCallSites
+termination_by t => sizeOf t
+decreasing_by
+  all_goals first
+    | decreasing_tactic
+    | (have := Array.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+    | (have := List.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+
+/-- Structurally splice every `.app g args .inlined` in `t`, given `done`,
+which maps each already-expanded callee to its input locals and its (already
+inline-free) body. At an inline site the callee's inputs and body are
+α-renamed to fresh `inl#N` names (`Term.freshen`, seeded with the inputs),
+then each fresh input is bound to its argument via a `let`. Freshening the
+inputs BEFORE binding the arguments is essential: arguments are caller terms,
+so a fresh input name cannot shadow a caller local an argument references (nor
+collide across copies).
+
+Bottom-up ordering (see `Toplevel.inlineCalls`) guarantees `done[g]` is
+already inline-free, so the spliced body is NOT re-traversed — the recursion
+is purely structural on `t` and needs no fuel. `cnt` threads the fresh-name
+counter. If `done` lacks `g` the site is left untouched; the ordering makes
+that unreachable. -/
+def Term.expandOnce (done : Std.HashMap Global (List Local × Term)) (cnt : Nat) :
+    Term → Nat × Term := fun t => match t with
+  | .app g args .inlined =>
+    let (cnt, args') := args.attach.foldl (init := (cnt, ([] : List Term)))
+      fun (cnt, acc) ⟨a, _⟩ => let (cnt, a') := Term.expandOnce done cnt a; (cnt, acc ++ [a'])
+    match done[g]? with
+    | none => (cnt, .app g args' .inlined)
+    | some (ins, body) =>
+      let (cnt, subst, freshInputs) := ins.foldl
+        (init := (cnt, (∅ : Std.HashMap Local Local), ([] : List Local)))
+        fun (cnt, subst, acc) inp =>
+          let inp' : Local := .str s!"inl#{cnt}"
+          (cnt + 1, subst.insert inp inp', acc ++ [inp'])
+      let (cnt, freshBody) := Term.freshen cnt subst body
+      -- A branching callee ends in a `match`. In a strict argument position
+      -- the splice's leading lets hoist out (`Term.hoistLets`) but the match
+      -- core would stay put, which lowering rejects as a non-tail match in
+      -- arbitrary position. Bind the match to a fresh local so hoisting
+      -- leaves only a variable behind; in let-RHS/tail positions the extra
+      -- binding is harmless.
+      let (cnt, freshBody) :=
+        match Term.peelLets freshBody with
+        | (fs, core@(.match ..)) =>
+          let out : Local := .str s!"inl#{cnt}"
+          (cnt + 1, Term.wrapLets fs (.let (.var out) core (.var out)))
+        | _ => (cnt, freshBody)
+      (cnt, (freshInputs.zip args').foldr
+        (fun (input, arg) acc => Term.let (.var input) arg acc) freshBody)
+  | .app g args mode =>
+    let (cnt, args') := args.attach.foldl (init := (cnt, ([] : List Term)))
+      fun (cnt, acc) ⟨a, _⟩ => let (cnt, a') := Term.expandOnce done cnt a; (cnt, acc ++ [a'])
+    (cnt, .app g args' mode)
+  | .unit | .var _ | .ref _ | .field _ | .u8Lit _ => (cnt, t)
+  | .tuple ts =>
+    let (cnt, ts') := ts.attach.foldl (init := (cnt, #[]))
+      fun (cnt, acc) ⟨a, _⟩ => let (cnt, a') := Term.expandOnce done cnt a; (cnt, acc.push a')
+    (cnt, .tuple ts')
+  | .array ts =>
+    let (cnt, ts') := ts.attach.foldl (init := (cnt, #[]))
+      fun (cnt, acc) ⟨a, _⟩ => let (cnt, a') := Term.expandOnce done cnt a; (cnt, acc.push a')
+    (cnt, .array ts')
+  | .match s arms =>
+    let (cnt, s') := Term.expandOnce done cnt s
+    let (cnt, arms') := arms.attach.foldl (init := (cnt, ([] : List (Pattern × Term))))
+      fun (cnt, acc) ⟨(p, a), _⟩ => let (cnt, a') := Term.expandOnce done cnt a; (cnt, acc ++ [(p, a')])
+    (cnt, .match s' arms')
+  | .let p v b =>
+    let (cnt, v') := Term.expandOnce done cnt v
+    let (cnt, b') := Term.expandOnce done cnt b
+    (cnt, .let p v' b')
+  | .ret a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .ret a')
+  | .add a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .add a' b')
+  | .sub a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .sub a' b')
+  | .mul a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .mul a' b')
+  | .eqZero a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .eqZero a')
+  | .proj a n => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .proj a' n)
+  | .get a n => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .get a' n)
+  | .slice a i j => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .slice a' i j)
+  | .set a n v => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, v') := Term.expandOnce done cnt v; (cnt, .set a' n v')
+  | .store a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .store a')
+  | .load a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .load a')
+  | .ptrVal a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .ptrVal a')
+  | .ann τ a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .ann τ a')
+  | .assertEq a b c =>
+    let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b
+    let (cnt, c') := Term.expandOnce done cnt c; (cnt, .assertEq a' b' c')
+  | .ioGetInfo c k => let (cnt, c') := Term.expandOnce done cnt c; let (cnt, k') := Term.expandOnce done cnt k; (cnt, .ioGetInfo c' k')
+  | .ioSetInfo c k i l rv =>
+    let (cnt, c') := Term.expandOnce done cnt c; let (cnt, k') := Term.expandOnce done cnt k
+    let (cnt, i') := Term.expandOnce done cnt i; let (cnt, l') := Term.expandOnce done cnt l
+    let (cnt, rv') := Term.expandOnce done cnt rv; (cnt, .ioSetInfo c' k' i' l' rv')
+  | .ioRead c i n => let (cnt, c') := Term.expandOnce done cnt c; let (cnt, i') := Term.expandOnce done cnt i; (cnt, .ioRead c' i' n)
+  | .ioWrite c d rv =>
+    let (cnt, c') := Term.expandOnce done cnt c; let (cnt, d') := Term.expandOnce done cnt d
+    let (cnt, rv') := Term.expandOnce done cnt rv; (cnt, .ioWrite c' d' rv')
+  | .u8BitDecomposition a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .u8BitDecomposition a')
+  | .u8ShiftLeft a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .u8ShiftLeft a')
+  | .u8ShiftRight a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .u8ShiftRight a')
+  | .u8Xor a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8Xor a' b')
+  | .u8Add a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8Add a' b')
+  | .u8Mul a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8Mul a' b')
+  | .u8Sub a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8Sub a' b')
+  | .u8And a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8And a' b')
+  | .u8Or a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8Or a' b')
+  | .u8LessThan a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8LessThan a' b')
+  | .u32LessThan a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u32LessThan a' b')
+  | .u8ChainRotr7 a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8ChainRotr7 a' b')
+  | .u8ChainRotr4 a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8ChainRotr4 a' b')
+  | .unconstrainedBigUintDivMod a b =>
+    let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .unconstrainedBigUintDivMod a' b')
+  | .u8RangeCheck a b => let (cnt, a') := Term.expandOnce done cnt a; let (cnt, b') := Term.expandOnce done cnt b; (cnt, .u8RangeCheck a' b')
+  | .toField a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .toField a')
+  | .u8FromFieldUnsafe a => let (cnt, a') := Term.expandOnce done cnt a; (cnt, .u8FromFieldUnsafe a')
+  | .debug s o a =>
+    let (cnt, o') := match o with
+      | none => (cnt, none)
+      | some x => let (cnt, x') := Term.expandOnce done cnt x; (cnt, some x')
+    let (cnt, a') := Term.expandOnce done cnt a
+    (cnt, .debug s o' a')
+termination_by t => sizeOf t
+decreasing_by
+  all_goals first
+    | decreasing_tactic
+    | (have := Array.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+    | (have := List.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+
+/-- Peel leading lets off each of `ts` (already hoisted), collecting the
+frames left-to-right so evaluation order is preserved, and returning the
+frame chain plus the cores. -/
+def Term.peelListLets (ts : List Term) : List (Pattern × Term) × List Term :=
+  ts.foldr
+    (fun t (fs, cs) => let (f, c) := Term.peelLets t; (f ++ fs, c :: cs))
+    ([], [])
+
+def Term.peelArrayLets (ts : Array Term) : List (Pattern × Term) × Array Term :=
+  let (fs, cs) := Term.peelListLets ts.toList
+  (fs, cs.toArray)
+
+/-- Hoist every `let`-chain out of a strict argument position into a
+wrapping `let`. Inlining splices a callee body (a `let`-chain ending in a
+value) wherever the `@`-call appeared; in a `let`-RHS or tail position the
+`Simple` pass already floats those lets outward, but in an argument
+position (a `set`/array element, an operator operand, …) they would stay
+nested, which the lowering cannot handle. This normalizes all such
+positions. `let`-RHS, `match` arm bodies, and `ret`/`debug` continuations
+are already handled downstream, so their lets are left in place. -/
+def Term.hoistLets : Term → Term :=
+  fun t =>
+  -- Hoist a construct's argument terms: peel each arg's lets and wrap.
+  match t with
+  | .unit | .var _ | .ref _ | .field _ | .u8Lit _ => t
+  | .let p v b => .let p (Term.hoistLets v) (Term.hoistLets b)
+  | .match s arms =>
+    let (fs, sc) := Term.peelLets (Term.hoistLets s)
+    Term.wrapLets fs (.match sc (arms.attach.map fun ⟨(p, a), _⟩ => (p, Term.hoistLets a)))
+  | .ret a => .ret (Term.hoistLets a)
+  | .debug s o a =>
+    .debug s (match o with | none => none | some x => some (Term.hoistLets x)) (Term.hoistLets a)
+  | .tuple ts =>
+    let (fs, cs) := Term.peelArrayLets (ts.attach.map fun ⟨x, _⟩ => Term.hoistLets x)
+    Term.wrapLets fs (.tuple cs)
+  | .array ts =>
+    let (fs, cs) := Term.peelArrayLets (ts.attach.map fun ⟨x, _⟩ => Term.hoistLets x)
+    Term.wrapLets fs (.array cs)
+  | .app g args mode =>
+    let (fs, cs) := Term.peelListLets (args.attach.map fun ⟨x, _⟩ => Term.hoistLets x)
+    Term.wrapLets fs (.app g cs mode)
+  | .assertEq a b c =>
+    let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b, Term.hoistLets c]
+    match cs with
+    | [a, b, c] => Term.wrapLets fs (.assertEq a b c)
+    | _ => t
+  | .ioSetInfo a b c d e =>
+    let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b, Term.hoistLets c, Term.hoistLets d, Term.hoistLets e]
+    match cs with
+    | [a, b, c, d, e] => Term.wrapLets fs (.ioSetInfo a b c d e)
+    | _ => t
+  | .ioWrite a b c =>
+    let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b, Term.hoistLets c]
+    match cs with
+    | [a, b, c] => Term.wrapLets fs (.ioWrite a b c)
+    | _ => t
+  | .ioGetInfo a b =>
+    let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+    match cs with | [a, b] => Term.wrapLets fs (.ioGetInfo a b) | _ => t
+  | .ioRead a b n =>
+    let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+    match cs with | [a, b] => Term.wrapLets fs (.ioRead a b n) | _ => t
+  | .add a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                match cs with | [a, b] => Term.wrapLets fs (.add a b) | _ => t
+  | .sub a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                match cs with | [a, b] => Term.wrapLets fs (.sub a b) | _ => t
+  | .mul a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                match cs with | [a, b] => Term.wrapLets fs (.mul a b) | _ => t
+  | .eqZero a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.eqZero c)
+  | .proj a n => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.proj c n)
+  | .get a n => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.get c n)
+  | .slice a i j => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.slice c i j)
+  | .set a n v =>
+    let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets v]
+    match cs with | [a, v] => Term.wrapLets fs (.set a n v) | _ => t
+  | .store a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.store c)
+  | .load a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.load c)
+  | .ptrVal a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.ptrVal c)
+  | .ann τ a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.ann τ c)
+  | .u8BitDecomposition a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.u8BitDecomposition c)
+  | .u8ShiftLeft a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.u8ShiftLeft c)
+  | .u8ShiftRight a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.u8ShiftRight c)
+  | .toField a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.toField c)
+  | .u8FromFieldUnsafe a => let (fs, c) := Term.peelLets (Term.hoistLets a); Term.wrapLets fs (.u8FromFieldUnsafe c)
+  | .u8Xor a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                  match cs with | [a, b] => Term.wrapLets fs (.u8Xor a b) | _ => t
+  | .u8Add a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                  match cs with | [a, b] => Term.wrapLets fs (.u8Add a b) | _ => t
+  | .u8Mul a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                  match cs with | [a, b] => Term.wrapLets fs (.u8Mul a b) | _ => t
+  | .u8Sub a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                  match cs with | [a, b] => Term.wrapLets fs (.u8Sub a b) | _ => t
+  | .u8And a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                  match cs with | [a, b] => Term.wrapLets fs (.u8And a b) | _ => t
+  | .u8Or a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                 match cs with | [a, b] => Term.wrapLets fs (.u8Or a b) | _ => t
+  | .u8LessThan a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                       match cs with | [a, b] => Term.wrapLets fs (.u8LessThan a b) | _ => t
+  | .u32LessThan a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                        match cs with | [a, b] => Term.wrapLets fs (.u32LessThan a b) | _ => t
+  | .u8ChainRotr7 a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                         match cs with | [a, b] => Term.wrapLets fs (.u8ChainRotr7 a b) | _ => t
+  | .u8ChainRotr4 a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                         match cs with | [a, b] => Term.wrapLets fs (.u8ChainRotr4 a b) | _ => t
+  | .unconstrainedBigUintDivMod a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                                       match cs with | [a, b] => Term.wrapLets fs (.unconstrainedBigUintDivMod a b) | _ => t
+  | .u8RangeCheck a b => let (fs, cs) := Term.peelListLets [Term.hoistLets a, Term.hoistLets b]
+                         match cs with | [a, b] => Term.wrapLets fs (.u8RangeCheck a b) | _ => t
+termination_by t => sizeOf t
+decreasing_by
+  all_goals first
+    | decreasing_tactic
+    | (have := Array.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+    | (have := List.sizeOf_lt_of_mem ‹_ ∈ _›; grind)
+
+/-- Kahn-style topological sort of the inline-dependency graph: each pass
+emits every function whose inline-callees are already emitted, so callees
+precede callers. `rounds` bounds the number of passes by the function count
+— a DAG on N nodes has depth < N, so N passes suffice — which is the honest
+structural termination measure (not an arbitrary fuel cap). A non-empty
+remaining set with no ready function is an inline cycle and is rejected. -/
+def inlineTopo (deps : Std.HashMap Global (List Global)) :
+    Nat → List Global → Std.HashSet Global → List Global → Except String (List Global)
+  | 0, remaining, _, acc =>
+    if remaining.isEmpty then pure acc
+    else throw "inline recursion: dependency graph did not converge"
+  | rounds + 1, remaining, emitted, acc =>
+    match remaining with
+    | [] => pure acc
+    | _ =>
+      let (ready, notReady) := remaining.partition fun g =>
+        (deps.getD g []).all emitted.contains
+      match ready with
+      | [] =>
+        throw s!"inline recursion among: {remaining.map Global.toName}"
+      | _ =>
+        let emitted := ready.foldl (fun s g => s.insert g) emitted
+        inlineTopo deps rounds notReady emitted (acc ++ ready)
+termination_by rounds _ _ _ => rounds
+
+/-- Inline-expand every function body in the toplevel, eliminating all
+`.inlined` applications. Run before typechecking.
+
+Bottom-up and fuel-free: `.inlined` calls form a DAG (cycles are rejected as
+inline recursion), so functions are expanded in topological order — every
+callee is fully expanded before any caller inlines it. Each body is therefore
+expanded exactly once (`Term.expandOnce`, structurally recursive on the term),
+and its already-inline-free result is memoized in `done` and spliced (with
+α-renaming) at every call site. -/
+def Toplevel.inlineCalls (t : Toplevel) : Except String Toplevel := do
+  let funcs : Std.HashMap Global Function :=
+    t.functions.foldl (fun m f => m.insert f.name f) ∅
+  -- Inline dependencies per function, validating callee existence and arity.
+  let deps : Std.HashMap Global (List Global) ← t.functions.foldlM (init := ∅)
+    fun deps f => do
+      let gs ← f.body.inlineCallSites.foldlM (init := ([] : List Global))
+        fun acc (g, n) => do
+          let some callee := funcs[g]?
+            | throw s!"inline call to unknown function `{g.toName}`"
+          if n != callee.inputs.length then
+            throw s!"inline `{g.toName}`: got {n} args, expects {callee.inputs.length}"
+          pure (acc ++ [g])
+      pure (deps.insert f.name gs)
+  -- Topological order (callees first). `funcs.size` rounds bound the passes.
+  let names := t.functions.toList.map Function.name
+  let order ← inlineTopo deps names.length names ∅ []
+  -- Expand each body once, in order, memoizing the inline-free result.
+  let done : Std.HashMap Global (List Local × Term) := order.foldl (init := ∅)
+    fun done g =>
+      match funcs[g]? with
+      | none => done
+      | some f => done.insert g (f.inputs.map Prod.fst, (f.body.expandOnce done 0).2)
+  -- Rebuild each function with its expanded body, then hoist argument-position
+  -- lets that splicing may have introduced.
+  let functions := t.functions.map fun f =>
+    match done[f.name]? with
+    | none => f
+    | some (_, body) => { f with body := body.hoistLets }
+  pure { t with functions }
 
 inductive Declaration
   | function : Function → Declaration

--- a/Ix/IxVM/Blake3.lean
+++ b/Ix/IxVM/Blake3.lean
@@ -300,108 +300,14 @@ def blake3 := ⟦
     x: [U8; 4],
     y: [U8; 4]
   ) -> [[U8; 4]; 4] {
-    -- a = (a + b) + x
-    let (r1_0, r1_c1) = u8_add(a[0], b[0]);
-    let (r1_s1, r1_o1) = u8_add(a[1], b[1]);
-    let (r1_1, r1_c1a) = u8_add(r1_s1, r1_c1);
-    let r1_c2 = u8_from_field_unsafe(to_field(r1_o1) + to_field(r1_c1a));
-    let (r1_s2, r1_o2) = u8_add(a[2], b[2]);
-    let (r1_2, r1_c2a) = u8_add(r1_s2, r1_c2);
-    let r1_c3 = u8_from_field_unsafe(to_field(r1_o2) + to_field(r1_c2a));
-    let (r1_s3, _z) = u8_add(a[3], b[3]);
-    let (r1_3, _z) = u8_add(r1_s3, r1_c3);
-    let (a0, r2_c1) = u8_add(r1_0, x[0]);
-    let (r2_s1, r2_o1) = u8_add(r1_1, x[1]);
-    let (a1, r2_c1a) = u8_add(r2_s1, r2_c1);
-    let r2_c2 = u8_from_field_unsafe(to_field(r2_o1) + to_field(r2_c1a));
-    let (r2_s2, r2_o2) = u8_add(r1_2, x[2]);
-    let (a2, r2_c2a) = u8_add(r2_s2, r2_c2);
-    let r2_c3 = u8_from_field_unsafe(to_field(r2_o2) + to_field(r2_c2a));
-    let (r2_s3, _z) = u8_add(r1_3, x[3]);
-    let (a3, _z) = u8_add(r2_s3, r2_c3);
-    let a = [a0, a1, a2, a3];
-
-    let d0 = u8_xor(d[0], a[0]);
-    let d1 = u8_xor(d[1], a[1]);
-    let d2 = u8_xor(d[2], a[2]);
-    let d3 = u8_xor(d[3], a[3]);
-    let d = [d2, d3, d0, d1]; -- Right-rotated 16
-
-    -- c = c + d
-    let (nc0, r3_c1) = u8_add(c[0], d[0]);
-    let (r3_s1, r3_o1) = u8_add(c[1], d[1]);
-    let (nc1, r3_c1a) = u8_add(r3_s1, r3_c1);
-    let r3_c2 = u8_from_field_unsafe(to_field(r3_o1) + to_field(r3_c1a));
-    let (r3_s2, r3_o2) = u8_add(c[2], d[2]);
-    let (nc2, r3_c2a) = u8_add(r3_s2, r3_c2);
-    let r3_c3 = u8_from_field_unsafe(to_field(r3_o2) + to_field(r3_c2a));
-    let (r3_s3, _z) = u8_add(c[3], d[3]);
-    let (nc3, _z) = u8_add(r3_s3, r3_c3);
-    let c = [nc0, nc1, nc2, nc3];
-
-    let b0 = u8_xor(b[0], c[0]);
-    let b1 = u8_xor(b[1], c[1]);
-    let b2 = u8_xor(b[2], c[2]);
-    let b3 = u8_xor(b[3], c[3]);
-    -- Right-rotated 12 = rotr8 (byte move) ∘ rotr4 (chained gadget).
-    -- rotr8 of [b0,b1,b2,b3] is [b1,b2,b3,b0]; rotr4 over that pairs (b1,b2)
-    -- and (b3,b0). Two gadget lookups + two free field adds.
-    let (e0, e1, e2) = u8_chain_rotr4(b1, b2);
-    let (f0, f1, f2) = u8_chain_rotr4(b3, b0);
-    -- Combined parts occupy disjoint bit positions: sum is a byte, add as `G`.
-    let b = [e0, u8_from_field_unsafe(to_field(e1) + to_field(f2)), f0,
-             u8_from_field_unsafe(to_field(f1) + to_field(e2))]; -- Right-rotated 12
-
-    -- a = (a + b) + y
-    let (r4_0, r4_c1) = u8_add(a[0], b[0]);
-    let (r4_s1, r4_o1) = u8_add(a[1], b[1]);
-    let (r4_1, r4_c1a) = u8_add(r4_s1, r4_c1);
-    let r4_c2 = u8_from_field_unsafe(to_field(r4_o1) + to_field(r4_c1a));
-    let (r4_s2, r4_o2) = u8_add(a[2], b[2]);
-    let (r4_2, r4_c2a) = u8_add(r4_s2, r4_c2);
-    let r4_c3 = u8_from_field_unsafe(to_field(r4_o2) + to_field(r4_c2a));
-    let (r4_s3, _z) = u8_add(a[3], b[3]);
-    let (r4_3, _z) = u8_add(r4_s3, r4_c3);
-    let (a0, r5_c1) = u8_add(r4_0, y[0]);
-    let (r5_s1, r5_o1) = u8_add(r4_1, y[1]);
-    let (a1, r5_c1a) = u8_add(r5_s1, r5_c1);
-    let r5_c2 = u8_from_field_unsafe(to_field(r5_o1) + to_field(r5_c1a));
-    let (r5_s2, r5_o2) = u8_add(r4_2, y[2]);
-    let (a2, r5_c2a) = u8_add(r5_s2, r5_c2);
-    let r5_c3 = u8_from_field_unsafe(to_field(r5_o2) + to_field(r5_c2a));
-    let (r5_s3, _z) = u8_add(r4_3, y[3]);
-    let (a3, _z) = u8_add(r5_s3, r5_c3);
-    let a = [a0, a1, a2, a3];
-
-    let d0 = u8_xor(d[0], a[0]);
-    let d1 = u8_xor(d[1], a[1]);
-    let d2 = u8_xor(d[2], a[2]);
-    let d3 = u8_xor(d[3], a[3]);
-    let d = [d1, d2, d3, d0]; -- Right-rotated 8
-
-    -- c = c + d
-    let (nc0, r6_c1) = u8_add(c[0], d[0]);
-    let (r6_s1, r6_o1) = u8_add(c[1], d[1]);
-    let (nc1, r6_c1a) = u8_add(r6_s1, r6_c1);
-    let r6_c2 = u8_from_field_unsafe(to_field(r6_o1) + to_field(r6_c1a));
-    let (r6_s2, r6_o2) = u8_add(c[2], d[2]);
-    let (nc2, r6_c2a) = u8_add(r6_s2, r6_c2);
-    let r6_c3 = u8_from_field_unsafe(to_field(r6_o2) + to_field(r6_c2a));
-    let (r6_s3, _z) = u8_add(c[3], d[3]);
-    let (nc3, _z) = u8_add(r6_s3, r6_c3);
-    let c = [nc0, nc1, nc2, nc3];
-
-    let b0 = u8_xor(b[0], c[0]);
-    let b1 = u8_xor(b[1], c[1]);
-    let b2 = u8_xor(b[2], c[2]);
-    let b3 = u8_xor(b[3], c[3]);
-    -- Right-rotated 7 via the chained gadget: pairs (b0,b1) and (b2,b3),
-    -- two lookups + two free field adds.
-    let (g0, g1, g2) = u8_chain_rotr7(b0, b1);
-    let (h0, h1, h2) = u8_chain_rotr7(b2, b3);
-    let b = [g0, u8_from_field_unsafe(to_field(g1) + to_field(h2)), h0,
-             u8_from_field_unsafe(to_field(h1) + to_field(g2))]; -- Right-rotated 7
-
+    let a = @u32_add(@u32_add(a, b), x);
+    let d = @u32_rotr16(@u32_xor(d, a));
+    let c = @u32_add(c, d);
+    let b = @u32_rotr12(@u32_xor(b, c));
+    let a = @u32_add(@u32_add(a, b), y);
+    let d = @u32_rotr8(@u32_xor(d, a));
+    let c = @u32_add(c, d);
+    let b = @u32_rotr7(@u32_xor(b, c));
     [a, b, c, d]
   }
 

--- a/Ix/IxVM/ByteStream.lean
+++ b/Ix/IxVM/ByteStream.lean
@@ -86,6 +86,35 @@ def byteStream := ⟦
     [c0, c1, c2, c3]
   }
 
+  -- Right-rotations of a little-endian word. rotr16 / rotr8 are pure byte
+  -- moves (free); rotr12 / rotr7 are a byte move composed with the chained
+  -- 4-/7-bit gadget (two lookups + two free field adds each).
+  fn u32_rotr16(w: [U8; 4]) -> [U8; 4] {
+    let [w0, w1, w2, w3] = w;
+    [w2, w3, w0, w1]
+  }
+
+  fn u32_rotr8(w: [U8; 4]) -> [U8; 4] {
+    let [w0, w1, w2, w3] = w;
+    [w1, w2, w3, w0]
+  }
+
+  fn u32_rotr12(w: [U8; 4]) -> [U8; 4] {
+    let [w0, w1, w2, w3] = w;
+    let (e0, e1, e2) = u8_chain_rotr4(w1, w2);
+    let (f0, f1, f2) = u8_chain_rotr4(w3, w0);
+    [e0, u8_from_field_unsafe(to_field(e1) + to_field(f2)), f0,
+     u8_from_field_unsafe(to_field(f1) + to_field(e2))]
+  }
+
+  fn u32_rotr7(w: [U8; 4]) -> [U8; 4] {
+    let [w0, w1, w2, w3] = w;
+    let (g0, g1, g2) = u8_chain_rotr7(w0, w1);
+    let (h0, h1, h2) = u8_chain_rotr7(w2, w3);
+    [g0, u8_from_field_unsafe(to_field(g1) + to_field(h2)), h0,
+     u8_from_field_unsafe(to_field(h1) + to_field(g2))]
+  }
+
   -- Byte-by-byte `u64` equality
   fn u64_eq(a: U64, b: U64) -> G {
     let [a0, a1, a2, a3, a4, a5, a6, a7] = a;

--- a/Tests/Aiur/Aiur.lean
+++ b/Tests/Aiur/Aiur.lean
@@ -791,6 +791,70 @@ def toplevel := ⟦
     r1 + r2 + r3 + r4 + r5 + r6 + r7 + r8 + r9 + r10
     + r11 + r12 + r13 + r14 + r15 + r16 + r17 + r18 + r19 + r20 + r21
   }
+
+  ---------------------------------------------------------------------------
+  -- Inlined function calls (`@fn(args)`)
+  --
+  -- An `@`-call splices the callee's body into the caller's circuit: no
+  -- separate circuit, no call interface. These cases cover the splice in
+  -- every position lowering treats specially (let-RHS, strict argument
+  -- slots), plus alpha-renaming, nesting, branching callees, gadget
+  -- lookups joining the caller, and mixing inlined with normal calls.
+  ---------------------------------------------------------------------------
+
+  fn inl_double(x: G) -> G {
+    let t = x + x;
+    t
+  }
+
+  fn inl_sq(x: G) -> G { x * x }
+
+  -- Callee that itself @-inlines another helper (nested splice)
+  fn inl_sq_plus(x: G, y: G) -> G { @inl_sq(x) + y }
+
+  -- Multi-output callee
+  fn inl_pair(x: G) -> (G, G) { (x + 1, x * 2) }
+
+  -- Branching callee: tail match spliced into a let-RHS position
+  fn inl_sign(x: G) -> G {
+    match x {
+      0 => 0,
+      _ => 1,
+    }
+  }
+
+  -- Gadget lookup inside the callee
+  fn inl_add8(a: U8, b: U8) -> (U8, U8) { u8_add(a, b) }
+
+  -- Single aggregate entry: every scenario in one circuit/proof.
+  pub fn inline_test() -> G {
+    -- Basic splice
+    let r1 = @inl_double(21);                     -- 42
+    -- Nested splice (callee @-inlines another helper)
+    let r2 = @inl_sq_plus(3, 4);                  -- 13
+    -- Capture safety: caller binds `t` (the callee's local name) and the
+    -- argument mentions it
+    let t = 5;
+    let r3 = @inl_double(t + 1) + t;              -- 17
+    -- Strict positions: array elements, operator operands, call argument
+    let arr = [@inl_double(3), @inl_sq(3)];       -- [6, 9]
+    let r4 = arr[0] + arr[1] * 100;               -- 906
+    let r5 = @inl_double(3) + @inl_sq(3);         -- 15
+    let r6 = id(@inl_double(7));                  -- 14
+    -- Multi-output callee
+    let (p1, p2) = @inl_pair(5);                  -- (6, 10)
+    let r7 = p1 + p2 * 100;                       -- 1006
+    -- Branching callee in operand position, both paths (the spliced match
+    -- gets bound to a fresh local before hoisting)
+    let r8 = @inl_sign(0) + @inl_sign(5) * 100;   -- 100
+    -- Same callee inlined and normally called: the normal call keeps its
+    -- own circuit + lookup, the inlined one joins this circuit
+    let r9 = @inl_sq(3) + inl_sq(4);              -- 25
+    -- Gadget lookup in the callee joins this circuit
+    let (s, c) = @inl_add8(200u8, 100u8);         -- (44, 1)
+    let r10 = to_field(s) + to_field(c) * 1000;   -- 1044
+    r1 + r2 + r3 + r4 + r5 + r6 + r7 + r8 + r9 + r10
+  }
 ⟧
 
 def aiurTestCases : List AiurTestCase := [
@@ -948,6 +1012,9 @@ def aiurTestCases : List AiurTestCase := [
 
     -- Non-tail match: all patterns in one proof (incl. function-call scrutinee)
     .noIO `non_tail_match #[] #[2593],
+
+    -- Inlined function calls (`@fn(args)`): all scenarios in one proof
+    .noIO `inline_test #[] #[3182],
   ]
 
 end

--- a/Tests/Aiur/Cross.lean
+++ b/Tests/Aiur/Cross.lean
@@ -1072,6 +1072,41 @@ def toplevel : Source.Toplevel := ⟦
     r1 + r2 + r3 + r4 + r5 + r6 + r7 + r8 + r9 + r10
     + r11 + r12 + r13 + r14 + r15 + r16 + r17 + r18 + r19 + r20 + r21
   }
+
+  -- Inlined function calls (`@fn(args)`): both evaluators execute an
+  -- inlined call exactly like a normal one, so source/bytecode agreement
+  -- checks the splice (alpha-renaming, nesting, strict-position hoisting,
+  -- branching callees) preserved the semantics.
+  fn inl_sq(x: G) -> G { x * x }
+
+  fn inl_sq_plus(x: G, y: G) -> G { @inl_sq(x) + y }
+
+  fn inl_sign(x: G) -> G {
+    match x {
+      0 => 0,
+      _ => 1,
+    }
+  }
+
+  -- Single aggregate entry: every scenario in one agreement run.
+  pub fn inline_test() -> G {
+    -- Basic splice
+    let r1 = @inl_sq(5) + 1;                      -- 26
+    -- Nested splice (callee @-inlines another helper)
+    let r2 = @inl_sq_plus(3, 4);                  -- 13
+    -- Capture safety: caller local named like a callee binding, argument
+    -- mentions it
+    let t = 5;
+    let r3 = @inl_sq(t + 1) + t;                  -- 41
+    -- Strict positions: operator operands
+    let r4 = @inl_sq(3) + @inl_sq(4) * 100;       -- 1609
+    -- Branching callee in operand position, both paths (the spliced match
+    -- gets bound to a fresh local before hoisting)
+    let r5 = @inl_sign(0) + @inl_sign(7) * 100;   -- 100
+    -- Same callee inlined and normally called
+    let r6 = @inl_sq(3) + inl_sq(4);              -- 25
+    r1 + r2 + r3 + r4 + r5 + r6
+  }
 ⟧
 
 /-- Generic helper: run both evaluators on `entryName` with `inputs` as
@@ -1329,7 +1364,9 @@ def tests : TestSeq :=
   runAgreement "fibonacci(6)" "fibonacci" [6] ++
   -- End-to-end non-tail match entry aggregating many ntm_* helpers
   runAgreement "ntm_recursive_test" "ntm_recursive_test" [] ++
-  runAgreement "non_tail_match" "non_tail_match" []
+  runAgreement "non_tail_match" "non_tail_match" [] ++
+  -- Inlined function calls (`@fn(args)`): all scenarios in one entry
+  runAgreement "inline_test" "inline_test" []
 
 end AiurTests.Cross
 


### PR DESCRIPTION
## Commits

1. **Aiur: inlined function calls (`@fn(args)`)**

   Replaces `Source.Term.app`'s `unconstrained : Bool` with a `CallMode`
   (normal | unconstrained | inlined). `@fn(args)` marks an inlined call:
   `Toplevel.inlineCalls`, run first in `compile`, splices the callee's body
   into the caller — each input Local bound to its argument via a let, the
   (recursively inline-expanded) body as the value. Inlining is forbidden for
   callees that are transitively inline-recursive.

   An inlined call compiles to no separate circuit and no call interface
   (no lookup, no output columns): the callee's work joins the caller's
   straight-line circuit. This lets a hot inner routine be written once and
   expanded into a single wide circuit, instead of paying the per-call
   state-rematerialization and the taller callee-circuit height.

   The mode only exists in the Source stage — `inlineCalls` eliminates
   `.inlined` before typechecking. Interpreters match the mode as `_` (an
   inlined call executes identically to a normal one), so evaluation is
   unchanged. Callee params and body are alpha-renamed to fresh `inl#N`
   locals before argument binding, so nested `@`-calls cannot capture caller
   bindings.

2. **Aiur blake3: extract G-function word-ops into @-inlined helpers**

   `blake3_g_function` was ~100 lines of inlined byte arithmetic: six
   little-endian carry chains, the add/xor/rotate quarter-round steps spelled
   out per byte. Rewritten as its eight-step dataflow over `@`-inlined word
   ops: ByteStream's existing `u32_add` / `u32_xor`, plus four
   right-rotations `u32_rotr16`/`u32_rotr8` (byte moves) and
   `u32_rotr12`/`u32_rotr7` (byte move + chained gadget), added to ByteStream
   next to the other unsigned-int ops. Still one circuit, byte-identical
   work. Includes the regenerated Aiur kernel.

## Verification

- All 56 pinned kernel-check FFT costs **unchanged** — full
  `lake test -- --ignored ixvm` run green (codegen/bytecode parity suite
  included). The refactor is cost-neutral by construction; the pins prove it.