### PR TITLE
params: blowup 4 + 20-bit query grinding — proven soundness regime

### DIFF
--- a/Benchmarks/Aiur.lean
+++ b/Benchmarks/Aiur.lean
@@ -52,7 +52,7 @@ def toplevel := ⟦
 ⟧
 
 def commitmentParameters : Aiur.CommitmentParameters := {
-  logBlowup := 1
+  logBlowup := 2
   capHeight := 0
 }
 
@@ -60,8 +60,8 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 -- Stages the e2e proving pipeline through `benchStep`: each call times a stage

--- a/Benchmarks/Blake3.lean
+++ b/Benchmarks/Blake3.lean
@@ -11,7 +11,7 @@ abbrev dataSizes := #[64, 128, 256, 512, 1024, 2048]
 abbrev numHashesPerProof := #[1, 2, 4, 8, 16, 32]
 
 def commitmentParameters : Aiur.CommitmentParameters := {
-  logBlowup := 1
+  logBlowup := 2
   capHeight := 0
 }
 
@@ -19,8 +19,8 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 def mergedToplevel : Except Aiur.Global Aiur.Source.Toplevel := do

--- a/Benchmarks/IxVM.lean
+++ b/Benchmarks/IxVM.lean
@@ -7,7 +7,7 @@ import Ix.Benchmark.Bench
 open BgroupM
 
 def commitmentParameters : Aiur.CommitmentParameters := {
-  logBlowup := 1
+  logBlowup := 2
   capHeight := 0
 }
 
@@ -15,8 +15,8 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 def main : IO Unit := do

--- a/Benchmarks/Sha256.lean
+++ b/Benchmarks/Sha256.lean
@@ -11,7 +11,7 @@ abbrev dataSizes := #[64, 128, 256, 512, 1024, 2048]
 abbrev numHashesPerProof := #[1, 2, 4, 8, 16, 32]
 
 def commitmentParameters : Aiur.CommitmentParameters := {
-  logBlowup := 1
+  logBlowup := 2
   capHeight := 0
 }
 
@@ -19,8 +19,8 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 def mergedToplevel : Except Aiur.Global Aiur.Source.Toplevel := do

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -106,7 +106,7 @@ bencher-specific reshaping is the caller's job (see
 open Lean (Json Name)
 
 def commitmentParameters : Aiur.CommitmentParameters := {
-  logBlowup := 1
+  logBlowup := 2
   capHeight := 0
 }
 
@@ -114,8 +114,8 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 /-- Recursion-tuned commitment parameters for `--recursive`, matching
@@ -136,8 +136,8 @@ def recursiveFriParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 

--- a/Ix/Cli/ProveCmd.lean
+++ b/Ix/Cli/ProveCmd.lean
@@ -48,14 +48,14 @@ namespace Ix.Cli.ProveCmd
     proof header, they MUST stay in sync between `prove` and
     `verify`. -/
 private def commitmentParameters : Aiur.CommitmentParameters :=
-  { logBlowup := 1, capHeight := 0 }
+  { logBlowup := 2, capHeight := 0 }
 
 private def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 def proveOne (aiurSystem : Aiur.AiurSystem)

--- a/Ix/Cli/VerifyCmd.lean
+++ b/Ix/Cli/VerifyCmd.lean
@@ -37,14 +37,14 @@ private def addrOfHex! (label : String) (s : String) : IO Address := do
     silently with no useful diagnostic, so these MUST match the
     proving side until they migrate into the proof header. -/
 private def commitmentParameters : Aiur.CommitmentParameters :=
-  { logBlowup := 1, capHeight := 0 }
+  { logBlowup := 2, capHeight := 0 }
 
 private def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 /-- Verify one persisted `Ixon.Proof` wrapper (by store address) against its

--- a/Tests/Aiur/Common.lean
+++ b/Tests/Aiur/Common.lean
@@ -36,7 +36,7 @@ def AiurTestCase.exec (functionName : Lean.Name)
   { functionName, input, expectedOutput, interpret := false, executionOnly := true }
 
 def commitmentParameters : Aiur.CommitmentParameters := {
-  logBlowup := 1
+  logBlowup := 2
   capHeight := 0
 }
 
@@ -44,8 +44,8 @@ def friParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
   numQueries := 100
-  commitProofOfWorkBits := 20
-  queryProofOfWorkBits := 0
+  commitProofOfWorkBits := 0
+  queryProofOfWorkBits := 20
 }
 
 structure AiurTestEnv where


### PR DESCRIPTION
# STARK parameters: blowup 4 + 20-bit query grinding — proven soundness regime

Moves the Aiur STARK parameters from

```
log_blowup = 1,  num_queries = 100,  commit_pow = 20,  query_pow = 0
```

to

```
log_blowup = 2,  num_queries = 100,  commit_pow = 0,   query_pow = 20
```

so that the security level is backed by the **proven** FRI soundness bound
within the unique decoding radius, instead of the list-decoding-capacity
conjecture.

## Why

At rate `ρ = 2^-log_blowup`, FRI's per-query soundness is only *proven* up to
the unique decoding radius `δ = (1 − ρ)/2`, giving a per-query error of
`1 − δ = (1 + ρ)/2`:

| | per-query error | bits/query | 100 queries | + query pow | total proven |
|---|---|---|---|---|---|
| `log_blowup = 1` (old) | 3/4 | 0.415 | ~41 bits | +0 | **~41 bits** |
| `log_blowup = 2` (new) | 5/8 | 0.678 | ~68 bits | +20 | **~88 bits** |

Under the usual capacity conjecture the same parameters give 200+ bits,
capped by the ~2⁻¹⁰⁰ field-size terms of the union bound — so the change
costs nothing in the conjectured regime and buys a defensible proven number.

**Query grinding (0 → 20 bits).** Grinding immediately before query sampling
adds its bits one-for-one to the query-phase error — the dominant term of the
union bound. Honest-prover cost: a one-off ~2²⁰ hashes (milliseconds).

**Commit grinding (20 → 0 bits).** The commit-phase error terms (FRI folding
challenges, constraint folding α, lookup collisions) are Schwartz–Zippel
bounds against the degree-2 Goldilocks extension, sitting around 2⁻¹⁰⁰ —
orders of magnitude below the ~2⁻⁸⁸ query phase in every regime, proven or
conjectured. Grinding them adds no measurable security; it only slowed honest
proving (2²⁰ work per FRI fold round). Dropping it to 0 keeps the parameter
honest rather than decorative.

## Costs and side effects

- Prover commit/FFT/Merkle work roughly doubles (LDEs go from 2n to 4n) and
  each Merkle path gains one hash. This is the price of the proven regime.
- The supported constraint degree rises from 3 to 5
  (`2^log_blowup + 1`), headroom the upcoming logup message-grouping change
  relies on.
- The higher per-query soundness (0.678 vs 0.415 proven bits, 2 vs 1
  conjectured) makes queries cheaper per bit, opening room to later trade
  query count against grinding for smaller proofs.

## Scope

Parameter definitions only: `Tests/Aiur/Common.lean`, `Ix/Cli/ProveCmd.lean`,
`Ix/Cli/VerifyCmd.lean`, and the `Benchmarks/{Aiur,Blake3,IxVM,Sha256,
Typecheck}.lean` configs.

`Benchmarks/RecursiveVerifier.lean` and `Tests/MultiStark.lean` intentionally
keep the old parameters: the Lean recursive verifier hardcodes
`query_pow = 0` as a protocol assumption (`Ix/MultiStark.lean`) and is being
ported separately.