### PR TITLE
aiur: typed FFI result structures instead of tuple nests

### DIFF
--- a/Ix/Aiur/Protocol.lean
+++ b/Ix/Aiur/Protocol.lean
@@ -42,6 +42,26 @@ private opaque AiurSystemNonempty : NonemptyType
 def AiurSystem : Type := AiurSystemNonempty.type
 instance : Nonempty AiurSystem := AiurSystemNonempty.property
 
+/-- Result of a prove FFI call, built directly by Rust
+(`LeanAiurProveResult` in `crates/ffi/src/lean.rs`). `ioData`/`ioMap`
+are the flattened `IOBuffer`; see `IOBuffer.ofArrays`. -/
+structure ProveResult where
+  claim : Array G
+  proof : Proof
+  ioData : Array (G × Array G)
+  ioMap : Array ((G × Array G) × IOKeyInfo)
+  deriving Nonempty
+
+/-- Result of a with-env prove FFI call, built directly by Rust
+(`LeanAiurProveEnvResult` in `crates/ffi/src/lean.rs`). `claimBytes`
+is the claim's wire serialization (`ixon::Claim::put`). -/
+structure ProveEnvResult where
+  claimBytes : ByteArray
+  proof : Proof
+  ioData : Array (G × Array G)
+  ioMap : Array ((G × Array G) × IOKeyInfo)
+  deriving Nonempty
+
 namespace AiurSystem
 
 @[extern "rs_aiur_system_build"]
@@ -56,7 +76,7 @@ private opaque prove' : @& AiurSystem →
   @& Bytecode.FunIdx → @& Array G →
   (ioData : @& Array (G × Array G)) →
   (ioMap : @& Array ((G × Array G) × IOKeyInfo)) →
-    Array G × Proof × Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)
+    ProveResult
 
 /-- Executes the bytecode function `funIdx` with the given `args` and `ioBuffer`,
 then generates a proof of the computation. Returns the claim
@@ -65,20 +85,15 @@ updated `IOBuffer`. -/
 def prove (system : @& AiurSystem)
   (funIdx : @& Bytecode.FunIdx) (args : @& Array G) (ioBuffer : IOBuffer) :
     Array G × Proof × IOBuffer :=
-  let ioData := ioBuffer.data.toArray
-  let ioMap := ioBuffer.map.toArray
-  let (claim, proof, ioData, ioMap) := prove' system funIdx args
-    ioData ioMap
-  let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-  let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-  (claim, proof, ⟨ioData, ioMap⟩)
+  let r := prove' system funIdx args ioBuffer.data.toArray ioBuffer.map.toArray
+  (r.claim, r.proof, .ofArrays r.ioData r.ioMap)
 
 @[extern "rs_aiur_system_prove_ixvm"]
 private opaque proveIxVM' : @& AiurSystem →
   @& Bytecode.FunIdx → @& Array G →
   (ioData : @& Array (G × Array G)) →
   (ioMap : @& Array ((G × Array G) × IOKeyInfo)) →
-    Array G × Proof × Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)
+    ProveResult
 
 /-- IxVM-native prove: same shape as `prove`, but routes execution
     through the codegen'd Rust kernel (`execute_generated`) instead
@@ -88,20 +103,8 @@ private opaque proveIxVM' : @& AiurSystem →
 def proveIxVM (system : @& AiurSystem)
   (funIdx : @& Bytecode.FunIdx) (args : @& Array G) (ioBuffer : IOBuffer) :
     Array G × Proof × IOBuffer :=
