### PR TITLE
ci: Bench fixes

### DIFF
--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -2,34 +2,24 @@ name: Benchmark main
 
 # Benchmarks tracked on Bencher on every push to main, all reusing the one
 # compiled `.ixe` so the compiler runs once. Every measurement is a single
-# `ix bench run` cell (backend × env × mode) — the same orchestrator local
+# `ix bench run` invocation (backend × env × mode) — the same orchestrator local
 # runs and the !benchmark PR workflow use — converted for upload by
-# `ix bench bmf`:
-#   1. compile      — `ix bench run --backend compile`: serialize the Lean env
-#                     to a `.ixe` (compile-throughput metrics) and cache the
-#                     `.ixe`.
-#   2. prove        — restore that `.ixe` (no recompile) and STARK-check selected
-#                     constants over it via bench-typecheck (Aiur execute + prove).
-#   3. zkvm-execute — restore that `.ixe` and execute the same constants through
-#                     the zkVM hosts (deterministic cycle counts +
-#                     time/throughput/RAM; proving needs a GPU, so execute-only).
-#   4. ooc-check    — restore that `.ixe` and run the out-of-circuit Rust kernel
-#                     (the same kernel, out-of-circuit and parallel — far faster)
-#                     over the whole env, tracking throughput.
-#   5. decompile    — restore that `.ixe` and decompile it back to Lean constants
-#                     (the inverse of step 1); tracks decompile-time /
-#                     throughput / peak-rss.
-#   6. aiur-recursive — the aiur-recursive toy
-#                     (bench-recursive-verifier):
-#                     prove fixed tiny statements, run the in-circuit
-#                     multi-stark verifier over each proof, then prove THAT
-#                     execution — the end-to-end recursion cost. Env-independent
-#                     (no `.ixe`), so it needs only the staged binaries.
-# Each job reports to its own bencher testbed/workload so a threshold reset only
-# touches its own measures. `ix bench run` exits 3 when the kernel REJECTS a
-# constant — the red X lands on that step (no output scraping), while the clean
-# rows still upload (`ix bench bmf` drops every non-ok row, so a rejected or
-# OOM'd constant never becomes a bencher data point).
+# `ix bench bmf`. Three stages, mirroring bench-pr.yml:
+#   1. plan      — `ix bench ci matrix` emits the registry's parameter fan-out
+#                  (Ix/Cli/BenchCmd.lean), each combination carrying its testbed,
+#                  workload, and threshold flags.
+#   2. compile   — `ix bench run --backend compile` per env: serialize the
+#                  Lean env to a `.ixe` (compile-throughput metrics) and
+#                  cache the `.ixe` for the runs.
+#   3. benchmark — ONE job per remaining parameter combination: restore the
+#                  `.ixe` and drive its backend over it (aiur STARK-check, zkVM
+#                  execute, out-of-circuit check, decompile, the
+#                  aiur-recursive toy).
+# Each run reports to its own bencher testbed/workload so a threshold reset
+# only touches its own measures. `ix bench run` exits 3 when the kernel
+# REJECTS a constant — the red X lands on that step (no output scraping),
+# while the clean rows still upload (`ix bench bmf` drops every non-ok row,
+# so a rejected or OOM'd constant never becomes a bencher data point).
 
 on:
   push:
@@ -82,10 +72,10 @@ jobs:
           path: ~/.local/bin
           key: bench-bins-${{ github.sha }}
 
-  # Derive the job matrices from the registry (Ix/Cli/BenchCmd.lean)
-  # via `ix bench ci matrix`, so the benched-env / enabled-backend fan-out is
-  # single-sourced instead of hand-copied per job. Runs beside the compile
-  # job; only the downstream matrix jobs wait on it.
+  # Derive the benchmark matrix from the registry (Ix/Cli/BenchCmd.lean)
+  # via `ix bench ci matrix`, so the parameter fan-out and its upload metadata
+  # are single-sourced instead of hand-copied. Runs beside the compile
+  # job; only the benchmark job waits on it.
   plan:
     needs: build
     # `ci matrix` is a pure-Lean subcommand (AVX-512 lives only in the
@@ -94,8 +84,7 @@ jobs:
     # the FFI.
     runs-on: ubuntu-latest
     outputs:
