### PR TITLE
IxVM kernel: six divergence fixes from sharded env checking

### DIFF
--- a/Ix/IxVM/Kernel/Inductive.lean
+++ b/Ix/IxVM/Kernel/Inductive.lean
@@ -14,6 +14,10 @@ validation, universe constraints, strict positivity, recursor synthesis).
 Structure-only validation, no name diagnostics.
 -/
 
+-- The Aiur quotation below is at the elaborator's default recursion
+-- limit; nested-statement chains (dbg!/sord_then continuations) push
+-- past it.
+set_option maxRecDepth 65536 in
 def inductive_check := ⟦
   -- Mirror: src/ix/kernel/inductive.rs:1968-2080 check_ctor_return_type.
   -- Validates that a ctor's declared type, after peeling
@@ -2669,17 +2673,38 @@ def inductive_check := ⟦
                                                     block_param_doms, sbase,
                                                     top, addrs),
                                     ctx, addrs),
-                          aux_view_ctors_cmp(ctors_a, np_a, sp_a, ou_a,
-                                             ctors_b, np_b, sp_b, ou_b,
-                                             aux, block_us, n_block_params,
-                                             block_param_doms, sbase, ctx,
-                                             top, addrs)))),
+                          sord_then(aux_view_ctors_cmp(ctors_a, np_a, sp_a, ou_a,
+                                                       ctors_b, np_b, sp_b, ou_b,
+                                                       aux, block_us, n_block_params,
+                                                       block_param_doms, sbase, ctx,
+                                                       top, addrs),
+                            -- Trailing identity marker (mirror
+                            -- inductive.rs canonical_aux_order): the ext
+                            -- applied to its occurrence universes and spec
+                            -- params, NOT sentinel-rewritten. Distinct exts
+                            -- (or phantom-distinct spec params over one
+                            -- ext) whose field views tie weak through
+                            -- sentinels are ordered strongly here —
+                            -- external consts by address, block-local refs
+                            -- by ctx class. Address-equal spec params still
+                            -- compare Equal and collapse.
+                            compare_kexpr_ctx(
+                              aux_marker_view(ext_a, ou_a, sp_a),
+                              aux_marker_view(ext_b, ou_b, sp_b),
+                              ctx, addrs))))),
                   _ => sord_eq_strong(),
                 },
               _ => sord_eq_strong(),
             },
         },
     }
+  }
+
+  -- The aux's nested-occurrence identity: `Ext spec_params` under the
+  -- occurrence's universe args. Mirror: the synthetic trailing marker
+  -- ctor in inductive.rs canonical_aux_order.
+  fn aux_marker_view(ext_idx: G, ou: List‹KLevel›, sp: List‹KExpr›) -> KExpr {
+    apply_spine(store(KExprNode.Const(ext_idx, ou)), sp)
   }
 
   fn aux_view_ind_ty(ext_ty: KExpr, ext_np: G, sp: List‹KExpr›,

--- a/Ix/IxVM/Kernel/Inductive.lean
+++ b/Ix/IxVM/Kernel/Inductive.lean
@@ -1525,6 +1525,26 @@ def inductive_check := ⟦
   -- `self_mem_pos` = self's POSITION in the flat block (signature-
   -- resolved by the caller); idx lookup would alias same-idx aux
   -- members.
