### PR TITLE
fix(ci): stop Open MPI signal handler wedging OOM'd zisk-host

### DIFF
--- a/.github/scripts/watchdog.sh
+++ b/.github/scripts/watchdog.sh
@@ -20,6 +20,18 @@ shift
 sudo -n loginctl enable-linger "${USER:-$(id -un)}" 2>/dev/null || true
 export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
 
+# Open MPI (linked into zisk-host via proofman) registers a
+# stacktrace-printing handler on fatal signals (opal default: ABRT,
+# BUS, FPE, SEGV). When the fault originates inside malloc — e.g. a
+# glibc heap-corruption abort — that handler allocates while the
+# corrupted arena lock is still held and deadlocks: the process wedges
+# at flat memory forever, the cgroup cap never fires, and the
+# orchestrator waits until the CI job timeout. Empty opal_signal skips
+# handler registration so fatal signals keep their default disposition
+# and the tool dies with 128+sig, which the orchestrator records as a
+# row. Harmless for tools that don't link Open MPI.
+export OMPI_MCA_opal_signal=
+
 # memory.oom.group=1: on breach the kernel kills the WHOLE scope (exit
 # 137 -> oom row), not just its biggest process. Without it, Zisk's ASM
 # service gets singled out and the surviving host converts the memory


### PR DESCRIPTION
Open MPI (linked into zisk-host via proofman) registers a stacktrace-printing handler on fatal signals (opal default: ABRT, BUS, FPE, SEGV). Under memory pressure the fault originates inside malloc, so the handler allocates while the corrupted arena lock is still held and deadlocks: the process wedges at peak memory, the cgroup OOM cap never fires, and the CI job hangs until its timeout. Example: https://github.com/argumentcomputer/ix/actions/runs/29823822610/job/88613664004

Setting OMPI_MCA_opal_signal= in watchdog.sh skips handler registration, so fatal signals keep their default disposition and the process dies promptly (137 kernel OOM kill, or 134 if a fatal signal lands first). The watchdog orchestrator then records a graceful status: oom row instead of hanging the runner. Harmless for tools that don't link Open MPI.

Successful test: https://github.com/argumentcomputer/ix/actions/runs/29773334553/job/88456655412