### PR TITLE
aiur: adopt multi-stark flat lookup witness (LookupValues)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=6382036e970ab508e69b2db2b8ae5ad64672e34b#6382036e970ab508e69b2db2b8ae5ad64672e34b"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=c178aaedaaea003331f0992d385266068cee32c8#c178aaedaaea003331f0992d385266068cee32c8"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "6382036e970ab508e69b2db2b8ae5ad64672e34b" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "c178aaedaaea003331f0992d385266068cee32c8" }
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"

--- a/crates/aiur/src/gadgets.rs
+++ b/crates/aiur/src/gadgets.rs
@@ -2,7 +2,8 @@ pub(crate) mod bytes1;
 pub(crate) mod bytes2;
 
 use multi_stark::{
-  builder::symbolic::SymbolicExpression, lookup::Lookup,
+  builder::symbolic::SymbolicExpression,
+  lookup::{Lookup, LookupValues},
   p3_matrix::dense::RowMajorMatrix,
 };
 
@@ -36,12 +37,14 @@ pub(crate) trait AiurGadget {
   fn lookups(&self) -> Vec<Lookup<SymbolicExpression<G>>>;
 
   /// Returns the witness data for the prover, including a row-major trace matrix and
-  /// the lookup values, which also follow a row-major layout.
+  /// the flat lookup values.
   ///
-  /// The lookups must be fully padded. That is, every row must have the exact same number
-  /// of lookups, matching the number of lookups returned by the `lookups` method.
+  /// `slot_arg_widths[j]` must be the maximum number of arguments of lookup slot `j`,
+  /// derived from the symbolic lookups returned by the `lookups` method so the witness
+  /// layout always matches the AIR.
   fn witness_data(
     &self,
     record: &QueryRecord,
-  ) -> (RowMajorMatrix<G>, Vec<Vec<Lookup<G>>>);
+    slot_arg_widths: &[usize],
+  ) -> (RowMajorMatrix<G>, LookupValues<G>);
 }