+  -- whnf-tolerant n-binder collector (mirror the Rust param peel):
+  -- whnf before each peel so binders hidden under definitional wrappers
+  -- expose, and stop without failing when the type runs out of Foralls.
+  fn collect_n_doms_whnf(ty: KExpr, n: G, top: List‹&KConstantInfo›,
+                         addrs: List‹Addr›) -> (List‹KExpr›, KExpr) {
+    match n {
+      0 => (store(ListNode.Nil), ty),
+      _ =>
+        let w = whnf(ty, store(ListNode.Nil), top, addrs);
+        match load(w) {
+          KExprNode.Forall(dom, body) =>
+            match collect_n_doms_whnf(body, n - 1, top, addrs) {
+              (rest_doms, rest) =>
+                (store(ListNode.Cons(dom, rest_doms)), rest),
+            },
+          _ => (store(ListNode.Nil), w),
+        },
+    }
+  }
+
   fn build_rec_type(ind_idx: G, ind_ty: KExpr, ctor_indices: List‹G›,
                     n_params: G, n_indices: G, ind_lvls: G,
                     self_own_params: G,
@@ -1545,13 +1565,20 @@ def inductive_check := ⟦
     let n_rec_params = n_params;
     let motive_base = n_rec_params;
 
-    -- Use self's concrete occurrence_us for ind_ty inst (so nested aux univ
-    -- args match what Lean stored).
-    let self_member0 = flat_member_at(flat, self_mem_pos);
-    let self_occ_us0 = match self_member0 { (_, _, _, ou) => ou, };
-    let ind_ty_inst = expr_inst_levels(ind_ty, self_occ_us0);
-
-    let params_walk = collect_n_doms(ind_ty_inst, n_params);
+    -- Params walk over the PRIMARY inductive's type under the first
+    -- inductive's univ_offset-shifted params, with a whnf-tolerant peel
+    -- (mirror inductive.rs build_rec_type: `ind_infos[0].4` +
+    -- `first_ind_univs`, whnf per step, break on non-Forall). Peeling
+    -- SELF's type with the primary's param count walks past the end for
+    -- aux-member recursors whose ext types have fewer binders.
+    let primary_ci0 = load(list_lookup(top, primary_ind_idx));
+    let params_walk = match primary_ci0 {
+      KConstantInfo.Induct(p_lvls, p_ty, _, _, _, _, _) =>
+        let p_us = build_param_lvls_range(univ_offset, p_lvls, 0);
+        collect_n_doms_whnf(expr_inst_levels(p_ty, p_us), n_params, top, addrs),
+      _ =>
+        collect_n_doms_whnf(ind_ty, n_params, top, addrs),
+    };
     match params_walk {
       (param_doms, after_params) =>
         let flat_own_params = flat_own_params_of(flat, top);
@@ -2294,7 +2321,15 @@ def inductive_check := ⟦
         match ctor_ci {
           KConstantInfo.Ctor(_, ctor_ty, _, _, _, _, _) =>
             let body = match is_aux {
-              0 => peel_n_foralls_tolerant(ctor_ty, n_params),
+              -- Instantiate the ctor's level params with the member's
+              -- occurrence universes BEFORE scanning (mirror inductive.rs
+              -- queue scan). For originals occ_us is the univ_offset-shifted
+              -- Param range, so occurrences found inside carry rec-frame
+              -- concrete levels — without this, aux members store raw
+              -- block-frame Params and every large-eliminator minor built
+              -- from them references the wrong universe (Param 0 where the
+              -- stored recursor has Param 1).
+              0 => peel_n_foralls_tolerant(expr_inst_levels(ctor_ty, occ_us), n_params),
               _ => synth_aux_ctor_ty(ctor_ty, n_params, spec_params, occ_us, top, addrs),
             };
             let from_this = detect_nested_in_field_chain(body, block_idxs, top, 0);

--- a/Ix/IxVM/Kernel/Inductive.lean
+++ b/Ix/IxVM/Kernel/Inductive.lean
@@ -1175,15 +1175,32 @@ def inductive_check := ⟦
   fn is_rec_field(dom: KExpr, flat: List‹(G, G, List‹KExpr›, List‹KLevel›)›,
                    types: List‹KExpr›, top: List‹&KConstantInfo›,
                    addrs: List‹Addr›, spec_lift_by: G) -> (G, G) {
-    match peel_leading_foralls(dom) {
-      (doms, body) =>
-        let inner_types = list_concat(list_reverse(doms), types);
-        let body_w = whnf(body, inner_types, top, addrs);
-        match collect_spine(body_w) {
+    -- Mirror inductive.rs is_rec_field's loop: whnf, peel ONE Forall,
+    -- repeat — WITHOUT pushing the peeled binder doms into a whnf
+    -- context. The body's loose BVars (field locals and the caller
+    -- frame's param refs) are stuck under whnf either way, and a
+    -- context built from local doms violates ctx-trim's frame
+    -- well-formedness (a param-referencing dom's lbr exceeds the depth
+    -- below it, running ctx_next_cut off the end of the list —
+    -- e.g. a Prop class `C (pat) where f (s t) : P pat s → ...`).
+    -- Per-peel whnf also exposes index binders hidden under
+    -- definitional wrappers, which the old peel-then-whnf missed.
+    let lift = spec_lift_by + list_length(types);
+    is_rec_field_peel(dom, flat, lift, top, addrs)
+  }
+
+  fn is_rec_field_peel(ty: KExpr, flat: List‹(G, G, List‹KExpr›, List‹KLevel›)›,
+                       lift: G, top: List‹&KConstantInfo›,
+                       addrs: List‹Addr›) -> (G, G) {
+    let w = whnf(ty, store(ListNode.Nil), top, addrs);
+    match load(w) {
+      KExprNode.Forall(_, body) =>
+        is_rec_field_peel(body, flat, lift, top, addrs),
+      _ =>
+        match collect_spine(w) {
           (head, spine_args) =>
             match load(head) {
               KExprNode.Const(idx, _) =>
-                let lift = spec_lift_by + list_length(types);
                 find_flat_member_match(flat, idx, spine_args, 0, lift),
               _ => (0, 0),
             },

--- a/Ix/IxVM/Kernel/Levels.lean
+++ b/Ix/IxVM/Kernel/Levels.lean
@@ -634,27 +634,146 @@ def levels := ⟦
     }
   }
 
+  -- Mirror level.rs KUniv::max exactly: explicit-numeral collapse,
+  -- STRUCTURAL equality (store dedup makes structurally identical levels
+  -- pointer-equal), zero absorption, max-subsumption, same-base offset
+  -- collapse — and NO Succ-over-Max factoring. Lean stores type-former
+  -- levels normalized with Succ distributed INTO Max (`max (u+1) (v+1)`);
+  -- factoring Succ back out here rebuilt Succ-headed forms whose variant
+  -- rank differs, diverging canonical-sort comparisons (aux view order)
+  -- from the stored/compile shapes.
   fn level_max(a: KLevel, b: KLevel) -> KLevel {
-    match load(a) {
-      KLevelNode.Zero => b,
-      _ =>
-        match load(b) {
-          KLevelNode.Zero => a,
+    match level_explicit_val(a) {
+      (1, na) =>
+        match level_explicit_val(b) {
+          (1, nb) =>
+            match u32_less_than(na, nb) {
+              1 => b,
+              0 => a,
+            },
+          _ => level_max_go(a, b),
+        },
+      _ => level_max_go(a, b),
+    }
+  }
+
+  fn level_max_go(a: KLevel, b: KLevel) -> KLevel {
+    match level_struct_eq(a, b) {
+      1 => a,
+      0 =>
+        match load(a) {
+          KLevelNode.Zero => b,
           _ =>
-            let eq = level_eq(a, b);
-            match eq {
-              1 => a,
-              0 =>
-                match load(a) {
-                  KLevelNode.Succ(a1) =>
-                    match load(b) {
-                      KLevelNode.Succ(b1) => store(KLevelNode.Succ(level_max(a1, b1))),
-                      _ => store(KLevelNode.Max(a, b)),
+            match load(b) {
+              KLevelNode.Zero => a,
+              _ =>
+                match level_max_subsumes(b, a) {
+                  1 => b,
+                  0 =>
+                    match level_max_subsumes(a, b) {
+                      1 => a,
+                      0 => level_max_offsets(a, b),
                     },
-                  _ => store(KLevelNode.Max(a, b)),
                 },
             },
         },
+    }
+  }
+
+  -- Structural (raw, non-normalizing) level equality — mirror of Rust's
+  -- KUniv `==` (hash equality over the raw structure). Pointer equality
+  -- is a sound fast path (same data), but pointer INEQUALITY does not
+  -- imply different data, so the fallback compares values recursively.
+  fn level_struct_eq(a: KLevel, b: KLevel) -> G {
+    match ptr_val(a) - ptr_val(b) {
+      0 => 1,
+      _ =>
+        match load(a) {
+          KLevelNode.Zero =>
+            match load(b) {
+              KLevelNode.Zero => 1,
+              _ => 0,
+            },
+          KLevelNode.Succ(x) =>
+            match load(b) {
+              KLevelNode.Succ(y) => level_struct_eq(x, y),
+              _ => 0,
+            },
+          KLevelNode.Max(x1, x2) =>
+            match load(b) {
+              KLevelNode.Max(y1, y2) =>
+                level_struct_eq(x1, y1) * level_struct_eq(x2, y2),
+              _ => 0,
+            },
+          KLevelNode.IMax(x1, x2) =>
+            match load(b) {
+              KLevelNode.IMax(y1, y2) =>
+                level_struct_eq(x1, y1) * level_struct_eq(x2, y2),
+              _ => 0,
+            },
+          KLevelNode.Param(i) =>
+            match load(b) {
+              KLevelNode.Param(j) =>
+                match i - j {
+                  0 => 1,
+                  _ => 0,
+                },
+              _ => 0,
+            },
+        },
+    }
+  }
+
+  -- 1 iff `m` is `Max(l, r)` with `l` or `r` structurally equal to `x`:
+  -- max(x, max(x, b)) = max(x, b) etc.
+  fn level_max_subsumes(m: KLevel, x: KLevel) -> G {
+    match load(m) {
+      KLevelNode.Max(l, r) =>
+        match level_struct_eq(l, x) {
+          1 => 1,
+          0 => level_struct_eq(r, x),
+        },
+      _ => 0,
+    }
+  }
+
+  -- Same-base offset collapse: succ^n(x) vs succ^m(x) with structurally
+  -- equal base → the larger; otherwise the raw Max node.
+  fn level_max_offsets(a: KLevel, b: KLevel) -> KLevel {
+    match level_offset_of(a, 0) {
+      (base_a, off_a) =>
+        match level_offset_of(b, 0) {
+          (base_b, off_b) =>
+            match level_struct_eq(base_a, base_b) {
+              1 =>
+                match u32_less_than(off_a, off_b) {
+                  1 => b,
+                  0 => a,
+                },
+              0 => store(KLevelNode.Max(a, b)),
+            },
+        },
+    }
+  }
+
+  -- (1, n) iff the level is the explicit numeral succ^n(Zero).
+  fn level_explicit_val(l: KLevel) -> (G, G) {
+    match load(l) {
+      KLevelNode.Zero => (1, 0),
+      KLevelNode.Succ(inner) =>
+        match level_explicit_val(inner) {
+          (1, n) => (1, n + 1),
+          _ => (0, 0),
+        },
+      _ => (0, 0),
+    }
+  }
+
+  -- Peel Succs: level_offset_of(succ^n(x), 0) = (x, n).
+  fn level_offset_of(l: KLevel, k: G) -> (KLevel, G) {
+    match load(l) {
+      KLevelNode.Succ(inner) => level_offset_of(inner, k + 1),
+      _ => (l, k),
     }
   }
 

--- a/Ix/IxVM/Kernel/Primitive.lean
+++ b/Ix/IxVM/Kernel/Primitive.lean
@@ -1293,7 +1293,13 @@ def primitive := ⟦
                       ListNode.Nil =>
                         store(KExprNode.Const(zero_idx, store(ListNode.Nil))),
                       ListNode.Cons(_, _) =>
-                        let pred = store(KExprNode.Lit(KLiteral.Nat(klimbs_dec(klimbs))));
+                        -- klimbs_dec at a limb boundary (e.g. 2^32 = [0,1] →
+                        -- [0xFFFFFFFF, 0]) leaves a trailing zero limb; without
+                        -- normalization the countdown reaches a Cons-shaped zero
+                        -- ([0,0]) that takes this succ arm again and decrements
+                        -- past zero — an unbounded descent. Canonical limbs also
+                        -- keep the per-layer Lit nodes shared in the memo.
+                        let pred = store(KExprNode.Lit(KLiteral.Nat(klimbs_normalize(klimbs_dec(klimbs)))));
                         let succ_const = store(KExprNode.Const(succ_idx, store(ListNode.Nil)));
                         store(KExprNode.App(succ_const, pred)),
                     },
@@ -1614,7 +1620,10 @@ def primitive := ⟦
                 match try_extract_nat(a0_w, addrs) {
                   (1, na) =>
                     let post = list_drop(spine, 1);
-                    (1, apply_spine(mk_nat_lit(klimbs_dec(na)), post)),
+                    -- Normalize: dec at a limb boundary leaves a trailing zero
+                    -- limb, and a non-canonical Lit poisons every downstream
+                    -- literal comparison and ctor-exposure countdown.
+                    (1, apply_spine(mk_nat_lit(klimbs_normalize(klimbs_dec(na))), post)),
                   _ => (0, store(KExprNode.BVar(0))),
                 },
             },
@@ -1682,10 +1691,42 @@ def primitive := ⟦
       0 => (0, store(KExprNode.BVar(0))),
       _ =>
         let post = list_drop(spine, 2);
-        match mk_nat_offset_stuck(a0_w, nb, post, addrs) {
-          (1, stuck) => (2, stuck),
-          (0, _) => (0, store(KExprNode.BVar(0))),
+        -- `Nat.add` keeps the canonical add-offset shape (shared with the
+        -- linear-rec collapse). Div/mod MUST keep their own head: routing
+        -- them through the add builder rewrote `x / n` into `x + n` —
+        -- wrong value — corrupting offset-aware def-eq (unsound equalities
+        -- between /- and +-derived forms) and sending genuinely equal
+        -- `x >>> k` comparisons into full delta-unfolds of the division
+        -- algorithm on symbolic args.
+        match is_add {
+          1 =>
+            match mk_nat_offset_stuck(a0_w, nb, post, addrs) {
+              (1, stuck) => (2, stuck),
+              (0, _) => (0, store(KExprNode.BVar(0))),
+            },
+          0 =>
+            match mk_nat_binop_stuck(head_addr, a0_w, nb, post, addrs) {
+              (1, stuck) => (2, stuck),
+              (0, _) => (0, store(KExprNode.BVar(0))),
+            },
         },
+    }
+  }
+
+  -- Rebuild a stuck binary Nat op `op base (Lit n)` applied to `post`,
+  -- preserving the op's own head (div stays div, mod stays mod). The
+  -- add-offset shape has its own builder (`mk_nat_offset_stuck`, shared
+  -- with the linear-rec collapse); this is the non-add sibling.
+  fn mk_nat_binop_stuck(op_addr: Addr, base_w: KExpr, n: KLimbs, post: List‹KExpr›,
+                        addrs: List‹Addr›) -> (G, KExpr) {
+    match find_addr_idx_safe(op_addr, addrs, 0) {
+      (0, _) => (0, store(KExprNode.BVar(0))),
+      (1, op_idx) =>
+        let op_const = store(KExprNode.Const(op_idx, store(ListNode.Nil)));
+        let stuck = store(KExprNode.App(
+          store(KExprNode.App(op_const, base_w)),
+          mk_nat_lit(n)));
+        (1, apply_spine(stuck, post)),
     }
   }
 

--- a/Tests/Ix/IxVM.lean
+++ b/Tests/Ix/IxVM.lean
@@ -174,88 +174,92 @@ public def kernelCheck (name : Lean.Name) (env : Lean.Environment) :
     observed cost in the message so it can be pasted back. -/
 private def kernelCheckEntries : List (String × Nat) := [
   -- Stdlib
-  ("HEq",                                                                1_556_325),
-  ("HEq.rec",                                                            2_417_206),
-  ("Eq.rec",                                                             2_332_891),
-  ("Nat",                                                                1_698_319),
-  ("Nat.add",                                                            11_807_595),
-  ("Nat.add_comm",                                                       48_862_551),
-  ("Nat.decEq",                                                          60_735_735),
-  ("Nat.decLe",                                                          169_311_896),
-  ("Nat.sub_le_of_le_add",                                               451_464_726),
+  ("HEq",                                                                1_559_457),
+  ("HEq.rec",                                                            2_422_967),
+  ("Eq.rec",                                                             2_334_924),
+  ("Nat",                                                                1_698_358),
+  ("Nat.add",                                                            11_824_593),
+  ("Nat.add_comm",                                                       48_903_406),
+  ("Nat.decEq",                                                          60_756_138),
+  ("Nat.decLe",                                                          169_365_021),
+  ("Nat.sub_le_of_le_add",                                               451_516_906),
   -- Offset-stuck regression driver: the succ-step unfold of `x >>> n`
   -- into a symbolic-base `Nat.div` chain. Exercises the div/mod
   -- offset-stuck path where rebuilding the stuck form with the wrong
   -- (add) head corrupted offset-aware def-eq and sent `x >>> k`
   -- comparisons into full delta-unfolds of the division algorithm.
-  ("Nat.shiftRight_succ",                                                329_837_593),
+  ("Nat.shiftRight_succ",                                                329_890_406),
   -- Newly-unlocked targets (level_leq Géran normalize).
-  ("Trans.mk",                                                           2_496_254),
-  ("Array.append_assoc",                                                 2_146_268_992),
-  ("Vector.append",                                                      2_209_763_282),
+  ("Trans.mk",                                                           2_544_904),
+  ("Array.append_assoc",                                                 2_145_425_940),
+  ("Vector.append",                                                      2_208_909_265),
   -- Primitive reduction theorems (`IxVMPrim`)
-  ("IxVMPrim.nat_add_lit",                                               25_451_208),
-  ("IxVMPrim.nat_sub_lit",                                               30_768_469),
-  ("IxVMPrim.nat_mul_lit",                                               22_451_656),
-  ("IxVMPrim.nat_mul_big",                                               21_923_403),
-  ("IxVMPrim.nat_div_lit",                                               321_613_602),
-  ("IxVMPrim.nat_mod_lit",                                               329_070_141),
-  ("IxVMPrim.nat_succ_lit",                                              6_677_777),
-  ("IxVMPrim.nat_pred_lit",                                              13_440_574),
-  ("IxVMPrim.nat_gcd_lit",                                               532_112_594),
-  ("IxVMPrim.nat_land_lit",                                              897_490_342),
-  ("IxVMPrim.nat_lor_lit",                                               898_170_281),
-  ("IxVMPrim.nat_xor_lit",                                               905_661_853),
-  ("IxVMPrim.nat_shl_lit",                                               31_708_857),
-  ("IxVMPrim.nat_shr_lit",                                               326_185_139),
-  ("IxVMPrim.nat_pow_big",                                                67_182_360),
-  ("IxVMPrim.nat_beq_lit",                                               22_013_834),
-  ("IxVMPrim.nat_ble_lit",                                               20_430_778),
-  ("IxVMPrim.nat_cases_big",                                             13_066_372),
-  ("IxVMPrim.nat_dec_le",                                                175_198_740),
-  ("IxVMPrim.nat_dec_lt",                                                178_855_101),
-  ("IxVMPrim.nat_dec_eq",                                                73_094_332),
-  ("IxVMPrim.str_size_lit",                                              639_000_365),
-  ("IxVMPrim.bv_to_nat_lit",                                             508_333_530),
+  ("IxVMPrim.nat_add_lit",                                               25_490_589),
+  ("IxVMPrim.nat_sub_lit",                                               30_807_699),
+  ("IxVMPrim.nat_mul_lit",                                               22_473_906),
+  ("IxVMPrim.nat_mul_big",                                               21_945_653),
+  ("IxVMPrim.nat_div_lit",                                               321_666_423),
+  ("IxVMPrim.nat_mod_lit",                                               329_123_683),
+  ("IxVMPrim.nat_succ_lit",                                              6_681_409),
+  ("IxVMPrim.nat_pred_lit",                                              13_443_881),
+  ("IxVMPrim.nat_gcd_lit",                                               532_187_335),
+  ("IxVMPrim.nat_land_lit",                                              897_558_707),
+  ("IxVMPrim.nat_lor_lit",                                               898_238_645),
+  ("IxVMPrim.nat_xor_lit",                                               905_734_695),
+  ("IxVMPrim.nat_shl_lit",                                               31_748_169),
+  ("IxVMPrim.nat_shr_lit",                                               326_237_956),
+  ("IxVMPrim.nat_pow_big",                                                67_235_827),
+  ("IxVMPrim.nat_beq_lit",                                               22_035_997),
+  ("IxVMPrim.nat_ble_lit",                                               20_452_984),
+  ("IxVMPrim.nat_cases_big",                                             13_069_681),
+  ("IxVMPrim.nat_dec_le",                                                175_251_856),
+  ("IxVMPrim.nat_dec_lt",                                                178_908_210),
+  ("IxVMPrim.nat_dec_eq",                                                73_119_688),
+  ("IxVMPrim.str_size_lit",                                              639_122_173),
+  ("IxVMPrim.bv_to_nat_lit",                                             508_393_723),
   -- Mutual block + multi-member recursors
-  ("IxVMInd.Even",                                                       23_637_408),
-  ("IxVMInd.Odd",                                                        23_394_275),
-  ("IxVMInd.Even.rec",                                                   28_757_667),
-  ("IxVMInd.Odd.rec",                                                    28_754_892),
+  ("IxVMInd.Even",                                                       23_674_961),
+  ("IxVMInd.Odd",                                                        23_431_829),
+  ("IxVMInd.Even.rec",                                                   28_795_159),
+  ("IxVMInd.Odd.rec",                                                    28_792_384),
   -- Nested inductive + aux recursor (Tree.mk : List Tree → Tree)
-  ("IxVMInd.Tree",                                                       2_414_963),
-  ("IxVMInd.Tree.rec",                                                   4_420_378),
+  ("IxVMInd.Tree",                                                       2_415_201),
+  ("IxVMInd.Tree.rec",                                                   4_420_813),
   -- Aux dedup: distinct spec_params on one external inductive (3 motives).
-  ("IxVMInd.DedupM",                                                     4_450_073),
-  ("IxVMInd.DedupM.rec",                                                 7_290_469),
+  ("IxVMInd.DedupM",                                                     4_449_694),
+  ("IxVMInd.DedupM.rec",                                                 7_290_226),
   -- Aux dedup de-lift guard: equal spec_params at field depths 0 and 2.
-  ("IxVMInd.DepthM",                                                     3_321_184),
-  ("IxVMInd.DepthM.rec",                                                 5_736_786),
+  ("IxVMInd.DepthM",                                                     3_320_804),
+  ("IxVMInd.DepthM.rec",                                                 5_736_811),
   -- Edge cases from prelude
-  ("String.Internal.append",                                             631_825_540),
-  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_425_856),
+  ("String.Internal.append",                                             631_896_616),
+  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_561_008),
   -- Aux recursor with transitively-nested inductives (Syntax → Array Syntax
   -- → List Syntax); shard 53 regression driver.
-  ("Lean.Syntax.rec",                                                    655_644_211),
+  ("Lean.Syntax.rec",                                                    655_699_286),
   -- Canonical aux order with structurally-distinct exts that tie weak
   -- through sentinels: the trailing identity marker must decide by
   -- external address, matching compile order (the Lean.Json.rec bug;
   -- Json itself is ~68G FFT, far too heavy to pin here). AuxTie is
   -- verified to fail on the pre-marker kernel.
-  ("IxVMInd.AuxTie",                                                     70_764_778),
-  ("IxVMInd.AuxTie.rec",                                                 79_624_774),
+  ("IxVMInd.AuxTie",                                                     70_815_273),
+  ("IxVMInd.AuxTie.rec",                                                 79_674_787),
   -- Parameterized Prop class whose ctor field references the params
   -- under local ∀-binders: is_rec_field's classification whnf must not
   -- build a context from the peeled binder doms (frame-level param refs
   -- give those doms loose ranges exceeding the local depth, running the
   -- ctx-trim cut walk off the end of the list).
-  ("String.Slice.Pattern.Model.NoPrefixForwardPatternModel.rec",         883_544_272),
+  ("String.Slice.Pattern.Model.NoPrefixForwardPatternModel.rec",         883_639_264),
   -- Universe-polymorphic nested inductive: aux occurrence universes must
   -- carry the univ_offset-shifted frame into minor construction.
-  ("Lean.Widget.TaggedText.rec",                                         637_083_287),
+  ("Lean.Widget.TaggedText.rec",                                         637_139_675),
   -- Aux-member recursors: the canonical param walk peels the PRIMARY
   -- inductive's type, not self's.
-  ("Lean.Doc.Part.rec",                                                  663_464_071),
+  ("Lean.Doc.Part.rec",                                                  663_597_364),
+  -- Multi-aux mutual block whose canonical aux order hinges on comparing
+  -- stored (Succ-distributed-into-Max) levels structurally: level_max
+  -- must not factor Succ back out of Max.
+  ("Lean.Doc.Block.rec",                                                 696_384_995),
   -- Evaporated-aux canonicalization (Tests/Ix/Compile/Mutual.lean AuxDedup*):
   -- SCC splitting strands `rec_N` auxes whose spec-param inductives moved to
   -- other SCCs; their claims alias the external inductive's recursor
@@ -263,15 +267,15 @@ private def kernelCheckEntries : List (String × Nat) := [
   -- whose claims are literally the same `List.rec` closure. AuxDedupMixed
   -- mixes one genuine canonical aux (`M.rec_1`, over `List M`) with one
   -- evaporated alias (`M.rec_2`, over `List B`).
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A",             3_270_587),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec",         4_089_552),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_1",       2_809_784),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_2",       2_809_784),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup2.A.rec_1",       2_809_784),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M",         3_303_388),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec",     5_653_750),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_1",   5_655_750),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_2",   2_809_784),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A",             3_270_820),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec",         4_090_056),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_1",       2_809_929),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_2",       2_809_929),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup2.A.rec_1",       2_809_929),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M",         3_303_621),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec",     5_654_142),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_1",   5_656_143),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_2",   2_809_929),
 ]
 
 private def nameOfString (str : String) : Lean.Name :=