-  let ioData := ioBuffer.data.toArray
-  let ioMap := ioBuffer.map.toArray
-  let (claim, proof, ioData, ioMap) := proveIxVM' system funIdx args
-    ioData ioMap
-  let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-  let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-  (claim, proof, ⟨ioData, ioMap⟩)
-
-@[extern "rs_aiur_multi_stark_prove"]
-private opaque proveMultiStark' : @& AiurSystem →
-  @& Bytecode.FunIdx → @& Array G →
-  (proofBytes : @& ByteArray) → (vkBytes : @& ByteArray) →
-  (claimBytes : @& ByteArray) → Bool →
-    Array G × Proof
+  let r := proveIxVM' system funIdx args ioBuffer.data.toArray ioBuffer.map.toArray
+  (r.claim, r.proof, .ofArrays r.ioData r.ioMap)
 
 /-- Prove the MultiStark recursive verifier over raw proof/vk/claims
     byte blobs. The IO advice buffer is built natively in Rust (see
@@ -112,18 +115,16 @@ private opaque proveMultiStark' : @& AiurSystem →
     production `MultiStark.multiStark` bytecode. Returns the claim
     (`#[functionChannel, funIdx] ++ pubInput ++ output`) and the
     `Proof`; the final buffer is not returned. -/
-def proveMultiStark (system : @& AiurSystem)
+@[extern "rs_aiur_multi_stark_prove"]
+opaque proveMultiStark (system : @& AiurSystem)
   (funIdx : @& Bytecode.FunIdx) (pubInput : @& Array G)
   (proofBytes vkBytes claimBytes : @& ByteArray) (useBytecode : Bool := false) :
-    Array G × Proof :=
-  proveMultiStark' system funIdx pubInput proofBytes vkBytes claimBytes
-    useBytecode
+    Array G × Proof
 
 @[extern "rs_aiur_system_prove_addr_with_env"]
 private opaque proveAddrWithEnv' : @& AiurSystem →
   @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray →
-    Except String (ByteArray × Proof ×
-      Array (G × Array G) × Array ((G × Array G) × IOKeyInfo))
+    Except String ProveEnvResult
 
 /-- Per-claim prove against a Rust-owned `EnvHandle`. Returns
     `(claimBytes, proof, ioBuffer)` — Rust serializes the
@@ -132,29 +133,20 @@ private opaque proveAddrWithEnv' : @& AiurSystem →
 def proveAddrWithEnv (system : @& AiurSystem)
   (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle) (addrBytes : ByteArray) :
     Except String (ByteArray × Proof × IOBuffer) :=
-  match proveAddrWithEnv' system funIdx envHandle addrBytes with
-  | .error e => .error e
-  | .ok (claimBytes, proof, ioData, ioMap) =>
-    let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-    .ok (claimBytes, proof, ⟨ioData, ioMap⟩)
+  (proveAddrWithEnv' system funIdx envHandle addrBytes).map
+    fun r => (r.claimBytes, r.proof, .ofArrays r.ioData r.ioMap)
 
 @[extern "rs_aiur_system_shard_prove_with_env"]
 private opaque shardProveWithEnv' : @& AiurSystem →
   @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray →
-    Except String (ByteArray × Proof ×
-      Array (G × Array G) × Array ((G × Array G) × IOKeyInfo))
+    Except String ProveEnvResult
 
 /-- Per-shard prove against a Rust-owned `EnvHandle`. -/
 def shardProveWithEnv (system : @& AiurSystem)
   (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle) (ownedBlob : ByteArray) :
     Except String (ByteArray × Proof × IOBuffer) :=
-  match shardProveWithEnv' system funIdx envHandle ownedBlob with
-  | .error e => .error e
-  | .ok (claimBytes, proof, ioData, ioMap) =>
-    let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-    .ok (claimBytes, proof, ⟨ioData, ioMap⟩)
+  (shardProveWithEnv' system funIdx envHandle ownedBlob).map
+    fun r => (r.claimBytes, r.proof, .ofArrays r.ioData r.ioMap)
 
 @[extern "rs_aiur_system_verify"]
 opaque verify : @& AiurSystem →

--- a/Ix/Aiur/Semantics/BytecodeFfi.lean
+++ b/Ix/Aiur/Semantics/BytecodeFfi.lean
@@ -47,6 +47,14 @@ def IOBuffer.extend (ioBuffer : IOBuffer) (channel : G) (key data : Array G) :
     data := ioBuffer.data.insert channel (arena ++ data)
     map := ioBuffer.map.insert (channel, key) { idx, len } }
 
+/-- Rebuild an `IOBuffer` from the flat arrays produced by the Rust FFI.
+Hashmaps don't cross the FFI boundary; Rust returns arrays and the
+hashmaps are populated here. -/
+def IOBuffer.ofArrays (data : Array (G × Array G))
+    (map : Array ((G × Array G) × IOKeyInfo)) : IOBuffer :=
+  ⟨data.foldl (fun acc (k, v) => acc.insert k v) ∅,
+   map.foldl (fun acc (k, v) => acc.insert k v) ∅⟩
+
 instance : BEq IOBuffer where
   beq x y :=
     @BEq.beq _ Std.HashMap.instBEq x.data y.data &&
@@ -66,6 +74,15 @@ structure QueryCount where
   uniqueRows : Nat
   totalHits : Nat
   deriving Inhabited
+
+/-- Result of an execution FFI call, built directly by Rust
+(`LeanAiurExecuteResult` in `crates/ffi/src/lean.rs`). `ioData`/`ioMap`
+are the flattened `IOBuffer`; see `IOBuffer.ofArrays`. -/
+structure ExecuteResult where
+  output : Array G
+  ioData : Array (G × Array G)
+  ioMap : Array ((G × Array G) × IOKeyInfo)
+  queryCounts : Array QueryCount
 
 -- ===========================================================================
 -- EnvHandle: Rust-owned `ixon::Env` exposed to Lean as an opaque handle.
@@ -105,9 +122,7 @@ private opaque execute' : @& Bytecode.Toplevel →
   @& Bytecode.FunIdx → @& Array G →
   (ioData : @& Array (G × Array G)) →
   (ioMap : @& Array ((G × Array G) × IOKeyInfo)) →
-    Except String (Array G ×
-      (Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)) ×
-      Array (Nat × Nat))
+    Except String ExecuteResult
 
 /-- Executes the bytecode function `funIdx` with the given `args` and `ioBuffer`,
 returning the raw output of the function, the updated `IOBuffer`, and an array
@@ -117,24 +132,15 @@ callers can recover instead of crashing. -/
 def execute (toplevel : @& Bytecode.Toplevel)
   (funIdx : @& Bytecode.FunIdx) (args : @& Array G) (ioBuffer : IOBuffer) :
     Except String (Array G × IOBuffer × Array QueryCount) :=
-  let ioData := ioBuffer.data.toArray
-  let ioMap := ioBuffer.map.toArray
-  match execute' toplevel funIdx args ioData ioMap with
-  | .error e => .error e
-  | .ok (output, (ioData, ioMap), queryCounts) =>
-    let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let queryCounts := queryCounts.map fun (uniqueRows, totalHits) => { uniqueRows, totalHits }
-    .ok (output, ⟨ioData, ioMap⟩, queryCounts)
+  (execute' toplevel funIdx args ioBuffer.data.toArray ioBuffer.map.toArray).map
+    fun r => (r.output, .ofArrays r.ioData r.ioMap, r.queryCounts)
 
 @[extern "rs_aiur_toplevel_execute_ixvm"]
 private opaque executeIxVM' : @& Bytecode.Toplevel →
   @& Bytecode.FunIdx → @& Array G →
   (ioData : @& Array (G × Array G)) →
   (ioMap : @& Array ((G × Array G) × IOKeyInfo)) →
-    Except String (Array G ×
-      (Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)) ×
-      Array (Nat × Nat))
+    Except String ExecuteResult
 
 /-- IxVM-native execution: same shape as `execute`, but routes the
     function invocation through the codegen'd Rust kernel
@@ -147,22 +153,8 @@ private opaque executeIxVM' : @& Bytecode.Toplevel →
 def executeIxVM (toplevel : @& Bytecode.Toplevel)
   (funIdx : @& Bytecode.FunIdx) (args : @& Array G) (ioBuffer : IOBuffer) :
     Except String (Array G × IOBuffer × Array QueryCount) :=
-  let ioData := ioBuffer.data.toArray
-  let ioMap := ioBuffer.map.toArray
-  match executeIxVM' toplevel funIdx args ioData ioMap with
-  | .error e => .error e
-  | .ok (output, (ioData, ioMap), queryCounts) =>
-    let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let queryCounts := queryCounts.map fun (uniqueRows, totalHits) => { uniqueRows, totalHits }
-    .ok (output, ⟨ioData, ioMap⟩, queryCounts)
-
-@[extern "rs_aiur_multi_stark_execute"]
-private opaque executeMultiStark' : @& Bytecode.Toplevel →
-  @& Bytecode.FunIdx → @& Array G →
-  (proofBytes : @& ByteArray) → (vkBytes : @& ByteArray) →
-  (claimBytes : @& ByteArray) → Bool →
-    Except String (Array G × Array (Nat × Nat))
+  (executeIxVM' toplevel funIdx args ioBuffer.data.toArray ioBuffer.map.toArray).map
+    fun r => (r.output, .ofArrays r.ioData r.ioMap, r.queryCounts)
 
 /-- MultiStark-native execution of `verify_multi_stark_proof`: the IO
     advice buffer (channel 0 = proof, 1 = vk, 2 = claims, key `[0]`
@@ -176,15 +168,11 @@ private opaque executeMultiStark' : @& Bytecode.Toplevel →
     `useBytecode := true`. Returns the output and per-circuit query
     counts; the final buffer is not returned (the verifier only reads
     its advice). -/
-def executeMultiStark (toplevel : @& Bytecode.Toplevel)
+@[extern "rs_aiur_multi_stark_execute"]
+opaque executeMultiStark (toplevel : @& Bytecode.Toplevel)
   (funIdx : @& Bytecode.FunIdx) (pubInput : @& Array G)
   (proofBytes vkBytes claimBytes : @& ByteArray) (useBytecode : Bool := false) :
-    Except String (Array G × Array QueryCount) :=
-  match executeMultiStark' toplevel funIdx pubInput proofBytes vkBytes
-    claimBytes useBytecode with
-  | .error e => .error e
-  | .ok (output, queryCounts) =>
-    .ok (output, queryCounts.map fun (uniqueRows, totalHits) => { uniqueRows, totalHits })
+    Except String (Array G × Array QueryCount)
 
 -- (EnvHandle opaque type + constructors live above `namespace
 -- Bytecode.Toplevel`; see `Aiur.EnvHandle`. The with-env FFI
@@ -194,17 +182,12 @@ def executeMultiStark (toplevel : @& Bytecode.Toplevel)
 @[extern "rs_aiur_toplevel_check_addr_with_env"]
 private opaque checkAddrWithEnv' : @& Bytecode.Toplevel →
   @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray → Bool →
-    Except String (Array G ×
-      (Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)) ×
-      Array (Nat × Nat))
+    Except String ExecuteResult
 
 @[extern "rs_aiur_toplevel_shard_check_with_env"]
 private opaque shardCheckWithEnv' : @& Bytecode.Toplevel →
   @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray → Bool →
-    Except String (Array G ×
-      (Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)) ×
-      Array (Nat × Nat))
-
+    Except String ExecuteResult
 
 /-- Per-claim check against a Rust-owned `EnvHandle`. `useBytecode`
     selects the generic Aiur bytecode interpreter
@@ -216,13 +199,8 @@ def checkAddrWithEnv (toplevel : @& Bytecode.Toplevel)
   (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle)
   (addrBytes : ByteArray) (useBytecode : Bool := false)
   : Except String (Array G × IOBuffer × Array QueryCount) :=
-  match checkAddrWithEnv' toplevel funIdx envHandle addrBytes useBytecode with
-  | .error e => .error e
-  | .ok (output, (ioData, ioMap), queryCounts) =>
-    let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let queryCounts := queryCounts.map fun (uniqueRows, totalHits) => { uniqueRows, totalHits }
-    .ok (output, ⟨ioData, ioMap⟩, queryCounts)
+  (checkAddrWithEnv' toplevel funIdx envHandle addrBytes useBytecode).map
+    fun r => (r.output, .ofArrays r.ioData r.ioMap, r.queryCounts)
 
 /-- Per-shard check against a Rust-owned `EnvHandle`. See
     `checkAddrWithEnv` for `useBytecode` semantics. -/
@@ -230,13 +208,8 @@ def shardCheckWithEnv (toplevel : @& Bytecode.Toplevel)
   (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle)
   (ownedBlob : ByteArray) (useBytecode : Bool := false)
   : Except String (Array G × IOBuffer × Array QueryCount) :=
-  match shardCheckWithEnv' toplevel funIdx envHandle ownedBlob useBytecode with
-  | .error e => .error e
-  | .ok (output, (ioData, ioMap), queryCounts) =>
-    let ioData := ioData.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let ioMap := ioMap.foldl (fun acc (k, v) => acc.insert k v) ∅
-    let queryCounts := queryCounts.map fun (uniqueRows, totalHits) => { uniqueRows, totalHits }
-    .ok (output, ⟨ioData, ioMap⟩, queryCounts)
+  (shardCheckWithEnv' toplevel funIdx envHandle ownedBlob useBytecode).map
+    fun r => (r.output, .ofArrays r.ioData r.ioMap, r.queryCounts)
 
 end Bytecode.Toplevel
 

--- a/crates/ffi/src/aiur/protocol.rs
+++ b/crates/ffi/src/aiur/protocol.rs
@@ -13,7 +13,9 @@ use lean_ffi::object::{
 use crate::{
   aiur::{lean_unbox_g, lean_unbox_nat_as_usize, toplevel::decode_toplevel},
   lean::{
-    LeanAiurCommitmentParameters, LeanAiurFriParameters, LeanAiurToplevel,
+    LeanAiurCommitmentParameters, LeanAiurExecuteResult, LeanAiurFriParameters,
+    LeanAiurIOKeyInfo, LeanAiurProveEnvResult, LeanAiurProveResult,
+    LeanAiurQueryCount, LeanAiurToplevel,
   },
 };
 use aiur::{
@@ -100,9 +102,7 @@ extern "C" fn rs_aiur_system_verify(
 }
 
 /// `Bytecode.Toplevel.execute`: runs execution only (no proof) and returns
-/// `Except String (Array G × (Array G × Array (Array G × IOKeyInfo)) × Array (Nat × Nat))`.
-/// The trailing `Array (Nat × Nat)` is one `(uniqueRows, totalHits)` pair per
-/// function circuit followed by one per memory size.
+/// `Except String ExecuteResult` (see `Ix/Aiur/Semantics/BytecodeFfi.lean`).
 /// On execution failure (e.g. assertion mismatch from a typechecker
 /// rejecting a constant), returns `Except.error msg` instead of panicking
 /// — letting Lean test runners (`KernelArena.lean`) classify failures.
@@ -127,48 +127,12 @@ extern "C" fn rs_aiur_toplevel_execute(
     Err(err) => return LeanExcept::error_string(&err.to_string()),
   };
 
-  // Build per-circuit (unique_rows, total_hits) pairs:
-  // one per function, then one per memory size. `unique_rows` is the trace
-  // height (number of distinct queries); `total_hits` is the sum of
-  // multiplicities (how often those rows were hit).
-  let mut query_counts: Vec<(usize, usize)> = Vec::with_capacity(
-    query_record.function_queries.len() + toplevel.memory_sizes.len(),
-  );
-  let summarize = |q: &aiur::querymap::QueryMap| -> (usize, usize) {
-    let mut rows = 0usize;
-    let mut hits = 0usize;
-    for (_, res) in q.iter() {
-      let m = usize::try_from(res.multiplicity.as_canonical_u64())
-        .expect("multiplicity exceeds usize");
-      if m != 0 {
-        rows += 1;
-        hits += m;
-      }
-    }
-    (rows, hits)
-  };
-  for queries in &query_record.function_queries {
-    query_counts.push(summarize(queries));
-  }
-  for size in &toplevel.memory_sizes {
-    let pair = query_record.memory_queries.get(size).map_or((0, 0), summarize);
-    query_counts.push(pair);
-  }
-  let lean_query_counts = {
-    let arr = LeanArray::alloc(query_counts.len());
-    for (i, &(rows, hits)) in query_counts.iter().enumerate() {
-      let pair =
-        LeanProd::new(LeanOwned::box_usize(rows), LeanOwned::box_usize(hits));
-      arr.set(i, pair);
-    }
-    arr
-  };
-
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  // (Array G, (Array G × Array (Array G × IOKeyInfo), Array (Nat × Nat)))
-  let io_counts = LeanProd::new(lean_io, lean_query_counts);
-  let result = LeanProd::new(build_g_array(&output), io_counts);
-  LeanExcept::ok(result)
+  LeanExcept::ok(build_execute_result(
+    &output,
+    &io_buffer,
+    &query_record,
+    &toplevel,
+  ))
 }
 
 /// `Bytecode.Toplevel.executeIxVM`: same shape as `rs_aiur_toplevel_execute`,
@@ -202,48 +166,16 @@ extern "C" fn rs_aiur_toplevel_execute_ixvm(
       Err(err) => return LeanExcept::error_string(&err.to_string()),
     };
 
-  // Same query-count summarisation as `rs_aiur_toplevel_execute`.
-  let mut query_counts: Vec<(usize, usize)> = Vec::with_capacity(
-    query_record.function_queries.len() + toplevel.memory_sizes.len(),
-  );
-  let summarize = |q: &aiur::querymap::QueryMap| -> (usize, usize) {
-    let mut rows = 0usize;
-    let mut hits = 0usize;
-    for (_, res) in q.iter() {
-      let m = usize::try_from(res.multiplicity.as_canonical_u64())
-        .expect("multiplicity exceeds usize");
-      if m != 0 {
-        rows += 1;
-        hits += m;
-      }
-    }
-    (rows, hits)
-  };
-  for queries in &query_record.function_queries {
-    query_counts.push(summarize(queries));
-  }
-  for size in &toplevel.memory_sizes {
-    let pair = query_record.memory_queries.get(size).map_or((0, 0), summarize);
-    query_counts.push(pair);
-  }
-  let lean_query_counts = {
-    let arr = LeanArray::alloc(query_counts.len());
-    for (i, &(rows, hits)) in query_counts.iter().enumerate() {
-      let pair =
-        LeanProd::new(LeanOwned::box_usize(rows), LeanOwned::box_usize(hits));
-      arr.set(i, pair);
-    }
-    arr
-  };
-
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  let io_counts = LeanProd::new(lean_io, lean_query_counts);
-  let result = LeanProd::new(build_g_array(&output), io_counts);
-  LeanExcept::ok(result)
+  LeanExcept::ok(build_execute_result(
+    &output,
+    &io_buffer,
+    &query_record,
+    &toplevel,
+  ))
 }
 
-/// `AiurSystem.prove`: runs the prover and returns
-/// `Array G × Proof × Array G × Array (Array G × IOKeyInfo)`
+/// `AiurSystem.prove`: runs the prover and returns a `ProveResult`
+/// (see `Ix/Aiur/Protocol.lean`).
 #[unsafe(no_mangle)]
 extern "C" fn rs_aiur_system_prove(
   aiur_system_obj: LeanExternal<AiurSystem, LeanBorrowed<'_>>,
@@ -251,7 +183,7 @@ extern "C" fn rs_aiur_system_prove(
   args: LeanArray<LeanBorrowed<'_>>,
   io_data_arr: LeanArray<LeanBorrowed<'_>>,
   io_map_arr: LeanArray<LeanBorrowed<'_>>,
-) -> LeanOwned {
+) -> LeanAiurProveResult<LeanOwned> {
   let fun_idx = lean_unbox_nat_as_usize(fun_idx.inner());
   let args = args.map(|x| lean_unbox_g(&x));
   let mut io_buffer = decode_io_buffer(&io_data_arr, &io_map_arr);
@@ -259,14 +191,7 @@ extern "C" fn rs_aiur_system_prove(
   let (claim, proof) =
     aiur_system_obj.get().prove(fun_idx, &args, &mut io_buffer);
 
-  let lean_proof: LeanOwned =
-    LeanExternal::alloc(&AIUR_PROOF_CLASS, proof).into();
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  // Proof × Array G × Array (Array G × IOKeyInfo)
-  let proof_io_tuple = LeanProd::new(lean_proof, lean_io);
-  // Array G × Proof × Array G × Array (Array G × IOKeyInfo)
-  let result = LeanProd::new(build_g_array(&claim), proof_io_tuple);
-  result.into()
+  build_prove_result(&claim, proof, &io_buffer)
 }
 
 // =============================================================================
@@ -313,9 +238,9 @@ extern "C" fn rs_aiur_env_handle_from_bytes(
 }
 
 /// Helper: summarise one execute's `QueryRecord` into a Lean
-/// `Array (Nat × Nat)` of `(unique_rows, total_hits)` pairs, one per
-/// function circuit followed by one per memory size. Mirrors the
-/// summary code used by every check/prove FFI.
+/// `Array QueryCount` of `(uniqueRows, totalHits)` structures, one per
+/// function circuit followed by one per memory size. Used by every
+/// check/prove FFI.
 fn build_query_counts_array(
   query_record: &QueryRecord,
   toplevel: &aiur::bytecode::Toplevel,
@@ -345,11 +270,60 @@ fn build_query_counts_array(
   }
   let arr = LeanArray::alloc(query_counts.len());
   for (i, &(rows, hits)) in query_counts.iter().enumerate() {
-    let pair =
-      LeanProd::new(LeanOwned::box_usize(rows), LeanOwned::box_usize(hits));
-    arr.set(i, pair);
+    let qc = LeanAiurQueryCount::alloc(0);
+    qc.set_obj(0, LeanOwned::box_usize(rows));
+    qc.set_obj(1, LeanOwned::box_usize(hits));
+    arr.set(i, qc);
   }
   arr
+}
+
+/// Helper: build a Lean `ExecuteResult` (output, ioData, ioMap,
+/// queryCounts) — the return shape shared by every execute/check FFI.
+fn build_execute_result(
+  output: &[G],
+  io_buffer: &IOBuffer,
+  query_record: &QueryRecord,
+  toplevel: &aiur::bytecode::Toplevel,
+) -> LeanAiurExecuteResult<LeanOwned> {
+  let result = LeanAiurExecuteResult::alloc(0);
+  result.set_obj(0, build_g_array(output));
+  result.set_obj(1, build_lean_io_data(io_buffer));
+  result.set_obj(2, build_lean_io_map(io_buffer));
+  result.set_obj(3, build_query_counts_array(query_record, toplevel));
+  result
+}
+
+/// Helper: build a Lean `ProveResult` (claim, proof, ioData, ioMap).
+fn build_prove_result(
+  claim: &[G],
+  proof: AiurProof,
+  io_buffer: &IOBuffer,
+) -> LeanAiurProveResult<LeanOwned> {
+  let result = LeanAiurProveResult::alloc(0);
+  result.set_obj(0, build_g_array(claim));
+  result.set_obj(1, LeanExternal::alloc(&AIUR_PROOF_CLASS, proof));
+  result.set_obj(2, build_lean_io_data(io_buffer));
+  result.set_obj(3, build_lean_io_map(io_buffer));
+  result
+}
+
+/// Helper: build a Lean `ProveEnvResult` (claimBytes, proof, ioData,
+/// ioMap) — the claim's wire bytes are serialized via
+/// `ixon::Claim::put` so Lean can deserialize directly.
+fn build_prove_env_result(
+  claim: &ixon::proof::Claim,
+  proof: AiurProof,
+  io_buffer: &IOBuffer,
+) -> LeanAiurProveEnvResult<LeanOwned> {
+  let mut claim_bytes: Vec<u8> = Vec::new();
+  claim.put(&mut claim_bytes);
+  let result = LeanAiurProveEnvResult::alloc(0);
+  result.set_obj(0, LeanByteArray::from_bytes(&claim_bytes));
+  result.set_obj(1, LeanExternal::alloc(&AIUR_PROOF_CLASS, proof));
+  result.set_obj(2, build_lean_io_data(io_buffer));
+  result.set_obj(3, build_lean_io_map(io_buffer));
+  result
 }
 
 /// Helper: decode a 32-byte address from a `LeanByteArray`.
@@ -463,11 +437,12 @@ extern "C" fn rs_aiur_toplevel_check_addr_with_env(
     Err(e) => return LeanExcept::error_string(&e),
   };
 
-  let lean_query_counts = build_query_counts_array(&query_record, &toplevel);
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  let io_counts = LeanProd::new(lean_io, lean_query_counts);
-  let result = LeanProd::new(build_g_array(&output), io_counts);
-  LeanExcept::ok(result)
+  LeanExcept::ok(build_execute_result(
+    &output,
+    &io_buffer,
+    &query_record,
+    &toplevel,
+  ))
 }
 
 /// `Bytecode.Toplevel.shardCheckWithEnv`: per-shard check against a
@@ -513,18 +488,19 @@ extern "C" fn rs_aiur_toplevel_shard_check_with_env(
     Err(e) => return LeanExcept::error_string(&e),
   };
 
-  let lean_query_counts = build_query_counts_array(&query_record, &toplevel);
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  let io_counts = LeanProd::new(lean_io, lean_query_counts);
-  let result = LeanProd::new(build_g_array(&output), io_counts);
-  LeanExcept::ok(result)
+  LeanExcept::ok(build_execute_result(
+    &output,
+    &io_buffer,
+    &query_record,
+    &toplevel,
+  ))
 }
 
 /// `AiurSystem.proveAddrWithEnv`: per-claim prove against a
-/// Rust-owned `EnvHandle`. Returns `(claim_bytes, proof, ioBuffer)`
-/// — the claim's wire bytes are serialized via `ixon::Claim::put`
-/// so Lean can deserialize directly into `Ix.Claim` without
-/// reconstructing it from the target addr.
+/// Rust-owned `EnvHandle`. Returns a `ProveEnvResult` — the claim's
+/// wire bytes are serialized via `ixon::Claim::put` so Lean can
+/// deserialize directly into `Ix.Claim` without reconstructing it
+/// from the target addr.
 #[unsafe(no_mangle)]
 extern "C" fn rs_aiur_system_prove_addr_with_env(
   aiur_system_obj: LeanExternal<AiurSystem, LeanBorrowed<'_>>,
@@ -558,20 +534,12 @@ extern "C" fn rs_aiur_system_prove_addr_with_env(
     ixvm_codegen::aiur_ixvm_runner::execute_ixvm,
   );
 
-  let mut claim_bytes: Vec<u8> = Vec::new();
-  claim.put(&mut claim_bytes);
-  let lean_claim_bytes = LeanByteArray::from_bytes(&claim_bytes);
-  let lean_proof: LeanOwned =
-    LeanExternal::alloc(&AIUR_PROOF_CLASS, proof).into();
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  let proof_io = LeanProd::new(lean_proof, lean_io);
-  let result = LeanProd::new(lean_claim_bytes, proof_io);
-  LeanExcept::ok(result)
+  LeanExcept::ok(build_prove_env_result(&claim, proof, &io_buffer))
 }
 
 /// `AiurSystem.shardProveWithEnv`: per-shard prove against a
-/// Rust-owned `EnvHandle`. Same `(claim_bytes, proof, ioBuffer)`
-/// return shape as `proveAddrWithEnv`.
+/// Rust-owned `EnvHandle`. Same `ProveEnvResult` return shape as
+/// `proveAddrWithEnv`.
 #[unsafe(no_mangle)]
 extern "C" fn rs_aiur_system_shard_prove_with_env(
   aiur_system_obj: LeanExternal<AiurSystem, LeanBorrowed<'_>>,
@@ -606,15 +574,7 @@ extern "C" fn rs_aiur_system_shard_prove_with_env(
     ixvm_codegen::aiur_ixvm_runner::execute_ixvm,
   );
 
-  let mut claim_bytes: Vec<u8> = Vec::new();
-  claim.put(&mut claim_bytes);
-  let lean_claim_bytes = LeanByteArray::from_bytes(&claim_bytes);
-  let lean_proof: LeanOwned =
-    LeanExternal::alloc(&AIUR_PROOF_CLASS, proof).into();
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  let proof_io = LeanProd::new(lean_proof, lean_io);
-  let result = LeanProd::new(lean_claim_bytes, proof_io);
-  LeanExcept::ok(result)
+  LeanExcept::ok(build_prove_env_result(&claim, proof, &io_buffer))
 }
 
 /// `AiurSystem.proveIxVM`: IxVM-native prove path. Same return shape
@@ -629,7 +589,7 @@ extern "C" fn rs_aiur_system_prove_ixvm(
   args: LeanArray<LeanBorrowed<'_>>,
   io_data_arr: LeanArray<LeanBorrowed<'_>>,
   io_map_arr: LeanArray<LeanBorrowed<'_>>,
-) -> LeanOwned {
+) -> LeanAiurProveResult<LeanOwned> {
   let fun_idx = lean_unbox_nat_as_usize(fun_idx.inner());
   let args = args.map(|x| lean_unbox_g(&x));
   let mut io_buffer = decode_io_buffer(&io_data_arr, &io_map_arr);
@@ -641,12 +601,7 @@ extern "C" fn rs_aiur_system_prove_ixvm(
     ixvm_codegen::aiur_ixvm_runner::execute_ixvm,
   );
 
-  let lean_proof: LeanOwned =
-    LeanExternal::alloc(&AIUR_PROOF_CLASS, proof).into();
-  let lean_io = build_lean_io_buffer(&io_buffer);
-  let proof_io_tuple = LeanProd::new(lean_proof, lean_io);
-  let result = LeanProd::new(build_g_array(&claim), proof_io_tuple);
-  result.into()
+  build_prove_result(&claim, proof, &io_buffer)
 }
 
 /// `Bytecode.Toplevel.executeMultiStark`: run the MultiStark recursive
@@ -764,38 +719,34 @@ fn decode_io_buffer(
   IOBuffer { data, map }
 }
 
-/// Build a Lean
-/// `Array (G × Array G) × Array ((G × Array G) × IOKeyInfo)` from an
-/// `IOBuffer`. The first array enumerates per-channel data arenas;
-/// the second is the channel-keyed info map.
-fn build_lean_io_buffer(io_buffer: &IOBuffer) -> LeanOwned {
-  let lean_io_data = {
-    let arr = LeanArray::alloc(io_buffer.data.len());
-    for (i, (channel, arena)) in io_buffer.data.iter().enumerate() {
-      let channel_box = LeanOwned::box_u64(channel.as_canonical_u64());
-      let arena_arr = build_g_array(arena);
-      let elt = LeanProd::new(channel_box, arena_arr);
-      arr.set(i, elt);
-    }
-    arr
-  };
-  let lean_io_map = {
-    let arr = LeanArray::alloc(io_buffer.map.len());
-    for (i, ((channel, key), info)) in io_buffer.map.iter().enumerate() {
-      let channel_box = LeanOwned::box_u64(channel.as_canonical_u64());
-      let key_arr = build_g_array(key);
-      let channel_key = LeanProd::new(channel_box, key_arr);
-      let key_info = LeanProd::new(
-        LeanOwned::box_usize(info.idx),
-        LeanOwned::box_usize(info.len),
-      );
-      let map_elt = LeanProd::new(channel_key, key_info);
-      arr.set(i, map_elt);
-    }
-    arr
-  };
-  let io_tuple = LeanProd::new(lean_io_data, lean_io_map);
-  io_tuple.into()
+/// Build a Lean `Array (G × Array G)` enumerating the per-channel
+/// data arenas of an `IOBuffer`.
+fn build_lean_io_data(io_buffer: &IOBuffer) -> LeanArray<LeanOwned> {
+  let arr = LeanArray::alloc(io_buffer.data.len());
+  for (i, (channel, arena)) in io_buffer.data.iter().enumerate() {
+    let channel_box = LeanOwned::box_u64(channel.as_canonical_u64());
+    let arena_arr = build_g_array(arena);
+    let elt = LeanProd::new(channel_box, arena_arr);
+    arr.set(i, elt);
+  }
+  arr
+}
+
+/// Build a Lean `Array ((G × Array G) × IOKeyInfo)` enumerating the
+/// channel-keyed info map of an `IOBuffer`.
+fn build_lean_io_map(io_buffer: &IOBuffer) -> LeanArray<LeanOwned> {
+  let arr = LeanArray::alloc(io_buffer.map.len());
+  for (i, ((channel, key), info)) in io_buffer.map.iter().enumerate() {
+    let channel_box = LeanOwned::box_u64(channel.as_canonical_u64());
+    let key_arr = build_g_array(key);
+    let channel_key = LeanProd::new(channel_box, key_arr);
+    let key_info = LeanAiurIOKeyInfo::alloc(0);
+    key_info.set_obj(0, LeanOwned::box_usize(info.idx));
+    key_info.set_obj(1, LeanOwned::box_usize(info.len));
+    let map_elt = LeanProd::new(channel_key, key_info);
+    arr.set(i, map_elt);
+  }
+  arr
 }
 
 fn decode_commitment_parameters(

--- a/crates/ffi/src/lean.rs
+++ b/crates/ffi/src/lean.rs
@@ -256,6 +256,20 @@ lean_ffi::lean_inductive! {
   LeanAiurToplevel [ { num_obj: 2 } ];
   LeanAiurFunction [ { num_obj: 2, num_8: 2 } ];
 
+  // Aiur FFI result structures (`Ix/Aiur/Semantics/BytecodeFfi.lean`,
+  // `Ix/Aiur/Protocol.lean`). `IOBuffer` hashmaps cross the boundary as
+  // flat `ioData`/`ioMap` arrays; Lean folds them back into hashmaps.
+  // idx, len
+  LeanAiurIOKeyInfo      [ { num_obj: 2 } ];
+  // uniqueRows, totalHits
+  LeanAiurQueryCount     [ { num_obj: 2 } ];
+  // output, ioData, ioMap, queryCounts
+  LeanAiurExecuteResult  [ { num_obj: 4 } ];
+  // claim, proof, ioData, ioMap
+  LeanAiurProveResult    [ { num_obj: 4 } ];
+  // claimBytes, proof, ioData, ioMap
+  LeanAiurProveEnvResult [ { num_obj: 4 } ];
+
   // --- Block / comparison types ---
 
   LeanIxBlockCompareResult [


### PR DESCRIPTION
Rust now populates Lean structures directly (ExecuteResult, ProveResult, ProveEnvResult, QueryCount, IOKeyInfo via lean_inductive! types) instead of returning anonymous LeanProd nests that Lean re-packed. IOBuffer hashmaps still cross the boundary as flat arrays, folded back in Lean by IOBuffer.ofArrays. Dedupes the per-FFI query-count summarisation into build_query_counts_array and attaches externs directly where no conversion remains (executeMultiStark, proveMultiStark).