--- a/crates/aiur/src/gadgets/bytes1.rs
+++ b/crates/aiur/src/gadgets/bytes1.rs
@@ -1,6 +1,6 @@
 use multi_stark::{
   builder::symbolic::{SymbolicExpression, preprocessed_var, var},
-  lookup::Lookup,
+  lookup::{Lookup, LookupValues},
   p3_air::{Air, AirBuilder, BaseAir},
   p3_field::{PrimeCharacteristicRing, PrimeField64},
   p3_matrix::dense::RowMajorMatrix,
@@ -160,11 +160,13 @@ impl AiurGadget for Bytes1 {
   fn witness_data(
     &self,
     record: &QueryRecord,
-  ) -> (RowMajorMatrix<G>, Vec<Vec<Lookup<G>>>) {
+    slot_arg_widths: &[usize],
+  ) -> (RowMajorMatrix<G>, LookupValues<G>) {
     let mut rows = vec![G::ZERO; 256 * TRACE_WIDTH];
 
     // There are `TRACE_WIDTH` lookups per row, one for each multiplicity.
-    let mut lookups = vec![vec![Lookup::empty(); TRACE_WIDTH]; 256];
+    let mut builder = LookupValues::builder(256, slot_arg_widths);
+    let mut row_writers = builder.rows_mut();
 
     let bit_decomposition_channel = u8_bit_decomposition_channel();
     let shift_left_channel = u8_shift_left_channel();
@@ -175,7 +177,7 @@ impl AiurGadget for Bytes1 {
       .chunks_exact_mut(TRACE_WIDTH)
       .enumerate()
       .zip(&record.bytes1_queries.0)
-      .zip(&mut lookups)
+      .zip(row_writers.iter_mut())
       .for_each(|(((byte, row), &[bd, shl, shr]), row_lookups)| {
         let byte = G::from_usize(byte);
         row[0] = bd;
@@ -186,21 +188,24 @@ impl AiurGadget for Bytes1 {
         let mut bit_decomposition_args = Vec::with_capacity(10);
         bit_decomposition_args.extend([bit_decomposition_channel, byte]);
         bit_decomposition_args.extend(Self::bit_decompose(&byte));
-        row_lookups[0] = Lookup::pull(bd, bit_decomposition_args);
+        row_lookups.pull(0, bd, &bit_decomposition_args);
 
         // Pull shift left.
-        row_lookups[1] = Lookup::pull(
+        row_lookups.pull(
+          1,
           shl,
-          vec![shift_left_channel, byte, Self::shift_left(&byte)],
+          &[shift_left_channel, byte, Self::shift_left(&byte)],
         );
 
         // Pull shift right.
-        row_lookups[2] = Lookup::pull(
+        row_lookups.pull(
+          2,
           shr,
-          vec![shift_right_channel, byte, Self::shift_right(&byte)],
+          &[shift_right_channel, byte, Self::shift_right(&byte)],
         );
       });
-    (RowMajorMatrix::new(rows, TRACE_WIDTH), lookups)
+    drop(row_writers);
+    (RowMajorMatrix::new(rows, TRACE_WIDTH), builder.finish())
   }
 }
 

--- a/crates/aiur/src/gadgets/bytes2.rs
+++ b/crates/aiur/src/gadgets/bytes2.rs
@@ -1,6 +1,6 @@
 use multi_stark::{
   builder::symbolic::{SymbolicExpression, preprocessed_var, var},
-  lookup::Lookup,
+  lookup::{Lookup, LookupValues},
   p3_air::{Air, AirBuilder, BaseAir},
   p3_field::{PrimeCharacteristicRing, PrimeField64},
   p3_matrix::dense::RowMajorMatrix,
@@ -313,11 +313,13 @@ impl AiurGadget for Bytes2 {
   fn witness_data(
     &self,
     record: &QueryRecord,
-  ) -> (RowMajorMatrix<G>, Vec<Vec<Lookup<G>>>) {
+    slot_arg_widths: &[usize],
+  ) -> (RowMajorMatrix<G>, LookupValues<G>) {
     let mut rows = vec![G::ZERO; 256 * 256 * TRACE_WIDTH];
 
     // There are `TRACE_WIDTH` lookups per row, one for each multiplicity.
-    let mut lookups = vec![vec![Lookup::empty(); TRACE_WIDTH]; 256 * 256];
+    let mut builder = LookupValues::builder(256 * 256, slot_arg_widths);
+    let mut row_writers = builder.rows_mut();
 
     let xor_channel = u8_xor_channel();
     let add_channel = u8_add_channel();
@@ -334,7 +336,7 @@ impl AiurGadget for Bytes2 {
       .chunks_exact_mut(TRACE_WIDTH)
       .enumerate()
       .zip(&record.bytes2_queries.0)
-      .zip(&mut lookups)
+      .zip(row_writers.iter_mut())
       .for_each(
         |(
           (
@@ -369,55 +371,55 @@ impl AiurGadget for Bytes2 {
           row[9] = chain_rotr4;
 
           // Pull xor.
-          row_lookups[0] =
-            Lookup::pull(xor, vec![xor_channel, i, j, Self::xor(&i, &j)]);
+          row_lookups.pull(0, xor, &[xor_channel, i, j, Self::xor(&i, &j)]);
 
           // Pull add (low byte only; carry derived in-circuit).
           let (r, _o) = Self::add(&i, &j);
-          row_lookups[1] = Lookup::pull(add, vec![add_channel, i, j, r]);
+          row_lookups.pull(1, add, &[add_channel, i, j, r]);
 
           // Pull sub (low byte only; borrow derived in-circuit).
           let (r, _u) = Self::sub(&i, &j);
-          row_lookups[2] = Lookup::pull(sub, vec![sub_channel, i, j, r]);
+          row_lookups.pull(2, sub, &[sub_channel, i, j, r]);
 
           // Pull and.
-          row_lookups[3] =
-            Lookup::pull(and, vec![and_channel, i, j, Self::and(&i, &j)]);
+          row_lookups.pull(3, and, &[and_channel, i, j, Self::and(&i, &j)]);
 
           // Pull or.
-          row_lookups[4] =
-            Lookup::pull(or, vec![or_channel, i, j, Self::or(&i, &j)]);
+          row_lookups.pull(4, or, &[or_channel, i, j, Self::or(&i, &j)]);
 
           // Pull less_than.
-          row_lookups[5] = Lookup::pull(
+          row_lookups.pull(
+            5,
             less_than,
-            vec![less_than_channel, i, j, Self::less_than(&i, &j)],
+            &[less_than_channel, i, j, Self::less_than(&i, &j)],
           );
 
           // Pull range_check.
-          row_lookups[6] =
-            Lookup::pull(range_check, vec![range_check_channel, i, j]);
+          row_lookups.pull(6, range_check, &[range_check_channel, i, j]);
 
           // Pull mul.
           let (lo, hi) = Self::mul(&i, &j);
-          row_lookups[7] = Lookup::pull(mul, vec![mul_channel, i, j, lo, hi]);
+          row_lookups.pull(7, mul, &[mul_channel, i, j, lo, hi]);
 
           // Pull chain_rotr7.
           let (o0, o1, o2) = Self::chain_rotr7(&i, &j);
-          row_lookups[8] = Lookup::pull(
+          row_lookups.pull(
+            8,
             chain_rotr7,
-            vec![chain_rotr7_channel, i, j, o0, o1, o2],
+            &[chain_rotr7_channel, i, j, o0, o1, o2],
           );
 
           // Pull chain_rotr4.
           let (o0, o1, o2) = Self::chain_rotr4(&i, &j);
-          row_lookups[9] = Lookup::pull(
+          row_lookups.pull(
+            9,
             chain_rotr4,
-            vec![chain_rotr4_channel, i, j, o0, o1, o2],
+            &[chain_rotr4_channel, i, j, o0, o1, o2],
           );
         },
       );
-    (RowMajorMatrix::new(rows, TRACE_WIDTH), lookups)
+    drop(row_writers);
+    (RowMajorMatrix::new(rows, TRACE_WIDTH), builder.finish())
   }
 }
 

--- a/crates/aiur/src/memory.rs
+++ b/crates/aiur/src/memory.rs
@@ -1,6 +1,6 @@
 use multi_stark::{
   builder::symbolic::{SymbolicExpression, var},
-  lookup::Lookup,
+  lookup::{Lookup, LookupValues},
   p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
   p3_field::PrimeCharacteristicRing,
   p3_matrix::dense::RowMajorMatrix,
@@ -19,16 +19,11 @@ pub struct Memory {
 }
 
 impl Memory {
-  pub(super) fn lookup(
-    multiplicity: G,
-    size: G,
-    ptr: G,
-    values: &[G],
-  ) -> Lookup<G> {
+  pub(super) fn lookup_args(size: G, ptr: G, values: &[G]) -> Vec<G> {
     let mut args = Vec::with_capacity(3 + values.len());
     args.extend([memory_channel(), size, ptr]);
     args.extend(values);
-    Lookup { multiplicity, args }
+    args
   }
 
   fn width(size: usize) -> usize {
@@ -54,7 +49,8 @@ impl Memory {
   pub fn witness_data(
     size: usize,
     record: &QueryRecord,
-  ) -> (RowMajorMatrix<G>, Vec<Vec<Lookup<G>>>) {
+    slot_arg_widths: &[usize],
+  ) -> (RowMajorMatrix<G>, LookupValues<G>) {
     let queries = record.memory_queries.get(&size).expect("Invalid size");
     let width = Self::width(size);
     let height_no_padding = queries.len();
@@ -69,12 +65,14 @@ impl Memory {
     let mut rows = vec![G::ZERO; height * width];
     let rows_no_padding = &mut rows[0..height_no_padding * width];
 
-    let mut lookups = vec![vec![Lookup::empty()]; height];
-    let lookups_no_padding = &mut lookups[0..height_no_padding];
+    // Builder rows start zeroed (`Lookup::empty()`), so padding rows need no
+    // writes at all.
+    let mut builder = LookupValues::builder(height, slot_arg_widths);
+    let mut row_writers = builder.rows_mut();
 
     rows_no_padding
       .par_chunks_mut(width)
-      .zip(lookups_no_padding.par_iter_mut())
+      .zip(row_writers[..height_no_padding].par_iter_mut())
       .enumerate()
       .for_each(|(i, (row, row_lookups))| {
         let (values, result) = queries.get_index(i).expect("index in range");
@@ -83,12 +81,13 @@ impl Memory {
         row[2] = G::from_usize(i);
         row[3..].copy_from_slice(values);
 
-        row_lookups[0] =
-          Self::lookup(-row[0], G::from_usize(size), row[2], &row[3..]);
+        let args = Self::lookup_args(G::from_usize(size), row[2], &row[3..]);
+        row_lookups.pull(0, row[0], &args);
       });
+    drop(row_writers);
 
     let trace = RowMajorMatrix::new(rows, width);
-    (trace, lookups)
+    (trace, builder.finish())
   }
 }
 

--- a/crates/aiur/src/synthesis.rs
+++ b/crates/aiur/src/synthesis.rs
@@ -11,7 +11,7 @@ use multi_stark::{
   verifier::VerificationError,
 };
 use rayon::iter::{
-  IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+  IndexedParallelIterator, IntoParallelIterator, ParallelIterator,
 };
 
 use crate::{
@@ -122,6 +122,36 @@ impl AiurSystem {
     AiurSystem { system, key, toplevel, commitment_parameters, fri_parameters }
   }
 
+  /// The circuit list in system order: constrained functions (ascending
+  /// index), then memories, then `Bytes1`, then `Bytes2`. This matches the
+  /// order the circuits were chained in [`AiurSystem::build`], so index `i`
+  /// of the returned `Vec` corresponds to `self.system.circuits[i]`.
+  fn circuit_types(&self) -> Vec<CircuitType> {
+    let functions = (0..self.toplevel.functions.len()).filter_map(|idx| {
+      self.toplevel.functions[idx]
+        .constrained
+        .then_some(CircuitType::Function { idx })
+    });
+    let memories = self
+      .toplevel
+      .memory_sizes
+      .iter()
+      .map(|&width| CircuitType::Memory { width });
+    let gadgets = [CircuitType::Bytes1, CircuitType::Bytes2];
+    functions.chain(memories).chain(gadgets).collect()
+  }
+
+  /// The argument width of each lookup slot of circuit `circuit_idx`, taken
+  /// from its symbolic lookups so the witness layout always matches the AIR.
+  fn slot_arg_widths(&self, circuit_idx: usize) -> Vec<usize> {
+    self.system.circuits[circuit_idx]
+      .air
+      .lookups
+      .iter()
+      .map(|lookup| lookup.args.len())
+      .collect()
+  }
+
   #[tracing::instrument(level = "info", skip_all, name = "aiur/prove")]
   pub fn prove(
     &self,
@@ -143,32 +173,29 @@ impl AiurSystem {
 
     // Build the `SystemWitness`
     let _g = tracing::info_span!("aiur/witness").entered();
-    let functions =
-      (0..self.toplevel.functions.len()).into_par_iter().filter_map(|idx| {
-        if self.toplevel.functions[idx].constrained {
-          Some(CircuitType::Function { idx })
-        } else {
-          None
+    let circuit_types = self.circuit_types();
+    let witness_data = circuit_types
+      .into_par_iter()
+      .enumerate()
+      .map(|(circuit_idx, circuit_type)| {
+        let slot_arg_widths = self.slot_arg_widths(circuit_idx);
+        match circuit_type {
+          CircuitType::Function { idx } => self.toplevel.witness_data(
+            idx,
+            &query_record,
+            io_buffer,
+            &slot_arg_widths,
+          ),
+          CircuitType::Memory { width } => {
+            Memory::witness_data(width, &query_record, &slot_arg_widths)
+          },
+          CircuitType::Bytes1 => {
+            Bytes1.witness_data(&query_record, &slot_arg_widths)
+          },
+          CircuitType::Bytes2 => {
+            Bytes2.witness_data(&query_record, &slot_arg_widths)
+          },
         }
-      });
-    let memories = self
-      .toplevel
-      .memory_sizes
-      .par_iter()
-      .map(|&width| CircuitType::Memory { width });
-    let gadgets = [CircuitType::Bytes1, CircuitType::Bytes2].into_par_iter();
-    let witness_data = functions
-      .chain(memories)
-      .chain(gadgets)
-      .map(|circuit_type| match circuit_type {
-        CircuitType::Function { idx } => {
-          self.toplevel.witness_data(idx, &query_record, io_buffer)
-        },
-        CircuitType::Memory { width } => {
-          Memory::witness_data(width, &query_record)
-        },
-        CircuitType::Bytes1 => Bytes1.witness_data(&query_record),
-        CircuitType::Bytes2 => Bytes2.witness_data(&query_record),
       })
       .collect::<Vec<_>>();
     drop(query_record); // Early drop to free memory.
@@ -220,32 +247,29 @@ impl AiurSystem {
     drop(_g);
 
     let _g = tracing::info_span!("aiur/witness").entered();
-    let functions =
-      (0..self.toplevel.functions.len()).into_par_iter().filter_map(|idx| {
-        if self.toplevel.functions[idx].constrained {
-          Some(CircuitType::Function { idx })
-        } else {
-          None
+    let circuit_types = self.circuit_types();
+    let witness_data = circuit_types
+      .into_par_iter()
+      .enumerate()
+      .map(|(circuit_idx, circuit_type)| {
+        let slot_arg_widths = self.slot_arg_widths(circuit_idx);
+        match circuit_type {
+          CircuitType::Function { idx } => self.toplevel.witness_data(
+            idx,
+            &query_record,
+            io_buffer,
+            &slot_arg_widths,
+          ),
+          CircuitType::Memory { width } => {
+            Memory::witness_data(width, &query_record, &slot_arg_widths)
+          },
+          CircuitType::Bytes1 => {
+            Bytes1.witness_data(&query_record, &slot_arg_widths)
+          },
+          CircuitType::Bytes2 => {
+            Bytes2.witness_data(&query_record, &slot_arg_widths)
+          },
         }
-      });
-    let memories = self
-      .toplevel
-      .memory_sizes
-      .par_iter()
-      .map(|&width| CircuitType::Memory { width });
-    let gadgets = [CircuitType::Bytes1, CircuitType::Bytes2].into_par_iter();
-    let witness_data = functions
-      .chain(memories)
-      .chain(gadgets)
-      .map(|circuit_type| match circuit_type {
-        CircuitType::Function { idx } => {
-          self.toplevel.witness_data(idx, &query_record, io_buffer)
-        },
-        CircuitType::Memory { width } => {
-          Memory::witness_data(width, &query_record)
-        },
-        CircuitType::Bytes1 => Bytes1.witness_data(&query_record),
-        CircuitType::Bytes2 => Bytes2.witness_data(&query_record),
       })
       .collect::<Vec<_>>();
     drop(query_record);

--- a/crates/aiur/src/trace.rs
+++ b/crates/aiur/src/trace.rs
@@ -1,5 +1,5 @@
 use multi_stark::{
-  lookup::Lookup,
+  lookup::{LookupRowMut, LookupValues},
   p3_field::{Field, PrimeCharacteristicRing, PrimeField64},
   p3_matrix::dense::RowMajorMatrix,
 };
@@ -31,20 +31,20 @@ struct ColumnIndex {
   lookup: usize,
 }
 
-struct ColumnMutSlice<'a> {
+struct ColumnMutSlice<'a, 'b> {
   inputs: &'a mut [G],
   selectors: &'a mut [G],
   auxiliaries: &'a mut [G],
-  lookups: &'a mut [Lookup<G>],
+  lookups: &'a mut LookupRowMut<'b, G>,
 }
 
 type Degree = u8;
 
-impl<'a> ColumnMutSlice<'a> {
+impl<'a, 'b> ColumnMutSlice<'a, 'b> {
   fn from_slice(
     function: &Function,
     slice: &'a mut [G],
-    lookups: &'a mut [Lookup<G>],
+    lookups: &'a mut LookupRowMut<'b, G>,
   ) -> Self {
     let (inputs, slice) = slice.split_at_mut(function.layout.input_size);
     let (selectors, slice) = slice.split_at_mut(function.layout.selectors);
@@ -58,8 +58,13 @@ impl<'a> ColumnMutSlice<'a> {
     index.auxiliary += 1;
   }
 
-  fn push_lookup(&mut self, index: &mut ColumnIndex, t: Lookup<G>) {
-    self.lookups[index.lookup] = t;
+  fn push_lookup(
+    &mut self,
+    index: &mut ColumnIndex,
+    multiplicity: G,
+    args: &[G],
+  ) {
+    self.lookups.push(index.lookup, multiplicity, args);
     index.lookup += 1;
   }
 }
@@ -79,7 +84,8 @@ impl Toplevel {
     function_index: usize,
     query_record: &QueryRecord,
     io_buffer: &IOBuffer,
-  ) -> (RowMajorMatrix<G>, Vec<Vec<Lookup<G>>>) {
+    slot_arg_widths: &[usize],
+  ) -> (RowMajorMatrix<G>, LookupValues<G>) {
     let func = &self.functions[function_index];
     let width = func.width();
     let unfiltered_queries = &query_record.function_queries[function_index];
@@ -97,12 +103,13 @@ impl Toplevel {
     };
     let mut rows = vec![G::ZERO; height * width];
     let rows_no_padding = &mut rows[0..height_no_padding * width];
-    let empty_lookup = Lookup::empty();
-    let mut lookups = vec![vec![empty_lookup; func.layout.lookups]; height];
-    let lookups_no_padding = &mut lookups[0..height_no_padding];
+    // Builder rows start zeroed (`Lookup::empty()` in every slot), so padding
+    // rows need no writes at all.
+    let mut builder = LookupValues::builder(height, slot_arg_widths);
+    let mut row_writers = builder.rows_mut();
     rows_no_padding
       .par_chunks_mut(width)
-      .zip(lookups_no_padding.par_iter_mut())
+      .zip(row_writers[..height_no_padding].par_iter_mut())
       .enumerate()
       .for_each(|(i, (row, lookups))| {
         let (inputs, result) = queries[i];
@@ -121,8 +128,9 @@ impl Toplevel {
         };
         func.populate_row(index, slice, context, io_buffer);
       });
+    drop(row_writers);
     let trace = RowMajorMatrix::new(rows, width);
-    (trace, lookups)
+    (trace, builder.finish())
   }
 }
 
@@ -134,7 +142,7 @@ impl Function {
   fn populate_row(
     &self,
     index: &mut ColumnIndex,
-    slice: &mut ColumnMutSlice<'_>,
+    slice: &mut ColumnMutSlice<'_, '_>,
     context: TraceContext<'_>,
     io_buffer: &IOBuffer,
   ) {
@@ -166,7 +174,7 @@ impl Block {
     &self,
     map: &mut Vec<(G, Degree)>,
     index: &mut ColumnIndex,
-    slice: &mut ColumnMutSlice<'_>,
+    slice: &mut ColumnMutSlice<'_, '_>,
     context: TraceContext<'_>,
     io_buffer: &IOBuffer,
   ) -> PopulateResult {
@@ -185,7 +193,7 @@ fn dispatch_branch<'a>(
   cases: &'a FxIndexMap<G, Block>,
   def: &'a Option<Box<Block>>,
   index: &mut ColumnIndex,
-  slice: &mut ColumnMutSlice<'_>,
+  slice: &mut ColumnMutSlice<'_, '_>,
 ) -> &'a Block {
   cases
     .get(&val)
@@ -204,20 +212,21 @@ impl Ctrl {
     &self,
     map: &mut Vec<(G, Degree)>,
     index: &mut ColumnIndex,
-    slice: &mut ColumnMutSlice<'_>,
+    slice: &mut ColumnMutSlice<'_, '_>,
     context: TraceContext<'_>,
     io_buffer: &IOBuffer,
   ) -> PopulateResult {
     match self {
       Ctrl::Return(sel, _) => {
         slice.selectors[*sel] = G::ONE;
-        let lookup = function_lookup(
-          -context.multiplicity,
+        let args = function_lookup_args(
           context.function_index,
           context.inputs,
           context.output,
         );
-        slice.lookups[0] = lookup;
+        // The first lookup slot is reserved for the function return, which
+        // pulls the query claim with the query's multiplicity.
+        slice.lookups.pull(0, context.multiplicity, &args);
         None
       },
       Ctrl::Yield(sel, vals) => {
@@ -269,7 +278,7 @@ impl Op {
     &self,
     map: &mut Vec<(G, Degree)>,
     index: &mut ColumnIndex,
-    slice: &mut ColumnMutSlice<'_>,
+    slice: &mut ColumnMutSlice<'_, '_>,
     context: TraceContext<'_>,
     io_buffer: &IOBuffer,
   ) {
@@ -322,13 +331,12 @@ impl Op {
           slice.push_auxiliary(index, *f);
         }
         if !op_unconstrained {
-          let lookup = function_lookup(
-            G::ONE,
+          let args = function_lookup_args(
             G::from_usize(*function_index),
             &inputs,
             result.output,
           );
-          slice.push_lookup(index, lookup);
+          slice.push_lookup(index, G::ONE, &args);
         }
       },
       Op::Store(values) => {
@@ -344,8 +352,8 @@ impl Op {
         );
         map.push((ptr, 1));
         slice.push_auxiliary(index, ptr);
-        let lookup = Memory::lookup(G::ONE, G::from_usize(size), ptr, &values);
-        slice.push_lookup(index, lookup);
+        let args = Memory::lookup_args(G::from_usize(size), ptr, &values);
+        slice.push_lookup(index, G::ONE, &args);
       },
       Op::Load(size, ptr) => {
         let memory_queries = context
@@ -362,8 +370,8 @@ impl Op {
           map.push((*f, 1));
           slice.push_auxiliary(index, *f);
         }
-        let lookup = Memory::lookup(G::ONE, G::from_usize(*size), ptr, values);
-        slice.push_lookup(index, lookup);
+        let args = Memory::lookup_args(G::from_usize(*size), ptr, values);
+        slice.push_lookup(index, G::ONE, &args);
       },
       Op::IOGetInfo(channel, key) => {
         let channel = map[*channel].0;
@@ -400,23 +408,29 @@ impl Op {
         }
         let mut lookup_args = vec![u8_bit_decomposition_channel(), byte];
         lookup_args.extend(bits);
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &lookup_args);
       },
       Op::U8ShiftLeft(byte) => {
         let (byte, _) = map[*byte];
         let byte_shifted = Bytes1::shift_left(&byte);
         map.push((byte_shifted, 1));
         slice.push_auxiliary(index, byte_shifted);
-        let lookup_args = vec![u8_shift_left_channel(), byte, byte_shifted];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(
+          index,
+          G::ONE,
+          &[u8_shift_left_channel(), byte, byte_shifted],
+        );
       },
       Op::U8ShiftRight(byte) => {
         let (byte, _) = map[*byte];
         let byte_shifted = Bytes1::shift_right(&byte);
         map.push((byte_shifted, 1));
         slice.push_auxiliary(index, byte_shifted);
-        let lookup_args = vec![u8_shift_right_channel(), byte, byte_shifted];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(
+          index,
+          G::ONE,
+          &[u8_shift_right_channel(), byte, byte_shifted],
+        );
       },
       Op::U8Xor(i, j) => {
         let (i, _) = map[*i];
@@ -424,8 +438,7 @@ impl Op {
         let xor = Bytes2::xor(&i, &j);
         map.push((xor, 1));
         slice.push_auxiliary(index, xor);
-        let lookup_args = vec![u8_xor_channel(), i, j, xor];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &[u8_xor_channel(), i, j, xor]);
       },
       Op::U8Add(i, j) => {
         let (i, _) = map[*i];
@@ -437,8 +450,7 @@ impl Op {
         map.push((r, 1));
         map.push((o, 1));
         slice.push_auxiliary(index, r);
-        let lookup_args = vec![u8_add_channel(), i, j, r];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &[u8_add_channel(), i, j, r]);
       },
       Op::U8Mul(i, j) => {
         let (i, _) = map[*i];
@@ -448,8 +460,7 @@ impl Op {
         map.push((hi, 1));
         slice.push_auxiliary(index, lo);
         slice.push_auxiliary(index, hi);
-        let lookup_args = vec![u8_mul_channel(), i, j, lo, hi];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &[u8_mul_channel(), i, j, lo, hi]);
       },
       Op::U8Sub(i, j) => {
         let (i, _) = map[*i];
@@ -461,8 +472,7 @@ impl Op {
         map.push((r, 1));
         map.push((u, 1));
         slice.push_auxiliary(index, r);
-        let lookup_args = vec![u8_sub_channel(), i, j, r];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &[u8_sub_channel(), i, j, r]);
       },
       Op::U8And(i, j) => {
         let (i, _) = map[*i];
@@ -470,8 +480,7 @@ impl Op {
         let and = Bytes2::and(&i, &j);
         map.push((and, 1));
         slice.push_auxiliary(index, and);
-        let lookup_args = vec![u8_and_channel(), i, j, and];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &[u8_and_channel(), i, j, and]);
       },
       Op::U8Or(i, j) => {
         let (i, _) = map[*i];
@@ -479,8 +488,7 @@ impl Op {
         let or = Bytes2::or(&i, &j);
         map.push((or, 1));
         slice.push_auxiliary(index, or);
-        let lookup_args = vec![u8_or_channel(), i, j, or];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(index, G::ONE, &[u8_or_channel(), i, j, or]);
       },
       Op::U8LessThan(i, j) => {
         let (i, _) = map[*i];
@@ -488,8 +496,11 @@ impl Op {
         let less_than = Bytes2::less_than(&i, &j);
         map.push((less_than, 1));
         slice.push_auxiliary(index, less_than);
-        let lookup_args = vec![u8_less_than_channel(), i, j, less_than];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(
+          index,
+          G::ONE,
+          &[u8_less_than_channel(), i, j, less_than],
+        );
       },
       Op::U8ChainRotr7(i, j) => {
         let (i, _) = map[*i];
@@ -501,8 +512,11 @@ impl Op {
         slice.push_auxiliary(index, o0);
         slice.push_auxiliary(index, o1);
         slice.push_auxiliary(index, o2);
-        let lookup_args = vec![u8_chain_rotr7_channel(), i, j, o0, o1, o2];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(
+          index,
+          G::ONE,
+          &[u8_chain_rotr7_channel(), i, j, o0, o1, o2],
+        );
       },
       Op::U8ChainRotr4(i, j) => {
         let (i, _) = map[*i];
@@ -514,8 +528,11 @@ impl Op {
         slice.push_auxiliary(index, o0);
         slice.push_auxiliary(index, o1);
         slice.push_auxiliary(index, o2);
-        let lookup_args = vec![u8_chain_rotr4_channel(), i, j, o0, o1, o2];
-        slice.push_lookup(index, Lookup::push(G::ONE, lookup_args));
+        slice.push_lookup(
+          index,
+          G::ONE,
+          &[u8_chain_rotr4_channel(), i, j, o0, o1, o2],
+        );
       },
       Op::U32LessThan(x_idx, y_idx) => {
         let (a, _) = map[*x_idx];
@@ -546,10 +563,8 @@ impl Op {
         ] {
           slice.push_lookup(
             index,
-            Lookup::push(
-              G::ONE,
-              vec![rc_channel, G::from_u8(i), G::from_u8(j)],
-            ),
+            G::ONE,
+            &[rc_channel, G::from_u8(i), G::from_u8(j)],
           );
         }
 
@@ -561,10 +576,8 @@ impl Op {
         // `(i, j)` pair from the byte-chip range-check table.
         slice.push_lookup(
           index,
-          Lookup::push(
-            G::ONE,
-            vec![u8_range_check_channel(), map[*i].0, map[*j].0],
-          ),
+          G::ONE,
+          &[u8_range_check_channel(), map[*i].0, map[*j].0],
         );
       },
       Op::UnconstrainedBigUintDivMod(a, b) => {
@@ -607,14 +620,13 @@ impl Op {
   }
 }
 
-fn function_lookup(
-  multiplicity: G,
+fn function_lookup_args(
   function_index: G,
   inputs: &[G],
   output: &[G],
-) -> Lookup<G> {
+) -> Vec<G> {
   let mut args = vec![function_channel(), function_index];
   args.extend(inputs);
   args.extend(output);
-  Lookup { multiplicity, args }
+  args
 }


### PR DESCRIPTION
multi-stark now stores the lookup witness flat per circuit instead of nested per-row vectors, removing one heap allocation per lookup per row and freeing the witness before the commit/quotient/FRI stages. Convert each circuit's nested lookups via `LookupValues::from_rows` inside the witness map so the nested form is a per-circuit transient.

Bumps multi-stark to b3a62f7 (perf/lookup-ram).