--- a/Tests/Ix/IxVM.lean
+++ b/Tests/Ix/IxVM.lean
@@ -113,6 +113,31 @@ public inductive Bar1 (α : Type) where
 public inductive DepthM (α : Type) where
   | mk : Bar1 (DepthM α) → Nat → Bar1 (DepthM α) → DepthM α
 
+-- Canonical-aux-order marker driver (the Lean.Json.rec bug shape,
+-- verified failing on the pre-marker kernel): WrapC/WrapI are
+-- same-shaped wrappers over same-shaped containers with different
+-- payloads (Char vs Int). The wraps' aux views tie weak through
+-- sentinels; pre-marker they resolved by the containers' refinement-
+-- class order (payload address), which for this payload pair disagrees
+-- with the compile-side order. Only the trailing identity marker
+-- (ext applied to spec params, external consts by address) recovers
+-- compile order.
+public inductive CellC (α : Type) where
+  | mk : α → Char → CellC α
+
+public inductive CellI (α : Type) where
+  | mk : α → Int → CellI α
+
+public inductive WrapC (α : Type) where
+  | mk : CellC α → WrapC α
+
+public inductive WrapI (α : Type) where
+  | mk : CellI α → WrapI α
+
+public inductive AuxTie where
+  | c : WrapC AuxTie → AuxTie
+  | i : WrapI AuxTie → AuxTie
+
 end IxVMInd
 
 /-! ## Test runners -/