-      bench-envs: ${{ steps.matrix.outputs.bench-envs }}
-      zkvm-cells: ${{ steps.matrix.outputs.zkvm-cells }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/cache/restore@v6
@@ -112,25 +101,27 @@ jobs:
           use-github-cache: false
       - id: matrix
         run: |
-          ix bench ci matrix --kind cells > cells.json
-          cat cells.json
-          # bench-envs: the benched env names — an env name (e.g. InitStd)
-          # is the single identifier: `ix bench run --env`, the `<env>.ixe`
-          # filename, the cache-key suffix, and the env-keyed bencher
-          # benchmark name.
-          # zkvm-cells: the zkVM subset of the cells (zisk today; sp1 comes
-          # back by re-enabling it in the registry).
-          echo "bench-envs=$(jq -c '[.[].env] | unique' cells.json)" >> "$GITHUB_OUTPUT"
-          echo "zkvm-cells=$(jq -c 'map(select(.backend == "zisk" or .backend == "sp1"))' cells.json)" >> "$GITHUB_OUTPUT"
+          ix bench ci matrix > matrix.json
+          cat matrix.json
+          # Every scheduled parameter combination (backend × env × mode), with its
+          # testbed / workload / threshold metadata from the registry. The
+          # compile runs get their own job below (the `.ixe` producers
+          # everything else restores — no intra-matrix ordering on GitHub),
+          # so the benchmark matrix takes the consumers. An env name (e.g.
+          # InitStd) is the single identifier: `ix bench run --env`, the
+          # `<env>.ixe` filename, the cache-key suffix, and the env-keyed
+          # bencher benchmark name.
+          echo "matrix=$(jq -c 'map(select(.backend == "compile" | not))' matrix.json)" >> "$GITHUB_OUTPUT"
 
   # Compile each library env to a `.ixe` and track compile throughput. Caches
-  # the `.ixe` (keyed by sha + env slug) for the prove job to consume.
+  # the `.ixe` (keyed by sha + env slug) for the benchmark runs to consume.
   compile:
     # Explicit names on the matrix jobs: the default would append every
     # matrix value (slugs, flags) to the job title.
     name: compile-${{ matrix.env }}
     needs: build
     runs-on: warp-ubuntu-latest-x64-32x
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -186,97 +177,112 @@ jobs:
           ix bench run --backend compile --env ${{ matrix.env }} --out bench.json
           ix bench bmf --in bench.json --out benchmark.json
           cat benchmark.json
-      # Gate for the two steps below: is this env benched (registry
-      # `benched: true`)? Derived from the registry via the in-job `ix`
-      # instead of hand-copying the env list into the conditionals.
-      - id: benched
-        name: Is this env benched?
+      # Registry reads for the steps below, all off the same parameter fan-out
+      # the benchmark matrix uses (no hand-copied env lists or upload
+      # metadata):
+      #   consumed — some downstream run restores this env's `.ixe`.
+      #   zkvm     — a zkVM run executes it, so pre-cut its closure shards.
+      #   testbed / workload / thresholds — this env's compile-run upload
+      #   metadata for the bencher-track step.
+      - id: gates
+        name: Read this env's registry metadata
         run: |
-          echo "yes=$(ix bench ci matrix --kind envs \
-            | jq 'index("${{ matrix.env }}") != null')" >> "$GITHUB_OUTPUT"
+          ix bench ci matrix > matrix.json
+          gate() { jq --arg env "${{ matrix.env }}" "[.[] | select($1).env] | index(\$env) >= 0" matrix.json; }
+          echo "consumed=$(gate '.backend == "compile" | not')" >> "$GITHUB_OUTPUT"
+          echo "zkvm=$(gate '.backend == "zisk" or .backend == "sp1"')" >> "$GITHUB_OUTPUT"
+          meta() { jq -r --arg env "${{ matrix.env }}" "first(.[] | select(.backend == \"compile\" and .env == \$env)).$1" matrix.json; }
+          echo "testbed=$(meta testbed)" >> "$GITHUB_OUTPUT"
+          echo "workload=$(meta workload)" >> "$GITHUB_OUTPUT"
+          { echo "thresholds<<EOF"; meta thresholds; echo "EOF"; } >> "$GITHUB_OUTPUT"
       # Pre-cut the zisk closure-shard artifacts for the heavy primaries
       # (`ix shard extract` → `ix profile` → `ix shard`, via `ix bench
-      # shard` — the same code path the zisk cells run lazily when the
+      # shard` — the same code path the zisk runs fall back to when the
       # artifacts are absent). Done here, next to the fresh `.ixe` with
-      # `ix` + the Lean toolchain on hand, so the zkvm job just restores the
-      # dir.
-      - if: steps.benched.outputs.yes == 'true'
+      # `ix` + the Lean toolchain on hand, so the zisk runs just restore
+      # the dir.
+      - if: steps.gates.outputs.zkvm == 'true'
         name: Cut closure shards for heavy primaries
         run: ix bench shard --env ${{ matrix.env }} --ixe ${{ matrix.env }}.ixe
-      # Cache the `.ixe` + closure-shard artifacts for the prove/zkvm jobs
-      # (reused, never regenerated there). Only the benched envs those
-      # consume, to stay under the repo cache limit. NB: every restore of
-      # this key must list the SAME paths — actions/cache versions the entry
-      # by its path list.
-      - if: steps.benched.outputs.yes == 'true'
+      # Cache the `.ixe` (+ closure-shard artifacts where the step above cut
+      # them) for every downstream consumer, reused never regenerated — for a
+      # decompile-only env (Lean/FLT) the `zkshards-*` dir is absent and
+      # simply not stored. NB: every restore of this key must list the SAME
+      # paths — actions/cache versions the entry by its path list.
+      - if: steps.gates.outputs.consumed == 'true'
         uses: actions/cache/save@v6
         with:
           path: |
             ${{ matrix.env }}.ixe
             zkshards-${{ matrix.env }}
           key: bench-ixe-${{ github.sha }}-${{ matrix.env }}
-      # Upload compile metrics. Every measure shares the per-workload baseline
-      # window (data points since the ix-compile reset tag): constants is
-      # deterministic, pinned exactly (0/0); file-size wiggles slightly
-      # run-to-run (the serialized env is not byte-reproducible — worth its
-      # own investigation for a content-addressed store) so it rides a tight
-      # ±1% band instead of a pin; compile-time a 5% upper bound; throughput
-      # a 5% lower bound (its regression is a drop); peak-rss a 10% upper
-      # bound (allocator-noisy, same as the other cells).
+      # Upload compile metrics — testbed / workload / threshold flags all
+      # from its registry matrix entry (bound rationale lives beside `thresholds`
+      # in Ix/Cli/BenchCmd.lean). Every measure shares the per-workload
+      # baseline window (data points since the workload's reset tag).
       - uses: ./.github/actions/bencher-track
         with:
-          testbed: ix-compile-x64-32x
-          workload: ix-compile
+          testbed: ${{ steps.gates.outputs.testbed }}
+          workload: ${{ steps.gates.outputs.workload }}
           file: benchmark.json
           key: ${{ secrets.BENCHER_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          thresholds: |
-            --threshold-measure compile-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
-            --threshold-lower-boundary _
-            --threshold-measure throughput --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary _
-            --threshold-lower-boundary 0.05
-            --threshold-measure file-size --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.01
-            --threshold-lower-boundary 0.01
-            --threshold-measure constants --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary 0
-            --threshold-measure peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
+          thresholds: ${{ steps.gates.outputs.thresholds }}
 
-  # Restore each matrix job's `.ixe` from the cache and run the Aiur execute +
-  # Aiur benchmark over the primary constants, one cell per mode, each on
-  # its own testbed (they share measure names — peak-rss, throughput —
-  # that mean that mode's phase, and a `!benchmark aiur [execute]` PR cell
-  # always finds a cached baseline this way):
-  #   - `prove` — the real-workload simulation: the full STARK prove under
-  #     the RAM watchdog, with per-constant subprocess isolation and a
-  #     `status: oom` row (keeping any Phase-1 metrics flushed before the
-  #     kill) for a too-large prove.
-  #   - `execute` — the fast Phase-1-only signal (witness generation).
-  # No compiler run here: `--ixe` points at the cached
-  # `.ixe`.
-  aiur:
-    name: aiur-${{ matrix.bench }}-${{ matrix.mode }}
+  # ONE job per remaining parameter combination (backend × env × mode),
+  # mirroring bench-pr.yml's single benchmark job: each combination's label,
+  # testbed, workload, and threshold flags all ride in its matrix entry, so
+  # no backend has bespoke steps here beyond the zkVM toolchain installs.
+  # Restores the compile job's cached `.ixe` — no recompile. Backend notes:
+  #   - aiur prove is the real-workload simulation (full STARK prove under
+  #     the RAM watchdog, per-constant subprocess isolation, `status: oom`
+  #     rows for a too-large prove); aiur execute is the fast Phase-1-only
+  #     signal. Separate testbeds share measure names (peak-rss,
+  #     throughput) meaning that mode's phase, so a `!benchmark aiur
+  #     [execute]` PR run always finds a cached baseline.
+  #   - zisk executes the same constants through the zkVM host
+  #     (deterministic cycle counts; proving needs a GPU, so execute-only),
+  #     reusing the pre-cut zkshards-<env>/ artifacts; `ix bench run`
+  #     builds the Rust host itself.
+  #   - ooc runs the same kernel out-of-circuit and in parallel (far
+  #     faster), one whole-env row plus one full-closure row per primary.
+  #   - decompile is the inverse of compile; deep roundtrip fidelity is
+  #     gated by the canonical checks (`ix validate` / roundtrip tests),
+  #     not measured here.
+  #   - aiur-recursive proves fixed tiny statements and the in-circuit
+  #     multi-stark verifier over each proof, then proves THAT execution —
+  #     env-independent, its run env is only the (already-cached)
+  #     `.ixe`-restore key.
+  benchmark:
+    name: ${{ matrix.params.label }}
     needs: [compile, plan]
     runs-on: warp-ubuntu-latest-x64-32x
+    # `ix bench run` persists completed rows incrementally, so even a
+    # job-level timeout keeps them on disk, but the bencher upload needs
+    # the job alive.
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        bench: ${{ fromJson(needs.plan.outputs.bench-envs) }}
-        mode: [execute, prove]
+        params: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
+      # The zkVM runs build their Rust host in-run; the rest run staged
+      # binaries only. (Restore an install-sp1 step here when sp1 is
+      # re-enabled in the registry.)
+      - if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: ${{ matrix.params.backend }}
+      - name: Install Zisk
+        if: matrix.params.backend == 'zisk'
+        uses: ./.github/actions/install-zisk
       - uses: actions/cache/restore@v6
         with:
           path: ~/.local/bin
           key: bench-bins-${{ github.sha }}
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      # Provision the toolchain so the bench-typecheck binary finds libleanshared
+      # Provision the toolchain so the staged binaries find libleanshared
       # (no package build). use-github-cache off: nothing to cache here, and
       # parallel matrix jobs share a key and would race the cache save.
       - uses: leanprover/lean-action@v1
@@ -284,416 +290,49 @@ jobs:
           auto-config: false
           build: false
           use-github-cache: false
-      # Pull the `.ixe` the compile job built — do NOT recompile it here.
-      # (The path list must match the compile job's save exactly.)
+      # Pull the `.ixe` (+ any pre-cut closure shards) the compile job
+      # built — do NOT recompile here. (The path list must match the
+      # compile job's save exactly.)
       - uses: actions/cache/restore@v6
         with:
           path: |
-            ${{ matrix.bench }}.ixe
-            zkshards-${{ matrix.bench }}
-          key: bench-ixe-${{ github.sha }}-${{ matrix.bench }}
+            ${{ matrix.params.env }}.ixe
+            zkshards-${{ matrix.params.env }}
+          key: bench-ixe-${{ github.sha }}-${{ matrix.params.env }}
           fail-on-cache-miss: true
-      # Exit 3 = the kernel REJECTED a constant (a correctness regression, not
-      # a benchmark blip): the job reddens right here, with the rows on disk
-      # for the upload below.
-      - name: Run Aiur typecheck benchmark
-        run: |
-          ix bench run --backend aiur --env ${{ matrix.bench }} \
-            --mode ${{ matrix.mode }} --ixe ${{ matrix.bench }}.ixe --out bench.json
-      # Upload whatever clean rows exist even when the run step reddened the
-      # job — bmf drops every non-ok row, so a rejected or OOM'd constant
-      # never reaches bencher.
-      - name: Convert to Bencher Metric Format
-        id: bmf
-        if: ${{ !cancelled() }}
-        run: |
-          ix bench bmf --in bench.json --out aiur.json
-          cat aiur.json
-      # Upload Aiur metrics. Every measure shares the per-workload baseline
-      # window (data points since the workload's reset tag). constants is
-      # deterministic → pinned exactly (0/0). fft-cost is deterministic but
-      # only ever drops on a real Aiur win, so it rides an upper-only 5%
-      # bound (flag a regression, let wins through) rather than a hard pin.
-      # The wall-clock/RAM/rate measures ride percentage bounds; peak-rss
-      # and throughput are phase-scoped by the CELL (execute vs prove
-      # testbed), and prove-time/verify-time/proof-size exist only on the
-      # prove testbed — a threshold naming an absent measure just sits
-      # empty there. The per-phase `phase-<span>` measures (witness gen,
-      # stage commits, quotient, …) are uploaded for trend visibility but
-      # intentionally left un-thresholded (noisy and dynamically named;
-      # the PR-comment drill-down does the phase-level comparison).
-      - uses: ./.github/actions/bencher-track
-        if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
-        with:
-          testbed: aiur-check-${{ matrix.mode }}-x64-32x
-          workload: aiur-check-${{ matrix.mode }}
-          file: aiur.json
-          key: ${{ secrets.BENCHER_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          thresholds: |
-            --threshold-measure constants --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary 0
-            --threshold-measure fft-cost --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
-            --threshold-lower-boundary _
-            --threshold-measure prove-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure verify-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure proof-size --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
-            --threshold-lower-boundary _
-            --threshold-measure execute-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure throughput --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary _
-            --threshold-lower-boundary 0.10
-
-  # The aiur-recursive toy cell (`ix bench run --backend
-  # aiur-recursive`):
-  # bench-recursive-verifier proves each fixed config's tiny statement, runs
-  # the in-circuit multi-stark verifier over the proof, then proves that
-  # execution — uploading the recursion-cost trend to its own testbed.
-  # Env-independent: no `.ixe`, no compile job — just the staged binaries
-  # and the toolchain (libleanshared). A config whose outer prove exceeds
-  # the watchdog ceiling lands as a `status: oom` row that bmf drops,
-  # keeping that row off bencher.
-  aiur-recursive:
-    name: aiur-recursive-prove
-    needs: build
-    runs-on: warp-ubuntu-latest-x64-32x
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.local/bin
-          key: bench-bins-${{ github.sha }}
-      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          use-github-cache: false
-      - name: Run aiur-recursive benchmark
-        run: ix bench run --backend aiur-recursive --out bench.json
-      - name: Convert to Bencher Metric Format
-        id: bmf
-        if: ${{ !cancelled() }}
-        run: |
-          ix bench bmf --in bench.json --out aiur-recursive-bmf.json
-          cat aiur-recursive-bmf.json
-      # recursive-fft-cost drifts ~±15% run-to-run (the parallel prover
-      # emits byte-different valid proofs, so the verifier authenticates
-      # different Merkle paths), hence the loose 25% bound; the proof
-      # sizes are structural (fixed query count and path depth) and ride
-      # the tight 5% bound like aiur's; wall-clock/RAM ride the standard
-      # 10% percentage bounds.
-      - uses: ./.github/actions/bencher-track
-        if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
-        with:
-          testbed: aiur-recursive-x64-32x
-          workload: aiur-recursive
-          file: aiur-recursive-bmf.json
-          key: ${{ secrets.BENCHER_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          thresholds: |
-            --threshold-measure recursive-fft-cost --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.25
-            --threshold-lower-boundary _
-            --threshold-measure recursive-execute-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure recursive-prove-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure recursive-verify-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure recursive-peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure recursive-proof-size --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
-            --threshold-lower-boundary _
-            --threshold-measure prove-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure proof-size --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.05
-            --threshold-lower-boundary _
-            --threshold-measure verify-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-
-  # Execute the same constants through the zkVM hosts and track cycles /
-  # execute-time / throughput / peak-rss (and shards / max-shard-cycles
-  # for the closure-sharded heavy primaries). Reuses the compile job's cached
-  # `.ixe` + pre-cut zkshards-<env>/ artifacts; `ix bench run` builds the Rust
-  # host itself and runs each heavy primary as its shard-manifest partition
-  # when the artifacts are present. zkVM proving needs a GPU (absent here), so
-  # this is execute-only. `ix` orchestrates the cell, so the staged binaries +
-  # Lean toolchain (libleanshared) are restored here too.
-  zkvm-execute:
-    name: ${{ matrix.cell.backend }}-${{ matrix.cell.env }}-execute
-    needs: [compile, plan]
-    runs-on: warp-ubuntu-latest-x64-32x
-    # Per-constant loop (heavy primaries ride the RAM watchdog to OOM rows) —
-    # `ix bench run` persists completed rows incrementally, so even a job-level
-    # timeout would keep them on disk, but the bencher upload needs the job
-    # alive.
-    timeout-minutes: 150
-    strategy:
-      fail-fast: false
-      matrix:
-        # Enabled zkVM backends × benched envs, from the registry. sp1 is
-        # disabled in the registry (execute too slow for a per-push job);
-        # re-enabling it there restores its cells — also restore an
-        # `if: matrix.cell.backend == 'sp1'` install-sp1 step then.
-        cell: ${{ fromJson(needs.plan.outputs.zkvm-cells) }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache-workspaces: ${{ matrix.cell.backend }}
-      - name: Install Zisk
-        if: matrix.cell.backend == 'zisk'
-        uses: ./.github/actions/install-zisk
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.local/bin
-          key: bench-bins-${{ github.sha }}
-      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      # Provision the toolchain so `ix` finds libleanshared (no package build).
-      - uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          use-github-cache: false
-      # Pull the `.ixe` + the pre-cut closure-shard artifacts the compile job
-      # built — `--ixe` means no recompile, and `ix bench run` skips
-      # re-cutting shards it finds in zkshards-<env>/.
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ${{ matrix.cell.env }}.ixe
-            zkshards-${{ matrix.cell.env }}
-          key: bench-ixe-${{ github.sha }}-${{ matrix.cell.env }}
-          fail-on-cache-miss: true
-      # Exit 3 = kernel rejection → red X here; clean rows still upload below.
-      - name: Run ${{ matrix.cell.backend }} execute benchmark
+      # Exit 3 = the kernel REJECTED a constant (a correctness regression,
+      # not a benchmark blip): the job reddens right here, with the rows on
+      # disk for the upload below.
+      - name: Run ${{ matrix.params.label }} benchmark
         run: |
           # ZisK's ASM microservices mmap with MAP_LOCKED: raise the memlock
           # hard limit in this shell so the tools `ix bench run` spawns
           # inherit it.
-          if [ "${{ matrix.cell.backend }}" = zisk ]; then
+          if [ "${{ matrix.params.backend }}" = zisk ]; then
             sudo prlimit --pid $$ --memlock=unlimited:unlimited
           fi
-          ix bench run --backend ${{ matrix.cell.backend }} \
-            --env ${{ matrix.cell.env }} --mode execute \
-            --ixe ${{ matrix.cell.env }}.ixe --out bench.json
+          ix bench run --backend ${{ matrix.params.backend }} \
+            --env ${{ matrix.params.env }} --mode ${{ matrix.params.mode }} \
+            --ixe ${{ matrix.params.env }}.ixe --out bench.json
       # Upload whatever clean rows exist even when the run step reddened the
-      # job — bmf drops every non-ok row.
+      # job — bmf drops every non-ok (rejected/oom) row, so those never
+      # reach bencher.
       - name: Convert to Bencher Metric Format
         id: bmf
         if: ${{ !cancelled() }}
         run: |
           ix bench bmf --in bench.json --out bench-bmf.json
           cat bench-bmf.json
-      # constants is deterministic and a drop means lost coverage → pinned
-      # (0/0), like the aiur/ooc/compile cells. cycles / shards /
-      # max-shard-cycles are deterministic per guest ELF, but a real guest /
-      # packer improvement legitimately drops them — upper-only 0% bound
-      # (flag regressions, let wins through), like `fft-cost` on the aiur
-      # job. execute-time / peak-rss / throughput are noisy wall-clock →
-      # percentage bounds (throughput's regression is a drop).
+      # Upload the run's metrics under its registry testbed/workload; the
+      # threshold flags (and their bound rationale) live beside the backend
+      # in Ix/Cli/BenchCmd.lean. Every measure shares the per-workload
+      # baseline window (data points since the workload's reset tag).
       - uses: ./.github/actions/bencher-track
         if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
         with:
-          testbed: ${{ matrix.cell.backend }}-check-${{ matrix.cell.mode }}-x64-32x
-          workload: ${{ matrix.cell.backend }}-check-${{ matrix.cell.mode }}
+          testbed: ${{ matrix.params.testbed }}
+          workload: ${{ matrix.params.workload }}
           file: bench-bmf.json
           key: ${{ secrets.BENCHER_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          thresholds: |
-            --threshold-measure constants --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary 0
-            --threshold-measure cycles --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary _
-            --threshold-measure shards --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary _
-            --threshold-measure max-shard-cycles --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary _
-            --threshold-measure execute-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure throughput --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary _
-            --threshold-lower-boundary 0.10
-
-  # Out-of-circuit Rust kernel typecheck — the same kernel as the zkVM guest,
-  # but run out-of-circuit and in parallel, so far faster than proving.
-  # `ix bench run --backend ooc` checks the whole env (one row keyed by the
-  # env slug) plus one full-closure row per primary constant, for an
-  # apples-to-apples baseline next to the zkVM cells. Reuses the compile job's
-  # cached `.ixe` and the staged `ix` binary — no recompile.
-  ooc-check:
-    name: ooc-${{ matrix.bench }}
-    needs: [compile, plan]
-    runs-on: warp-ubuntu-latest-x64-32x
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        bench: ${{ fromJson(needs.plan.outputs.bench-envs) }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.local/bin
-          key: bench-bins-${{ github.sha }}
-      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      # Provision the toolchain so `ix` finds libleanshared (no package build).
-      - uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          use-github-cache: false
-      # (The path list must match the compile job's save exactly.)
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ${{ matrix.bench }}.ixe
-            zkshards-${{ matrix.bench }}
-          key: bench-ixe-${{ github.sha }}-${{ matrix.bench }}
-          fail-on-cache-miss: true
-      # Exit 3 = kernel rejection → red X here; clean rows still upload below.
-      - name: Run out-of-circuit kernel check
-        run: |
-          ix bench run --backend ooc --env ${{ matrix.bench }} --mode execute \
-            --ixe ${{ matrix.bench }}.ixe --out bench.json
-      # Upload whatever clean rows exist even when the run step reddened the
-      # job — bmf drops every non-ok row.
-      - name: Convert to Bencher Metric Format
-        id: bmf
-        if: ${{ !cancelled() }}
-        run: |
-          ix bench bmf --in bench.json --out bench-bmf.json
-          cat bench-bmf.json
-      # constants is deterministic → pinned (0/0); check-time / throughput /
-      # peak-rss are noisy parallel wall-clock → percentage bounds.
-      - uses: ./.github/actions/bencher-track
-        if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
-        with:
-          testbed: ooc-check-x64-32x
-          workload: ooc-check
-          file: bench-bmf.json
-          key: ${{ secrets.BENCHER_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          thresholds: |
-            --threshold-measure constants --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary 0
-            --threshold-measure check-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure throughput --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary _
-            --threshold-lower-boundary 0.10
-            --threshold-measure peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-
-  # Decompile — the inverse of compile. Restore the compile job's cached
-  # `.ixe` and decompile it back to Lean constants. One env-keyed row per
-  # benched env, mirroring the `compile` cell. A malformed decompile exits
-  # nonzero and reddens this step; deep roundtrip fidelity is gated by the
-  # canonical checks (`ix validate` / roundtrip tests), not measured here. No
-  # compiler or Lean toolchain build — `ix decompile` is a Rust FFI pass over
-  # the cached `.ixe`, so this reuses the staged `ix` binary like ooc-check.
-  decompile:
-    name: decompile-${{ matrix.bench }}
-    needs: [compile, plan]
-    runs-on: warp-ubuntu-latest-x64-32x
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        bench: ${{ fromJson(needs.plan.outputs.bench-envs) }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.local/bin
-          key: bench-bins-${{ github.sha }}
-      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      # Provision the toolchain so `ix` finds libleanshared (no package build).
-      - uses: leanprover/lean-action@v1
-        with:
-          auto-config: false
-          build: false
-          use-github-cache: false
-      # (The path list must match the compile job's save exactly.)
-      - uses: actions/cache/restore@v6
-        with:
-          path: |
-            ${{ matrix.bench }}.ixe
-            zkshards-${{ matrix.bench }}
-          key: bench-ixe-${{ github.sha }}-${{ matrix.bench }}
-          fail-on-cache-miss: true
-      # A malformed decompile exits nonzero → red X here; a clean run's row
-      # uploads below.
-      - name: Run decompile benchmark
-        run: |
-          ix bench run --backend decompile --env ${{ matrix.bench }} --mode execute \
-            --ixe ${{ matrix.bench }}.ixe --out bench.json
-      # Upload whatever clean rows exist even when the run step reddened the
-      # job — bmf drops every non-ok (rejected/oom) row.
-      - name: Convert to Bencher Metric Format
-        id: bmf
-        if: ${{ !cancelled() }}
-        run: |
-          ix bench bmf --in bench.json --out bench-bmf.json
-          cat bench-bmf.json
-      # constants is deterministic → pinned (0/0); decompile-time / throughput
-      # / peak-rss are noisy wall-clock → percentage bounds. file-size (the
-      # input `.ixe`) duplicates the compile cell's, so it uploads for the
-      # row's completeness but rides no threshold here.
-      - uses: ./.github/actions/bencher-track
-        if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
-        with:
-          testbed: ix-decompile-x64-32x
-          workload: ix-decompile
-          file: bench-bmf.json
-          key: ${{ secrets.BENCHER_API_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          thresholds: |
-            --threshold-measure constants --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0
-            --threshold-lower-boundary 0
-            --threshold-measure decompile-time --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
-            --threshold-measure throughput --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary _
-            --threshold-lower-boundary 0.10
-            --threshold-measure peak-rss --threshold-test percentage
-            --threshold-max-sample-size __WINDOW__ --threshold-upper-boundary 0.10
-            --threshold-lower-boundary _
+          thresholds: ${{ matrix.params.thresholds }}

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -1,25 +1,26 @@
 name: Benchmark main
 
-# Benchmarks tracked on Bencher on every push to main, all reusing the one
-# compiled `.ixe` so the compiler runs once. Every measurement is a single
-# `ix bench run` invocation (backend × env × mode) — the same orchestrator local
-# runs and the !benchmark PR workflow use — converted for upload by
-# `ix bench bmf`. Three stages, mirroring bench-pr.yml:
-#   1. plan      — `ix bench ci matrix` emits the registry's parameter fan-out
-#                  (Ix/Cli/BenchCmd.lean), each combination carrying its testbed,
-#                  workload, and threshold flags.
-#   2. compile   — `ix bench run --backend compile` per env: serialize the
-#                  Lean env to a `.ixe` (compile-throughput metrics) and
-#                  cache the `.ixe` for the runs.
-#   3. benchmark — ONE job per remaining parameter combination: restore the
-#                  `.ixe` and drive its backend over it (aiur STARK-check, zkVM
-#                  execute, out-of-circuit check, decompile, the
-#                  aiur-recursive toy).
-# Each run reports to its own bencher testbed/workload so a threshold reset
-# only touches its own measures. `ix bench run` exits 3 when the kernel
-# REJECTS a constant — the red X lands on that step (no output scraping),
-# while the clean rows still upload (`ix bench bmf` drops every non-ok row,
-# so a rejected or OOM'd constant never becomes a bencher data point).
+# Benchmarks every push to main and uploads the results to bencher.dev.
+# Each measurement is one `ix bench run` with a (backend, env, mode)
+# parameter combination — the same command you can run locally, and the
+# same one the !benchmark PR workflow uses. Three stages:
+#
+#   1. plan      — `ix bench ci matrix` prints the list of parameter
+#                  combinations to run. The list comes from the registry
+#                  (Ix/Cli/BenchCmd.lean) and each entry already carries
+#                  its bencher testbed, workload, and threshold flags, so
+#                  this file hardcodes none of that.
+#   2. compile   — compiles each Lean env to a `.ixe` file (this IS the
+#                  compile benchmark) and caches the file for stage 3.
+#   3. benchmark — one job per remaining entry: restore the `.ixe` and
+#                  run the entry's backend over it (aiur, zisk, ooc,
+#                  decompile, aiur-recursive).
+#
+# Each entry uploads to its own bencher testbed/workload, so a threshold
+# reset for one workload never touches another. When the kernel REJECTS a
+# constant, `ix bench run` exits 3 and that step fails visibly — but the
+# clean rows still upload, because `ix bench bmf` drops every non-ok row
+# (rejected or OOM) before the upload.
 
 on:
   push:
@@ -30,25 +31,23 @@ permissions:
   contents: read
   checks: write
 
-# No concurrency group: push-to-main and manual dispatch only — every merged
-# commit gets benchmarked; a later merge must never cancel or queue behind an
-# in-flight run.
+# No concurrency group on purpose: every merged commit gets benchmarked,
+# and a later merge must never cancel or queue behind an in-flight run.
 
 env:
   COMPILE_DIR: Benchmarks/Compile
 
 jobs:
-  # Build + stage the `ix`, `bench-typecheck`, and `bench-recursive-verifier`
-  # binaries once, then restore them on the matrix runners.
-  # `-Ctarget-cpu=native`: every job that RUNS these binaries must also be a
-  # warp host.
+  # Build the `ix`, `bench-typecheck`, and `bench-recursive-verifier`
+  # binaries once and cache them; every later job restores them instead of
+  # rebuilding. They are built with -Ctarget-cpu=native, so every job that
+  # runs them must use the same warp runner class.
   build:
     runs-on: warp-ubuntu-latest-x64-32x
     steps:
       - uses: actions/checkout@v7
-      # Pinned Rust toolchain + cargo cache (~/.cargo + target/, via the action's
-      # built-in rust-cache), so `lake build`'s cargo step doesn't recompile the
-      # Plonky3/multi-stark deps from scratch on every run.
+      # Rust toolchain + cargo cache, so the cargo step inside `lake build`
+      # does not recompile the Plonky3/multi-stark dependencies every run.
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       # Log the build CPU so a benchmark shift can be traced to a host change.
       - name: Log build CPU
@@ -72,16 +71,15 @@ jobs:
           path: ~/.local/bin
           key: bench-bins-${{ github.sha }}
 
-  # Derive the benchmark matrix from the registry (Ix/Cli/BenchCmd.lean)
-  # via `ix bench ci matrix`, so the parameter fan-out and its upload metadata
-  # are single-sourced instead of hand-copied. Runs beside the compile
+  # Ask the registry which benchmarks to run. `ix bench ci matrix` prints
+  # one JSON entry per (backend, env, mode) combination, each carrying its
+  # own testbed, workload, and threshold flags — so nothing benchmark-
+  # specific is written into this file. Runs in parallel with the compile
   # job; only the benchmark job waits on it.
   plan:
     needs: build
-    # `ci matrix` is a pure-Lean subcommand (AVX-512 lives only in the
-    # binary's Rust objects, which it never executes) — cheap host is fine.
-    # Move to a warp host if `ix` startup or this subcommand ever touches
-    # the FFI.
+    # `ci matrix` only runs Lean code (the AVX-512 parts of the binary are
+    # never executed here), so a cheap non-warp host is fine.
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -103,21 +101,18 @@ jobs:
         run: |
           ix bench ci matrix > matrix.json
           cat matrix.json
-          # Every scheduled parameter combination (backend × env × mode), with its
-          # testbed / workload / threshold metadata from the registry. The
-          # compile runs get their own job below (the `.ixe` producers
-          # everything else restores — no intra-matrix ordering on GitHub),
-          # so the benchmark matrix takes the consumers. An env name (e.g.
-          # InitStd) is the single identifier: `ix bench run --env`, the
-          # `<env>.ixe` filename, the cache-key suffix, and the env-keyed
-          # bencher benchmark name.
+          # Drop the compile entries: they run as their own job below,
+          # because they produce the `.ixe` files everything else consumes
+          # and GitHub cannot order entries within one matrix. Everything
+          # else becomes the benchmark job's matrix.
           echo "matrix=$(jq -c 'map(select(.backend == "compile" | not))' matrix.json)" >> "$GITHUB_OUTPUT"
 
-  # Compile each library env to a `.ixe` and track compile throughput. Caches
-  # the `.ixe` (keyed by sha + env slug) for the benchmark runs to consume.
+  # Compile each Lean env to a `.ixe` file. The compile itself is the
+  # benchmark (compile time, throughput, env size); the `.ixe` is then
+  # cached for the benchmark job to restore.
   compile:
-    # Explicit names on the matrix jobs: the default would append every
-    # matrix value (slugs, flags) to the job title.
+    # Explicit name — the default would append every matrix value to the
+    # job title.
     name: compile-${{ matrix.env }}
     needs: build
     runs-on: warp-ubuntu-latest-x64-32x
@@ -125,12 +120,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # env = the registry key (Ix/Cli/BenchCmd.lean): the `ix bench run --env`
-        # token, `<env>.ixe` filename, lake target suffix (Compile<env>),
-        # cache-key suffix, and bencher row name, all one spelling.
-        # Every registry env compiles; the per-constant benchmark entries
-        # fan over whichever envs Vectors.csv selects constants in.
-        # Add FC if updated to latest Lean.
+        # The env name (e.g. InitStd) is the one identifier used
+        # everywhere: `ix bench run --env`, the `<env>.ixe` filename, the
+        # lake target (Compile<env>), the cache-key suffix, and the
+        # bencher row name. Every registry env compiles here; which envs
+        # the benchmark job then proves/checks depends on which envs have
+        # constants in Vectors.csv. Add FC once it's on current Lean.
         include:
           - { env: InitStd }
           - { env: Lean }
@@ -148,9 +143,10 @@ jobs:
       # point COMPILE_DIR there for the FC matrix job.
       # - if: matrix.env == 'FC'
       #   run: echo "COMPILE_DIR=${{ env.COMPILE_DIR }}FC" | tee -a $GITHUB_ENV
-      # Download elan; fetch the mathlib cache only for benches that import
-      # Mathlib (Mathlib, FLT) — InitStd/Lean would otherwise pull it for
-      # nothing, since the shared Benchmarks/Compile package depends on mathlib.
+      # Install the Lean toolchain. The mathlib olean cache is fetched only
+      # for envs that import Mathlib (Mathlib, FLT) — the shared
+      # Benchmarks/Compile package depends on mathlib, so without this
+      # guard InitStd/Lean would download it for nothing.
       - uses: leanprover/lean-action@v1
         with:
           lake-package-directory: ${{ env.COMPILE_DIR }}
@@ -167,23 +163,24 @@ jobs:
       # warning that must not fail the build.
       - run: lake build Compile${{ matrix.env }}
         working-directory: ${{ env.COMPILE_DIR }}
-      # Serialize the env to a `.ixe` and measure the compile via `ix bench
-      # run` — for the `compile` backend the compile IS the benchmark (always
-      # fresh; `--ixe` is ignored by design). Writes `<env>.ixe` at the
-      # workspace root and one results row keyed by the CamelCase env slug —
-      # the same driver the !benchmark PR path uses; bmf wraps it for bencher.
+      # The measured compile: serializes the env to `<env>.ixe` at the
+      # workspace root and writes one results row keyed by the env name.
+      # For the compile backend the compile IS the benchmark, so it always
+      # compiles fresh (`--ixe` is ignored on purpose). `bmf` converts the
+      # row to bencher's upload format.
       - name: Run ix compile benchmark
         run: |
           ix bench run --backend compile --env ${{ matrix.env }} --out bench.json
           ix bench bmf --in bench.json --out benchmark.json
           cat benchmark.json
-      # Registry reads for the steps below, all off the same parameter fan-out
-      # the benchmark matrix uses (no hand-copied env lists or upload
-      # metadata):
-      #   consumed — some downstream run restores this env's `.ixe`.
-      #   zkvm     — a zkVM run executes it, so pre-cut its closure shards.
-      #   testbed / workload / thresholds — this env's compile-run upload
-      #   metadata for the bencher-track step.
+      # Ask the registry three things about this env (instead of keeping
+      # hand-written env lists here):
+      #   consumed — does any benchmark entry restore this env's `.ixe`?
+      #              If yes, cache it below.
+      #   zkvm     — does a zkVM entry execute this env? If yes, pre-cut
+      #              its closure shards below.
+      #   testbed / workload / thresholds — the upload metadata for this
+      #              env's own compile benchmark.
       - id: gates
         name: Read this env's registry metadata
         run: |
@@ -195,20 +192,19 @@ jobs:
           echo "testbed=$(meta testbed)" >> "$GITHUB_OUTPUT"
           echo "workload=$(meta workload)" >> "$GITHUB_OUTPUT"
           { echo "thresholds<<EOF"; meta thresholds; echo "EOF"; } >> "$GITHUB_OUTPUT"
-      # Pre-cut the zisk closure-shard artifacts for the heavy primaries
-      # (`ix shard extract` → `ix profile` → `ix shard`, via `ix bench
-      # shard` — the same code path the zisk runs fall back to when the
-      # artifacts are absent). Done here, next to the fresh `.ixe` with
-      # `ix` + the Lean toolchain on hand, so the zisk runs just restore
-      # the dir.
+      # Pre-cut the closure shards zisk needs for heavy constants
+      # (extract → profile → shard). The zisk runs can cut these lazily
+      # themselves, but doing it here — right next to the fresh `.ixe`,
+      # with the toolchain already installed — means they just restore a
+      # directory.
       - if: steps.gates.outputs.zkvm == 'true'
         name: Cut closure shards for heavy primaries
         run: ix bench shard --env ${{ matrix.env }} --ixe ${{ matrix.env }}.ixe
-      # Cache the `.ixe` (+ closure-shard artifacts where the step above cut
-      # them) for every downstream consumer, reused never regenerated — for a
-      # decompile-only env (Lean/FLT) the `zkshards-*` dir is absent and
-      # simply not stored. NB: every restore of this key must list the SAME
-      # paths — actions/cache versions the entry by its path list.
+      # Cache the `.ixe` (plus the shard directory when the step above ran)
+      # for the benchmark job. For an env only decompile consumes, the
+      # `zkshards-*` directory doesn't exist and simply isn't stored.
+      # IMPORTANT: every restore of this key must list the same paths —
+      # actions/cache versions the entry by its path list.
       - if: steps.gates.outputs.consumed == 'true'
         uses: actions/cache/save@v6
         with:
@@ -216,10 +212,9 @@ jobs:
             ${{ matrix.env }}.ixe
             zkshards-${{ matrix.env }}
           key: bench-ixe-${{ github.sha }}-${{ matrix.env }}
-      # Upload compile metrics — testbed / workload / threshold flags all
-      # from its registry matrix entry (bound rationale lives beside `thresholds`
-      # in Ix/Cli/BenchCmd.lean). Every measure shares the per-workload
-      # baseline window (data points since the workload's reset tag).
+      # Upload the compile metrics. Testbed, workload, and threshold flags
+      # all come from the registry (the reasoning behind each bound lives
+      # next to `thresholds` in Ix/Cli/BenchCmd.lean).
       - uses: ./.github/actions/bencher-track
         with:
           testbed: ${{ steps.gates.outputs.testbed }}
@@ -229,30 +224,31 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           thresholds: ${{ steps.gates.outputs.thresholds }}
 
-  # ONE job per remaining parameter combination (backend × env × mode),
-  # mirroring bench-pr.yml's single benchmark job: each combination's label,
-  # testbed, workload, and threshold flags all ride in its matrix entry, so
-  # no backend has bespoke steps here beyond the zkVM toolchain installs.
-  # Restores the compile job's cached `.ixe` — no recompile. Backend notes:
-  #   - aiur prove is the real-workload simulation (full STARK prove under
-  #     the RAM watchdog, per-constant subprocess isolation, `status: oom`
-  #     rows for a too-large prove); aiur execute is the fast Phase-1-only
-  #     signal. Separate testbeds share measure names (peak-rss,
-  #     throughput) meaning that mode's phase, so a `!benchmark aiur
-  #     [execute]` PR run always finds a cached baseline.
-  #   - zisk executes the same constants through the zkVM host
-  #     (deterministic cycle counts; proving needs a GPU, so execute-only),
-  #     reusing the pre-cut zkshards-<env>/ artifacts; `ix bench run`
-  #     builds the Rust host itself.
-  #   - ooc runs the same kernel out-of-circuit and in parallel (far
-  #     faster), one whole-env row plus one full-closure row per primary.
-  #   - decompile is the inverse of compile; deep roundtrip fidelity is
-  #     gated by the canonical checks (`ix validate` / roundtrip tests),
-  #     not measured here.
-  #   - aiur-recursive proves fixed tiny statements and the in-circuit
-  #     multi-stark verifier over each proof, then proves THAT execution —
-  #     env-independent, its run env is only the (already-cached)
-  #     `.ixe`-restore key.
+  # One job per remaining matrix entry, all sharing this one step list
+  # (same shape as bench-pr.yml's benchmark job). Each entry brings its
+  # own label, testbed, workload, and threshold flags, so the only
+  # backend-specific steps are the zkVM toolchain installs. Every entry
+  # restores the compile job's cached `.ixe` — nothing recompiles here.
+  #
+  # What each backend measures:
+  #   - aiur prove: the real workload — a full STARK prove per constant,
+  #     one subprocess per constant under the RAM watchdog; a too-large
+  #     prove is killed and recorded as a `status: oom` row.
+  #     aiur execute: the fast signal — witness generation only.
+  #     The two modes upload to separate testbeds; shared measure names
+  #     (peak-rss, throughput) mean that mode's phase.
+  #   - zisk: executes the same constants in the zkVM (deterministic
+  #     cycle counts; proving would need a GPU, so execute-only). Reuses
+  #     the pre-cut zkshards-<env>/ dirs; builds its Rust host in-job.
+  #   - ooc: the same kernel run out-of-circuit and in parallel (much
+  #     faster). One whole-env row plus one row per primary constant.
+  #   - decompile: the inverse of compile. Roundtrip correctness is
+  #     checked elsewhere (`ix validate` / roundtrip tests) — this only
+  #     measures speed and memory.
+  #   - aiur-recursive: proves small fixed statements, runs the
+  #     in-circuit verifier over each proof, then proves THAT — the cost
+  #     of recursion. Env-independent: its `env` field only names the
+  #     (already-cached) `.ixe` the shared restore step pulls.
   benchmark:
     name: ${{ matrix.params.label }}
     needs: [compile, plan]
@@ -300,9 +296,9 @@ jobs:
             zkshards-${{ matrix.params.env }}
           key: bench-ixe-${{ github.sha }}-${{ matrix.params.env }}
           fail-on-cache-miss: true
-      # Exit 3 = the kernel REJECTED a constant (a correctness regression,
-      # not a benchmark blip): the job reddens right here, with the rows on
-      # disk for the upload below.
+      # If the kernel rejects a constant, `ix bench run` exits 3 and this
+      # step fails — that is a correctness regression, not a benchmark
+      # blip. The completed rows are already on disk for the upload below.
       - name: Run ${{ matrix.params.label }} benchmark
         run: |
           # ZisK's ASM microservices mmap with MAP_LOCKED: raise the memlock
@@ -314,8 +310,8 @@ jobs:
           ix bench run --backend ${{ matrix.params.backend }} \
             --env ${{ matrix.params.env }} --mode ${{ matrix.params.mode }} \
             --ixe ${{ matrix.params.env }}.ixe --out bench.json
-      # Upload whatever clean rows exist even when the run step reddened the
-      # job — bmf drops every non-ok (rejected/oom) row, so those never
+      # Convert rows for upload even when the run step failed: bmf drops
+      # every non-ok row (rejected or OOM), so only clean measurements
       # reach bencher.
       - name: Convert to Bencher Metric Format
         id: bmf
@@ -323,10 +319,9 @@ jobs:
         run: |
           ix bench bmf --in bench.json --out bench-bmf.json
           cat bench-bmf.json
-      # Upload the run's metrics under its registry testbed/workload; the
-      # threshold flags (and their bound rationale) live beside the backend
-      # in Ix/Cli/BenchCmd.lean. Every measure shares the per-workload
-      # baseline window (data points since the workload's reset tag).
+      # Upload under this entry's testbed and workload. The threshold
+      # flags (and the reasoning behind each bound) live next to the
+      # backend in Ix/Cli/BenchCmd.lean.
       - uses: ./.github/actions/bencher-track
         if: ${{ !cancelled() && steps.bmf.outcome == 'success' }}
         with:

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -128,9 +128,9 @@ jobs:
         # env = the registry key (Ix/Cli/BenchCmd.lean): the `ix bench run --env`
         # token, `<env>.ixe` filename, lake target suffix (Compile<env>),
         # cache-key suffix, and bencher row name, all one spelling.
-        # Deliberately wider than the benched set: Lean/FLT
-        # compile-throughput is tracked even though no downstream job proves
-        # them. Add FC if updated to latest Lean.
+        # Every registry env compiles; the per-constant benchmark entries
+        # fan over whichever envs Vectors.csv selects constants in.
+        # Add FC if updated to latest Lean.
         include:
           - { env: InitStd }
           - { env: Lean }

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -4,8 +4,9 @@
 #   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [decompile] [aiur-recursive] | all) [execute]
 #     (sp1 is disabled in the registry (Ix/Cli/BenchCmd.lean) — the parser skips it
 #      with a note in the config summary)
-#   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (default InitStd; case-insensitive;
-#                                  #  compile-only requests may name any registry env, e.g. Lean/FLT)
+#   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (case-insensitive; defaults to every
+#                                  #  registry env for compile/decompile, InitStd for the rest;
+#                                  #  env-keyed-only requests may name any registry env, e.g. Lean/FLT)
 #   BENCH_FULL=1                   # run the full curated set, not just primary
 #   BENCH_SHARD=1                  # restrict to the multi-shard target constants
 #   BENCH_PHASES=1                 # add per-constant phase drill-downs to the comment
@@ -19,24 +20,24 @@
 # `prove` — the real-workload simulation, whose report also carries the
 # Phase-1 columns `fft-cost` / `execute-time` measured en route; `zisk` /
 # `sp1` / `ooc` run `execute`; `compile` runs `ix compile <env>.lean →
-# <env>.ixe` (the same cell bench-main.yml uploads under testbed
+# <env>.ixe` (the same run bench-main.yml uploads under testbed
 # `ix-compile-*`); `decompile` runs `ix decompile <env>.ixe` over the
-# compile cell's fresh PR `.ixe` (testbed `ix-decompile-*`);
+# compile run's fresh PR `.ixe` (testbed `ix-decompile-*`);
 # `aiur-recursive` runs the aiur-recursive toy (bench-recursive-verifier's
-# fixed configs — env-independent, so it always schedules exactly one cell
+# fixed configs — env-independent, so it always schedules exactly one run
 # no matter what BENCH_ENVS says). The optional bare `execute` token flips
 # `aiur` to execute-only (Phase 1, skipping the prove); bench-main runs
-# both aiur modes as separate cells on separate testbeds, so either kind
-# of cell fetches a cached main-side baseline from bencher. The bare
+# both aiur modes as separate runs on separate testbeds, so either kind
+# of run fetches a cached main-side baseline from bencher. The bare
 # `recursive` token flips aiur to its recursive mode instead — an
 # unscheduled testbed with no bencher baseline (its main side is a base-SHA
 # run), and the verifier execute OOMs the standard CI host, so it's meant
-# for a bigger manual dispatch. The bare `fresh` token makes every cell
+# for a bigger manual dispatch. The bare `fresh` token makes every run
 # skip the bencher fetch and re-measure the main side with a base-SHA run
 # (nothing here uploads to bencher, so the canonical baseline is
 # untouched).
 #
-# Each matrix cell is one `ix bench run` per side, driven by the PR's `ix`
+# Each matrix entry is one `ix bench run` per side, driven by the PR's `ix`
 # (`--repo` points it at the checkout to measure). main's numbers come from
 # bencher.dev (`ix bench fetch-main`); the workflow re-runs the base SHA
 # locally only when bencher can't supply them — the base SHA isn't ingested yet
@@ -114,8 +115,8 @@ jobs:
   # Build the PR's `ix` + `bench-typecheck` + `bench-recursive-verifier`
   # once (they embed the IxVM kernel
   # and the Aiur prover), stage under ~/.local/bin, and cache by head SHA —
-  # the matrix cells restore instead of re-running the full Lean build per
-  # cell, and re-running !benchmark on the same commit skips the build
+  # the matrix runs restore instead of re-running the full Lean build per
+  # run, and re-running !benchmark on the same commit skips the build
   # entirely. Built on warp, mirroring bench-main.yml's build job, so PR
   # binaries carry the same instruction-set provenance (uniform AVX-512
   # fleet) as the binaries behind bencher's main-side numbers — and every
@@ -195,16 +196,79 @@ jobs:
           COMMENT_BODY: ${{ inputs.comment-body }}
         run: ix bench ci parse
 
-  # ONE measured `ix compile` per requested env, before the cells: it
-  # publishes the `.ixe` the prover cells restore (no per-cell compile
-  # races), and its results row doubles as the compile cell's PR side —
+  # Post the initial PR comment the instant the command is parsed: a red-X
+  # diagnostic if the parse/build failed (the same message the final comment
+  # would carry), otherwise a "running" placeholder so the commenter gets
+  # immediate feedback. The `comment` job edits THIS comment in place with
+  # the results at the end (its id is this job's output). Privileged (App
+  # token) like `comment`, and like it runs no checkout and no PR-derived
+  # code — only build's string outputs.
+  announce:
+    needs: build
+    if: always() && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      comment-id: ${{ steps.post.outputs.comment-id }}
+    steps:
+      # PR-derived strings (parse-error, config-summary) arrive via env, not
+      # inline `${{ }}`; a quoted `echo "$VAR"` never re-evaluates the value,
+      # so a crafted summary can't inject shell (the rule the other jobs
+      # follow).
+      - name: Compose initial body
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          PARSE_ERROR: ${{ needs.build.outputs.parse-error }}
+          SUMMARY: ${{ needs.build.outputs.config-summary }}
+          HEAD_SHA: ${{ inputs.head-sha }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "$BUILD_RESULT" != success ]; then
+            {
+              echo "## ❌ benchmark run failed"
+              if [ -n "$PARSE_ERROR" ]; then
+                echo
+                echo "> $PARSE_ERROR"
+              fi
+              echo
+              echo "[Workflow logs]($RUN_URL)"
+            } > comment-body.md
+          else
+            {
+              echo "## ⏳ Benchmark running…"
+              echo
+              if [ -n "$SUMMARY" ]; then
+                echo "> $SUMMARY"
+                echo
+              fi
+              echo "Benchmarking \`${HEAD_SHA:0:7}\` — this comment will be replaced with the results when the run finishes."
+              echo
+              echo "[Watch progress]($RUN_URL)"
+            } > comment-body.md
+          fi
+      - name: Generate token to write PR comment
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.TOKEN_APP_ID }}
+          private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
+      - name: Post initial comment
+        id: post
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          issue-number: ${{ inputs.pr }}
+          body-path: comment-body.md
+
+  # ONE measured `ix compile` per requested env, before the runs: it
+  # publishes the `.ixe` the prover runs restore (no per-run compile
+  # races), and its results row doubles as the compile run's PR side —
   # requesting the compile backend never compiles the env twice.
   compile:
     name: compile-${{ matrix.env }}
     needs: build
     if: needs.build.outputs.envs != '[]'
     runs-on: warp-ubuntu-latest-x64-32x
-    timeout-minutes: 120
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -271,7 +335,7 @@ jobs:
         with:
           path: ${{ matrix.env }}.ixe
           key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
-      # The measured row: the compile cell reuses it as its PR side (same
+      # The measured row: the compile run reuses it as its PR side (same
       # runner class, same binaries, same command it would run itself).
       - name: Publish compile row
         if: steps.pr-ixe.outputs.cache-hit != 'true'
@@ -282,26 +346,26 @@ jobs:
 
   benchmark:
     # Explicit name: the default would append EVERY matrix value (backend,
-    # env, mode, runner, label); the label already is the cell id.
-    name: ${{ matrix.cell.label }}
+    # env, mode, runner, label); the label already is the run id.
+    name: ${{ matrix.params.label }}
     needs: [build, compile]
-    # A compile failure stops the cells (they would just re-fail the same
+    # A compile failure stops the runs (they would just re-fail the same
     # compile lazily); the skipped case can't arise (envs is never empty)
     # but is tolerated for robustness.
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.compile.result != 'failure' && needs.compile.result != 'cancelled' }}
-    runs-on: ${{ matrix.cell.runner }}
-    # Wide enough for the zisk cell's worst case: per-constant loop + PR-side
+    runs-on: ${{ matrix.params.runner }}
+    # Wide enough for the zisk run's worst case: per-constant loop + PR-side
     # `ix profile` when a heavy primary's closure shards must be cut fresh.
-    timeout-minutes: 180
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        cell: ${{ fromJSON(needs.build.outputs.matrix) }}
+        params: ${{ fromJSON(needs.build.outputs.matrix) }}
     env:
-      BACKEND: ${{ matrix.cell.backend }}
-      BENV: ${{ matrix.cell.env }}
-      MODE: ${{ matrix.cell.mode }}
-      LABEL: ${{ matrix.cell.label }}
+      BACKEND: ${{ matrix.params.backend }}
+      BENV: ${{ matrix.params.env }}
+      MODE: ${{ matrix.params.mode }}
+      LABEL: ${{ matrix.params.label }}
       BASE_SHA: ${{ inputs.base-sha }}
       HEAD_SHA: ${{ inputs.head-sha }}
       SHARD: ${{ needs.build.outputs.shard }}
@@ -343,11 +407,11 @@ jobs:
           echo "$PWD/.lake/build/bin" >> "$GITHUB_PATH"
       # Toolchain provisioning only (no package build, no mathlib cache):
       # the restored binaries link against the toolchain's libleanshared.
-      # Cells never compile an env: the `.ixe` and the compile row come
+      # Runs never compile an env: the `.ixe` and the compile row come
       # from the compile job, and their restores fail on a miss — both
       # were published moments ago in this same run, so a miss is an
       # infrastructure failure, not something to recompile around (and an
-      # in-cell compile couldn't rebuild the Mathlib env anyway: its
+      # in-run compile couldn't rebuild the Mathlib env anyway: its
       # oleans live only in the compile job's subpackage provisioning).
       - name: Provision Lean toolchain
         uses: leanprover/lean-action@v1
@@ -356,42 +420,42 @@ jobs:
           auto-config: false
           build: false
           use-github-cache: false
-      # The compiled env is identical across every cell of the same PR commit —
-      # the compile job published it; cells pass it via `--ixe` instead of
+      # The compiled env is identical across every run of the same PR commit —
+      # the compile job published it; runs pass it via `--ixe` instead of
       # recompiling.
       - name: Restore PR .ixe
         uses: actions/cache/restore@v6
         with:
-          path: ${{ matrix.cell.env }}.ixe
-          key: bench-pr-ixe-${{ env.HEAD_SHA }}-${{ matrix.cell.env }}-${{ hashFiles('ptenv.txt') }}
+          path: ${{ matrix.params.env }}.ixe
+          key: bench-pr-ixe-${{ env.HEAD_SHA }}-${{ matrix.params.env }}-${{ hashFiles('ptenv.txt') }}
           fail-on-cache-miss: true
-      # Compile cells reuse the compile job's measured row as their PR side.
+      # Compile runs reuse the compile job's measured row as their PR side.
       - name: Restore compile row
-        if: matrix.cell.backend == 'compile'
+        if: matrix.params.backend == 'compile'
         uses: actions/cache/restore@v6
         with:
           path: compile.json
-          key: bench-pr-row-${{ env.HEAD_SHA }}-${{ matrix.cell.env }}-${{ hashFiles('ptenv.txt') }}
+          key: bench-pr-row-${{ env.HEAD_SHA }}-${{ matrix.params.env }}-${{ hashFiles('ptenv.txt') }}
           fail-on-cache-miss: true
-      # zkVM cells additionally need the Rust toolchain + the backend's toolchain
+      # zkVM runs additionally need the Rust toolchain + the backend's toolchain
       # and system deps (the shared composite install actions).
       - name: Set up zkVM Rust toolchain
-        if: matrix.cell.backend == 'zisk' || matrix.cell.backend == 'sp1'
+        if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-workspaces: ${{ matrix.cell.backend }}
+          cache-workspaces: ${{ matrix.params.backend }}
       # sp1 is disabled in the registry (execute too slow for CI);
       # re-enable it there and uncomment this install step to restore it.
       # - name: Install SP1
-      #   if: matrix.cell.backend == 'sp1'
+      #   if: matrix.params.backend == 'sp1'
       #   uses: ./.github/actions/install-sp1
       - name: Install Zisk
-        if: matrix.cell.backend == 'zisk'
+        if: matrix.params.backend == 'zisk'
         uses: ./.github/actions/install-zisk
 
       # ---------- PR side ----------
       # The PR side runs FIRST: `ix bench run` does its own constant selection
-      # from Vectors.csv, so pr.json's row names are this cell's canonical
+      # from Vectors.csv, so pr.json's row names are this run's canonical
       # name list — the main-side bencher fetch below filters on them.
       - name: Run backend on PR → pr.json
         id: pr-run
@@ -425,7 +489,7 @@ jobs:
       # ingested yet) → fall back to a local base run; anything else (2 =
       # backend/mode has no main testbed — a registry /
       # bench-main.yml drift) is a permanent misconfiguration that a local
-      # rebuild can never fix, so fail the cell loudly instead of silently
+      # rebuild can never fix, so fail the run loudly instead of silently
       # paying the fallback on every future run.
       #
       # Partial miss (exit 0 + non-empty missing.txt): the PR's Vectors.csv
@@ -445,7 +509,7 @@ jobs:
             echo "run-base=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # This cell's names = pr.json's row keys (empty when the PR run
+          # This run's names = pr.json's row keys (empty when the PR run
           # produced nothing — fetch-main then exits 3 and the base run
           # supplies the whole main side).
           NAMES=$(jq -r 'keys | join(",")' "$GITHUB_WORKSPACE/pr.json" 2>/dev/null || true)
@@ -498,9 +562,9 @@ jobs:
           # versions entries by path list); the key suffix is the env name
           # (bench-main's matrix.env).
           path: |
-            ${{ matrix.cell.env }}.ixe
-            zkshards-${{ matrix.cell.env }}
-          key: bench-ixe-${{ env.BASE_SHA }}-${{ matrix.cell.env }}
+            ${{ matrix.params.env }}.ixe
+            zkshards-${{ matrix.params.env }}
+          key: bench-ixe-${{ env.BASE_SHA }}-${{ matrix.params.env }}
       # Cached base binaries are usable only when the two `lean-toolchain`
       # files are identical (plain `cmp`), and — for the mathlib env — only
       # when the `.ixe` was also restored (otherwise base's `ix compile` needs
@@ -535,19 +599,19 @@ jobs:
       # Base-side `ix compile` of a mathlib-importing env (Mathlib, FLT)
       # resolves imports from the base tree's Benchmarks/Compile subpackage —
       # mathlib lives there, not in the root workspace, so the cache fetch
-      # can't ride the build action above. Compile cells need this even with
+      # can't ride the build action above. Compile runs need this even with
       # cached binaries: the compile backend always compiles (`--ixe` is
-      # ignored by design), while a prover cell with cached binaries rides
+      # ignored by design), while a prover run with cached binaries rides
       # the restored `.ixe` and skips the compile entirely.
       - name: Fetch base Mathlib oleans
         if: >-
           steps.bencher.outputs.run-base == 'true' &&
-          (matrix.cell.env == 'Mathlib' || matrix.cell.env == 'FLT') &&
-          (matrix.cell.backend == 'compile' || steps.base-src.outputs.cached != 'true')
+          (matrix.params.env == 'Mathlib' || matrix.params.env == 'FLT') &&
+          (matrix.params.backend == 'compile' || steps.base-src.outputs.cached != 'true')
         working-directory: base/Benchmarks/Compile
         run: |
           lake exe cache get
-          lake build Compile${{ matrix.cell.env }}
+          lake build Compile${{ matrix.params.env }}
       # NOTE: the PR's `ix bench` orchestrates the base run (--repo base); the
       # MEASURED tools resolve from base/.lake/build/bin. When a PR changes
       # the benchmark CLIs themselves, the base tools may reject the new
@@ -557,16 +621,16 @@ jobs:
       # Partial bencher miss (missing.txt non-empty): the base side runs JUST
       # the uncovered names (passed via `--consts`) — typically constants the PR
       # itself adds to Vectors.csv, which base's Vectors.csv doesn't list, so
-      # `--csv` points at the PR's copy. Full miss: the whole cell runs on
+      # `--csv` points at the PR's copy. Full miss: the whole selection runs on
       # base with the normal CSV selection.
       - name: Run backend on base → merge into main.json
         if: steps.bencher.outputs.run-base == 'true'
         run: |
           if [ "${{ steps.base-ixe.outputs.cache-hit }}" = true ]; then
-            mv "${{ matrix.cell.env }}.ixe" "base/${{ matrix.cell.env }}.ixe"
+            mv "${{ matrix.params.env }}.ixe" "base/${{ matrix.params.env }}.ixe"
             # bench-main's pre-cut closure shards ride the same cache entry;
             # in place, `ix bench run` skips re-cutting them for the base tree.
-            mv "zkshards-${{ matrix.cell.env }}" "base/zkshards-${{ matrix.cell.env }}" 2>/dev/null || true
+            mv "zkshards-${{ matrix.params.env }}" "base/zkshards-${{ matrix.params.env }}" 2>/dev/null || true
           fi
           if [ "$BACKEND" = zisk ]; then
             sudo prlimit --pid $$ --memlock=unlimited:unlimited
@@ -577,7 +641,7 @@ jobs:
           if [ -s "$GITHUB_WORKSPACE/main.json" ] && [ -s "$GITHUB_WORKSPACE/missing.txt" ]; then
             flags="$flags --consts $(paste -sd, "$GITHUB_WORKSPACE/missing.txt")"
           fi
-          # A base-side rejection or empty run must not redden the PR's cell:
+          # A base-side rejection or empty run must not redden the PR's run:
           # whatever rows landed are merged and the table says the rest.
           set +e
           # Cached base .ixe when the restore above hit; else the base run
@@ -617,7 +681,7 @@ jobs:
 
       - name: Upload table
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: table-${{ env.LABEL }}
           path: out/table-${{ env.LABEL }}.md
@@ -631,7 +695,7 @@ jobs:
           echo "::error::ix bench run failed on the PR side (kernel rejection or empty run) — see the 'Run backend on PR' step"
           exit 1
 
-  # Assemble the comment body from the per-cell tables. Deliberately
+  # Assemble the comment body from the per-run tables. Deliberately
   # UNPRIVILEGED: this job checks out and executes PR-derived code (the
   # PR-built `ix bench report`), so it must never share a job with the App
   # token — the posting job below only downloads the finished body as an
@@ -639,7 +703,7 @@ jobs:
   # execution in a privileged workflow).
   assemble:
     needs: [build, benchmark]
-    # Assemble even when benchmark cells failed (the tables carry the ❌
+    # Assemble even when benchmark runs failed (the tables carry the ❌
     # rows); the build job must have produced the binaries.
     if: always() && needs.build.result == 'success'
     # `bench report` is a pure-Lean subcommand (AVX-512 lives only in the
@@ -667,7 +731,7 @@ jobs:
           build: false
           use-github-cache: false
       - name: Download tables
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           path: tables
           pattern: table-*
@@ -677,79 +741,16 @@ jobs:
           SUMMARY: ${{ needs.build.outputs.config-summary }}
           HEAD_SHA: ${{ inputs.head-sha }}
         run: |
-          mkdir -p tables   # absent when no cell uploaded a table
+          mkdir -p tables   # absent when no run uploaded a table
           ix bench report \
             --tables tables --summary "$SUMMARY" \
             --head "$HEAD_SHA" \
             --repo-url "${{ github.server_url }}/${{ github.repository }}" \
             --run-id "${{ github.run_id }}" --out comment-body.md
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v4
         with:
           name: comment-body
           path: comment-body.md
-
-  # Post the initial PR comment the instant the command is parsed: a red-X
-  # diagnostic if the parse/build failed (the same message the final comment
-  # would carry), otherwise a "running" placeholder so the commenter gets
-  # immediate feedback. The `comment` job edits THIS comment in place with
-  # the results at the end (its id is this job's output). Privileged (App
-  # token) like `comment`, and like it runs no checkout and no PR-derived
-  # code — only build's string outputs.
-  announce:
-    needs: build
-    if: always() && github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      comment-id: ${{ steps.post.outputs.comment-id }}
-    steps:
-      # PR-derived strings (parse-error, config-summary) arrive via env, not
-      # inline `${{ }}`; a quoted `echo "$VAR"` never re-evaluates the value,
-      # so a crafted summary can't inject shell (the rule the other jobs
-      # follow).
-      - name: Compose initial body
-        env:
-          BUILD_RESULT: ${{ needs.build.result }}
-          PARSE_ERROR: ${{ needs.build.outputs.parse-error }}
-          SUMMARY: ${{ needs.build.outputs.config-summary }}
-          HEAD_SHA: ${{ inputs.head-sha }}
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          if [ "$BUILD_RESULT" != success ]; then
-            {
-              echo "## ❌ benchmark run failed"
-              if [ -n "$PARSE_ERROR" ]; then
-                echo
-                echo "> $PARSE_ERROR"
-              fi
-              echo
-              echo "[Workflow logs]($RUN_URL)"
-            } > comment-body.md
-          else
-            {
-              echo "## ⏳ Benchmark running…"
-              echo
-              if [ -n "$SUMMARY" ]; then
-                echo "> $SUMMARY"
-                echo
-              fi
-              echo "Benchmarking \`${HEAD_SHA:0:7}\` — this comment will be replaced with the results when the run finishes."
-              echo
-              echo "[Watch progress]($RUN_URL)"
-            } > comment-body.md
-          fi
-      - name: Generate token to write PR comment
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.TOKEN_APP_ID }}
-          private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
-      - name: Post initial comment
-        id: post
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          issue-number: ${{ inputs.pr }}
-          body-path: comment-body.md
 
   # Edit the announce comment in place with the assembled body — or a red-X
   # diagnostic when any stage failed (a rejected command or broken run must
@@ -764,12 +765,12 @@ jobs:
       - name: Download comment body
         if: needs.assemble.result == 'success'
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: comment-body
       # Any failed stage prepends a red-X header (quoting the parse error
       # when that's the cause) to the report — or replaces it when
-      # assemble produced none. A rejection-reddened cell still shows its
+      # assemble produced none. A rejection-reddened run still shows its
       # tables below the header.
       - name: Note failures
         if: contains(needs.*.result, 'failure') || needs.assemble.result != 'success'

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -4,14 +4,15 @@
 #   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [decompile] [aiur-recursive] | all) [execute]
 #     (sp1 is disabled in the registry (Ix/Cli/BenchCmd.lean) — the parser skips it
 #      with a note in the config summary)
-#   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (case-insensitive; defaults to every
-#                                  #  registry env for compile/decompile, InitStd for the rest;
-#                                  #  env-keyed-only requests may name any registry env, e.g. Lean/FLT)
+#   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (case-insensitive, any registry env;
+#                                  #  defaults to every env for compile/decompile, InitStd
+#                                  #  for the rest)
 #   BENCH_CONSTS=Mathlib.X,Y       # bench exactly these constants on the per-constant
 #                                  #  backends (overrides the curated selection); each name's
 #                                  #  env comes from its Vectors.csv row, so a Mathlib constant
-#                                  #  schedules a Mathlib entry by itself — BENCH_ENVS is only
-#                                  #  needed (single env) to place a name the CSV doesn't list
+#                                  #  schedules a Mathlib entry by itself. A single-env
+#                                  #  BENCH_ENVS overrides the attribution and places names
+#                                  #  the CSV doesn't list
 #   BENCH_FULL=1                   # run the full curated set, not just primary
 #   BENCH_SHARD=1                  # restrict to the multi-shard target constants
 #   BENCH_PHASES=1                 # add per-constant phase drill-downs to the comment

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -7,12 +7,12 @@
 #   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (case-insensitive, any registry env;
 #                                  #  defaults to every env for compile/decompile, InitStd
 #                                  #  for the rest)
-#   BENCH_CONSTS=Mathlib.X,Y       # bench exactly these constants on the per-constant
-#                                  #  backends (overrides the curated selection); each name's
-#                                  #  env comes from its Vectors.csv row, so a Mathlib constant
-#                                  #  schedules a Mathlib entry by itself. A single-env
-#                                  #  BENCH_ENVS overrides the attribution and places names
-#                                  #  the CSV doesn't list
+#   BENCH_CONSTS=Nat.gcd,Y        # bench exactly these constants on the per-constant
+#                                  #  backends (overrides the curated selection). Each name's
+#                                  #  env is found automatically — Vectors.csv row first, else
+#                                  #  defining module, else Mathlib (FLT for FLT.* names) — so
+#                                  #  BENCH_ENVS is never required; a single-env BENCH_ENVS
+#                                  #  still forces placement
 #   BENCH_FULL=1                   # run the full curated set, not just primary
 #   BENCH_SHARD=1                  # restrict to the multi-shard target constants
 #   BENCH_PHASES=1                 # add per-constant phase drill-downs to the comment

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -7,6 +7,11 @@
 #   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (case-insensitive; defaults to every
 #                                  #  registry env for compile/decompile, InitStd for the rest;
 #                                  #  env-keyed-only requests may name any registry env, e.g. Lean/FLT)
+#   BENCH_CONSTS=Mathlib.X,Y       # bench exactly these constants on the per-constant
+#                                  #  backends (overrides the curated selection); each name's
+#                                  #  env comes from its Vectors.csv row, so a Mathlib constant
+#                                  #  schedules a Mathlib entry by itself — BENCH_ENVS is only
+#                                  #  needed (single env) to place a name the CSV doesn't list
 #   BENCH_FULL=1                   # run the full curated set, not just primary
 #   BENCH_SHARD=1                  # restrict to the multi-shard target constants
 #   BENCH_PHASES=1                 # add per-constant phase drill-downs to the comment
@@ -365,6 +370,7 @@ jobs:
       BACKEND: ${{ matrix.params.backend }}
       BENV: ${{ matrix.params.env }}
       MODE: ${{ matrix.params.mode }}
+      CONSTS: ${{ matrix.params.consts }}
       LABEL: ${{ matrix.params.label }}
       BASE_SHA: ${{ inputs.base-sha }}
       HEAD_SHA: ${{ inputs.head-sha }}
@@ -480,6 +486,7 @@ jobs:
           flags=""
           [ "$FULL" = 1 ] && flags="$flags --full"
           [ "$SHARD" = 1 ] && flags="$flags --shard-only"
+          [ -n "$CONSTS" ] && flags="$flags --consts $CONSTS"
           ix bench run --backend "$BACKEND" --env "$BENV" --mode "$MODE" \
             --ixe "$BENV.ixe" --out "$GITHUB_WORKSPACE/pr.json" $flags
 
@@ -640,6 +647,10 @@ jobs:
           [ "$SHARD" = 1 ] && flags="$flags --shard-only"
           if [ -s "$GITHUB_WORKSPACE/main.json" ] && [ -s "$GITHUB_WORKSPACE/missing.txt" ]; then
             flags="$flags --consts $(paste -sd, "$GITHUB_WORKSPACE/missing.txt")"
+          elif [ -n "$CONSTS" ]; then
+            # Full miss with a BENCH_CONSTS override: the base side must
+            # measure the same explicit names, not the default selection.
+            flags="$flags --consts $CONSTS"
           fi
           # A base-side rejection or empty run must not redden the PR's run:
           # whatever rows landed are merged and the table says the rest.

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -22,43 +22,35 @@
 #                                  # compile` and keys its caches, so a knob run gets
 #                                  # its own row instead of the default run's
 #
-# Mode defaults per backend (the registry's defaultMode): `aiur` runs
-# `prove` — the real-workload simulation, whose report also carries the
-# Phase-1 columns `fft-cost` / `execute-time` measured en route; `zisk` /
-# `sp1` / `ooc` run `execute`; `compile` runs `ix compile <env>.lean →
-# <env>.ixe` (the same run bench-main.yml uploads under testbed
-# `ix-compile-*`); `decompile` runs `ix decompile <env>.ixe` over the
-# compile run's fresh PR `.ixe` (testbed `ix-decompile-*`);
-# `aiur-recursive` runs the aiur-recursive toy (bench-recursive-verifier's
-# fixed configs — env-independent, so it always schedules exactly one run
-# no matter what BENCH_ENVS says). The optional bare `execute` token flips
-# `aiur` to execute-only (Phase 1, skipping the prove); bench-main runs
-# both aiur modes as separate runs on separate testbeds, so either kind
-# of run fetches a cached main-side baseline from bencher. The bare
-# `recursive` token flips aiur to its recursive mode instead — an
-# unscheduled testbed with no bencher baseline (its main side is a base-SHA
-# run), and the verifier execute OOMs the standard CI host, so it's meant
-# for a bigger manual dispatch. The bare `fresh` token makes every run
-# skip the bencher fetch and re-measure the main side with a base-SHA run
-# (nothing here uploads to bencher, so the canonical baseline is
-# untouched).
+# Each backend runs its registry default mode:
+#   - aiur: `prove` (the real workload; the report also shows the
+#     fft-cost / execute-time measured on the way). The bare `execute`
+#     token switches aiur to the fast execute-only mode; the bare
+#     `recursive` token switches it to recursive mode (no bencher
+#     baseline exists for that, and it needs more RAM than CI has — meant
+#     for a bigger manual dispatch).
+#   - zisk / sp1 / ooc: `execute`.
+#   - compile: `ix compile <env>.lean` → `<env>.ixe`.
+#   - decompile: `ix decompile` over the compile run's fresh `.ixe`.
+#   - aiur-recursive: fixed toy statements; env-independent, so it always
+#     schedules exactly one run regardless of BENCH_ENVS.
+# The bare `fresh` token skips the bencher fetch and re-measures the main
+# side with a local base-SHA run. Nothing in this workflow uploads to
+# bencher, so the canonical baseline is never touched.
 #
-# Each matrix entry is one `ix bench run` per side, driven by the PR's `ix`
-# (`--repo` points it at the checkout to measure). main's numbers come from
-# bencher.dev (`ix bench fetch-main`); the workflow re-runs the base SHA
-# locally only when bencher can't supply them — the base SHA isn't ingested yet
-# (freshly-pushed main whose CI is still running), or the PR's Vectors.csv
-# selects constants main was never benched on (constants the PR itself adds) —
-# or when the `fresh` token demands it.
-# Two-stage trigger: the issue_comment run only gates the commenter and
-# re-dispatches this same file as workflow_dispatch. GitHub classifies
-# issue_comment as a low-trust trigger with unconditionally READ-ONLY cache
-# access in the default branch's scope (anti-cache-poisoning; no token
-# permission can override it), so every cache save in a comment-triggered
-# run fails with "token has no writable scopes". workflow_dispatch is on
-# the trusted-trigger allowlist, so the dispatched run's cache saves work
-# with an ordinary read-only token. The commenter gate (org MEMBER/OWNER)
-# lives in the dispatch job; manual dispatch needs repo write access.
+# For each matrix entry the job runs `ix bench run` twice: once on the PR
+# checkout, once for the main side. The main side normally comes from
+# bencher.dev (`ix bench fetch-main`); the workflow only runs the base
+# SHA locally when bencher can't supply the numbers — the base SHA isn't
+# uploaded yet, or the PR selects constants main never benched (typically
+# ones the PR itself adds), or `fresh` demands it.
+#
+# Why two trigger stages: GitHub gives issue_comment runs read-only cache
+# access (anti-poisoning; no token permission can override it), so cache
+# saves would all fail. The issue_comment run therefore only checks the
+# commenter is an org MEMBER/OWNER and re-dispatches this same file as
+# workflow_dispatch, which is allowed to save caches. Manual dispatch
+# needs repo write access.
 name: Benchmark pull requests
 
 on:
@@ -118,18 +110,15 @@ jobs:
             -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
             -f comment-body="$COMMENT_BODY"
 
-  # Build the PR's `ix` + `bench-typecheck` + `bench-recursive-verifier`
-  # once (they embed the IxVM kernel
-  # and the Aiur prover), stage under ~/.local/bin, and cache by head SHA —
-  # the matrix runs restore instead of re-running the full Lean build per
-  # run, and re-running !benchmark on the same commit skips the build
-  # entirely. Built on warp, mirroring bench-main.yml's build job, so PR
-  # binaries carry the same instruction-set provenance (uniform AVX-512
-  # fleet) as the binaries behind bencher's main-side numbers — and every
-  # job that RUNS them must be a warp host too, or a non-AVX-512 GitHub
-  # host SIGILLs. The job ends by parsing the !benchmark command with
-  # the freshly built `ix bench ci parse` — the registry lives in Lean, so the
-  # matrix can only exist post-build.
+  # Build the PR's `ix`, `bench-typecheck`, and `bench-recursive-verifier`
+  # once, cache them by head SHA, and let every other job restore them.
+  # Re-running !benchmark on the same commit skips the build entirely.
+  # Built on a warp runner like bench-main's binaries, so both sides share
+  # the same instruction set (AVX-512) — and every job that runs these
+  # binaries must be a warp host too, or a plain GitHub host crashes with
+  # an illegal instruction. The job ends by parsing the !benchmark command
+  # with the freshly built `ix bench ci parse`: the registry lives in
+  # Lean, so the matrix can only be computed after the build.
   build:
     if: github.event_name == 'workflow_dispatch'
     runs-on: warp-ubuntu-latest-x64-32x
@@ -202,13 +191,13 @@ jobs:
           COMMENT_BODY: ${{ inputs.comment-body }}
         run: ix bench ci parse
 
-  # Post the initial PR comment the instant the command is parsed: a red-X
-  # diagnostic if the parse/build failed (the same message the final comment
-  # would carry), otherwise a "running" placeholder so the commenter gets
-  # immediate feedback. The `comment` job edits THIS comment in place with
-  # the results at the end (its id is this job's output). Privileged (App
-  # token) like `comment`, and like it runs no checkout and no PR-derived
-  # code — only build's string outputs.
+  # Post the initial PR comment as soon as the command is parsed: an
+  # error message if the parse/build failed, otherwise a "running…"
+  # placeholder so the commenter gets immediate feedback. The `comment`
+  # job at the end edits this same comment in place with the results
+  # (this job's output is the comment id). Holds the App token, so — like
+  # `comment` — it never checks out or runs PR code; it only reads
+  # build's string outputs.
   announce:
     needs: build
     if: always() && github.event_name == 'workflow_dispatch'
@@ -216,10 +205,10 @@ jobs:
     outputs:
       comment-id: ${{ steps.post.outputs.comment-id }}
     steps:
-      # PR-derived strings (parse-error, config-summary) arrive via env, not
-      # inline `${{ }}`; a quoted `echo "$VAR"` never re-evaluates the value,
-      # so a crafted summary can't inject shell (the rule the other jobs
-      # follow).
+      # PR-derived strings (parse-error, config-summary) come in as env
+      # vars, never inline `${{ }}` in the script — a quoted `echo "$VAR"`
+      # can't be tricked into running shell code. Every job here follows
+      # this rule.
       - name: Compose initial body
         env:
           BUILD_RESULT: ${{ needs.build.result }}
@@ -265,10 +254,10 @@ jobs:
           issue-number: ${{ inputs.pr }}
           body-path: comment-body.md
 
-  # ONE measured `ix compile` per requested env, before the runs: it
-  # publishes the `.ixe` the prover runs restore (no per-run compile
-  # races), and its results row doubles as the compile run's PR side —
-  # requesting the compile backend never compiles the env twice.
+  # One measured `ix compile` per requested env, before the benchmark
+  # runs. It publishes the `.ixe` the other runs restore (so they never
+  # race to compile it themselves), and its results row doubles as the
+  # compile backend's PR side — requesting compile never compiles twice.
   compile:
     name: compile-${{ matrix.env }}
     needs: build
@@ -286,16 +275,17 @@ jobs:
           ref: ${{ inputs.head-sha }}
           # The job runs PR code; never leave the token in .git.
           persist-credentials: false
-      # Allowlisted KEY=VALUE lines from the !benchmark comment. Applied
-      # here so IX_COMPILE_* knobs reach the measured compile, and staged
-      # to a file so the cache keys below can hash it — a knob run must
-      # not reuse (or overwrite) the default run's published .ixe/row.
+      # Apply the allowlisted KEY=VALUE lines from the !benchmark comment,
+      # so IX_COMPILE_* knobs reach the measured compile. Also written to
+      # a file so the cache keys below can hash it: a run with different
+      # knobs must not reuse or overwrite the default run's published
+      # .ixe and row.
       - name: Apply passthrough env
         env:
           PTENV: ${{ needs.build.outputs.passthrough-env }}
         run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' | tee ptenv.txt >> "$GITHUB_ENV"
-      # Re-running !benchmark on the same commit with the same config: the
-      # .ixe is already published — nothing to do.
+      # If !benchmark already ran on this commit with the same config, the
+      # .ixe is already published and this whole job short-circuits.
       - name: Check for published .ixe
         id: pr-ixe
         uses: actions/cache/restore@v6
@@ -312,9 +302,9 @@ jobs:
           fail-on-cache-miss: true
       - if: steps.pr-ixe.outputs.cache-hit != 'true'
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      # Pointed at the Benchmarks/Compile SUBPACKAGE (same toolchain as the
-      # root): mathlib is a dependency there only, so `lake exe cache get`
-      # (use-mathlib-cache) is an unknown executable from the root.
+      # Pointed at the Benchmarks/Compile subpackage (same toolchain as
+      # the root): mathlib is a dependency only there, so the mathlib
+      # cache fetch has to run from that directory.
       - name: Provision Lean toolchain
         if: steps.pr-ixe.outputs.cache-hit != 'true'
         uses: leanprover/lean-action@v1
@@ -325,9 +315,8 @@ jobs:
           use-github-cache: false
           # Mathlib oleans for every env that imports Mathlib (FLT does).
           use-mathlib-cache: ${{ (matrix.env == 'Mathlib' || matrix.env == 'FLT') && 'true' || 'false' }}
-      # The measured `ix compile` resolves the env's imports from the
-      # subpackage's oleans — bench-main builds the same target before its
-      # measured compile.
+      # The measured compile resolves the env's imports from these oleans;
+      # bench-main builds the same target before its measured compile.
       - name: Build env oleans
         if: steps.pr-ixe.outputs.cache-hit != 'true'
         working-directory: Benchmarks/Compile
@@ -341,8 +330,8 @@ jobs:
         with:
           path: ${{ matrix.env }}.ixe
           key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
-      # The measured row: the compile run reuses it as its PR side (same
-      # runner class, same binaries, same command it would run itself).
+      # Publish the measured row too: the compile backend's benchmark run
+      # reuses it as its PR side (same runner class, binaries, command).
       - name: Publish compile row
         if: steps.pr-ixe.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
@@ -351,17 +340,17 @@ jobs:
           key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
 
   benchmark:
-    # Explicit name: the default would append EVERY matrix value (backend,
-    # env, mode, runner, label); the label already is the run id.
+    # Explicit name — the default would append every matrix value; the
+    # label already identifies the run.
     name: ${{ matrix.params.label }}
     needs: [build, compile]
-    # A compile failure stops the runs (they would just re-fail the same
-    # compile lazily); the skipped case can't arise (envs is never empty)
-    # but is tolerated for robustness.
+    # A compile failure stops the runs (they would only re-fail the same
+    # compile lazily). The skipped case cannot actually arise (envs is
+    # never empty) but is tolerated for robustness.
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.compile.result != 'failure' && needs.compile.result != 'cancelled' }}
     runs-on: ${{ matrix.params.runner }}
-    # Wide enough for the zisk run's worst case: per-constant loop + PR-side
-    # `ix profile` when a heavy primary's closure shards must be cut fresh.
+    # `ix bench run` saves completed rows as it goes, so a timeout keeps
+    # them on disk — but the compare and upload need the job alive.
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -379,29 +368,28 @@ jobs:
       FULL: ${{ needs.build.outputs.full }}
       FRESH: ${{ needs.build.outputs.fresh }}
     steps:
-      # PR checked out at the workspace root so the local install actions
-      # resolve; base (bencher-miss fallback only) goes under base/.
+      # The PR is checked out at the workspace root (the local composite
+      # actions resolve from there); the base checkout, when needed, goes
+      # under base/.
       - name: Checkout PR
         uses: actions/checkout@v7
         with:
           ref: ${{ env.HEAD_SHA }}
           # The job runs PR code; never leave the token in .git.
           persist-credentials: false
-      # Allowlisted KEY=VALUE lines from the !benchmark comment (often
-      # empty). Delivered via an env var — inline `${{ }}` inside a heredoc
-      # both risks injection and breaks the quoted terminator's required
-      # column-0 position under YAML block indentation.
+      # Apply the allowlisted KEY=VALUE lines from the !benchmark comment
+      # (often empty). Delivered via an env var, not inline `${{ }}` —
+      # inlining would risk shell injection.
       - name: Apply passthrough env
         env:
           PTENV: ${{ needs.build.outputs.passthrough-env }}
         run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' | tee ptenv.txt >> "$GITHUB_ENV"
-      # Restore the once-built PR binaries (see the build job) into the PR
-      # tree's own bin dir: `ix bench run` resolves the measured tools from
-      # <repo>/.lake/build/bin first, then PATH, so staging in-tree keeps the
-      # PR and base sides cleanly separated (~/.local/bin stays free for the
-      # base side's cache restore below). The same dir goes on PATH — the
-      # PR's `ix bench` orchestrates BOTH sides, with `--repo` selecting
-      # whose tools get measured.
+      # Restore the PR binaries into the PR tree's own bin dir.
+      # `ix bench run` looks for the measured tools in <repo>/.lake/build/bin
+      # before PATH, so keeping them in-tree separates the PR side from the
+      # base side (whose binaries land in base/.lake/build/bin, and whose
+      # cache restore reuses ~/.local/bin). The PR's `ix bench` drives BOTH
+      # sides; `--repo` picks whose tools get measured.
       - name: Restore PR binaries
         uses: actions/cache/restore@v6
         with:
@@ -412,14 +400,12 @@ jobs:
           mkdir -p .lake/build/bin
           mv ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier .lake/build/bin/
           echo "$PWD/.lake/build/bin" >> "$GITHUB_PATH"
-      # Toolchain provisioning only (no package build, no mathlib cache):
-      # the restored binaries link against the toolchain's libleanshared.
-      # Runs never compile an env: the `.ixe` and the compile row come
-      # from the compile job, and their restores fail on a miss — both
-      # were published moments ago in this same run, so a miss is an
-      # infrastructure failure, not something to recompile around (and an
-      # in-run compile couldn't rebuild the Mathlib env anyway: its
-      # oleans live only in the compile job's subpackage provisioning).
+      # Toolchain only (no package build, no mathlib cache): the restored
+      # binaries need the toolchain's libleanshared to run. This job never
+      # compiles an env — the `.ixe` and compile row come from the compile
+      # job, published moments ago in this same workflow run, so a cache
+      # miss below is an infrastructure failure, not something to
+      # recompile around.
       - name: Provision Lean toolchain
         uses: leanprover/lean-action@v1
         with:
@@ -427,9 +413,8 @@ jobs:
           auto-config: false
           build: false
           use-github-cache: false
-      # The compiled env is identical across every run of the same PR commit —
-      # the compile job published it; runs pass it via `--ixe` instead of
-      # recompiling.
+      # The compiled env is the same for every run of this PR commit; the
+      # compile job published it and runs pass it via `--ixe`.
       - name: Restore PR .ixe
         uses: actions/cache/restore@v6
         with:
@@ -461,15 +446,16 @@ jobs:
         uses: ./.github/actions/install-zisk
 
       # ---------- PR side ----------
-      # The PR side runs FIRST: `ix bench run` does its own constant selection
-      # from Vectors.csv, so pr.json's row names are this run's canonical
-      # name list — the main-side bencher fetch below filters on them.
+      # The PR side runs first: `ix bench run` selects its constants from
+      # Vectors.csv, and pr.json's row names become the canonical name
+      # list this run measures — the main-side fetch below asks bencher
+      # for exactly those names.
       - name: Run backend on PR → pr.json
         id: pr-run
-        # Exit 3 = the kernel rejected a constant on the PR side (rows on
-        # disk). Don't stop the job here — the compare table and PR comment
-        # must still render the ❌ row; the failure is re-raised LOUDLY at
-        # the end of the job, after the table upload.
+        # Exit 3 = the kernel rejected a constant on the PR side (rows are
+        # on disk). Keep going: the compare table and PR comment must
+        # still show the ❌ row. The failure is re-raised at the end of
+        # the job, after the table upload.
         continue-on-error: true
         run: |
           if [ "$BACKEND" = zisk ]; then
@@ -492,34 +478,30 @@ jobs:
             --ixe "$BENV.ixe" --out "$GITHUB_WORKSPACE/pr.json" $flags
 
       # ---------- main side ----------
-      # Try bencher.dev first (bench-main.yml has uploaded main's numbers).
-      # fetch-main's exit codes are load-bearing: 3 = transient (base SHA not
-      # ingested yet) → fall back to a local base run; anything else (2 =
-      # backend/mode has no main testbed — a registry /
-      # bench-main.yml drift) is a permanent misconfiguration that a local
-      # rebuild can never fix, so fail the run loudly instead of silently
-      # paying the fallback on every future run.
-      #
-      # Partial miss (exit 0 + non-empty missing.txt): the PR's Vectors.csv
-      # selects names main was never benched on — typically constants the PR
-      # itself adds. Bencher's numbers stand for the covered set; the base run
-      # below fills the gaps and the merge keeps bencher canonical. `run-base`
-      # gates every base-side step.
+      # Try bencher.dev first (bench-main.yml uploads main's numbers).
+      # fetch-main's exit codes matter:
+      #   3     = transient (base SHA not uploaded yet) — fall back to
+      #           running the base SHA locally.
+      #   other = permanent misconfiguration (e.g. no testbed for this
+      #           backend/mode) that a local run can never fix — fail
+      #           loudly instead of silently paying the fallback forever.
+      # Partial miss (exit 0 with a non-empty missing.txt): bencher covers
+      # some names but not all — typically constants this PR adds. The
+      # base run below fills only the gaps; bencher stays canonical for
+      # the rest. `run-base` gates every base-side step.
       - name: Fetch main from bencher
         id: bencher
         run: |
-          # The `fresh` token bypasses bencher entirely: same path as a full
-          # miss (exit 3) — no main.json, so the base run below supplies the
-          # whole main side. Nothing in this workflow uploads to bencher, so
-          # the canonical baseline is untouched.
+          # `fresh` skips bencher entirely — same as a full miss: no
+          # main.json, so the base run below supplies the whole main side.
           if [ "$FRESH" = 1 ]; then
             echo "source=base run @ ${BASE_SHA::7} (fresh — bencher bypassed)" >> "$GITHUB_OUTPUT"
             echo "run-base=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # This run's names = pr.json's row keys (empty when the PR run
-          # produced nothing — fetch-main then exits 3 and the base run
-          # supplies the whole main side).
+          # The names to fetch = pr.json's row keys. Empty when the PR run
+          # produced nothing; fetch-main then exits 3 and the base run
+          # covers everything.
           NAMES=$(jq -r 'keys | join(",")' "$GITHUB_WORKSPACE/pr.json" 2>/dev/null || true)
           set +e
           ix bench fetch-main \
@@ -548,12 +530,12 @@ jobs:
           ref: ${{ env.BASE_SHA }}
           path: base
           persist-credentials: false
-      # bench-main.yml's build/compile jobs already cached the base SHA's
-      # binaries and `.ixe` on the push to main — restore both before paying
-      # for a from-scratch base build.
-      # The bench-bins-<sha> key family has two producers: bench-main's build
-      # job (main commits) and this workflow's own build job (any PR head that
-      # ran !benchmark) — a stacked-PR base hits the latter.
+      # bench-main already cached the base SHA's binaries and `.ixe` when
+      # that commit was pushed to main — restore both before paying for a
+      # from-scratch base build. (The bench-bins-<sha> keys have two
+      # producers: bench-main's build job for main commits, and this
+      # workflow's build job for PR heads — a stacked-PR base hits the
+      # latter.)
       - name: Restore base binaries (bench-bins cache)
         if: steps.bencher.outputs.run-base == 'true'
         id: base-bins
@@ -573,12 +555,12 @@ jobs:
             ${{ matrix.params.env }}.ixe
             zkshards-${{ matrix.params.env }}
           key: bench-ixe-${{ env.BASE_SHA }}-${{ matrix.params.env }}
-      # Cached base binaries are usable only when the two `lean-toolchain`
-      # files are identical (plain `cmp`), and — for the mathlib env — only
-      # when the `.ixe` was also restored (otherwise base's `ix compile` needs
-      # mathlib oleans that only the full build fetches). Usable binaries are
-      # staged into base/.lake/build/bin, where `ix bench run --repo base`
-      # resolves them (a from-scratch base build lands there natively).
+      # Cached base binaries are only usable when both `lean-toolchain`
+      # files match, and — for Mathlib — only when the `.ixe` also
+      # restored (otherwise the base side would need mathlib oleans that
+      # only a full build fetches). Usable binaries go into
+      # base/.lake/build/bin, where `ix bench run --repo base` finds them;
+      # a from-scratch base build puts them there natively.
       - name: Resolve base binaries
         if: steps.bencher.outputs.run-base == 'true'
         id: base-src
@@ -604,13 +586,12 @@ jobs:
           build: true
           build-args: "ix bench-typecheck bench-recursive-verifier"
           use-github-cache: false
-      # Base-side `ix compile` of a mathlib-importing env (Mathlib, FLT)
-      # resolves imports from the base tree's Benchmarks/Compile subpackage —
-      # mathlib lives there, not in the root workspace, so the cache fetch
-      # can't ride the build action above. Compile runs need this even with
-      # cached binaries: the compile backend always compiles (`--ixe` is
-      # ignored by design), while a prover run with cached binaries rides
-      # the restored `.ixe` and skips the compile entirely.
+      # For a mathlib-importing env (Mathlib, FLT), the base-side compile
+      # resolves imports from the base tree's Benchmarks/Compile
+      # subpackage — mathlib lives only there, so its cache fetch must run
+      # from that directory. Compile runs need this even with cached
+      # binaries (the compile backend always compiles fresh); prover runs
+      # with cached binaries ride the restored `.ixe` and skip it.
       - name: Fetch base Mathlib oleans
         if: >-
           steps.bencher.outputs.run-base == 'true' &&
@@ -620,17 +601,16 @@ jobs:
         run: |
           lake exe cache get
           lake build Compile${{ matrix.params.env }}
-      # NOTE: the PR's `ix bench` orchestrates the base run (--repo base); the
-      # MEASURED tools resolve from base/.lake/build/bin. When a PR changes
-      # the benchmark CLIs themselves, the base tools may reject the new
-      # flags and every constant drops — compare then renders the loud
-      # "main produced no results" note instead of a silent all-n/a table.
+      # The PR's `ix bench` drives the base run (--repo base); the MEASURED
+      # tools come from base/.lake/build/bin. If the PR changed the
+      # benchmark CLIs themselves, the base tools may reject the new flags
+      # and every constant drops — the compare then shows a loud "main
+      # produced no results" note instead of a silent all-n/a table.
       #
-      # Partial bencher miss (missing.txt non-empty): the base side runs JUST
-      # the uncovered names (passed via `--consts`) — typically constants the PR
-      # itself adds to Vectors.csv, which base's Vectors.csv doesn't list, so
-      # `--csv` points at the PR's copy. Full miss: the whole selection runs on
-      # base with the normal CSV selection.
+      # Partial bencher miss: run just the uncovered names (via --consts).
+      # They are typically constants the PR itself adds, which the base
+      # tree's Vectors.csv doesn't list — so --csv points at the PR's copy.
+      # Full miss: run the normal selection (or the BENCH_CONSTS override).
       - name: Run backend on base → merge into main.json
         if: steps.bencher.outputs.run-base == 'true'
         run: |
@@ -653,8 +633,8 @@ jobs:
             # measure the same explicit names, not the default selection.
             flags="$flags --consts $CONSTS"
           fi
-          # A base-side rejection or empty run must not redden the PR's run:
-          # whatever rows landed are merged and the table says the rest.
+          # A base-side failure must not fail the PR's job: whatever rows
+          # landed get merged, and the table reports the rest.
           set +e
           # Cached base .ixe when the restore above hit; else the base run
           # compiles it fresh (no flag).
@@ -665,11 +645,9 @@ jobs:
             --out "$GITHUB_WORKSPACE/base.json" $flags
           echo "base-side ix bench run exit $?"
           set -e
-          # Partial fallback: bencher already supplied main.json for the
-          # covered names; fill only the gaps from the base run. Bencher wins
-          # any overlap (e.g. ooc's always-emitted whole-env row) — it is the
-          # canonical main-side number. Full fallback: main.json doesn't exist
-          # (fetch-main exits 3 before writing), so the base run IS main.json.
+          # Merge: bencher's numbers win any overlap (they are canonical);
+          # the base run only fills the gaps. On a full miss there is no
+          # main.json yet, so the base run becomes it.
           if [ -s "$GITHUB_WORKSPACE/base.json" ]; then
             if [ -s "$GITHUB_WORKSPACE/main.json" ]; then
               jq -s '.[0] + .[1]' "$GITHUB_WORKSPACE/base.json" "$GITHUB_WORKSPACE/main.json" \
@@ -699,8 +677,8 @@ jobs:
           path: out/table-${{ env.LABEL }}.md
           if-no-files-found: warn
       # A PR-side rejection is a correctness regression: re-raise the run
-      # step's failure LOUDLY (red X on the PR) — after the table upload, so
-      # the comment still posts with the constant's ❌ row and note.
+      # step's failure now that the table is uploaded, so the job goes red
+      # while the comment still posts with the constant's ❌ row.
       - name: Fail on PR-side benchmark failure
         if: steps.pr-run.outcome != 'success'
         run: |
@@ -708,20 +686,16 @@ jobs:
           exit 1
 
   # Assemble the comment body from the per-run tables. Deliberately
-  # UNPRIVILEGED: this job checks out and executes PR-derived code (the
-  # PR-built `ix bench report`), so it must never share a job with the App
-  # token — the posting job below only downloads the finished body as an
-  # artifact and never touches PR code (CodeQL: untrusted checkout /
-  # execution in a privileged workflow).
+  # UNPRIVILEGED: this job runs PR-built code (`ix bench report`), so it
+  # must never hold the App token. The posting job below only downloads
+  # the finished body and never touches PR code.
   assemble:
     needs: [build, benchmark]
-    # Assemble even when benchmark runs failed (the tables carry the ❌
-    # rows); the build job must have produced the binaries.
+    # Assemble even when benchmark runs failed — the tables carry the ❌
+    # rows. Only the build job must have succeeded (it made the binaries).
     if: always() && needs.build.result == 'success'
-    # `bench report` is a pure-Lean subcommand (AVX-512 lives only in the
-    # binary's Rust objects, which it never executes) — cheap host is fine.
-    # Move to a warp host if `ix` startup or this subcommand ever touches
-    # the FFI.
+    # `bench report` only runs Lean code (the AVX-512 parts of the binary
+    # are never executed here), so a cheap non-warp host is fine.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -764,11 +738,11 @@ jobs:
           name: comment-body
           path: comment-body.md
 
-  # Edit the announce comment in place with the assembled body — or a red-X
-  # diagnostic when any stage failed (a rejected command or broken run must
-  # never end in silence on the PR). This job and `announce` are the only
-  # ones with the App token, and neither runs a checkout or repo-derived
-  # code — just an artifact download and two actions.
+  # Replace the announce comment with the assembled results — or with an
+  # error note when a stage failed: a rejected command or broken run must
+  # never end in silence on the PR. This job and `announce` are the only
+  # two with the App token, and neither checks out or runs repo code —
+  # just an artifact download and two actions.
   comment:
     needs: [build, compile, benchmark, assemble, announce]
     if: always() && github.event_name == 'workflow_dispatch'
@@ -780,10 +754,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: comment-body
-      # Any failed stage prepends a red-X header (quoting the parse error
-      # when that's the cause) to the report — or replaces it when
-      # assemble produced none. A rejection-reddened run still shows its
-      # tables below the header.
+      # A failed stage prepends a warning header to the report (quoting
+      # the parse error when that was the cause) — or replaces the report
+      # entirely when assemble produced none. A run that failed on a
+      # kernel rejection still shows its tables below the header.
       - name: Note failures
         if: contains(needs.*.result, 'failure') || needs.assemble.result != 'success'
         env:
@@ -818,10 +792,9 @@ jobs:
           # takes either), so the existing secret works unchanged.
           client-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
-      # `comment-id` edits the announce comment in place; `issue-number` is
-      # the fallback that creates a fresh comment if announce never posted
-      # one (empty id). `replace` overwrites the "running" placeholder rather
-      # than appending to it.
+      # `comment-id` targets the announce comment; if announce never
+      # posted one (empty id), `issue-number` makes this create a fresh
+      # comment instead. `replace` overwrites the "running…" placeholder.
       - name: Post / update comment
         uses: peter-evans/create-or-update-comment@v5
         with:

--- a/.github/workflows/bencher-plots.yml
+++ b/.github/workflows/bencher-plots.yml
@@ -2,8 +2,9 @@ name: Sync bencher dashboard plots
 
 # Manual bencher op, like bencher-thresholds-reset: `ix bench plots` syncs
 # the dashboard plots to the registry (one plot per tracked (testbed,
-# measure) plus the input-constants overlay; see Ix/Cli/BenchPlots.lean
-# for the keep/replace semantics). Dispatch it after a registry change —
+# measure) plus the input-constants and Zisk-heavy-shards cross-cutting
+# plots; see Ix/Cli/BenchPlots.lean for the keep/replace semantics).
+# Dispatch it after a registry change —
 # new primary constant, measure-list edit, plot-title change — has merged
 # to main AND bench-main has run on it: the registry is compiled into the
 # `ix` binary this restores, and a brand-new constant only gets its plot
@@ -23,7 +24,7 @@ permissions:
 
 jobs:
   sync-plots:
-    # `ci matrix` is a pure-Lean subcommand and the rest is bencher API
+    # `bench plots` is a pure-Lean subcommand and the rest is bencher API
     # calls — cheap host is fine (same rationale as bench-main's plan job).
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,9 @@ jobs:
   # zkVM host build + execute gate: do the Zisk/SP1 hosts (and their guest
   # ELFs, via each workspace's build.rs) still compile AND run? rust-test
   # doesn't build these workspaces (special toolchains), and bench-main.yml's
-  # zkvm-execute job — which also runs real executions — tolerates per-constant
-  # failures by design (dropped rows, OOM sentinels), so it never turns red on
-  # a breakage. These jobs are the red-X signal: each builds its host, then
+  # zkVM runs — which also run real executions — tolerate per-constant
+  # failures by design (dropped rows, OOM sentinels), so they never turn red
+  # on a breakage. These jobs are the red-X signal: each builds its host, then
   # runs the guest in the VM over `nataddcomm.ixe` (a ~40-constant closure the
   # lean-test job compiles + caches). They run in parallel with lean-test, each
   # waiting for that cache entry before its execute step. Both hosts exit

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -56,7 +56,7 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  `recursive-proof-size`, `recursive-verify-time`). The whole
                  system, inner prove included, switches to the recursion-tuned
                  parameters (`recursiveFriParameters`), so recursive rows are
-                 NOT comparable to the standard prove cell — they land on
+                 NOT comparable to the standard prove run — they land on
                  their own testbed (`ix bench run --backend aiur --mode
                  recursive`). An IxVM-scale verifier execute needs >108 GB,
                  so a watchdog kill landing as a `status: oom` row (dropped
@@ -128,10 +128,10 @@ def recursiveCommitmentParameters : Aiur.CommitmentParameters := {
 /-- Recursion FRI parameters for `--recursive`. The query count IS the
     soundness level, so a real (secure) recursive proof needs the full query
     count, not a toy handful. The in-circuit verifier's cost scales with that
-    count, so at IxVM scale the cell is expected to exceed even a 128 GB host —
+    count, so at IxVM scale the run is expected to exceed even a 128 GB host —
     an OOM row here documents the gap between secure recursion and what fits
     today. `--recursive` runs the WHOLE system, inner prove included, under
-    these, so its rows are not comparable to the standard `prove` cell's. -/
+    these, so its rows are not comparable to the standard `prove` run's. -/
 def recursiveFriParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
@@ -211,7 +211,7 @@ def jsonRound (d : Nat) (f : Float) : Json :=
     the execute; a prove run's row carries the prove-phase peak and
     constants/sec over the prove. The two modes upload to separate bencher
     testbeds (aiur-check-execute-* / aiur-check-prove-*), so the shared names never
-    collide — run the execute cell when you want execute-side numbers. -/
+    collide — run the execute run when you want execute-side numbers. -/
 def Result.toJsonEntry (executeOnly : Bool) (r : Result) : String × Json :=
   if r.failed then
     (r.name, Json.mkObj [("status", Json.str "rejected")]) else

--- a/Benchmarks/Vectors.csv
+++ b/Benchmarks/Vectors.csv
@@ -62,6 +62,7 @@ Char.ofOrdinal_le_of_le,InitStd,heavy,0,1
 Array.extract_append,InitStd,heavy,0,1
 Std.Tactic.BVDecide.BVExpr.bitblast.goCache_Inv_of_Inv._mutual,InitStd,heavy,0,1
 Lean.Expr.replace,Lean,cheap
+Lean.Json,Lean,heavy,0,1
 List.Sorted,Mathlib,cheap
 Nat.choose,Mathlib,cheap
 Nat.factorial,Mathlib,cheap,0,1

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -1,15 +1,16 @@
 /-
-  `ix bench run`: the benchmark cell orchestrator — one command that
-  reproduces a CI benchmark cell locally, byte-for-byte on the same tools.
+  `ix bench run`: the benchmark orchestrator — one command that
+  reproduces a CI benchmark run locally, byte-for-byte on the same tools.
 
-  A cell is (backend, env, mode). The orchestrator:
+  A run executes one parameter combination: (backend, env, mode). The
+  orchestrator:
 
   1. selects constant names from `Benchmarks/Vectors.csv` (filters ported
      from the `!benchmark` manifest: env, tier, primary subset, shard flag);
   2. resolves the env's `.ixe` (an explicit `--ixe` path, else `ix
      compile` — except for the `compile` backend, where the compile IS
      the benchmark);
-  3. spawns the cell's measured tool — `bench-typecheck` (aiur),
+  3. spawns the run's measured tool — `bench-typecheck` (aiur),
      `zisk-host`/`sp1-host` (zkVM execute), `ix check-rs` (ooc),
      `ix compile` (compile) — wrapped in the RAM watchdog (`watchdog.sh`:
      cgroup `memory.max` via a systemd user scope; the kernel OOM-kills
@@ -19,7 +20,7 @@
      spawn's texray window (`<out>.spans`) belongs wholly to it, folded
      into the row as flat `phase-<span>` fields — independent bencher
      measures with no attribution machinery;
-  4. gates the cell on the row contract (`Ix.Benchmark.Results`): exit 3
+  4. gates the run on the row contract (`Ix.Benchmark.Results`): exit 3
      when any row is `rejected`, exit 1 when NO rows were produced, else 0.
 
   Every tool self-reports through the same `--json` results-rows contract,
@@ -91,7 +92,7 @@ def selectNames (rows : Array VectorRow) (env : String) (mode : String)
 `Benchmarks/Vectors.csv` holds the per-constant rows; everything else lives
 here, in one language with one owner. The workflows never read it directly:
 `ix bench ci matrix` serves the job matrices and `ix bench ci parse` the
-`!benchmark` cells, both post-build. (`bencher-thresholds-reset.yml` keeps
+`!benchmark` runs, both post-build. (`bencher-thresholds-reset.yml` keeps
 a static workload list with a sync note — it runs on cheap runners with no
 built `ix`.) -/
 
@@ -116,13 +117,40 @@ def envSpecs : List EnvSpec := [
 def findEnv (token : String) : Option EnvSpec :=
   envSpecs.find? fun e => e.name.toLower == token.toLower
 
-/-- One benchmark backend. Backends with several modes run one bench-main
-    cell per (mode, testbed) entry — shared measure names (`peak-rss`,
-    `throughput`) mean that mode's phase, and a `!benchmark` cell of either
+/-- How a backend enumerates the inputs its runs measure over — the single
+    registry declaration every consumer (plot specs, CI job matrices, the
+    `.ixe` cache gate) reads, so none special-cases a backend by name.
+      · `perEnv` — one row per compiled env, keyed by the env name itself; runs
+        over EVERY compiled env. The env-keyed compile/decompile pair: a `.ixe`
+        producer and its consumer, both measuring the whole env.
+      · `perConstant` — one row per selected `Vectors.csv` constant, over the
+        benched envs. The prove/execute backends (aiur, zisk, sp1).
+      · `perConstantWithEnv` — `perConstant` plus a whole-env row (ooc).
+      · `fixedConfigs` — env-independent fixed configs, a single matrix entry
+        (aiur-recursive: fixed toy statements, no `.ixe`). -/
+inductive BenchInputs
+  | perEnv
+  | perConstant
+  | perConstantWithEnv
+  | fixedConfigs
+  deriving BEq
+
+/-- A testbed minus its runner-arch suffix — the workload key the threshold
+    reset anchors (`refs/bencher/<workload>`), the dashboard plot titles,
+    and the run metadata are written against. -/
+def workloadOf (testbed : String) : String :=
+  if testbed.endsWith "-x64-32x" then (testbed.dropEnd 8).toString
+  else testbed
+
+/-- One benchmark backend. Backends with several modes schedule one bench-main
+    matrix entry per (mode, testbed) — shared measure names (`peak-rss`,
+    `throughput`) mean that mode's phase, and a `!benchmark` request of either
     mode finds a cached bencher baseline. -/
 structure BackendSpec where
   name : String
   defaultMode : String
+  /-- The inputs (envs and row names) this backend's runs fan over. -/
+  inputs : BenchInputs
   /-- `some reason` ⇒ `parse` skips the backend with the note in the
       config summary. -/
   disabled : Option String := none
@@ -138,20 +166,38 @@ structure BackendSpec where
       wall-clock time, throughput, peak-rss, then detail (secondary times,
       sizes, deterministic counters). -/
   metrics : List (String × List String)
+  /-- Regression bounds per tracked measure: (measure, upper, lower), each
+      bound a percentage over the baseline as a decimal fraction ("0.10"),
+      "0" for an exact pin, or "_" for unbounded on that side. Rendered by
+      `thresholdFlags` into the bencher-track action's `--threshold-*`
+      triples. Shared across the backend's scheduled modes: a threshold
+      naming a measure absent from a mode's upload just sits empty on that
+      testbed. Bound conventions:
+        · deterministic counters (constants) pin exactly (0/0) — a drop
+          means lost coverage, not an improvement;
+        · deterministic costs that only drop on a real win (cycles, shards,
+          fft-cost) take an upper-only bound — flag regressions, let wins
+          through;
+        · noisy wall-clock / RAM take ~10% upper bounds; throughput's
+          regression is a drop, so its bound is the lower side;
+        · sizes are structural (fixed layout) and ride tight 1–5% bands.
+      The dynamically-named `phase-<span>` measures upload un-thresholded
+      (noisy; the PR-comment drill-down does the phase-level compare). -/
+  thresholds : List (String × String × String) := []
 
 def backendSpecs : List BackendSpec := [
   -- prove is aiur's default: the real-workload simulation (it measures
   -- Phase 1 — execute-time, fft-cost — inside the same process en route).
   -- execute is the fast Phase-1-only signal. recursive layers the in-circuit
   -- multi-stark verifier on prove: execute it over each fresh proof, then
-  -- prove that execution — the recursion cell. It runs under the
+  -- prove that execution — the recursion run. It runs under the
   -- recursion-tuned FRI parameters, so even its shared-name metrics
-  -- (prove-time, peak-rss) are not comparable to the prove cell's. An
+  -- (prove-time, peak-rss) are not comparable to the prove run's. An
   -- IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling; the
   -- kill lands as a `status: oom` row that bmf drops, which is why it's
   -- marked `unscheduled`: a testbed for local `--mode recursive` runs only —
   -- never uploaded to bencher, never plotted.
-  { name := "aiur", defaultMode := "prove",
+  { name := "aiur", defaultMode := "prove", inputs := .perConstant,
     testbeds := [("prove", "aiur-check-prove-x64-32x"),
                  ("execute", "aiur-check-execute-x64-32x"),
                  ("recursive", "aiur-check-recursive-x64-32x")],
@@ -164,43 +210,85 @@ def backendSpecs : List BackendSpec := [
                 ("recursive", ["recursive-prove-time", "recursive-peak-rss",
                                "recursive-proof-size", "recursive-verify-time",
                                "recursive-execute-time", "recursive-fft-cost",
-                               "prove-time", "proof-size"])] },
+                               "prove-time", "proof-size"])],
+    -- fft-cost is deterministic but only ever drops on a real Aiur win →
+    -- upper-only 5% instead of a hard pin. peak-rss and throughput are
+    -- phase-scoped by the CELL (execute vs prove testbed);
+    -- prove/verify-time and proof-size exist only on the prove testbed.
+    thresholds := [("constants", "0", "0"), ("fft-cost", "0.05", "_"),
+                   ("prove-time", "0.10", "_"), ("verify-time", "0.10", "_"),
+                   ("proof-size", "0.05", "_"), ("execute-time", "0.10", "_"),
+                   ("peak-rss", "0.10", "_"), ("throughput", "_", "0.10")] },
   -- The aiur-recursive toy (bench-recursive-verifier): fixed tiny
   -- statements (`recursiveConfigs`), proving the in-circuit multi-stark
-  -- verifier end-to-end. Env-independent: the cell ignores --env and never
+  -- verifier end-to-end. Env-independent: the run ignores --env and never
   -- needs an .ixe. Unlike the aiur recursive mode above, the floor
   -- config's outer prove fits a 128 GB host, so CI schedules this testbed.
-  { name := "aiur-recursive", defaultMode := "prove",
+  { name := "aiur-recursive", defaultMode := "prove", inputs := .fixedConfigs,
     testbeds := [("prove", "aiur-recursive-x64-32x")],
     metrics := [("prove", ["recursive-prove-time", "recursive-peak-rss",
                            "recursive-proof-size", "recursive-verify-time",
                            "recursive-execute-time", "recursive-fft-cost",
                            "prove-time", "proof-size", "verify-time",
-                           "peak-rss"])] },
-  { name := "zisk", defaultMode := "execute",
+                           "peak-rss"])],
+    -- recursive-fft-cost drifts ~±15% run-to-run (the parallel prover
+    -- emits byte-different valid proofs, so the verifier authenticates
+    -- different Merkle paths) → the loose 25% bound; proof sizes are
+    -- structural (fixed query count and path depth) → the tight 5%.
+    thresholds := [("recursive-fft-cost", "0.25", "_"),
+                   ("recursive-execute-time", "0.10", "_"),
+                   ("recursive-prove-time", "0.10", "_"),
+                   ("recursive-verify-time", "0.10", "_"),
+                   ("recursive-peak-rss", "0.10", "_"),
+                   ("recursive-proof-size", "0.05", "_"),
+                   ("prove-time", "0.10", "_"), ("proof-size", "0.05", "_"),
+                   ("verify-time", "0.10", "_"), ("peak-rss", "0.10", "_")] },
+  { name := "zisk", defaultMode := "execute", inputs := .perConstant,
     testbeds := [("execute", "zisk-check-execute-x64-32x")],
     metrics := [("execute", ["execute-time", "throughput", "peak-rss",
-                             "cycles", "constants", "shards"])] },
-  { name := "sp1", defaultMode := "execute",
+                             "cycles", "constants", "shards"])],
+    -- cycles / shards / max-shard-cycles are deterministic per guest ELF,
+    -- but a real guest / packer improvement legitimately drops them →
+    -- upper-only 0% bounds.
+    thresholds := [("constants", "0", "0"), ("cycles", "0", "_"),
+                   ("shards", "0", "_"), ("max-shard-cycles", "0", "_"),
+                   ("execute-time", "0.10", "_"), ("peak-rss", "0.10", "_"),
+                   ("throughput", "_", "0.10")] },
+  { name := "sp1", defaultMode := "execute", inputs := .perConstant,
     disabled := some "execute run too slow for per-push CI; re-enable here once trimmed",
     testbeds := [("execute", "sp1-check-execute-x64-32x")],
     metrics := [("execute", ["execute-time", "throughput", "peak-rss",
-                             "cycles"])] },
-  { name := "ooc", defaultMode := "execute",
+                             "cycles"])],
+    thresholds := [("constants", "0", "0"), ("cycles", "0", "_"),
+                   ("execute-time", "0.10", "_"), ("peak-rss", "0.10", "_"),
+                   ("throughput", "_", "0.10")] },
+  { name := "ooc", defaultMode := "execute", inputs := .perConstantWithEnv,
     testbeds := [("execute", "ooc-check-x64-32x")],
-    metrics := [("execute", ["check-time", "throughput", "peak-rss"])] },
-  { name := "compile", defaultMode := "execute",
+    metrics := [("execute", ["check-time", "throughput", "peak-rss"])],
+    thresholds := [("constants", "0", "0"), ("check-time", "0.10", "_"),
+                   ("throughput", "_", "0.10"), ("peak-rss", "0.10", "_")] },
+  { name := "compile", defaultMode := "execute", inputs := .perEnv,
     testbeds := [("execute", "ix-compile-x64-32x")],
     metrics := [("execute", ["compile-time", "throughput", "peak-rss",
-                             "file-size", "constants"])] },
+                             "file-size", "constants"])],
+    -- file-size wiggles slightly run-to-run (the serialized env is not
+    -- byte-reproducible — worth its own investigation for a
+    -- content-addressed store) → a tight ±1% band instead of a pin.
+    thresholds := [("compile-time", "0.05", "_"), ("throughput", "_", "0.05"),
+                   ("file-size", "0.01", "0.01"), ("constants", "0", "0"),
+                   ("peak-rss", "0.10", "_")] },
   -- The inverse of compile: decompiles the env's `.ixe` back to Lean
   -- constants (roundtrip-verified). Env-keyed like compile, but a `.ixe`
-  -- CONSUMER — it reuses the compile cell's fresh `.ixe` rather than
+  -- CONSUMER — it reuses the compile run's fresh `.ixe` rather than
   -- producing one.
-  { name := "decompile", defaultMode := "execute",
+  { name := "decompile", defaultMode := "execute", inputs := .perEnv,
     testbeds := [("execute", "ix-decompile-x64-32x")],
     metrics := [("execute", ["decompile-time", "throughput", "peak-rss",
-                             "file-size", "constants"])] }
+                             "file-size", "constants"])],
+    -- file-size (the input `.ixe`) duplicates the compile run's, so it
+    -- uploads for the row's completeness but rides no threshold here.
+    thresholds := [("constants", "0", "0"), ("decompile-time", "0.10", "_"),
+                   ("throughput", "_", "0.10"), ("peak-rss", "0.10", "_")] }
 ]
 
 def findBackend (name : String) : Option BackendSpec :=
@@ -224,6 +312,49 @@ def BackendSpec.testbedFor (b : BackendSpec) (mode : String) : Option String :=
 
 def BackendSpec.metricsFor (b : BackendSpec) (mode : String) : List String :=
   ((b.metrics.find? (·.1 == mode)).map (·.2)).getD []
+
+/-- `thresholds` rendered as the bencher-track action's `--threshold-*`
+    flags, one percentage-test triple per measure. `__WINDOW__` is the
+    action's placeholder for the per-workload baseline window (data points
+    since the workload's reset anchor); the action word-splits the string,
+    so every flag value stays a single token. -/
+def BackendSpec.thresholdFlags (b : BackendSpec) : String :=
+  "\n".intercalate <| b.thresholds.map fun (m, upper, lower) =>
+    s!"--threshold-measure {m} --threshold-test percentage\n" ++
+    s!"--threshold-max-sample-size __WINDOW__ --threshold-upper-boundary {upper}\n" ++
+    s!"--threshold-lower-boundary {lower}"
+
+/-- The envs this backend's runs cover, from its `inputs`: `perEnv` covers
+    every compiled env; the per-constant backends cover the benched subset; the
+    fixed-config backend is env-independent, represented by a single (head
+    benched) env so CI schedules exactly one run. -/
+def BackendSpec.envNames (b : BackendSpec) : List String :=
+  let benched := (envSpecs.filter (·.benched)).map (·.name)
+  match b.inputs with
+  | .perEnv => envSpecs.map (·.name)
+  | .perConstant | .perConstantWithEnv => benched
+  | .fixedConfigs => benched.take 1
+
+/-- The benchmark row names this backend uploads — the bencher slugs the
+    dashboard plots and compare table key on — from its `inputs`: env-keyed
+    backends key one row per compiled env; the per-constant backends select
+    from `Vectors.csv` (`perConstantWithEnv` prepends a whole-env row); the
+    fixed-config backend lists its configs. Dynamic shard sub-rows
+    (`<name>/shard-N`) are excluded — the parent row carries the headline
+    trend. -/
+def BackendSpec.benchmarkNames (b : BackendSpec) (rows : Array VectorRow)
+    (mode : String) : Array String := Id.run do
+  match b.inputs with
+  | .perEnv => return (envSpecs.map (·.name)).toArray
+  | .fixedConfigs => return (recursiveConfigs.map (·.1)).toArray
+  | .perConstant | .perConstantWithEnv =>
+    let benched := (envSpecs.filter (·.benched)).map (·.name)
+    let mut ns : Array String := #[]
+    for env in benched do
+      if b.inputs == .perConstantWithEnv then ns := ns.push env
+      ns := ns ++ (selectNames rows env mode
+        (full := false) (tier := "") (shardOnly := false)).map (·.name)
+    return ns
 
 /-- Default RAM watchdog ceiling, same rule for all backends: the
     machine's total RAM minus 15 GB (the ~123 GiB CI runner lands at
@@ -327,7 +458,7 @@ def mergeSpans (out : String) (name : String) : IO Unit := do
     to it. Per exit: ≥128 (watchdog TERM/KILL or the kernel OOM killer) →
     mark the row `oom` (keeping whatever the tool flushed, spans included)
     and continue; `exitRejected` → the rejected row is on disk, continue
-    (the final gate reddens the cell); any other nonzero exit is
+    (the final gate reddens the run); any other nonzero exit is
     deterministic (usage error, missing input, crash on startup) and would
     repeat for every remaining name — abort loudly.
 
@@ -341,7 +472,7 @@ def runPerConstant (out : String) (names : Array String)
     let exit ← spawn name
     -- 255 is never a signal death (our kills exit 134/137/143) — it's a
     -- failed exec ("could not execute external process") or a tool bailing
-    -- with -1; labeling it oom would turn a broken spawn into a green cell
+    -- with -1; labeling it oom would turn a broken spawn into a green run
     -- of fake-OOM rows.
     if exit == 255 || (exit != 0 && exit != exitRejected && exit < 128) then
       IO.eprintln s!"[bench] tool failed on '{name}' (exit {exit}, not a kill); aborting the remaining names"
@@ -402,10 +533,10 @@ def cutClosureShards (ix : String) (envIxe : String)
       return none
   return some (subIxe, manifest)
 
-/-- Final cell gate from the rows themselves: exit 1 when any EXPECTED name
+/-- Final run gate from the rows themselves: exit 1 when any EXPECTED name
     lacks a row (an aborted loop, a killed batch, or a dropped whole-env
     check must never look green — every selected name owes exactly one
-    row), exit 3 when any row is `rejected` (red cell, rows on disk say
+    row), exit 3 when any row is `rejected` (red run, rows on disk say
     why), else 0. -/
 def gate (out : String) (expected : Array String) : IO UInt32 := do
   let rows ← readRows out
@@ -433,16 +564,16 @@ def gate (out : String) (expected : Array String) : IO UInt32 := do
 def benchOutputDir : IO String :=
   return (← IO.getEnv "BENCH_OUTPUT_DIR").getD ".lake/benches"
 
-/-- Save the run as the local baseline (`<benchOutputDir>/<cell>.json`),
+/-- Save the run as the local baseline (`<benchOutputDir>/<params>.json`),
     rotating the previous baseline to `.prev.json` — `ix bench compare`
     defaults to the pair, so a bare local rerun compares against the last
     run automatically. -/
-def saveBaseline (out : String) (cell : String) : IO Unit := do
+def saveBaseline (out : String) (params : String) : IO Unit := do
   let dir ← benchOutputDir
   IO.FS.createDirAll dir
-  let base := s!"{dir}/{cell}.json"
+  let base := s!"{dir}/{params}.json"
   if ← FilePath.pathExists base then
-    IO.FS.writeFile s!"{dir}/{cell}.prev.json" (← IO.FS.readFile base)
+    IO.FS.writeFile s!"{dir}/{params}.prev.json" (← IO.FS.readFile base)
   IO.FS.writeFile base (← IO.FS.readFile out)
 
 def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
@@ -492,9 +623,9 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
   let names := selected.map (·.name)
   match backend with
   | "aiur-recursive" =>
-    IO.eprintln s!"[bench] cell {backend}-{mode}: {recursiveConfigs.length} config(s)"
+    IO.eprintln s!"[bench] run {backend}-{mode}: {recursiveConfigs.length} config(s)"
   | _ =>
-    IO.eprintln s!"[bench] cell {backend}-{env}-{mode}: {names.size} constant(s)"
+    IO.eprintln s!"[bench] run {backend}-{env}-{mode}: {names.size} constant(s)"
 
   -- Fresh accumulator per run.
   if ← FilePath.pathExists out then IO.FS.removeFile out
@@ -511,9 +642,9 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
       IO.eprintln s!"[bench] ix compile failed (exit {exit})"
       return 1
   | "decompile" =>
-    -- The inverse of compile: consume the env's `.ixe` (the compile cell's
+    -- The inverse of compile: consume the env's `.ixe` (the compile run's
     -- fresh artifact) and decompile it back to Lean constants. Env-keyed row,
-    -- like compile. A malformed decompile exits nonzero and reddens the cell;
+    -- like compile. A malformed decompile exits nonzero and reddens the run;
     -- deep roundtrip fidelity is gated by the canonical roundtrip checks
     -- (`ix validate` / the roundtrip tests), not measured here.
     let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))
@@ -585,7 +716,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
     let bin := (← IO.FS.realPath s!"{work}/target/release/{host}").toString
     -- Heavy-tier zisk constants run as their closure-shard partition (a
     -- single full-closure leaf would blow the runner's RAM); everything
-    -- else runs as one host process per constant like the aiur cells.
+    -- else runs as one host process per constant like the aiur runs.
     let heavy := if backend == "zisk"
       then (selected.filter (·.tier == "heavy")).map (·.name) else #[]
     let light := names.filter (!heavy.contains ·)
@@ -628,9 +759,9 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
 /-- `ix bench shard`: pre-cut the closure-shard artifacts for the env's
     heavy-tier constants into `zkshards-<env>/` — `ix shard extract` →
     `ix profile` → `ix shard` per name, skipping names whose artifacts
-    already exist. Not a benchmark cell (no rows, no watchdog): bench-main's
+    already exist. Not a benchmark run (no rows, no watchdog): bench-main's
     compile job runs it next to the fresh `.ixe` so the artifacts ride the
-    same cache; the zisk cells cut lazily as a fallback when they're
+    same cache; the zisk runs cut lazily as a fallback when they're
     absent. -/
 def runBenchShardCmd (p : Cli.Parsed) : IO UInt32 := do
   let some info := findEnv ((p.flag? "env").map (·.as! String) |>.getD "InitStd")
@@ -658,7 +789,7 @@ end Ix.Cli.BenchCmd
 open Ix.Cli.BenchCmd in
 def benchRunCmd : Cli.Cmd := `[Cli|
   "run" VIA runBenchRunCmd;
-  "Run one benchmark cell (backend × env × mode), writing benchmark results JSON. Exits 0 on success (rows saved as the local baseline), 3 when the kernel rejected any constant, 1 when no rows were produced."
+  "Execute one benchmark run (backend × env × mode), writing benchmark results JSON. Exits 0 on success (rows saved as the local baseline), 3 when the kernel rejected any constant, 1 when no rows were produced."
 
   FLAGS:
     backend      : String; "aiur | zisk | sp1 | ooc | compile | decompile | aiur-recursive"
@@ -679,7 +810,7 @@ def benchRunCmd : Cli.Cmd := `[Cli|
 open Ix.Cli.BenchCmd in
 def benchShardCmd : Cli.Cmd := `[Cli|
   "shard" VIA runBenchShardCmd;
-  "Pre-cut closure-shard artifacts (ix shard extract → profile → shard) for the env's heavy-tier constants into zkshards-<env>/; skips names already cut. The zisk cells cut lazily when these are absent — this front-loads the work so the artifacts can be cached once per commit."
+  "Pre-cut closure-shard artifacts (ix shard extract → profile → shard) for the env's heavy-tier constants into zkshards-<env>/; skips names already cut. The zisk runs cut lazily when these are absent — this front-loads the work so the artifacts can be cached once per commit."
 
   FLAGS:
     env          : String; "Benchmark env from the registry (default: InitStd)"

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -463,7 +463,7 @@ def mergeSpans (out : String) (name : String) : IO Unit := do
     to it. Per exit: ≥128 (watchdog TERM/KILL or the kernel OOM killer) →
     mark the row `oom` (keeping whatever the tool flushed, spans included)
     and continue; `exitRejected` → the rejected row is on disk, continue
-    (the final gate reddens the run); any other nonzero exit is
+    (the final gate fails the job); any other nonzero exit is
     deterministic (usage error, missing input, crash on startup) and would
     repeat for every remaining name — abort loudly.
 
@@ -477,7 +477,7 @@ def runPerConstant (out : String) (names : Array String)
     let exit ← spawn name
     -- 255 is never a signal death (our kills exit 134/137/143) — it's a
     -- failed exec ("could not execute external process") or a tool bailing
-    -- with -1; labeling it oom would turn a broken spawn into a green run
+    -- with -1; labeling it oom would turn a broken spawn into a passing job
     -- of fake-OOM rows.
     if exit == 255 || (exit != 0 && exit != exitRejected && exit < 128) then
       IO.eprintln s!"[bench] tool failed on '{name}' (exit {exit}, not a kill); aborting the remaining names"
@@ -541,8 +541,8 @@ def cutClosureShards (ix : String) (envIxe : String)
 /-- Final run gate from the rows themselves: exit 1 when any EXPECTED name
     lacks a row (an aborted loop, a killed batch, or a dropped whole-env
     check must never look green — every selected name owes exactly one
-    row), exit 3 when any row is `rejected` (red run, rows on disk say
-    why), else 0. -/
+    row), exit 3 when any row is `rejected` (a failing exit, with the rows
+    on disk saying why), else 0. -/
 def gate (out : String) (expected : Array String) : IO UInt32 := do
   let rows ← readRows out
   match rows with
@@ -649,7 +649,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
   | "decompile" =>
     -- The inverse of compile: consume the env's `.ixe` (the compile run's
     -- fresh artifact) and decompile it back to Lean constants. Env-keyed row,
-    -- like compile. A malformed decompile exits nonzero and reddens the run;
+    -- like compile. A malformed decompile exits nonzero and fails the job;
     -- deep roundtrip fidelity is gated by the canonical roundtrip checks
     -- (`ix validate` / the roundtrip tests), not measured here.
     let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -104,14 +104,12 @@ structure EnvSpec where
   name : String
   /-- The Lean source `ix compile` builds the env from. -/
   module : String
-  /-- In the bench-main matrices (and `!benchmark`'s allowed env set). -/
-  benched : Bool
 
 def envSpecs : List EnvSpec := [
-  { name := "InitStd", module := "Benchmarks/Compile/CompileInitStd.lean", benched := true },
-  { name := "Lean",    module := "Benchmarks/Compile/CompileLean.lean",    benched := false },
-  { name := "Mathlib", module := "Benchmarks/Compile/CompileMathlib.lean", benched := true },
-  { name := "FLT",     module := "Benchmarks/Compile/CompileFLT.lean",     benched := false }
+  { name := "InitStd", module := "Benchmarks/Compile/CompileInitStd.lean" },
+  { name := "Lean",    module := "Benchmarks/Compile/CompileLean.lean" },
+  { name := "Mathlib", module := "Benchmarks/Compile/CompileMathlib.lean" },
+  { name := "FLT",     module := "Benchmarks/Compile/CompileFLT.lean" }
 ]
 
 def findEnv (token : String) : Option EnvSpec :=
@@ -123,8 +121,10 @@ def findEnv (token : String) : Option EnvSpec :=
       · `perEnv` — one row per compiled env, keyed by the env name itself; runs
         over EVERY compiled env. The env-keyed compile/decompile pair: a `.ixe`
         producer and its consumer, both measuring the whole env.
-      · `perConstant` — one row per selected `Vectors.csv` constant, over the
-        benched envs. The prove/execute backends (aiur, zisk, sp1).
+      · `perConstant` — one row per selected `Vectors.csv` constant, over
+        the envs whose CSV rows select any — an env joins this fan-out by
+        gaining rows, not by a registry flag. The prove/execute backends
+        (aiur, zisk, sp1).
       · `perConstantWithEnv` — `perConstant` plus a whole-env row (ooc).
       · `fixedConfigs` — env-independent fixed configs, a single matrix entry
         (aiur-recursive: fixed toy statements, no `.ixe`). -/
@@ -325,32 +325,37 @@ def BackendSpec.thresholdFlags (b : BackendSpec) : String :=
     s!"--threshold-lower-boundary {lower}"
 
 /-- The envs this backend's runs cover, from its `inputs`: `perEnv` covers
-    every compiled env; the per-constant backends cover the benched subset; the
-    fixed-config backend is env-independent, represented by a single (head
-    benched) env so CI schedules exactly one run. -/
-def BackendSpec.envNames (b : BackendSpec) : List String :=
-  let benched := (envSpecs.filter (·.benched)).map (·.name)
+    every registry env; the per-constant backends cover the envs whose
+    `Vectors.csv` rows select at least one primary constant — an env joins
+    their fan-out by gaining rows, not by a registry flag; the
+    fixed-config backend is env-independent, pinned to the head env so CI
+    schedules exactly one entry. -/
+def BackendSpec.envNames (b : BackendSpec) (rows : Array VectorRow) :
+    List String :=
+  let names := envSpecs.map (·.name)
   match b.inputs with
-  | .perEnv => envSpecs.map (·.name)
-  | .perConstant | .perConstantWithEnv => benched
-  | .fixedConfigs => benched.take 1
+  | .perEnv => names
+  | .perConstant | .perConstantWithEnv =>
+    names.filter fun env =>
+      !(selectNames rows env b.defaultMode
+        (full := false) (tier := "") (shardOnly := false)).isEmpty
+  | .fixedConfigs => names.take 1
 
 /-- The benchmark row names this backend uploads — the bencher slugs the
     dashboard plots and compare table key on — from its `inputs`: env-keyed
     backends key one row per compiled env; the per-constant backends select
-    from `Vectors.csv` (`perConstantWithEnv` prepends a whole-env row); the
-    fixed-config backend lists its configs. Dynamic shard sub-rows
-    (`<name>/shard-N`) are excluded — the parent row carries the headline
-    trend. -/
+    from `Vectors.csv` over their env set (`perConstantWithEnv` prepends a
+    whole-env row); the fixed-config backend lists its configs. Dynamic
+    shard sub-rows (`<name>/shard-N`) are excluded — the parent row
+    carries the headline trend. -/
 def BackendSpec.benchmarkNames (b : BackendSpec) (rows : Array VectorRow)
     (mode : String) : Array String := Id.run do
   match b.inputs with
   | .perEnv => return (envSpecs.map (·.name)).toArray
   | .fixedConfigs => return (recursiveConfigs.map (·.1)).toArray
   | .perConstant | .perConstantWithEnv =>
-    let benched := (envSpecs.filter (·.benched)).map (·.name)
     let mut ns : Array String := #[]
-    for env in benched do
+    for env in b.envNames rows do
       if b.inputs == .perConstantWithEnv then ns := ns.push env
       ns := ns ++ (selectNames rows env mode
         (full := false) (tier := "") (shardOnly := false)).map (·.name)

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -86,11 +86,17 @@ def plotTitle (workload measure : String) : String :=
     `ix-decompile` reuses the compile cell's `.ixe`, so its `file-size` /
     `constants` duplicate "Ix Environment Size" / "Ix Input Constants"
     exactly — the decompile cell tracks only its own decompile-time /
-    throughput / peak-rss trends. -/
+    throughput / peak-rss trends. The aiur-recursive cell's plain
+    prove-time / proof-size / verify-time / peak-rss measure the INNER
+    toy-statement proof — tracked for the compare table, but the
+    dashboard trend that matters is the recursion layer's own
+    `recursive-*` series, so the inner metrics aren't plotted. -/
 def plotSkips : List (String × String) :=
   [("aiur-check-prove", "execute-time"), ("aiur-check-execute", "fft-cost"),
    ("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),
-   ("ix-decompile", "file-size"), ("ix-decompile", "constants")]
+   ("ix-decompile", "file-size"), ("ix-decompile", "constants"),
+   ("aiur-recursive", "prove-time"), ("aiur-recursive", "proof-size"),
+   ("aiur-recursive", "verify-time"), ("aiur-recursive", "peak-rss")]
 
 /-- Canonical units per measure slug, asserted on every sync: bencher
     auto-creates a measure with placeholder units ("Measure (units)") on

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -36,11 +36,10 @@ open Lean (Json)
 
 namespace Ix.Cli.BenchPlots
 
-/-- A testbed minus its runner-arch suffix — the workload key the titles,
-    skips, and ordering are written against. -/
+/-- The registry's workload key (testbed minus runner-arch suffix) — what
+    the titles, skips, and ordering here are written against. -/
 def workloadOf (testbed : String) : String :=
-  if testbed.endsWith "-x64-32x" then (testbed.dropEnd 8).toString
-  else testbed
+  BenchCmd.workloadOf testbed
 
 /-- Dashboard display title per (workload, measure). Presentation only —
     measurement identity stays the slugs — which is why it lives here and
@@ -74,19 +73,25 @@ def plotTitle (workload measure : String) : String :=
   | "ooc-check", "check-time"            => "OOC Check Time"
   | "ooc-check", "throughput"            => "OOC Check Throughput"
   | "ooc-check", "peak-rss"              => "OOC Check Peak RAM Usage"
+  | "aiur-recursive", "recursive-execute-time" => "Aiur Recursive Verifier Execute Time"
+  | "aiur-recursive", "recursive-prove-time"   => "Aiur Recursive Verifier Prove Time"
+  | "aiur-recursive", "recursive-verify-time"  => "Aiur Recursive Verifier Verify Time"
+  | "aiur-recursive", "recursive-peak-rss"     => "Aiur Recursive Verifier Peak RAM Usage"
+  | "aiur-recursive", "recursive-proof-size"   => "Aiur Recursive Verifier Proof Size"
+  | "aiur-recursive", "recursive-fft-cost"     => "Aiur Recursive Verifier FFT Cost"
   | w, m => s!"{w}: {m}"
 
-/-- Tracked but not plotted solo. The two aiur cells re-measure each
+/-- Tracked but not plotted solo. The two aiur runs re-measure each
     other's deterministic Phase-1 numbers as a redundancy check — one
-    trend line each is enough ("Aiur Execute Time" from the execute cell,
-    "Aiur FFT Cost" from the prove cell). Zisk `shards` is charted below
+    trend line each is enough ("Aiur Execute Time" from the execute run,
+    "Aiur FFT Cost" from the prove run). Zisk `shards` is charted below
     over the heavy-tier primaries alone (light constants are pinned at a
     single shard, a flat line at 1), not over the full set here; zisk
     `constants` charts on the input-constants plot below instead of alone.
-    `ix-decompile` reuses the compile cell's `.ixe`, so its `file-size` /
+    `ix-decompile` reuses the compile run's `.ixe`, so its `file-size` /
     `constants` duplicate "Ix Environment Size" / "Ix Input Constants"
-    exactly — the decompile cell tracks only its own decompile-time /
-    throughput / peak-rss trends. The aiur-recursive cell's plain
+    exactly — the decompile run tracks only its own decompile-time /
+    throughput / peak-rss trends. The aiur-recursive run's plain
     prove-time / proof-size / verify-time / peak-rss measure the INNER
     toy-statement proof — tracked for the compare table, but the
     dashboard trend that matters is the recursion layer's own
@@ -139,16 +144,14 @@ structure PlotSpec where
   measures : List String
   benchmarks : Array String
 
-/-- One spec per bench-main testbed: its measure slugs and the benchmark
-    row names uploaded there, mirroring the row emitters — compile keys
-    one row per env (benched or not: the compile matrix is deliberately
-    wider), decompile one row per benched env (a `.ixe` consumer), ooc one
-    whole-env row plus one full-closure row per primary,
-    the per-constant backends one row per primary. Dynamic sub-rows
-    (`<name>/shard-N`) are left out: their multiplicity shifts with the
+/-- One spec per bench-main testbed: its measure slugs and the benchmark row
+    names uploaded there, both from the registry (`BackendSpec.benchmarkNames`,
+    keyed off `inputs`) — env-keyed backends (compile, decompile) key one row
+    per compiled env, the per-constant backends one row per primary, ooc adds a
+    whole-env row, and the fixed-config backend lists its configs. Dynamic
+    sub-rows (`<name>/shard-N`) are left out: their multiplicity shifts with the
     shard manifest, and the parent row carries the headline trend. -/
 def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
-  let benched := (BenchCmd.envSpecs.filter (·.benched)).map (·.name)
   let mut specs : Array PlotSpec := #[]
   for b in BenchCmd.backendSpecs do
     if b.disabled.isSome then continue
@@ -156,23 +159,9 @@ def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
       -- On-demand modes (e.g. aiur `recursive`) upload nothing, so there's
       -- nothing to plot — the registry marks them explicitly.
       if b.unscheduled.contains mode then continue
-      let names : Array String := Id.run do
-        if b.name == "compile" then
-          return (BenchCmd.envSpecs.map (·.name)).toArray
-        if b.name == "aiur-recursive" then
-          return (BenchCmd.recursiveConfigs.map (·.1)).toArray
-        -- decompile is env-keyed like compile but a `.ixe` consumer: one row
-        -- per benched env (it runs only where a benched `.ixe` exists).
-        if b.name == "decompile" then
-          return benched.toArray
-        let mut ns : Array String := #[]
-        for env in benched do
-          if b.name == "ooc" then ns := ns.push env
-          ns := ns ++ (BenchCmd.selectNames rows env mode
-            (full := false) (tier := "") (shardOnly := false)).map (·.name)
-        return ns
       specs := specs.push
-        { testbed, measures := b.metricsFor mode, benchmarks := names }
+        { testbed, measures := b.metricsFor mode,
+          benchmarks := b.benchmarkNames rows mode }
   return specs.qsort fun a b =>
     workloadOrder.idxOf (workloadOf a.testbed)
       < workloadOrder.idxOf (workloadOf b.testbed)
@@ -223,12 +212,23 @@ def findUuid (items : Array Json) (key val : String) : Option String :=
 
 /-! ## Sync -/
 
+/-- History window (seconds) for a plot, overriding the global `--window`
+    default by display title. A listed title renders a tighter rolling span so
+    its recent trend isn't compressed by older history; every other title uses
+    the default. Keyed by title — the same identity the sync keeps/replaces
+    on. -/
+def windowFor (title : String) (dflt : Nat) : Nat :=
+  match title with
+  | "Zisk Execute Throughput" => 4 * 7 * 24 * 3600  -- 4 weeks
+  | _ => dflt
+
 /-- A plot as the sync wants it: everything already resolved to UUIDs. -/
 structure DesiredPlot where
   title : String
   testbeds : Array String
   benchmarks : Array String
   measure : String
+  window : Nat
 
 inductive Outcome | created | replaced | kept
 
@@ -236,7 +236,7 @@ inductive Outcome | created | replaced | kept
     dimensions (order-insensitively), window, and axis → keep, re-asserting
     only the dashboard index (the list JSON carries no index field, so it
     can't be diffed). Anything else is deleted and recreated. -/
-def syncPlot (project : String) (dryRun : Bool) (window : Nat)
+def syncPlot (project : String) (dryRun : Bool)
     (xAxis branchUuid : String) (plots : Array Json) (idx : Nat)
     (d : DesiredPlot) : IO Outcome := do
   let sorted := fun (a : Array String) => a.qsort (· < ·)
@@ -248,7 +248,7 @@ def syncPlot (project : String) (dryRun : Bool) (window : Nat)
       && sorted (objStrArr pl "benchmarks") == sorted d.benchmarks
       && objStrArr pl "measures" == #[d.measure]
       && ((pl.getObjVal? "window").toOption.bind (·.getNat?.toOption))
-           == some window
+           == some d.window
       && objStr pl "x_axis" == some xAxis
     if same then
       IO.println s!"keep:    {d.title}"
@@ -264,7 +264,7 @@ def syncPlot (project : String) (dryRun : Bool) (window : Nat)
   unless dryRun do
     let mut args := #["plot", "create", project,
       "--title", d.title, "--index", toString idx,
-      "--x-axis", xAxis, "--window", toString window,
+      "--x-axis", xAxis, "--window", toString d.window,
       "--branches", branchUuid, "--measures", d.measure]
     for t in d.testbeds do args := args ++ #["--testbeds", t]
     for b in d.benchmarks do args := args ++ #["--benchmarks", b]
@@ -312,7 +312,7 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut desired : Array DesiredPlot := #[]
   for spec in specs do
     let workload := workloadOf spec.testbed
-    -- A registry testbed bencher hasn't seen yet (its bench-main cell isn't
+    -- A registry testbed bencher hasn't seen yet (its bench-main run isn't
     -- scheduled — e.g. the aiur `recursive` mode, whose outer prove doesn't
     -- fit the CI host, so nothing ever uploads to it) has no plots to sync:
     -- warn and skip it, like a not-yet-uploaded benchmark, instead of
@@ -331,9 +331,10 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
       if plotSkips.contains (workload, measure) then continue
       let some measureUuid := findUuid measures "slug" measure
         | p.printError s!"error: no measure slug '{measure}'"; return 1
+      let title := plotTitle workload measure
       desired := desired.push
-        { title := plotTitle workload measure, testbeds := #[testbedUuid],
-          benchmarks := benchUuids, measure := measureUuid }
+        { title, testbeds := #[testbedUuid], benchmarks := benchUuids,
+          measure := measureUuid, window := windowFor title window }
 
   -- Input-constants trend over the primary set. aiur and zisk report the
   -- SAME named-constant count for each checked closure (the pre-shard input
@@ -348,7 +349,7 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
       (·.benchmarks.filterMap (findUuid benchmarks "name" ·))
     return { title := "Aiur/Zisk Input Constants",
              testbeds := #[aiurTb], benchmarks := primaries,
-             measure := consts }
+             measure := consts, window := windowFor "Aiur/Zisk Input Constants" window }
   match overlay with
   | some d => desired := desired.push d
   | none => do
@@ -368,7 +369,7 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
         (full := false) (tier := "heavy") (shardOnly := false)).map (·.name)
     return { title := "Zisk Shards", testbeds := #[ziskTb],
              benchmarks := heavy.filterMap (findUuid benchmarks "name" ·),
-             measure := shardsM }
+             measure := shardsM, window := windowFor "Zisk Shards" window }
   match ziskShards with
   | some d => desired := desired.push d
   | none => do
@@ -376,7 +377,7 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
       "warn: Zisk shards plot skipped (missing testbed or measure)"
 
   for d in desired do
-    match ← syncPlot project dryRun window xAxis branchUuid plots idx d with
+    match ← syncPlot project dryRun xAxis branchUuid plots idx d with
     | .created => created := created + 1
     | .replaced => replaced := replaced + 1
     | .kept => kept := kept + 1

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -374,10 +374,10 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
   let ziskShards : Option DesiredPlot := do
     let ziskTb ← findUuid testbeds "slug" "zisk-check-execute-x64-32x"
     let shardsM ← findUuid measures "slug" "shards"
-    let benched := (BenchCmd.envSpecs.filter (·.benched)).map (·.name)
-    let heavy := benched.foldl (init := (#[] : Array String)) fun acc env =>
-      acc ++ (BenchCmd.selectNames rows env "execute"
-        (full := false) (tier := "heavy") (shardOnly := false)).map (·.name)
+    let heavy := (BenchCmd.envSpecs.map (·.name)).foldl
+      (init := (#[] : Array String)) fun acc env =>
+        acc ++ (BenchCmd.selectNames rows env "execute"
+          (full := false) (tier := "heavy") (shardOnly := false)).map (·.name)
     return { title := "Zisk Shards", testbeds := #[ziskTb],
              benchmarks := heavy.filterMap (findUuid benchmarks "name" ·),
              measure := shardsM, window := windowFor "Zisk Shards" window }

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -11,8 +11,10 @@
   Idempotent, keyed by title (the display names in `plotTitle`): a plot
   whose dimensions already match is left alone (only its dashboard index
   is re-asserted); a stale one is deleted and recreated (the plot PATCH
-  endpoint only takes index/title/window, not dimensions). Unrecognized
-  titles are untouched, so hand-pinned plots survive. A registry benchmark
+  endpoint only takes index/title/window, not dimensions). The registry
+  owns the dashboard: every plot whose title is not in the desired set is
+  deleted, so each sync converges to exactly the registry's plots — a
+  hand-created plot does not survive a sync. A registry benchmark
   — or a whole testbed — bencher hasn't seen yet (first upload still
   pending) is skipped with a warning and picked up on the next sync.
 
@@ -385,6 +387,20 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
     IO.eprintln
       "warn: Zisk shards plot skipped (missing testbed or measure)"
 
+  -- The registry owns the dashboard: delete every plot whose title isn't
+  -- in the desired set, so each sync converges to exactly the registry's
+  -- plots (a renamed or de-listed plot goes away instead of lingering
+  -- beside its replacement).
+  let desiredTitles := desired.map (·.title)
+  let mut removed := 0
+  for pl in plots do
+    if let some title := objStr pl "title" then
+      if !desiredTitles.contains title then
+        IO.println s!"remove:  {title}"
+        unless dryRun do
+          bencherRun #["plot", "delete", project, (objStr pl "uuid").getD ""]
+        removed := removed + 1
+
   for d in desired do
     match ← syncPlot project dryRun xAxis branchUuid plots idx d with
     | .created => created := created + 1
@@ -392,7 +408,7 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
     | .kept => kept := kept + 1
     idx := idx + 1
 
-  IO.println s!"plots: {created} created, {replaced} replaced, {kept} kept \
+  IO.println s!"plots: {created} created, {replaced} replaced, {removed} removed, {kept} kept \
     → https://bencher.dev/console/projects/{project}/plots"
   return 0
 

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -168,9 +168,18 @@ def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
 
 /-! ## bencher CLI plumbing -/
 
+/-- Spawn env for the bencher CLI: drop LD_LIBRARY_PATH. `lake exe`
+    prepends the Lean toolchain's lib dirs there (for libleanshared), and
+    the loader consults LD_LIBRARY_PATH before a binary's own RUNPATH — so
+    bencher would resolve the toolchain's bundled, older `libgcc_s.so.1`
+    and die on a missing GCC symbol version. bencher is self-contained;
+    it needs nothing from the Lean runtime. -/
+def bencherEnv : Array (String × Option String) :=
+  #[("LD_LIBRARY_PATH", none)]
+
 /-- Run the bencher CLI and parse its JSON stdout. -/
 def bencherJson (args : Array String) : IO Json := do
-  let r ← IO.Process.output { cmd := "bencher", args }
+  let r ← IO.Process.output { cmd := "bencher", args, env := bencherEnv }
   if r.exitCode != 0 then
     throw <| IO.userError
       s!"bencher {" ".intercalate args.toList} failed (exit {r.exitCode}):\n{r.stderr}"
@@ -182,7 +191,7 @@ def bencherJson (args : Array String) : IO Json := do
 
 /-- Run a bencher write call (create/update/delete), output discarded. -/
 def bencherRun (args : Array String) : IO Unit := do
-  let r ← IO.Process.output { cmd := "bencher", args }
+  let r ← IO.Process.output { cmd := "bencher", args, env := bencherEnv }
   if r.exitCode != 0 then
     throw <| IO.userError
       s!"bencher {" ".intercalate args.toList} failed (exit {r.exitCode}):\n{r.stderr}"

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -3,12 +3,12 @@
   JSON (`Ix.Benchmark.Results`) and a human or bencher.dev:
 
     compare     two rows files → a Markdown main-vs-PR table. With no
-                explicit inputs, compares the cell's local baseline against
-                its previous run (`.lake/benches/<cell>.json` vs `.prev.json`), so
+                explicit inputs, compares the parameter combination's local baseline against
+                its previous run (`.lake/benches/<params>.json` vs `.prev.json`), so
                 a bare local rerun reports its own delta.
-    report      per-cell table files → one Markdown report (the PR comment)
+    report      per-combination table files → one Markdown report (the PR comment)
     bmf         rows JSON → Bencher Metric Format (status ≠ ok rows dropped)
-    fetch-main  base SHA + cell → rows JSON pulled from bencher.dev (curl)
+    fetch-main  base SHA + params → rows JSON pulled from bencher.dev (curl)
     ci …        CI adapters: parse (!benchmark comment → job matrix) and
                 matrix (registry → workflow job matrices)
 
@@ -54,7 +54,7 @@ def metricKind (metric : String) : String :=
     rendering differs. `file-size` is the serialized `.ixe` env — bencher
     plots it as "Environment Size"; `peak-rss` reads better as plain RAM,
     in every slug that embeds it (`recursive-peak-rss` → …-peak-ram);
-    `throughput` carries its unit here because the cells print bare
+    `throughput` carries its unit here because the runs print bare
     magnitudes (matching `unitsFor`'s "constants / second" on bencher). -/
 def metricLabel (metric : String) : String :=
   if metric == "file-size" then "env-size"
@@ -221,7 +221,7 @@ def renderCompare (a : CompareArgs) : String := Id.run do
     if prStatus == "rejected" then failures := failures.push (n, "PR")
     let mut rowRegressed := false
     let mut rowImproved := false
-    let mut cells := #[s!"`{n}`"]
+    let mut cols := #[s!"`{n}`"]
     for m in a.metrics do
       let mv := rowNum a.mainRows n m
       let pv := rowNum a.prRows n m
@@ -245,13 +245,13 @@ def renderCompare (a : CompareArgs) : String := Id.run do
             delta := delta ++ " ⚠️"; rowRegressed := true
           else if bad < -a.threshold then
             delta := delta ++ " 🟢"; rowImproved := true
-      cells := cells ++ #[renderSide mainStatus mv, renderSide prStatus pv, delta]
+      cols := cols ++ #[renderSide mainStatus mv, renderSide prStatus pv, delta]
     -- Independent tallies: a row can regress on one metric and improve
     -- on another (compile-time up, peak-ram down), and the summary must
     -- not hide either side.
     if rowRegressed then regressed := regressed + 1
     if rowImproved then improved := improved + 1
-    lines := lines.push ("| " ++ " | ".intercalate cells.toList ++ " |")
+    lines := lines.push ("| " ++ " | ".intercalate cols.toList ++ " |")
 
   let mut out := #[a.title, ""] ++ lines ++ #[""]
   -- Typecheck failures first and loud — a constant the kernel REJECTS is a
@@ -311,14 +311,14 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   let env := (p.flag? "env").map (·.as! String) |>.getD "InitStd"
   let mode := (p.flag? "mode").map (·.as! String)
     |>.getD (((Ix.Cli.BenchCmd.findBackend backend).map (·.defaultMode)).getD "execute")
-  let cell := s!"{backend}-{env}-{mode}"
+  let params := s!"{backend}-{env}-{mode}"
   -- Explicit paths win; otherwise the local baseline pair, so a bare
   -- `ix bench compare --backend …` after two runs reports the local delta.
   let benchDir ← Ix.Cli.BenchCmd.benchOutputDir
   let mainPath := (p.flag? "main").map (·.as! String)
-    |>.getD s!"{benchDir}/{cell}.prev.json"
+    |>.getD s!"{benchDir}/{params}.prev.json"
   let prPath := (p.flag? "pr").map (·.as! String)
-    |>.getD s!"{benchDir}/{cell}.json"
+    |>.getD s!"{benchDir}/{params}.json"
   let metrics :=
     let flagged := (p.flag? "metric").map (·.as! (Array String)) |>.getD #[]
     if flagged.isEmpty then
@@ -357,8 +357,8 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
 
 /-! ## report -/
 
-/-- Assemble per-cell compare tables (`<dir>/table-*.md`) into one Markdown
-    report — run several cells locally, `--out table-<cell>.md` each, and
+/-- Assemble per-run compare tables (`<dir>/table-*.md`) into one Markdown
+    report — run several parameter combinations locally, `--out table-<params>.md` each, and
     read them as a single document. The link flags are optional garnish:
     with `--head`/`--repo-url`/`--run-id` (the PR workflow passes them) the
     header links the commit and a logs footer is appended. -/
@@ -464,7 +464,7 @@ def curlJson (url : String) : IO (Except String Json) := do
     load-bearing for the workflow: 3 = transient (no report at that hash
     yet, or the API failed) — the caller falls back to running main
     locally; 2 = config error (unknown backend/mode) — the caller fails
-    the cell loudly instead of paying the fallback forever. A PARTIAL miss
+    the run loudly instead of paying the fallback forever. A PARTIAL miss
     still exits 0: `--missing-out` lists the uncovered names so the caller
     measures just those against the base checkout and merges. -/
 def runFetchMainCmd (p : Cli.Parsed) : IO UInt32 := do
@@ -561,35 +561,37 @@ def runFetchMainCmd (p : Cli.Parsed) : IO UInt32 := do
 
 /-! ## matrix -/
 
-/-- Emit GitHub Actions matrix JSON from the registry, so workflow matrices
-    are generated instead of hand-copied. `--kind envs` lists the benched
-    env names; `--kind cells` fans enabled backends × benched envs. -/
-def runMatrixCmd (p : Cli.Parsed) : IO UInt32 := do
-  let kind := (p.flag? "kind").map (·.as! String) |>.getD "envs"
-  let benched := (Ix.Cli.BenchCmd.envSpecs.filter (·.benched)).map (·.name)
-  match kind with
-  | "envs" =>
-    IO.println (Json.arr (benched.map Json.str).toArray).compress
-  | "cells" =>
-    let mut cells : Array Json := #[]
-    for b in Ix.Cli.BenchCmd.backendSpecs do
-      if b.disabled.isSome then continue
-      -- The aiur-recursive backend is env-independent (fixed toy
-      -- statements, no `.ixe`): one cell, not one per env.
-      let envsFor := if b.name == "aiur-recursive" then benched.take 1 else benched
-      for env in envsFor do
-        cells := cells.push <| Json.mkObj
+/-- Emit the benchmark matrix from the registry, so workflow matrices are
+    generated instead of hand-copied: each enabled backend fanned over its
+    env set (`BackendSpec.envNames`) × its scheduled modes — the one
+    fan-out every workflow matrix and gate derives from (any projection,
+    like an env list, is a jq away). Each entry carries the metadata its
+    job needs verbatim: the display label, the bencher testbed/workload
+    pair, and the rendered `--threshold-*` flags, so the workflow
+    hardcodes none of it. -/
+def runMatrixCmd (_ : Cli.Parsed) : IO UInt32 := do
+  let mut entries : Array Json := #[]
+  for b in Ix.Cli.BenchCmd.backendSpecs do
+    if b.disabled.isSome then continue
+    for (mode, testbed) in b.testbeds do
+      if b.unscheduled.contains mode then continue
+      for env in b.envNames do
+        -- The fixed-config backend's env is only its `.ixe`-restore key,
+        -- not what it measures — keep it out of the label.
+        let label := if b.inputs == .fixedConfigs then s!"{b.name}-{mode}"
+          else s!"{b.name}-{env}-{mode}"
+        entries := entries.push <| Json.mkObj
           [("backend", Json.str b.name), ("env", Json.str env),
-           ("mode", Json.str b.defaultMode)]
-    IO.println (Json.arr cells).compress
-  | other =>
-    p.printError s!"error: unknown --kind '{other}' (envs | cells)"
-    return exitUsage
+           ("mode", Json.str mode), ("label", Json.str label),
+           ("testbed", Json.str testbed),
+           ("workload", Json.str (Ix.Cli.BenchCmd.workloadOf testbed)),
+           ("thresholds", Json.str b.thresholdFlags)]
+  IO.println (Json.arr entries).compress
   return 0
 
 /-! ## parse -/
 
-/-- The runner every CI benchmark cell measures on — a `runs-on` field for
+/-- The runner every CI benchmark run measures on — a `runs-on` field for
     the workflows' job matrices, meaningless locally. -/
 def ciRunner : String := "warp-ubuntu-latest-x64-32x"
 
@@ -604,9 +606,9 @@ def parseError (msg : String) : IO UInt32 := do
     h.flush
   return 2
 
-/-- Parse a `!benchmark` command into the cells it schedules — locally a
+/-- Parse a `!benchmark` command into the runs it schedules — locally a
     dry-run preview (`ix bench ci parse --comment "!benchmark aiur"` prints
-    the summary and cell list), in CI the matrix generator. The text comes
+    the summary and run list), in CI the matrix generator. The text comes
     from `--comment`, else the `COMMENT_BODY` env var (how the PR workflow
     passes the comment without inline shell interpolation). When
     `$GITHUB_OUTPUT` is set, the machine outputs (matrix, flags, summary,
@@ -617,9 +619,12 @@ def parseError (msg : String) : IO UInt32 := do
 
       !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all)
                  [execute | recursive] [fresh] [KEY=VALUE …]
-      BENCH_ENVS=InitStd,Mathlib   (case-insensitive; default InitStd;
-                                    compile-only requests may name any
-                                    registry env, e.g. Lean or FLT)
+      BENCH_ENVS=InitStd,Mathlib   (case-insensitive; defaults to every
+                                    registry env for the env-keyed
+                                    backends (compile, decompile), InitStd
+                                    for the rest; env-keyed-only requests
+                                    may name any registry env, e.g. Lean
+                                    or FLT)
       BENCH_FULL=1                 (full curated set, not just primary)
       BENCH_SHARD=1                (only the multi-shard target constants)
       BENCH_PHASES=1 / RUST_LOG=… / WITHOUT_VK_VERIFICATION=… /
@@ -639,13 +644,13 @@ def parseError (msg : String) : IO UInt32 := do
 
     The bare `execute` token flips a backend with an execute metrics entry
     to execute-only — a real switch only for aiur, whose modes store on
-    separate testbeds, so either kind of cell finds a cached baseline.
+    separate testbeds, so either kind of run finds a cached baseline.
     `recursive` likewise flips aiur to its recursive mode; that testbed is
-    `unscheduled`, so the cell has no bencher baseline (its main side comes
+    `unscheduled`, so the run has no bencher baseline (its main side comes
     from a base-SHA run) and the verifier execute OOMs on the 128 GB CI
     host — reserved for a bigger manual dispatch.
 
-    The bare `fresh` token makes every cell bypass its bencher baseline and
+    The bare `fresh` token makes every run bypass its bencher baseline and
     re-measure the main side with a base-SHA run — for when the published
     baseline is suspect (corrupted upload, stale toolchain). The comparison
     prints in the comment only; PR runs never upload to bencher, so the
@@ -733,14 +738,16 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
           let tok := tok.trimAscii.toString
           match Ix.Cli.BenchCmd.findEnv tok with
           | some e =>
-            -- `compile` measures any registry env (its row is env-keyed;
-            -- no curated constants involved). Every other backend selects
-            -- constants from Vectors.csv, which only covers the benched
-            -- envs — so an unbenched env needs a compile-only request.
-            if !e.benched && backends.any (·.name != "compile") then
-              return ← parseError s!"env `{e.name}` is only available for a \
-                compile-only `!benchmark compile` (the other backends need \
-                curated constants; benched: \
+            -- The env-keyed backends (`inputs := .perEnv` — compile,
+            -- decompile) measure any registry env: their row is the env
+            -- itself, no curated constants involved. Every other backend
+            -- selects constants from Vectors.csv, which only covers the
+            -- benched envs — so an unbenched env needs an env-keyed-only
+            -- request.
+            if !e.benched && backends.any (·.inputs != .perEnv) then
+              return ← parseError s!"env `{e.name}` is only available for the \
+                env-keyed backends (compile, decompile); the others need \
+                curated constants (benched: \
                 {", ".intercalate benchedEnvNames})"
             if !envs.contains e.name then envs := envs.push e.name
           | none =>
@@ -761,33 +768,49 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
             WITHOUT_VK_VERIFICATION, RUSTFLAGS, IX_COMPILE_EAGER, \
             IX_COMPILE_DEMOTE, IX_COMPILE_WORKERS)"
     | [] => continue
-  if envs.isEmpty then envs := #["InitStd"]
+  -- Env defaults, per backend, when BENCH_ENVS is absent: the env-keyed
+  -- backends (`inputs := .perEnv` — compile, decompile) cover their full
+  -- registry env set — their row IS the env, so a compiler PR sees every
+  -- env's delta without asking — while the per-constant backends default
+  -- to the light InitStd (a Mathlib prove is too heavy for an unasked-for
+  -- default). An explicit BENCH_ENVS applies to every requested backend.
+  let envsFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>
+    if !envs.isEmpty then envs
+    else if b.inputs == .perEnv then b.envNames.toArray
+    else #["InitStd"]
 
   let modeFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>
     if recursiveFlag && !(b.metricsFor "recursive").isEmpty then "recursive"
     else if executeFlag && !(b.metricsFor "execute").isEmpty then "execute"
     else b.defaultMode
-  let mut cells : Array Json := #[]
+  let mut entries : Array Json := #[]
   for b in backends do
-    -- The aiur-recursive backend is env-independent (fixed toy
-    -- statements, no `.ixe`): one cell no matter how many envs BENCH_ENVS
-    -- lists. The env kept is the first requested one, so the cell's `.ixe`
-    -- restore (an unconditional workflow step) still finds a compiled
-    -- artifact.
-    let cellEnvs := if b.name == "aiur-recursive" then envs.take 1 else envs
-    for e in cellEnvs do
-      cells := cells.push <| Json.mkObj
+    -- The fixed-config backend (`inputs := .fixedConfigs` — aiur-recursive)
+    -- is env-independent (fixed toy statements, no `.ixe`): one run no
+    -- matter how many envs BENCH_ENVS lists. The env kept is the first
+    -- requested one, so the run's `.ixe` restore (an unconditional workflow
+    -- step) still finds a compiled artifact.
+    let runEnvs := if b.inputs == .fixedConfigs then (envsFor b).take 1
+      else envsFor b
+    for e in runEnvs do
+      entries := entries.push <| Json.mkObj
         [("backend", Json.str b.name), ("env", Json.str e),
          ("mode", Json.str (modeFor b)),
          ("runner", Json.str ciRunner),
          ("label", Json.str s!"{b.name}-{e}-{modeFor b}")]
+
+  -- The union of every backend's env set (first-seen order): the compile
+  -- stage's matrix — each env compiled exactly once — and the summary line.
+  let allEnvs := backends.foldl (init := #[]) fun acc b =>
+    (envsFor b).foldl (init := acc) fun acc e =>
+      if acc.contains e then acc else acc.push e
 
   -- Annotate the mode only where a mode CHOICE exists (aiur's
   -- execute/prove); `ooc=execute` for a single-mode backend is noise.
   let modes := " ".intercalate
     (backends.map (fun b =>
       if b.testbeds.length > 1 then s!"{b.name}={modeFor b}" else b.name)).toList
-  let mut summary := s!"backends: `{modes}` · envs: `{",".intercalate envs.toList}` · \
+  let mut summary := s!"backends: `{modes}` · envs: `{",".intercalate allEnvs.toList}` · \
     set: `{if full == "1" then "full" else "primary"}` · shard: `{shard}`"
   if freshFlag then
     summary := summary ++ " · baseline: `fresh` (base-SHA run, bencher bypassed)"
@@ -798,13 +821,13 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
     summary := summary ++ " · env: `" ++ " ".intercalate passthrough.toList ++ "`"
 
   -- `envs` drives the workflow's compile stage: every requested env is
-  -- compiled exactly once — the `.ixe` artifact the prover cells restore,
-  -- AND the measured row the compile cell reuses as its PR side instead
+  -- compiled exactly once — the `.ixe` artifact the prover runs restore,
+  -- AND the measured row the compile run reuses as its PR side instead
   -- of compiling a second time.
   if let some outPath := ← IO.getEnv "GITHUB_OUTPUT" then
     let h ← IO.FS.Handle.mk outPath IO.FS.Mode.append
-    h.putStr <| s!"matrix={(Json.arr cells).compress}\n"
-      ++ s!"envs={(Json.arr (envs.map Json.str)).compress}\n"
+    h.putStr <| s!"matrix={(Json.arr entries).compress}\n"
+      ++ s!"envs={(Json.arr (allEnvs.map Json.str)).compress}\n"
       ++ s!"shard={shard}\nfull={full}\n"
       ++ s!"fresh={if freshFlag then 1 else 0}\n"
       ++ s!"config-summary={summary}\n"
@@ -813,7 +836,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       ++ (if passthrough.isEmpty then "" else "\n") ++ "PTENV\n"
     h.flush
   IO.println summary
-  IO.println (Json.arr cells).pretty
+  IO.println (Json.arr entries).pretty
   return 0
 
 end Ix.Cli.BenchReport
@@ -821,17 +844,17 @@ end Ix.Cli.BenchReport
 open Ix.Cli.BenchReport in
 def benchCompareCmd : Cli.Cmd := `[Cli|
   "compare" VIA runCompareCmd;
-  "Render a Markdown main-vs-PR table from two results rows files. Defaults to the cell's local baseline pair (<BENCH_OUTPUT_DIR or .lake/benches>/<cell>{.prev,}.json), so a bare rerun compares against the previous local run."
+  "Render a Markdown main-vs-PR table from two results rows files. Defaults to the parameter combination's local baseline pair (<BENCH_OUTPUT_DIR or .lake/benches>/<params>{.prev,}.json), so a bare rerun compares against the previous local run."
 
   FLAGS:
-    backend       : String; "Cell backend (metrics come from the registry)"
-    env           : String; "Cell env (default: InitStd)"
-    mode          : String; "Cell mode (default: the backend's default_mode)"
-    main          : String; "Main-side rows JSON (default: the cell baseline .prev.json)"
-    pr            : String; "PR-side rows JSON (default: the cell baseline .json)"
+    backend       : String; "Run backend (metrics come from the registry)"
+    env           : String; "Run env (default: InitStd)"
+    mode          : String; "Run mode (default: the backend's default_mode)"
+    main          : String; "Main-side rows JSON (default: the run baseline .prev.json)"
+    pr            : String; "PR-side rows JSON (default: the run baseline .json)"
     metric        : Array String; "Metric column(s), overriding the registry"
     threshold     : Nat;    "Flag |Δ| above this percentage (default: 3)"
-    title         : String; "Table title (default: derived from the cell)"
+    title         : String; "Table title (default: derived from the run)"
     "main-source" : String; "Where the main side came from, for the title"
     out           : String; "Write the table here instead of stdout"
 ]
@@ -839,7 +862,7 @@ def benchCompareCmd : Cli.Cmd := `[Cli|
 open Ix.Cli.BenchReport in
 def benchReportCmd : Cli.Cmd := `[Cli|
   "report" VIA runReportCmd;
-  "Assemble per-cell compare tables (<dir>/table-*.md) into one Markdown report. The link flags are optional: the PR workflow passes them to make the report a linkable comment body."
+  "Assemble per-run compare tables (<dir>/table-*.md) into one Markdown report. The link flags are optional: the PR workflow passes them to make the report a linkable comment body."
 
   FLAGS:
     tables     : String; "Directory of table-*.md files (default: tables)"
@@ -867,9 +890,9 @@ def benchFetchMainCmd : Cli.Cmd := `[Cli|
 
   FLAGS:
     sha           : String; "Base commit SHA to fetch reports for"
-    backend       : String; "Cell backend (testbed from the registry)"
-    env           : String; "Cell env — admits the env-keyed row past --names"
-    mode          : String; "Cell mode"
+    backend       : String; "Run backend (testbed from the registry)"
+    env           : String; "Run env — admits the env-keyed row past --names"
+    mode          : String; "Run mode"
     consts        : String; "Only fetch these comma-separated benchmark names"
     names         : String; "Additionally read names from a file (one per line); unions with --consts"
     "missing-out" : String; "Write the --names entries bencher lacked (the caller measures just these on the base checkout)"
@@ -879,16 +902,13 @@ def benchFetchMainCmd : Cli.Cmd := `[Cli|
 open Ix.Cli.BenchReport in
 def benchCiMatrixCmd : Cli.Cmd := `[Cli|
   "matrix" VIA runMatrixCmd;
-  "Emit GitHub Actions matrix JSON from the registry (--kind envs | cells)"
-
-  FLAGS:
-    kind   : String; "envs = benched env names; cells = enabled backends × benched envs"
+  "Emit the benchmark matrix from the registry: each enabled backend × its env set × scheduled modes, with per-entry testbed/workload/threshold metadata"
 ]
 
 open Ix.Cli.BenchReport in
 def benchCiParseCmd : Cli.Cmd := `[Cli|
   "parse" VIA runParseCmd;
-  "Parse a !benchmark command into the cells it schedules and write the job matrix to $GITHUB_OUTPUT (when set). Unknown tokens fall off the allowlist; --comment doubles as a local pre-flight of a comment before posting it."
+  "Parse a !benchmark command into the runs it schedules and write the job matrix to $GITHUB_OUTPUT (when set). Unknown tokens fall off the allowlist; --comment doubles as a local pre-flight of a comment before posting it."
 
   FLAGS:
     comment : String; "The command text (default: the COMMENT_BODY env var)"
@@ -905,7 +925,7 @@ def benchCiCmd : Cli.Cmd := `[Cli|
 
 def benchCmd : Cli.Cmd := `[Cli|
   bench NOOP;
-  "Benchmark cells: run, compare, and publish locally exactly what CI runs"
+  "Benchmark runs: run, compare, and publish locally exactly what CI runs"
 
   SUBCOMMANDS:
     benchRunCmd;

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -625,6 +625,13 @@ def parseError (msg : String) : IO UInt32 := do
                                     for the rest; env-keyed-only requests
                                     may name any registry env, e.g. Lean
                                     or FLT)
+      BENCH_CONSTS=Mathlib.X,…     (bench exactly these constants on the
+                                    per-constant backends, overriding the
+                                    curated selection; each name's env
+                                    comes from its Vectors.csv row —
+                                    BENCH_ENVS is needed only to place a
+                                    name the CSV doesn't list, and then
+                                    must name a single env)
       BENCH_FULL=1                 (full curated set, not just primary)
       BENCH_SHARD=1                (only the multi-shard target constants)
       BENCH_PHASES=1 / RUST_LOG=… / WITHOUT_VK_VERIFICATION=… /
@@ -712,6 +719,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let benchedEnvNames :=
     (Ix.Cli.BenchCmd.envSpecs.filter (·.benched)).map (·.name)
   let mut envs : Array String := #[]
+  let mut consts : Array String := #[]
   let mut shard := "0"
   let mut full := "0"
   let mut passthrough : Array String := #[]
@@ -754,6 +762,9 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
             return ← parseError s!"unknown env `{tok}` in BENCH_ENVS \
               (registry: \
               {", ".intercalate (Ix.Cli.BenchCmd.envSpecs.map (·.name))})"
+      | "BENCH_CONSTS" =>
+        for tok in Ix.Cli.ConstsFile.parseCommaList val do
+          if !consts.contains tok then consts := consts.push tok
       | "BENCH_SHARD" => if val == "1" then shard := "1"
       | "BENCH_FULL" => if val == "1" then full := "1"
       | k =>
@@ -763,19 +774,56 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
           passthrough := passthrough.push s!"{k}={val}"
         else if strict then
           return ← parseError s!"unknown config key `{k}` in the \
-            benchmark command (expected BENCH_ENVS / BENCH_FULL / \
-            BENCH_SHARD, or passthrough: BENCH_PHASES, RUST_LOG, \
-            WITHOUT_VK_VERIFICATION, RUSTFLAGS, IX_COMPILE_EAGER, \
-            IX_COMPILE_DEMOTE, IX_COMPILE_WORKERS)"
+            benchmark command (expected BENCH_ENVS / BENCH_CONSTS / \
+            BENCH_FULL / BENCH_SHARD, or passthrough: BENCH_PHASES, \
+            RUST_LOG, WITHOUT_VK_VERIFICATION, RUSTFLAGS, \
+            IX_COMPILE_EAGER, IX_COMPILE_DEMOTE, IX_COMPILE_WORKERS)"
     | [] => continue
+
+  -- BENCH_CONSTS: bench exactly these constants on the per-constant
+  -- backends, overriding the curated selection (`ix bench run --consts`
+  -- downstream). Each name is attributed to the env(s) whose Vectors.csv
+  -- rows list it — `BENCH_CONSTS=Mathlib.X` alone schedules a Mathlib
+  -- entry scoped to it, no BENCH_ENVS needed. A name the CSV doesn't
+  -- list (a curated-set candidate being scouted) can't be attributed:
+  -- a single-env BENCH_ENVS adopts it, anything else rejects.
+  let mut constsByEnv : Array (String × Array String) := #[]
+  if !consts.isEmpty then
+    let csvPath := (p.flag? "csv").map (·.as! String)
+      |>.getD "Benchmarks/Vectors.csv"
+    let rows := Ix.Cli.BenchCmd.parseVectorsCsv
+      (← try IO.FS.readFile csvPath catch _ => pure "")
+    for n in consts do
+      let owners := ((rows.filter (·.name == n)).map (·.env)).toList.eraseDups
+      let owners := if !envs.isEmpty then owners.filter envs.contains else owners
+      let owners := if owners.isEmpty && envs.size == 1 then envs.toList else owners
+      if owners.isEmpty then
+        return ← parseError <| s!"BENCH_CONSTS: `{n}` has no row in {csvPath}" ++
+          (if envs.isEmpty then " — pass BENCH_ENVS with a single env to place it"
+           else s!" under BENCH_ENVS ({", ".intercalate envs.toList})")
+      for o in owners do
+        match constsByEnv.findIdx? (·.1 == o) with
+        | some i =>
+          constsByEnv := constsByEnv.set! i (o, constsByEnv[i]!.2.push n)
+        | none => constsByEnv := constsByEnv.push (o, #[n])
+  -- Registry order, so the entry order is stable.
+  let constEnvs := ((Ix.Cli.BenchCmd.envSpecs.map (·.name)).filter
+    (fun e => constsByEnv.any (·.1 == e))).toArray
+
   -- Env defaults, per backend, when BENCH_ENVS is absent: the env-keyed
   -- backends (`inputs := .perEnv` — compile, decompile) cover their full
   -- registry env set — their row IS the env, so a compiler PR sees every
   -- env's delta without asking — while the per-constant backends default
   -- to the light InitStd (a Mathlib prove is too heavy for an unasked-for
-  -- default). An explicit BENCH_ENVS applies to every requested backend.
+  -- default). An explicit BENCH_ENVS applies to every requested backend —
+  -- except under BENCH_CONSTS, where the per-constant backends fan over
+  -- exactly the envs owning a listed constant (no empty-selection
+  -- entries).
   let envsFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>
-    if !envs.isEmpty then envs
+    if !consts.isEmpty
+        && (b.inputs == .perConstant || b.inputs == .perConstantWithEnv) then
+      constEnvs
+    else if !envs.isEmpty then envs
     else if b.inputs == .perEnv then b.envNames.toArray
     else #["InitStd"]
 
@@ -793,10 +841,19 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
     let runEnvs := if b.inputs == .fixedConfigs then (envsFor b).take 1
       else envsFor b
     for e in runEnvs do
+      -- The entry's `--consts` override: the listed names this env owns,
+      -- on the per-constant backends only (env-keyed and fixed-config
+      -- backends measure regardless of constant selection).
+      let entryConsts :=
+        if b.inputs == .perConstant || b.inputs == .perConstantWithEnv then
+          ",".intercalate
+            (((constsByEnv.find? (·.1 == e)).map (·.2.toList)).getD [])
+        else ""
       entries := entries.push <| Json.mkObj
         [("backend", Json.str b.name), ("env", Json.str e),
          ("mode", Json.str (modeFor b)),
          ("runner", Json.str ciRunner),
+         ("consts", Json.str entryConsts),
          ("label", Json.str s!"{b.name}-{e}-{modeFor b}")]
 
   -- The union of every backend's env set (first-seen order): the compile
@@ -812,6 +869,8 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       if b.testbeds.length > 1 then s!"{b.name}={modeFor b}" else b.name)).toList
   let mut summary := s!"backends: `{modes}` · envs: `{",".intercalate allEnvs.toList}` · \
     set: `{if full == "1" then "full" else "primary"}` · shard: `{shard}`"
+  if !consts.isEmpty then
+    summary := summary ++ s!" · consts: `{",".intercalate consts.toList}`"
   if freshFlag then
     summary := summary ++ " · baseline: `fresh` (base-SHA run, bencher bypassed)"
   for b in skipped do
@@ -912,6 +971,7 @@ def benchCiParseCmd : Cli.Cmd := `[Cli|
 
   FLAGS:
     comment : String; "The command text (default: the COMMENT_BODY env var)"
+    csv     : String; "Vectors path for BENCH_CONSTS env attribution (default: Benchmarks/Vectors.csv)"
 ]
 
 def benchCiCmd : Cli.Cmd := `[Cli|

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -569,13 +569,16 @@ def runFetchMainCmd (p : Cli.Parsed) : IO UInt32 := do
     job needs verbatim: the display label, the bencher testbed/workload
     pair, and the rendered `--threshold-*` flags, so the workflow
     hardcodes none of it. -/
-def runMatrixCmd (_ : Cli.Parsed) : IO UInt32 := do
+def runMatrixCmd (p : Cli.Parsed) : IO UInt32 := do
+  let csv := (p.flag? "csv").map (·.as! String)
+    |>.getD "Benchmarks/Vectors.csv"
+  let rows := Ix.Cli.BenchCmd.parseVectorsCsv (← IO.FS.readFile csv)
   let mut entries : Array Json := #[]
   for b in Ix.Cli.BenchCmd.backendSpecs do
     if b.disabled.isSome then continue
     for (mode, testbed) in b.testbeds do
       if b.unscheduled.contains mode then continue
-      for env in b.envNames do
+      for env in b.envNames rows do
         -- The fixed-config backend's env is only its `.ixe`-restore key,
         -- not what it measures — keep it out of the label.
         let label := if b.inputs == .fixedConfigs then s!"{b.name}-{mode}"
@@ -614,24 +617,22 @@ def parseError (msg : String) : IO UInt32 := do
     `$GITHUB_OUTPUT` is set, the machine outputs (matrix, flags, summary,
     passthrough env) are appended there in Actions format.
 
-    Grammar (an unknown command-line token, or an unknown/unbenched env in
+    Grammar (an unknown command-line token, or an unknown env in
     BENCH_ENVS, rejects the command — exit 2 and a `parse-error` output):
 
       !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all)
                  [execute | recursive] [fresh] [KEY=VALUE …]
-      BENCH_ENVS=InitStd,Mathlib   (case-insensitive; defaults to every
-                                    registry env for the env-keyed
-                                    backends (compile, decompile), InitStd
-                                    for the rest; env-keyed-only requests
-                                    may name any registry env, e.g. Lean
-                                    or FLT)
+      BENCH_ENVS=InitStd,Mathlib   (case-insensitive, any registry env;
+                                    defaults to every env for the
+                                    env-keyed backends (compile,
+                                    decompile), InitStd for the rest)
       BENCH_CONSTS=Mathlib.X,…     (bench exactly these constants on the
                                     per-constant backends, overriding the
                                     curated selection; each name's env
-                                    comes from its Vectors.csv row —
-                                    BENCH_ENVS is needed only to place a
-                                    name the CSV doesn't list, and then
-                                    must name a single env)
+                                    comes from its Vectors.csv row — a
+                                    single-env BENCH_ENVS overrides the
+                                    attribution and places names the CSV
+                                    doesn't list)
       BENCH_FULL=1                 (full curated set, not just primary)
       BENCH_SHARD=1                (only the multi-shard target constants)
       BENCH_PHASES=1 / RUST_LOG=… / WITHOUT_VK_VERIFICATION=… /
@@ -716,8 +717,6 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   -- unknown key rejects, same as a typo'd backend), then the lines below
   -- the command (lenient — comments contain prose, and prose contains
   -- `=`, so only recognized keys are consulted there).
-  let benchedEnvNames :=
-    (Ix.Cli.BenchCmd.envSpecs.filter (·.benched)).map (·.name)
   let mut envs : Array String := #[]
   let mut consts : Array String := #[]
   let mut shard := "0"
@@ -746,17 +745,6 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
           let tok := tok.trimAscii.toString
           match Ix.Cli.BenchCmd.findEnv tok with
           | some e =>
-            -- The env-keyed backends (`inputs := .perEnv` — compile,
-            -- decompile) measure any registry env: their row is the env
-            -- itself, no curated constants involved. Every other backend
-            -- selects constants from Vectors.csv, which only covers the
-            -- benched envs — so an unbenched env needs an env-keyed-only
-            -- request.
-            if !e.benched && backends.any (·.inputs != .perEnv) then
-              return ← parseError s!"env `{e.name}` is only available for the \
-                env-keyed backends (compile, decompile); the others need \
-                curated constants (benched: \
-                {", ".intercalate benchedEnvNames})"
             if !envs.contains e.name then envs := envs.push e.name
           | none =>
             return ← parseError s!"unknown env `{tok}` in BENCH_ENVS \
@@ -824,7 +812,8 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
         && (b.inputs == .perConstant || b.inputs == .perConstantWithEnv) then
       constEnvs
     else if !envs.isEmpty then envs
-    else if b.inputs == .perEnv then b.envNames.toArray
+    else if b.inputs == .perEnv then
+      (Ix.Cli.BenchCmd.envSpecs.map (·.name)).toArray
     else #["InitStd"]
 
   let modeFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>
@@ -962,6 +951,9 @@ open Ix.Cli.BenchReport in
 def benchCiMatrixCmd : Cli.Cmd := `[Cli|
   "matrix" VIA runMatrixCmd;
   "Emit the benchmark matrix from the registry: each enabled backend × its env set × scheduled modes, with per-entry testbed/workload/threshold metadata"
+
+  FLAGS:
+    csv : String; "Vectors path for the per-constant env fan-out (default: Benchmarks/Vectors.csv)"
 ]
 
 open Ix.Cli.BenchReport in

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -21,6 +21,8 @@ public import Lean.Data.Json
 public import Ix.Benchmark.Results
 public import Ix.Cli.BenchCmd
 public import Ix.Cli.BenchPlots
+public import Ix.Cli.NameResolve
+public import Ix.Meta
 
 public section
 
@@ -626,13 +628,16 @@ def parseError (msg : String) : IO UInt32 := do
                                     defaults to every env for the
                                     env-keyed backends (compile,
                                     decompile), InitStd for the rest)
-      BENCH_CONSTS=Mathlib.X,…     (bench exactly these constants on the
+      BENCH_CONSTS=Nat.gcd,…       (bench exactly these constants on the
                                     per-constant backends, overriding the
-                                    curated selection; each name's env
-                                    comes from its Vectors.csv row — a
-                                    single-env BENCH_ENVS overrides the
-                                    attribution and places names the CSV
-                                    doesn't list)
+                                    curated selection. Each name's env is
+                                    found automatically: its Vectors.csv
+                                    row first, else its defining module
+                                    (Init/Std → InitStd, Lean → Lean),
+                                    else Mathlib — or FLT for FLT.* names
+                                    — so BENCH_ENVS is never required. A
+                                    single-env BENCH_ENVS still forces
+                                    placement.)
       BENCH_FULL=1                 (full curated set, not just primary)
       BENCH_SHARD=1                (only the multi-shard target constants)
       BENCH_PHASES=1 / RUST_LOG=… / WITHOUT_VK_VERIFICATION=… /
@@ -770,25 +775,55 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
 
   -- BENCH_CONSTS: bench exactly these constants on the per-constant
   -- backends, overriding the curated selection (`ix bench run --consts`
-  -- downstream). Each name is attributed to the env(s) whose Vectors.csv
-  -- rows list it — `BENCH_CONSTS=Mathlib.X` alone schedules a Mathlib
-  -- entry scoped to it, no BENCH_ENVS needed. A name the CSV doesn't
-  -- list (a curated-set candidate being scouted) can't be attributed:
-  -- a single-env BENCH_ENVS adopts it, anything else rejects.
+  -- downstream). Each name finds its own env — no BENCH_ENVS needed:
+  --   1. a Vectors.csv row wins (curated attribution);
+  --   2. otherwise, locate the name by defining module: import the
+  --      `Lean` environment (toolchain oleans only — its closure IS the
+  --      Lean bench env, and it contains InitStd's) and map the module
+  --      root — Init/Std → InitStd, anything else found → Lean;
+  --   3. not found there means it lives above: FLT when the name's root
+  --      is `FLT`, else Mathlib (safe default — Mathlib ⊂ FLT, and a
+  --      wrong guess fails at run time with a clear name-not-found).
+  -- An explicit single-env BENCH_ENVS still overrides the attribution.
   let mut constsByEnv : Array (String × Array String) := #[]
   if !consts.isEmpty then
     let csvPath := (p.flag? "csv").map (·.as! String)
       |>.getD "Benchmarks/Vectors.csv"
     let rows := Ix.Cli.BenchCmd.parseVectorsCsv
       (← try IO.FS.readFile csvPath catch _ => pure "")
+    -- Loaded lazily, once, and only when some name has no CSV row.
+    let mut lookupEnv? : Option Lean.Environment := none
     for n in consts do
-      let owners := ((rows.filter (·.name == n)).map (·.env)).toList.eraseDups
-      let owners := if !envs.isEmpty then owners.filter envs.contains else owners
-      let owners := if owners.isEmpty && envs.size == 1 then envs.toList else owners
+      let csvOwners :=
+        ((rows.filter (·.name == n)).map (·.env)).toList.eraseDups
+      let mut owners := csvOwners
       if owners.isEmpty then
-        return ← parseError <| s!"BENCH_CONSTS: `{n}` has no row in {csvPath}" ++
-          (if envs.isEmpty then " — pass BENCH_ENVS with a single env to place it"
-           else s!" under BENCH_ENVS ({", ".intercalate envs.toList})")
+        let env ← match lookupEnv? with
+          | some e => pure e
+          | none => do
+            IO.eprintln
+              s!"[parse] locating uncurated constant(s) by module: importing Lean"
+            let e ← getCompileEnv #[`Lean]
+            lookupEnv? := some e
+            pure e
+        owners := match Ix.Cli.NameResolve.resolveName env n with
+          | some ln =>
+            let root := match env.getModuleIdxFor? ln with
+              | some idx => env.allImportedModuleNames[idx.toNat]!.getRoot
+              | none => Lean.Name.anonymous
+            if root == `Init || root == `Std then ["InitStd"] else ["Lean"]
+          | none =>
+            if (Ix.Cli.NameResolve.parseName n).getRoot == `FLT then ["FLT"]
+            else ["Mathlib"]
+      let resolvedOwners := owners
+      if !envs.isEmpty then
+        let inter := owners.filter envs.contains
+        owners := if inter.isEmpty && envs.size == 1 then envs.toList else inter
+      if owners.isEmpty then
+        return ← parseError s!"BENCH_CONSTS: `{n}` belongs to env \
+          `{", ".intercalate resolvedOwners}`, which BENCH_ENVS \
+          ({", ".intercalate envs.toList}) excludes — drop BENCH_ENVS, \
+          include that env, or name a single env to force placement"
       for o in owners do
         match constsByEnv.findIdx? (·.1 == o) with
         | some i =>

--- a/Ix/Cli/DecompileCmd.lean
+++ b/Ix/Cli/DecompileCmd.lean
@@ -5,7 +5,7 @@
 
   With `--json` the run records one env-keyed results row (decompile-time,
   file-size, constants, throughput, peak-rss). A malformed decompile is a hard
-  error (nonzero exit → red cell). Deeper compile→decompile roundtrip fidelity
+  error (nonzero exit → red run). Deeper compile→decompile roundtrip fidelity
   is gated by the canonical roundtrip checks (`ix validate` / the roundtrip
   tests), which need the original Lean env a `.ixe` can't supply — so this
   performance tool does not reproduce them.

--- a/Ix/Cli/DecompileCmd.lean
+++ b/Ix/Cli/DecompileCmd.lean
@@ -5,7 +5,7 @@
 
   With `--json` the run records one env-keyed results row (decompile-time,
   file-size, constants, throughput, peak-rss). A malformed decompile is a hard
-  error (nonzero exit → red run). Deeper compile→decompile roundtrip fidelity
+  error (nonzero exit). Deeper compile→decompile roundtrip fidelity
   is gated by the canonical roundtrip checks (`ix validate` / the roundtrip
   tests), which need the original Lean env a `.ixe` can't supply — so this
   performance tool does not reproduce them.


### PR DESCRIPTION
- Simplifies `bench-main.yml` to derive all parameters from `Ix/Cli/BenchCmd.lean` rather than hardcoded across CI files. This simplifies the matrix job structure and maintenance going forward.
- Sets all of `InitStd,Lean,FLT,Mathlib` as the default `BENCH_ENVS` for `!benchmark compile/decompile`
- Adds a `BENCH_CONSTS` env var to allow overriding the default inputs with any input from the above four envs, which are already compiled to .ixe files in the prior job
- Fixes the recursive verifier plot titles on bencher.dev and makes the script declarative by deleting any old/untracked plots and replacing them with exactly the printed (pass --dry-run to see the plan)