@@ -202,7 +227,7 @@ private def kernelCheckEntries : List (String × Nat) := [
   ("IxVMInd.Tree.rec",                                                   4_420_271),
   -- Aux dedup: distinct spec_params on one external inductive (3 motives).
   ("IxVMInd.DedupM",                                                     4_450_073),
-  ("IxVMInd.DedupM.rec",                                                 7_284_018),
+  ("IxVMInd.DedupM.rec",                                                 7_290_244),
   -- Aux dedup de-lift guard: equal spec_params at field depths 0 and 2.
   ("IxVMInd.DepthM",                                                     3_321_184),
   ("IxVMInd.DepthM.rec",                                                 5_739_958),
@@ -211,7 +236,14 @@ private def kernelCheckEntries : List (String × Nat) := [
   ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_420_819),
   -- Aux recursor with transitively-nested inductives (Syntax → Array Syntax
   -- → List Syntax); shard 53 regression driver.
-  ("Lean.Syntax.rec",                                                    655_636_606),
+  ("Lean.Syntax.rec",                                                    655_639_415),
+  -- Canonical aux order with structurally-distinct exts that tie weak
+  -- through sentinels: the trailing identity marker must decide by
+  -- external address, matching compile order (the Lean.Json.rec bug;
+  -- Json itself is ~68G FFT, far too heavy to pin here). AuxTie is
+  -- verified to fail on the pre-marker kernel.
+  ("IxVMInd.AuxTie",                                                     70_764_688),
+  ("IxVMInd.AuxTie.rec",                                                 79_623_363),
   -- Evaporated-aux canonicalization (Tests/Ix/Compile/Mutual.lean AuxDedup*):
   -- SCC splitting strands `rec_N` auxes whose spec-param inductives moved to
   -- other SCCs; their claims alias the external inductive's recursor

--- a/Tests/Ix/IxVM.lean
+++ b/Tests/Ix/IxVM.lean
@@ -178,72 +178,78 @@ private def kernelCheckEntries : List (String × Nat) := [
   ("HEq.rec",                                                            2_416_399),
   ("Eq.rec",                                                             2_332_121),
   ("Nat",                                                                1_698_319),
-  ("Nat.add",                                                            11_807_504),
-  ("Nat.add_comm",                                                       48_861_132),
-  ("Nat.decEq",                                                          60_734_041),
-  ("Nat.decLe",                                                          169_310_370),
-  ("Nat.sub_le_of_le_add",                                               451_462_297),
+  ("Nat.add",                                                            11_807_536),
+  ("Nat.add_comm",                                                       48_861_164),
+  ("Nat.decEq",                                                          60_734_073),
+  ("Nat.decLe",                                                          169_306_538),
+  ("Nat.sub_le_of_le_add",                                               451_457_296),
   -- Offset-stuck regression driver: the succ-step unfold of `x >>> n`
   -- into a symbolic-base `Nat.div` chain. Exercises the div/mod
   -- offset-stuck path where rebuilding the stuck form with the wrong
   -- (add) head corrupted offset-aware def-eq and sent `x >>> k`
   -- comparisons into full delta-unfolds of the division algorithm.
-  ("Nat.shiftRight_succ",                                                329_836_066),
+  ("Nat.shiftRight_succ",                                                329_831_133),
   -- Newly-unlocked targets (level_leq Géran normalize).
   ("Trans.mk",                                                           2_496_254),
-  ("Array.append_assoc",                                                 2_146_262_349),
-  ("Vector.append",                                                      2_209_756_647),
+  ("Array.append_assoc",                                                 2_146_252_953),
+  ("Vector.append",                                                      2_209_747_230),
   -- Primitive reduction theorems (`IxVMPrim`)
-  ("IxVMPrim.nat_add_lit",                                               25_451_118),
-  ("IxVMPrim.nat_sub_lit",                                               30_768_378),
-  ("IxVMPrim.nat_mul_lit",                                               22_451_565),
-  ("IxVMPrim.nat_mul_big",                                               21_923_312),
-  ("IxVMPrim.nat_div_lit",                                               321_612_085),
-  ("IxVMPrim.nat_mod_lit",                                               329_068_630),
+  ("IxVMPrim.nat_add_lit",                                               25_451_150),
+  ("IxVMPrim.nat_sub_lit",                                               30_768_410),
+  ("IxVMPrim.nat_mul_lit",                                               22_451_597),
+  ("IxVMPrim.nat_mul_big",                                               21_923_344),
+  ("IxVMPrim.nat_div_lit",                                               321_607_170),
+  ("IxVMPrim.nat_mod_lit",                                               329_063_705),
   ("IxVMPrim.nat_succ_lit",                                              6_677_777),
-  ("IxVMPrim.nat_pred_lit",                                              13_440_484),
-  ("IxVMPrim.nat_gcd_lit",                                               532_108_947),
-  ("IxVMPrim.nat_land_lit",                                              897_482_110),
-  ("IxVMPrim.nat_lor_lit",                                               898_162_047),
-  ("IxVMPrim.nat_xor_lit",                                               905_653_630),
-  ("IxVMPrim.nat_shl_lit",                                               31_708_766),
-  ("IxVMPrim.nat_shr_lit",                                               326_183_624),
-  ("IxVMPrim.nat_pow_big",                                                67_182_269),
-  ("IxVMPrim.nat_beq_lit",                                               22_013_744),
-  ("IxVMPrim.nat_ble_lit",                                               20_430_687),
-  ("IxVMPrim.nat_cases_big",                                             13_066_282),
-  ("IxVMPrim.nat_dec_le",                                                175_197_216),
-  ("IxVMPrim.nat_dec_lt",                                                178_853_566),
-  ("IxVMPrim.nat_dec_eq",                                                73_092_188),
-  ("IxVMPrim.str_size_lit",                                              638_996_410),
-  ("IxVMPrim.bv_to_nat_lit",                                             508_331_308),
+  ("IxVMPrim.nat_pred_lit",                                              13_440_516),
+  ("IxVMPrim.nat_gcd_lit",                                               532_103_382),
+  ("IxVMPrim.nat_land_lit",                                              897_473_285),
+  ("IxVMPrim.nat_lor_lit",                                               898_153_222),
+  ("IxVMPrim.nat_xor_lit",                                               905_644_794),
+  ("IxVMPrim.nat_shl_lit",                                               31_708_798),
+  ("IxVMPrim.nat_shr_lit",                                               326_178_706),
+  ("IxVMPrim.nat_pow_big",                                                67_182_301),
+  ("IxVMPrim.nat_beq_lit",                                               22_013_776),
+  ("IxVMPrim.nat_ble_lit",                                               20_430_719),
+  ("IxVMPrim.nat_cases_big",                                             13_066_314),
+  ("IxVMPrim.nat_dec_le",                                                175_193_377),
+  ("IxVMPrim.nat_dec_lt",                                                178_849_722),
+  ("IxVMPrim.nat_dec_eq",                                                73_092_400),
+  ("IxVMPrim.str_size_lit",                                              638_990_482),
+  ("IxVMPrim.bv_to_nat_lit",                                             508_326_806),
   -- Mutual block + multi-member recursors
-  ("IxVMInd.Even",                                                       23_637_318),
-  ("IxVMInd.Odd",                                                        23_394_185),
-  ("IxVMInd.Even.rec",                                                   28_754_578),
-  ("IxVMInd.Odd.rec",                                                    28_751_803),
+  ("IxVMInd.Even",                                                       23_637_350),
+  ("IxVMInd.Odd",                                                        23_394_217),
+  ("IxVMInd.Even.rec",                                                   28_757_483),
+  ("IxVMInd.Odd.rec",                                                    28_754_708),
   -- Nested inductive + aux recursor (Tree.mk : List Tree → Tree)
   ("IxVMInd.Tree",                                                       2_414_963),
-  ("IxVMInd.Tree.rec",                                                   4_420_271),
+  ("IxVMInd.Tree.rec",                                                   4_420_360),
   -- Aux dedup: distinct spec_params on one external inductive (3 motives).
   ("IxVMInd.DedupM",                                                     4_450_073),
-  ("IxVMInd.DedupM.rec",                                                 7_290_244),
+  ("IxVMInd.DedupM.rec",                                                 7_290_397),
   -- Aux dedup de-lift guard: equal spec_params at field depths 0 and 2.
   ("IxVMInd.DepthM",                                                     3_321_184),
-  ("IxVMInd.DepthM.rec",                                                 5_739_958),
+  ("IxVMInd.DepthM.rec",                                                 5_736_672),
   -- Edge cases from prelude
-  ("String.Internal.append",                                             631_821_582),
-  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_420_819),
+  ("String.Internal.append",                                             631_815_659),
+  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_413_174),
   -- Aux recursor with transitively-nested inductives (Syntax → Array Syntax
   -- → List Syntax); shard 53 regression driver.
-  ("Lean.Syntax.rec",                                                    655_639_415),
+  ("Lean.Syntax.rec",                                                    655_634_037),
   -- Canonical aux order with structurally-distinct exts that tie weak
   -- through sentinels: the trailing identity marker must decide by
   -- external address, matching compile order (the Lean.Json.rec bug;
   -- Json itself is ~68G FFT, far too heavy to pin here). AuxTie is
   -- verified to fail on the pre-marker kernel.
-  ("IxVMInd.AuxTie",                                                     70_764_688),
-  ("IxVMInd.AuxTie.rec",                                                 79_623_363),
+  ("IxVMInd.AuxTie",                                                     70_764_720),
+  ("IxVMInd.AuxTie.rec",                                                 79_624_475),
+  -- Parameterized Prop class whose ctor field references the params
+  -- under local ∀-binders: is_rec_field's classification whnf must not
+  -- build a context from the peeled binder doms (frame-level param refs
+  -- give those doms loose ranges exceeding the local depth, running the
+  -- ctx-trim cut walk off the end of the list).
+  ("String.Slice.Pattern.Model.NoPrefixForwardPatternModel.rec",         883_530_683),
   -- Evaporated-aux canonicalization (Tests/Ix/Compile/Mutual.lean AuxDedup*):
   -- SCC splitting strands `rec_N` auxes whose spec-param inductives moved to
   -- other SCCs; their claims alias the external inductive's recursor
@@ -252,14 +258,14 @@ private def kernelCheckEntries : List (String × Nat) := [
   -- mixes one genuine canonical aux (`M.rec_1`, over `List M`) with one
   -- evaporated alias (`M.rec_2`, over `List B`).
   ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A",             3_270_587),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec",         4_089_781),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_1",       2_808_766),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_2",       2_808_766),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup2.A.rec_1",       2_808_766),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec",         4_089_499),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_1",       2_808_314),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_2",       2_808_314),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup2.A.rec_1",       2_808_314),
   ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M",         3_303_388),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec",     5_653_817),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_1",   5_655_817),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_2",   2_808_766),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec",     5_653_733),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_1",   5_655_733),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_2",   2_808_314),
 ]
 
 private def nameOfString (str : String) : Lean.Name :=

--- a/Tests/Ix/IxVM.lean
+++ b/Tests/Ix/IxVM.lean
@@ -175,81 +175,87 @@ public def kernelCheck (name : Lean.Name) (env : Lean.Environment) :
 private def kernelCheckEntries : List (String × Nat) := [
   -- Stdlib
   ("HEq",                                                                1_556_325),
-  ("HEq.rec",                                                            2_416_399),
-  ("Eq.rec",                                                             2_332_121),
+  ("HEq.rec",                                                            2_417_206),
+  ("Eq.rec",                                                             2_332_891),
   ("Nat",                                                                1_698_319),
-  ("Nat.add",                                                            11_807_536),
-  ("Nat.add_comm",                                                       48_861_164),
-  ("Nat.decEq",                                                          60_734_073),
-  ("Nat.decLe",                                                          169_306_538),
-  ("Nat.sub_le_of_le_add",                                               451_457_296),
+  ("Nat.add",                                                            11_807_595),
+  ("Nat.add_comm",                                                       48_862_551),
+  ("Nat.decEq",                                                          60_735_735),
+  ("Nat.decLe",                                                          169_311_896),
+  ("Nat.sub_le_of_le_add",                                               451_464_726),
   -- Offset-stuck regression driver: the succ-step unfold of `x >>> n`
   -- into a symbolic-base `Nat.div` chain. Exercises the div/mod
   -- offset-stuck path where rebuilding the stuck form with the wrong
   -- (add) head corrupted offset-aware def-eq and sent `x >>> k`
   -- comparisons into full delta-unfolds of the division algorithm.
-  ("Nat.shiftRight_succ",                                                329_831_133),
+  ("Nat.shiftRight_succ",                                                329_837_593),
   -- Newly-unlocked targets (level_leq Géran normalize).
   ("Trans.mk",                                                           2_496_254),
-  ("Array.append_assoc",                                                 2_146_252_953),
-  ("Vector.append",                                                      2_209_747_230),
+  ("Array.append_assoc",                                                 2_146_268_992),
+  ("Vector.append",                                                      2_209_763_282),
   -- Primitive reduction theorems (`IxVMPrim`)
-  ("IxVMPrim.nat_add_lit",                                               25_451_150),
-  ("IxVMPrim.nat_sub_lit",                                               30_768_410),
-  ("IxVMPrim.nat_mul_lit",                                               22_451_597),
-  ("IxVMPrim.nat_mul_big",                                               21_923_344),
-  ("IxVMPrim.nat_div_lit",                                               321_607_170),
-  ("IxVMPrim.nat_mod_lit",                                               329_063_705),
+  ("IxVMPrim.nat_add_lit",                                               25_451_208),
+  ("IxVMPrim.nat_sub_lit",                                               30_768_469),
+  ("IxVMPrim.nat_mul_lit",                                               22_451_656),
+  ("IxVMPrim.nat_mul_big",                                               21_923_403),
+  ("IxVMPrim.nat_div_lit",                                               321_613_602),
+  ("IxVMPrim.nat_mod_lit",                                               329_070_141),
   ("IxVMPrim.nat_succ_lit",                                              6_677_777),
-  ("IxVMPrim.nat_pred_lit",                                              13_440_516),
-  ("IxVMPrim.nat_gcd_lit",                                               532_103_382),
-  ("IxVMPrim.nat_land_lit",                                              897_473_285),
-  ("IxVMPrim.nat_lor_lit",                                               898_153_222),
-  ("IxVMPrim.nat_xor_lit",                                               905_644_794),
-  ("IxVMPrim.nat_shl_lit",                                               31_708_798),
-  ("IxVMPrim.nat_shr_lit",                                               326_178_706),
-  ("IxVMPrim.nat_pow_big",                                                67_182_301),
-  ("IxVMPrim.nat_beq_lit",                                               22_013_776),
-  ("IxVMPrim.nat_ble_lit",                                               20_430_719),
-  ("IxVMPrim.nat_cases_big",                                             13_066_314),
-  ("IxVMPrim.nat_dec_le",                                                175_193_377),
-  ("IxVMPrim.nat_dec_lt",                                                178_849_722),
-  ("IxVMPrim.nat_dec_eq",                                                73_092_400),
-  ("IxVMPrim.str_size_lit",                                              638_990_482),
-  ("IxVMPrim.bv_to_nat_lit",                                             508_326_806),
+  ("IxVMPrim.nat_pred_lit",                                              13_440_574),
+  ("IxVMPrim.nat_gcd_lit",                                               532_112_594),
+  ("IxVMPrim.nat_land_lit",                                              897_490_342),
+  ("IxVMPrim.nat_lor_lit",                                               898_170_281),
+  ("IxVMPrim.nat_xor_lit",                                               905_661_853),
+  ("IxVMPrim.nat_shl_lit",                                               31_708_857),
+  ("IxVMPrim.nat_shr_lit",                                               326_185_139),
+  ("IxVMPrim.nat_pow_big",                                                67_182_360),
+  ("IxVMPrim.nat_beq_lit",                                               22_013_834),
+  ("IxVMPrim.nat_ble_lit",                                               20_430_778),
+  ("IxVMPrim.nat_cases_big",                                             13_066_372),
+  ("IxVMPrim.nat_dec_le",                                                175_198_740),
+  ("IxVMPrim.nat_dec_lt",                                                178_855_101),
+  ("IxVMPrim.nat_dec_eq",                                                73_094_332),
+  ("IxVMPrim.str_size_lit",                                              639_000_365),
+  ("IxVMPrim.bv_to_nat_lit",                                             508_333_530),
   -- Mutual block + multi-member recursors
-  ("IxVMInd.Even",                                                       23_637_350),
-  ("IxVMInd.Odd",                                                        23_394_217),
-  ("IxVMInd.Even.rec",                                                   28_757_483),
-  ("IxVMInd.Odd.rec",                                                    28_754_708),
+  ("IxVMInd.Even",                                                       23_637_408),
+  ("IxVMInd.Odd",                                                        23_394_275),
+  ("IxVMInd.Even.rec",                                                   28_757_667),
+  ("IxVMInd.Odd.rec",                                                    28_754_892),
   -- Nested inductive + aux recursor (Tree.mk : List Tree → Tree)
   ("IxVMInd.Tree",                                                       2_414_963),
-  ("IxVMInd.Tree.rec",                                                   4_420_360),
+  ("IxVMInd.Tree.rec",                                                   4_420_378),
   -- Aux dedup: distinct spec_params on one external inductive (3 motives).
   ("IxVMInd.DedupM",                                                     4_450_073),
-  ("IxVMInd.DedupM.rec",                                                 7_290_397),
+  ("IxVMInd.DedupM.rec",                                                 7_290_469),
   -- Aux dedup de-lift guard: equal spec_params at field depths 0 and 2.
   ("IxVMInd.DepthM",                                                     3_321_184),
-  ("IxVMInd.DepthM.rec",                                                 5_736_672),
+  ("IxVMInd.DepthM.rec",                                                 5_736_786),
   -- Edge cases from prelude
-  ("String.Internal.append",                                             631_815_659),
-  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_413_174),
+  ("String.Internal.append",                                             631_825_540),
+  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_425_856),
   -- Aux recursor with transitively-nested inductives (Syntax → Array Syntax
   -- → List Syntax); shard 53 regression driver.
-  ("Lean.Syntax.rec",                                                    655_634_037),
+  ("Lean.Syntax.rec",                                                    655_644_211),
   -- Canonical aux order with structurally-distinct exts that tie weak
   -- through sentinels: the trailing identity marker must decide by
   -- external address, matching compile order (the Lean.Json.rec bug;
   -- Json itself is ~68G FFT, far too heavy to pin here). AuxTie is
   -- verified to fail on the pre-marker kernel.
-  ("IxVMInd.AuxTie",                                                     70_764_720),
-  ("IxVMInd.AuxTie.rec",                                                 79_624_475),
+  ("IxVMInd.AuxTie",                                                     70_764_778),
+  ("IxVMInd.AuxTie.rec",                                                 79_624_774),
   -- Parameterized Prop class whose ctor field references the params
   -- under local ∀-binders: is_rec_field's classification whnf must not
   -- build a context from the peeled binder doms (frame-level param refs
   -- give those doms loose ranges exceeding the local depth, running the
   -- ctx-trim cut walk off the end of the list).
-  ("String.Slice.Pattern.Model.NoPrefixForwardPatternModel.rec",         883_530_683),
+  ("String.Slice.Pattern.Model.NoPrefixForwardPatternModel.rec",         883_544_272),
+  -- Universe-polymorphic nested inductive: aux occurrence universes must
+  -- carry the univ_offset-shifted frame into minor construction.
+  ("Lean.Widget.TaggedText.rec",                                         637_083_287),
+  -- Aux-member recursors: the canonical param walk peels the PRIMARY
+  -- inductive's type, not self's.
+  ("Lean.Doc.Part.rec",                                                  663_464_071),
   -- Evaporated-aux canonicalization (Tests/Ix/Compile/Mutual.lean AuxDedup*):
   -- SCC splitting strands `rec_N` auxes whose spec-param inductives moved to
   -- other SCCs; their claims alias the external inductive's recursor
@@ -258,14 +264,14 @@ private def kernelCheckEntries : List (String × Nat) := [
   -- mixes one genuine canonical aux (`M.rec_1`, over `List M`) with one
   -- evaporated alias (`M.rec_2`, over `List B`).
   ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A",             3_270_587),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec",         4_089_499),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_1",       2_808_314),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_2",       2_808_314),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup2.A.rec_1",       2_808_314),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec",         4_089_552),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_1",       2_809_784),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup1.A.rec_2",       2_809_784),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedup2.A.rec_1",       2_809_784),
   ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M",         3_303_388),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec",     5_653_733),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_1",   5_655_733),
-  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_2",   2_808_314),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec",     5_653_750),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_1",   5_655_750),
+  ("_private.Tests.Ix.Compile.Mutual.0.Tests.Ix.Compile.Mutual.AuxDedupMixed.M.rec_2",   2_809_784),
 ]
 
 private def nameOfString (str : String) : Lean.Name :=

--- a/Tests/Ix/IxVM.lean
+++ b/Tests/Ix/IxVM.lean
@@ -56,6 +56,12 @@ public theorem nat_pow_big : (2 ^ 16384 : Nat) - (2 ^ 16384) = 0 := rfl
 public theorem nat_beq_lit : Nat.beq 42 42 = true := rfl
 public theorem nat_ble_lit : Nat.ble 5 10 = true := rfl
 
+-- Limb-boundary iota: Nat.casesOn on a literal ≥ 2^32 forces the kernel's
+-- one-layer ctor exposure across a limb boundary, where an unnormalized
+-- `klimbs_dec` (trailing zero limb) sends the countdown past zero forever.
+public theorem nat_cases_big :
+    (match (4294967296 : Nat) with | 0 => (0 : Nat) | n+1 => n) = 4294967295 := rfl
+
 -- Decidable instances (try_reduce_decidable)
 public theorem nat_dec_le : decide (5 ≤ 10) = true := rfl
 public theorem nat_dec_lt : decide (5 < 10) = true := rfl
@@ -147,43 +153,50 @@ private def kernelCheckEntries : List (String × Nat) := [
   ("HEq.rec",                                                            2_416_399),
   ("Eq.rec",                                                             2_332_121),
   ("Nat",                                                                1_698_319),
-  ("Nat.add",                                                            11_807_476),
-  ("Nat.add_comm",                                                       48_860_647),
-  ("Nat.decEq",                                                          60_733_582),
-  ("Nat.decLe",                                                          169_309_603),
-  ("Nat.sub_le_of_le_add",                                               451_458_671),
+  ("Nat.add",                                                            11_807_504),
+  ("Nat.add_comm",                                                       48_861_132),
+  ("Nat.decEq",                                                          60_734_041),
+  ("Nat.decLe",                                                          169_310_370),
+  ("Nat.sub_le_of_le_add",                                               451_462_297),
+  -- Offset-stuck regression driver: the succ-step unfold of `x >>> n`
+  -- into a symbolic-base `Nat.div` chain. Exercises the div/mod
+  -- offset-stuck path where rebuilding the stuck form with the wrong
+  -- (add) head corrupted offset-aware def-eq and sent `x >>> k`
+  -- comparisons into full delta-unfolds of the division algorithm.
+  ("Nat.shiftRight_succ",                                                329_836_066),
   -- Newly-unlocked targets (level_leq Géran normalize).
   ("Trans.mk",                                                           2_496_254),
-  ("Array.append_assoc",                                                 2_146_251_810),
-  ("Vector.append",                                                      2_209_745_406),
+  ("Array.append_assoc",                                                 2_146_262_349),
+  ("Vector.append",                                                      2_209_756_647),
   -- Primitive reduction theorems (`IxVMPrim`)
-  ("IxVMPrim.nat_add_lit",                                               25_451_079),
-  ("IxVMPrim.nat_sub_lit",                                               30_768_340),
-  ("IxVMPrim.nat_mul_lit",                                               22_451_527),
-  ("IxVMPrim.nat_mul_big",                                               21_923_274),
-  ("IxVMPrim.nat_div_lit",                                               321_609_831),
-  ("IxVMPrim.nat_mod_lit",                                               329_066_375),
-  ("IxVMPrim.nat_succ_lit",                                              6_677_774),
-  ("IxVMPrim.nat_pred_lit",                                              13_440_481),
-  ("IxVMPrim.nat_gcd_lit",                                               532_104_752),
-  ("IxVMPrim.nat_land_lit",                                              897_109_605),
-  ("IxVMPrim.nat_lor_lit",                                               897_790_962),
-  ("IxVMPrim.nat_xor_lit",                                               905_298_820),
-  ("IxVMPrim.nat_shl_lit",                                               31_708_728),
-  ("IxVMPrim.nat_shr_lit",                                               326_181_369),
-  ("IxVMPrim.nat_pow_big",                                                67_182_209),
-  ("IxVMPrim.nat_beq_lit",                                               22_013_696),
-  ("IxVMPrim.nat_ble_lit",                                               20_430_639),
-  ("IxVMPrim.nat_dec_le",                                                175_196_431),
-  ("IxVMPrim.nat_dec_lt",                                                178_852_761),
-  ("IxVMPrim.nat_dec_eq",                                                73_091_714),
-  ("IxVMPrim.str_size_lit",                                              638_992_249),
-  ("IxVMPrim.bv_to_nat_lit",                                             508_327_246),
+  ("IxVMPrim.nat_add_lit",                                               25_451_118),
+  ("IxVMPrim.nat_sub_lit",                                               30_768_378),
+  ("IxVMPrim.nat_mul_lit",                                               22_451_565),
+  ("IxVMPrim.nat_mul_big",                                               21_923_312),
+  ("IxVMPrim.nat_div_lit",                                               321_612_085),
+  ("IxVMPrim.nat_mod_lit",                                               329_068_630),
+  ("IxVMPrim.nat_succ_lit",                                              6_677_777),
+  ("IxVMPrim.nat_pred_lit",                                              13_440_484),
+  ("IxVMPrim.nat_gcd_lit",                                               532_108_947),
+  ("IxVMPrim.nat_land_lit",                                              897_482_110),
+  ("IxVMPrim.nat_lor_lit",                                               898_162_047),
+  ("IxVMPrim.nat_xor_lit",                                               905_653_630),
+  ("IxVMPrim.nat_shl_lit",                                               31_708_766),
+  ("IxVMPrim.nat_shr_lit",                                               326_183_624),
+  ("IxVMPrim.nat_pow_big",                                                67_182_269),
+  ("IxVMPrim.nat_beq_lit",                                               22_013_744),
+  ("IxVMPrim.nat_ble_lit",                                               20_430_687),
+  ("IxVMPrim.nat_cases_big",                                             13_066_282),
+  ("IxVMPrim.nat_dec_le",                                                175_197_216),
+  ("IxVMPrim.nat_dec_lt",                                                178_853_566),
+  ("IxVMPrim.nat_dec_eq",                                                73_092_188),
+  ("IxVMPrim.str_size_lit",                                              638_996_410),
+  ("IxVMPrim.bv_to_nat_lit",                                             508_331_308),
   -- Mutual block + multi-member recursors
-  ("IxVMInd.Even",                                                       23_637_289),
-  ("IxVMInd.Odd",                                                        23_394_156),
-  ("IxVMInd.Even.rec",                                                   28_754_550),
-  ("IxVMInd.Odd.rec",                                                    28_751_775),
+  ("IxVMInd.Even",                                                       23_637_318),
+  ("IxVMInd.Odd",                                                        23_394_185),
+  ("IxVMInd.Even.rec",                                                   28_754_578),
+  ("IxVMInd.Odd.rec",                                                    28_751_803),
   -- Nested inductive + aux recursor (Tree.mk : List Tree → Tree)
   ("IxVMInd.Tree",                                                       2_414_963),
   ("IxVMInd.Tree.rec",                                                   4_420_271),
@@ -194,11 +207,11 @@ private def kernelCheckEntries : List (String × Nat) := [
   ("IxVMInd.DepthM",                                                     3_321_184),
   ("IxVMInd.DepthM.rec",                                                 5_739_958),
   -- Edge cases from prelude
-  ("String.Internal.append",                                             631_817_443),
-  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_415_658),
+  ("String.Internal.append",                                             631_821_582),
+  ("_private.Init.Prelude.0.Lean.extractMainModule._unsafe_rec",         949_420_819),
   -- Aux recursor with transitively-nested inductives (Syntax → Array Syntax
   -- → List Syntax); shard 53 regression driver.
-  ("Lean.Syntax.rec",                                                    655_632_466),
+  ("Lean.Syntax.rec",                                                    655_636_606),
   -- Evaporated-aux canonicalization (Tests/Ix/Compile/Mutual.lean AuxDedup*):
   -- SCC splitting strands `rec_N` auxes whose spec-param inductives moved to
   -- other SCCs; their claims alias the external inductive's recursor


### PR DESCRIPTION
## Summary

This branch fixes six divergences between the IxVM Aiur kernel
(`Ix/IxVM/*.lean`) and the Rust kernel (`crates/kernel/src/*.rs`), found by
shard-checking whole environments: `ix compile → ix profile → ix shard →
ix check --ixe <env> --ixes <manifest> --shard K`, debugging each rejected
constant down to the exact kernel-code divergence and mirroring the Rust
behavior.

With these fixes the IxVM kernel accepts, end to end:

- **Init** (60,598 consts): 2/2 shards
- **Lean** (159,741 consts): 4/4 shards

Every fix ships with a pinned-FFT-cost driver in the ixvm test suite
(`Tests/Ix/IxVM.lean`, `lake test -- --ignored ixvm`), currently green at
644 assertions.

## Fixes (one commit each)

1. **nat offset-stuck head + limb-boundary literal normalization**
   Offset-stuck `Nat.div`/`Nat.mod` applications reduced with a corrupted
   head, and `klimbs_normalize` mis-normalized literals exactly at limb
   boundaries.

2. **trailing identity marker in canonical aux order**
   `compare_aux_view` ignored the trailing identity marker when comparing a
   recursor's canonical aux order, accepting/rejecting the wrong aux
   permutations.

3. **rec-field classification without a local-binder whnf context**
   `is_rec_field` peeled binders with a whnf context carrying local binders;
   the Rust kernel classifies each peel in an empty context. Divergence
   surfaced via ctx-trim frame well-formedness.

4. **aux occurrence-universe shift + primary-type param peel**
   Two divergences in nested-inductive aux handling: occurrence scanning ran
   before instantiating the ctor type at the occurrence universes
   (`expr_inst_levels`), and recursor-type construction peeled params from
   the member's own type instead of `collect_n_doms_whnf` over the primary's
   type.

5. **exact mirror of the Rust max-level constructor**
   `level_max` factored `Succ` out of `Max` nodes; Lean/Rust store
   `Type (max u v)` with `Succ` distributed *into* the `Max`
   (`max (u+1) (v+1)`) and the kernel must preserve that shape. Rewritten as
   an exact mirror (explicit-numeral collapse, zero absorption, subsumption,
   offset comparison), with structural equality (`level_struct_eq`) rather
   than pointer inequality anywhere a "different data" conclusion is needed —
   pointer inequality never implies data inequality.