### PR TITLE
commitPow -> queryPow

### DIFF
--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -85,7 +85,7 @@ def recCommitParams (args : List String) : Aiur.CommitmentParameters :=
 def innerFri (args : List String) : Aiur.FriParameters :=
   { logFinalPolyLen := argNat args "--final-poly" 0, maxLogArity := 1,
     numQueries := argNat args "--queries" 100,
-    commitProofOfWorkBits := argNat args "--pow" 20, queryProofOfWorkBits := 0 }
+    commitProofOfWorkBits := argNat args "--pow" 0, queryProofOfWorkBits := 20 }
 
 def secs (t0 t1 : Nat) : Float := (Float.ofNat (t1 - t0)) / 1e9
 

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -136,13 +136,12 @@ def main (args : List String) : IO UInt32 := do
     IO.eprintln "inner proof failed to verify"
     return 1
   -- Proof (advice, channel 0), vk (channel 1), claims (channel 2), plus the
-  -- Blake3-bound vk/claims digests and FRI params as public input. The
-  -- advice buffer is built natively in Rust from the raw byte blobs
-  -- (`executeMultiStark` / `proveMultiStark`).
+  -- Blake3-bound vk/claims digests as public input (the FRI params ride in
+  -- the digest-bound vk). The advice buffer is built natively in Rust from
+  -- the raw byte blobs (`executeMultiStark` / `proveMultiStark`).
   let claimBytes := MultiStark.serializeClaims #[claim]
   let vkBytes := facSystem.vkBytes
   let pubInput := MultiStark.verifierPubInput vkBytes claimBytes
-    recCommitParams innerFri
   -- Compile the verifier toplevel and run it over the proof.
   let vTop ← match MultiStark.multiStark with
     | .ok t => pure t

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -25,8 +25,8 @@ lake exe bench-recursive-verifier --execute-only  # skip the outer prove (FFT/ex
   --trivial        square(5) instead of factorial(5) — the per-statement floor
   --queries N      FRI query count (default 100 = soundness level; pass a
                    small value for a cheap local run)
-  --blowup N       log2 blowup            (default 2)
-  --pow N          commit PoW bits        (default 20)
+  --log-blowup N   log2 blowup            (default 2)
+  --pow N          query PoW bits         (default 20)
   --json <path>    write a benchmark results row (Ix.Benchmark.Results); the
                    row lands after the verifier execute and is refined after
                    the outer prove, so a kill mid-prove keeps the execute
@@ -81,11 +81,11 @@ def argStr (args : List String) (flag : String) : Option String :=
   | _ => none
 
 def recCommitParams (args : List String) : Aiur.CommitmentParameters :=
-  { logBlowup := argNat args "--blowup" 2, capHeight := 0 }
+  { logBlowup := argNat args "--log-blowup" 2, capHeight := 0 }
 def innerFri (args : List String) : Aiur.FriParameters :=
   { logFinalPolyLen := argNat args "--final-poly" 0, maxLogArity := 1,
     numQueries := argNat args "--queries" 100,
-    commitProofOfWorkBits := argNat args "--pow" 0, queryProofOfWorkBits := 20 }
+    commitProofOfWorkBits := 0, queryProofOfWorkBits := argNat args "--pow" 20 }
 
 def secs (t0 t1 : Nat) : Float := (Float.ofNat (t1 - t0)) / 1e9
 
@@ -97,7 +97,7 @@ def main (args : List String) : IO UInt32 := do
   let jsonOut := argStr args "--json"
   IO.println s!"params: logBlowup={recCommitParams.logBlowup} \
     numQueries={innerFri.numQueries} finalPoly={innerFri.logFinalPolyLen} \
-    pow={innerFri.commitProofOfWorkBits}"
+    pow={innerFri.queryProofOfWorkBits}"
   -- Inner proof: factorial(5) (or `square(5)` under --trivial) under the
   -- multi-stark backend.
   let (program, entry) :=

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -500,7 +500,6 @@ def runTypecheckCmd (p : Cli.Parsed) : IO UInt32 := do
           let claimBytes := MultiStark.serializeClaims #[claim]
           let vkBytes := aiurSystem.vkBytes
           let pubInput := MultiStark.verifierPubInput vkBytes claimBytes
-            commitParams friParams
           -- Native path: the advice buffer is built in Rust from the raw
           -- byte blobs and execution routes through the codegen'd verifier.
           let (rvRes, rvSec) ← timed fun _ =>

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -344,7 +344,7 @@ def findBackend (name : String) : Option BackendSpec :=
     both outer proves strain a 128 GB host, so an OOM row is the honest signal
     that secure recursion does not yet fit. -/
 def recursiveConfigs : List (String × Array String) := [
-  ("square-q100-b1", #["--trivial", "--queries", "100", "--blowup", "1"]),
+  ("square-q100-b1", #["--trivial", "--queries", "100", "--log-blowup", "1"]),
   ("factorial-q100-b2", #["--queries", "100"])
 ]
 

--- a/Ix/MultiStark.lean
+++ b/Ix/MultiStark.lean
@@ -132,26 +132,12 @@ def serializeClaims (claims : Array (Array Aiur.G)) : ByteArray := Id.run do
 digest. The FRI parameters are read in-circuit from the digest-bound vk, not
 passed publicly. The proof/vk/claims advice itself goes through the
 natively-built IO buffer (`executeMultiStark` / `proveMultiStark`, which take
-the raw byte blobs directly), or through `verifierInput` on the Lean-buffer
-fallback path. -/
+the raw byte blobs directly: channel 0 = proof, 1 = vk, 2 = claims, each
+under key `[0]`). -/
 def verifierPubInput (vkBytes claimBytes : ByteArray) : Array Aiur.G :=
   let digestGs : ByteArray → Array Aiur.G :=
     fun b => (Blake3.Rust.hash b).val.data.map .ofUInt8
   digestGs vkBytes ++ digestGs claimBytes
-
-/-- Assemble `verify_multi_stark_proof`'s inputs from the serialized proof, vk
-(`AiurSystem.vkBytes`), and claims (`serializeClaims`): the public input
-(`verifierPubInput`) and the IO buffer (channel 0 = proof advice, 1 = vk,
-2 = claims, each under key `[0]`). The Lean-built buffer boxes every byte
-into a `G` and is marshalled across FFI — prefer the raw-bytes entrypoints
-(`executeMultiStark` / `proveMultiStark`) off the hot path. -/
-def verifierInput (proofBytes vkBytes claimBytes : ByteArray) :
-    Array Aiur.G × Aiur.IOBuffer :=
-  let gs := fun (b : ByteArray) => b.data.map Aiur.G.ofUInt8
-  let pubInput := verifierPubInput vkBytes claimBytes
-  let io := (((default : Aiur.IOBuffer).extend 0 #[.ofNat 0] (gs proofBytes)).extend
-    1 #[.ofNat 0] (gs vkBytes)).extend 2 #[.ofNat 0] (gs claimBytes)
-  (pubInput, io)
 
 /-- The verifier toplevel PLUS its self-test entrypoints
 (`Ix/MultiStark/Tests.lean`), unpruned. Kept separate from `multiStark`

--- a/Ix/MultiStark.lean
+++ b/Ix/MultiStark.lean
@@ -17,9 +17,12 @@ public import Ix.MultiStark.Tests
 # Multi-STARK proof verifier (Aiur)
 
 The recursive verifier. Its public statement is purely existential: *"there
-exists a valid multi-stark proof, under the FRI parameters given as public
-input, for the constraint system with this Blake3 digest and these public
-claims."* The proof itself is **non-deterministic advice** (fed on IO channel 0,
+exists a valid multi-stark proof for the constraint system with this Blake3
+digest and these public claims."* The FRI parameters (blowup, query count,
+PoW bits, …) are NOT separate public inputs: they live in the verifying key,
+which the statement already binds through `system_digest` — repeating them
+publicly would be redundant. The proof itself is
+**non-deterministic advice** (fed on IO channel 0,
 never hashed or otherwise bound as a public input): the Fiat-Shamir transcript
 replay plus the Merkle/OOD/FRI checks are exactly what make any accepted advice
 a valid proof — a hash binding of the proof bytes would add nothing to the
@@ -28,9 +31,10 @@ statement, while costing an extra in-circuit hash over those bytes.
 The verifying key and claims, by contrast, ARE digest-bound (`system_digest`,
 `claims_digest`): they determine *what was proven*.
 
-Fixed protocol assumptions (our system): `queryProofOfWorkBits = 0`,
-`capHeight = 0`, `maxLogArity = 1`, `logFinalPolyLen = 0`. The variable FRI
-parameters (`num_queries`, `commit_pow_bits`, `log_blowup`) are public inputs.
+Fixed protocol assumptions (our system): `capHeight = 0`, `maxLogArity = 1`,
+`logFinalPolyLen = 0`. The variable FRI parameters (`num_queries`,
+`commit_pow_bits`, `query_pow_bits`, `log_blowup`) are read from the
+digest-bound verifying key.
 -/
 
 public section
@@ -39,11 +43,11 @@ namespace MultiStark
 
 def entrypoints := ⟦
   -- Public inputs: the Blake3 digests of the verifying key and the claims
-  -- (32 bytes = 4 little-endian u64 lanes each) plus the variable FRI parameters. The
-  -- proof is pure non-deterministic advice on IO channel 0 — see the module
-  -- docstring. One stream per channel (0 = proof, 1 = vk, 2 = claims), each
-  -- registered under key `[0]` on its channel.
-  pub fn verify_multi_stark_proof(system_digest: [[U8; 8]; 4], claims_digest: [[U8; 8]; 4], num_queries: G, commit_pow_bits: G, log_blowup: G) {
+  -- (32 bytes = 4 little-endian u64 lanes each). The proof is pure
+  -- non-deterministic advice on IO channel 0 — see the module docstring. One
+  -- stream per channel (0 = proof, 1 = vk, 2 = claims), each registered under
+  -- key `[0]` on its channel.
+  pub fn verify_multi_stark_proof(system_digest: [[U8; 8]; 4], claims_digest: [[U8; 8]; 4]) {
     -- Proof advice from IO channel 0: deserialize directly from the IO arena
     -- by byte offset (no materialized byte stream), assert fully consumed.
     -- The byte FETCHES inside the readers are unconstrained (the proof is
@@ -73,7 +77,7 @@ def entrypoints := ⟦
     assert_eq!(verify(proof), 1);
     -- Step 3 + 5: prover-faithful Fiat-Shamir replay and the out-of-domain
     -- composition/quotient check, `composition(ζ)·inv_vanishing(ζ) == quotient(ζ)`.
-    assert_eq!(ood_verify(sys, proof, claims, num_queries, commit_pow_bits, log_blowup), 1);
+    assert_eq!(ood_verify(sys, proof, claims), 1);
     ()
   }
 ⟧
@@ -125,18 +129,15 @@ def serializeClaims (claims : Array (Array Aiur.G)) : ByteArray := Id.run do
 
 /-- Assemble `verify_multi_stark_proof`'s public input from the serialized vk
 (`AiurSystem.vkBytes`) and claims (`serializeClaims`): vk digest ++ claims
-digest ++ the variable FRI parameters. The proof/vk/claims advice itself goes
-through the natively-built IO buffer (`executeMultiStark` /
-`proveMultiStark`, which take the raw byte blobs directly), or through
-`verifierInput` on the Lean-buffer fallback path. -/
-def verifierPubInput (vkBytes claimBytes : ByteArray)
-    (commitParams : Aiur.CommitmentParameters) (friParams : Aiur.FriParameters) :
-    Array Aiur.G :=
+digest. The FRI parameters are read in-circuit from the digest-bound vk, not
+passed publicly. The proof/vk/claims advice itself goes through the
+natively-built IO buffer (`executeMultiStark` / `proveMultiStark`, which take
+the raw byte blobs directly), or through `verifierInput` on the Lean-buffer
+fallback path. -/
+def verifierPubInput (vkBytes claimBytes : ByteArray) : Array Aiur.G :=
   let digestGs : ByteArray → Array Aiur.G :=
     fun b => (Blake3.Rust.hash b).val.data.map .ofUInt8
-  digestGs vkBytes ++ digestGs claimBytes ++
-    #[.ofNat friParams.numQueries, .ofNat friParams.commitProofOfWorkBits,
-      .ofNat commitParams.logBlowup]
+  digestGs vkBytes ++ digestGs claimBytes
 
 /-- Assemble `verify_multi_stark_proof`'s inputs from the serialized proof, vk
 (`AiurSystem.vkBytes`), and claims (`serializeClaims`): the public input
@@ -144,11 +145,10 @@ def verifierPubInput (vkBytes claimBytes : ByteArray)
 2 = claims, each under key `[0]`). The Lean-built buffer boxes every byte
 into a `G` and is marshalled across FFI — prefer the raw-bytes entrypoints
 (`executeMultiStark` / `proveMultiStark`) off the hot path. -/
-def verifierInput (proofBytes vkBytes claimBytes : ByteArray)
-    (commitParams : Aiur.CommitmentParameters) (friParams : Aiur.FriParameters) :
+def verifierInput (proofBytes vkBytes claimBytes : ByteArray) :
     Array Aiur.G × Aiur.IOBuffer :=
   let gs := fun (b : ByteArray) => b.data.map Aiur.G.ofUInt8
-  let pubInput := verifierPubInput vkBytes claimBytes commitParams friParams
+  let pubInput := verifierPubInput vkBytes claimBytes
   let io := (((default : Aiur.IOBuffer).extend 0 #[.ofNat 0] (gs proofBytes)).extend
     1 #[.ofNat 0] (gs vkBytes)).extend 2 #[.ofNat 0] (gs claimBytes)
   (pubInput, io)

--- a/Ix/MultiStark/Pcs.lean
+++ b/Ix/MultiStark/Pcs.lean
@@ -593,11 +593,12 @@ def pcs := ⟦
   -- ==========================================================================
   -- PCS (FRI) verification — `two_adic_pcs::verify` + `fri::verify_fri`.
   --
-  -- Specialised to `innerFri`: arity 2 (log_arity = 1 every round),
-  -- log_blowup = 1, log_final_poly_len = 0 (final_poly is ONE constant
-  -- coefficient ⇒ the final Horner eval is just `final_poly[0]`, no `x` needed),
-  -- num_queries = 1, commit/query PoW bits = 0 (a challenger no-op). Field
-  -- arithmetic is the non-native byte Goldilocks (`gl_*`/`eg_*`).
+  -- Specialised to our system: arity 2 (log_arity = 1 every round) and
+  -- log_final_poly_len = 0 (final_poly is ONE constant coefficient ⇒ the final
+  -- Horner eval is just `final_poly[0]`, no `x` needed). The variable FRI
+  -- parameters (log_blowup, num_queries, commit/query PoW bits) come in as
+  -- arguments. Field arithmetic is the non-native byte Goldilocks
+  -- (`gl_*`/`eg_*`).
   --
   -- A reduced-opening accumulator, one per distinct log-height. `alpha_pow`
   -- threads across every (batch, matrix, point, column) at that height, in the
@@ -645,13 +646,14 @@ def pcs := ⟦
         obs_log_arities(snoc_b8(input, [1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8]), rest),
     }
   }
-  -- Per round: observe the commitment, then sample β (PoW bits = 0 ⇒ no-op).
-  -- `GrindingChallenger::check_witness` for one commit round: when `bits > 0`,
-  -- observe the PoW witness then sample `bits` bits and assert they are all zero
-  -- (else InvalidPowWitness). Returns the post-PoW `(input, output)` so the
-  -- immediately-following β sample continues the SAME hash stream (no observe in
-  -- between). `bits == 0` is the short-circuit: no observe, no sample.
-  fn pcs_commit_pow(input: ByteStream, witness: U64, bits: G) -> (ByteStream, ByteStream) {
+  -- `GrindingChallenger::check_witness`, shared by the commit-phase (per-round)
+  -- and query-phase grinding checks: when `bits > 0`, observe the PoW witness
+  -- then sample `bits` bits and assert they are all zero (else
+  -- InvalidPowWitness). Returns the post-PoW `(input, output)` so the
+  -- immediately-following sample (β / query index) continues the SAME hash
+  -- stream (no observe in between). `bits == 0` is the short-circuit: no
+  -- observe, no sample.
+  fn pcs_check_witness(input: ByteStream, witness: U64, bits: G) -> (ByteStream, ByteStream) {
     match bits {
       0 => (input, store(ListNode.Nil)),
       _ =>
@@ -668,7 +670,7 @@ def pcs := ⟦
       ListNode.Nil => (store(ListNode.Nil), input),
       ListNode.Cons(c, rest) =>
         let &ListNode.Cons(w, wrest) = witnesses;
-        let (i1, o1) = pcs_commit_pow(snoc_cap(input, c), w, bits);
+        let (i1, o1) = pcs_check_witness(snoc_cap(input, c), w, bits);
         let (b0, b1, i2, _o) = ch_sample_ext(i1, o1);
         let (bs, i3) = pcs_betas(i2, rest, wrest, bits);
         (store(ListNode.Cons([gl_val(b0), gl_val(b1)], bs)), i3),
@@ -992,15 +994,15 @@ def pcs := ⟦
   }
 
   -- ── top-level FRI verification ────────────────────────────────────────────
-  -- `log_blowup` comes from the verifying key; `num_queries` / `commit_pow_bits`
-  -- are the protocol's FRI parameters (public). `query_pow_bits` is taken to be 0
-  -- (our system), so the query-phase grinding check is a no-op.
+  -- All FRI parameters (`log_blowup`, `num_queries`, `commit_pow_bits`,
+  -- `query_pow_bits`) come from the digest-bound verifying key.
   fn pcs_fri_verify(post_zeta_input: ByteStream, stage1: OpenedRound, stage2: OpenedRound,
       q_opened: OpenedRound, prep_opt: PreprocessedOpt, opening: FriProof,
       s1c: MerkleCap, s2c: MerkleCap, qc: MerkleCap, prep_commit: MerkleCap,
       circuits: List‹SysCircuit›, prep_indices: List‹OptIdx›, log_degrees: List‹U8›,
-      zeta: Ext, num_circuits: G, log_blowup: G, num_queries: G, commit_pow_bits: G) -> G {
-    let FriProof.Mk(commit_phase_commits, pw, query_proofs, final_poly, _qpw) = opening;
+      zeta: Ext, num_circuits: G, log_blowup: G, num_queries: G, commit_pow_bits: G,
+      query_pow_bits: G) -> G {
+    let FriProof.Mk(commit_phase_commits, pw, query_proofs, final_poly, qpw) = opening;
     let num_rounds = list_length(commit_phase_commits);
     -- FRI shape: one PoW witness per round, num_queries query proofs, and (since
     -- log_final_poly_len = 0) a single final-poly coefficient.
@@ -1021,9 +1023,13 @@ def pcs := ⟦
     let (betas, input) = pcs_betas(input, commit_phase_commits, pw, commit_pow_bits);
     let input = list_concat(input, ext_row_onto(final_poly, store(ListNode.Nil)));
     let input = obs_log_arities(input, commit_phase_commits);
+    -- query-phase grinding: check_witness over the query PoW witness, sampled
+    -- AFTER the log-arity schedule and BEFORE the query indices (the query
+    -- sampling continues the post-PoW stream). No-op when query_pow_bits == 0.
+    let (input, output) = pcs_check_witness(input, qpw, query_pow_bits);
     -- query indices + per-query verification (log_global_max_height = #rounds + log_blowup)
     let log_gmax = num_rounds + log_blowup;
-    query_loop(input, store(ListNode.Nil), query_proofs, alpha, stage1, stage2, q_opened,
+    query_loop(input, output, query_proofs, alpha, stage1, stage2, q_opened,
       prep_opt, s1c, s2c, qc, prep_commit, circuits, prep_indices, log_degrees, zeta,
       num_circuits, log_blowup, log_gmax, betas, commit_phase_commits, final_poly, num_rounds)
   }

--- a/Ix/MultiStark/Verifier.lean
+++ b/Ix/MultiStark/Verifier.lean
@@ -832,18 +832,14 @@ def verifier := ⟦
   -- commitments + log_degrees + claims, seed the lookup accumulator from the
   -- claims, then run the OOD composition/quotient check for every circuit.
   -- Returns 1 on success (any mismatch aborts via `assert_eq!`).
-  fn ood_verify(sys: Sys, proof: Proof, claims: List‹List‹U64››,
-      num_queries: G, commit_pow_bits: G, log_blowup_pub: G) -> G {
-    -- The FRI parameters (`num_queries`, `commit_pow_bits`, `log_blowup`) are
-    -- public inputs. All parameters also live in the (digest-bound) verifying
-    -- key — assert the public ones agree with it.
+  fn ood_verify(sys: Sys, proof: Proof, claims: List‹List‹U64››) -> G {
+    -- The FRI parameters (`log_blowup`, `num_queries`, `commit_pow_bits`,
+    -- `query_pow_bits`) all come from the verifying key, which the public
+    -- statement binds through `system_digest` — no separate public inputs.
     let Sys.Mk(params, tlimbs, circuits, commit, prep_indices) = sys;
     let SysParams.Mk(log_blowup, _cap_height, _log_final_poly_len,
-                     _max_log_arity, vk_num_queries, vk_commit_pow_bits,
-                     _query_pow_bits) = params;
-    assert_eq!(eq_zero(log_blowup - log_blowup_pub), 1);
-    assert_eq!(eq_zero(vk_num_queries - num_queries), 1);
-    assert_eq!(eq_zero(vk_commit_pow_bits - commit_pow_bits), 1);
+                     _max_log_arity, num_queries, commit_pow_bits,
+                     query_pow_bits) = params;
     match proof {
       Proof.Mk(active, commitments, accs, log_degrees, opening,
                q_opened, prep_opt, stage1, stage2) =>
@@ -870,7 +866,8 @@ def verifier := ⟦
                  prep_opt, q_opened, 0, acc0, 0, lch, fch, alpha, zeta);
         pcs_fri_verify(post_zeta_input, stage1, stage2, q_opened, prep_opt, opening,
           s1c, s2c, qc, prep_cap, acirc, aprep, log_degrees, zeta,
-          list_length(acirc), log_blowup, num_queries, commit_pow_bits),
+          list_length(acirc), log_blowup, num_queries, commit_pow_bits,
+          query_pow_bits),
     }
   }
 

--- a/Tests/MultiStark.lean
+++ b/Tests/MultiStark.lean
@@ -113,7 +113,7 @@ def recCommitParams : Aiur.CommitmentParameters :=
   { logBlowup := 2, capHeight := 0 }
 def innerFri : Aiur.FriParameters :=
   { logFinalPolyLen := 0, maxLogArity := 1, numQueries := 3,
-    commitProofOfWorkBits := 20, queryProofOfWorkBits := 0 }
+    commitProofOfWorkBits := 20, queryProofOfWorkBits := 16 }
 
 /-- 8 little-endian bytes of a `Nat` (taken mod 2^64). -/
 def u64le (n : Nat) : Array UInt8 :=
@@ -154,11 +154,9 @@ def endToEndSuite : IO UInt32 := do
   let claimBytes := serializeClaims #[claim]
   let claimsDigestInput : Array Aiur.G := (Blake3.Rust.hash claimBytes).val.data.map .ofUInt8
   let claimGs : Array Aiur.G := claimBytes.data.map .ofUInt8
-  -- Public input = vk digest ++ claims digest ++ (num_queries, commit_pow, log_blowup).
-  let friParamInput : Array Aiur.G :=
-    #[Aiur.G.ofNat innerFri.numQueries, Aiur.G.ofNat innerFri.commitProofOfWorkBits,
-      Aiur.G.ofNat recCommitParams.logBlowup]
-  let pubInput : Array Aiur.G := sysDigestInput ++ claimsDigestInput ++ friParamInput
+  -- Public input = vk digest ++ claims digest (the FRI parameters are read
+  -- in-circuit from the digest-bound vk, not passed publicly).
+  let pubInput : Array Aiur.G := sysDigestInput ++ claimsDigestInput
   -- IO advice buffer: proof on channel 0, vk on 1, claims on 2 (each keyed `[0]`).
   let mkIO := fun (pGs cGs : Array Aiur.G) =>
     (((default : IOBuffer).extend 0 #[Aiur.G.ofNat 0] pGs).extend 1 #[Aiur.G.ofNat 0] vkGs).extend
@@ -186,7 +184,7 @@ def endToEndSuite : IO UInt32 := do
   let badClaim : Array Aiur.G := claim.set! (claim.size - 1) (Aiur.G.ofNat 121)
   let badClaimBytes := serializeClaims #[badClaim]
   let badClaimInput : Array Aiur.G :=
-    sysDigestInput ++ ((Blake3.Rust.hash badClaimBytes).val.data.map .ofUInt8) ++ friParamInput
+    sysDigestInput ++ ((Blake3.Rust.hash badClaimBytes).val.data.map .ofUInt8)
 
   -- ── run the (expensive) checks, then assert ─────────────────────────────────
   IO.println "recursive-verifier (proving + recursive verification, ~1.5 min)…"

--- a/Tests/MultiStark.lean
+++ b/Tests/MultiStark.lean
@@ -107,13 +107,15 @@ def factorialProgram : Source.Toplevel := ⟦
 ⟧
 
 /-- Inner-proof commitment/FRI parameters. A tractable subset of production
-(`numQueries := 3`) that still drives every generalized verifier path; the
-verifier code itself is blowup/query-count agnostic. -/
+(`numQueries := 3`, standard PoW regime: commit 0 / query 20); the verifier
+code itself is blowup/query-count agnostic, and `pcs_check_witness` is shared
+by both PoW phases, so the query-phase grinding exercises the commit-phase
+code path too. -/
 def recCommitParams : Aiur.CommitmentParameters :=
   { logBlowup := 2, capHeight := 0 }
 def innerFri : Aiur.FriParameters :=
   { logFinalPolyLen := 0, maxLogArity := 1, numQueries := 3,
-    commitProofOfWorkBits := 20, queryProofOfWorkBits := 16 }
+    commitProofOfWorkBits := 0, queryProofOfWorkBits := 20 }
 
 /-- 8 little-endian bytes of a `Nat` (taken mod 2^64). -/
 def u64le (n : Nat) : Array UInt8 :=

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -12775,8 +12775,8 @@ fn aiur_fn_148(
   })
 }
 
-const INPUT_SIZE_149: usize = 31;
-const IN_149: usize = 31;
+const INPUT_SIZE_149: usize = 32;
+const IN_149: usize = 32;
 const OUT_149: usize = 1;
 fn aiur_fn_149(
   inp: [G; IN_149],
@@ -12816,88 +12816,89 @@ fn aiur_fn_149(
     let __v_28: G = inp[28];
     let __v_29: G = inp[29];
     let __v_30: G = inp[30];
+    let __v_31: G = inp[31];
     match __v_6.as_canonical_u64() {
       _ => {
         let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-        let __v_31: G = __r_arr[0];
-        let __v_32: G = G::from_u64(1);
+        let __v_32: G = __r_arr[0];
         let __v_33: G = G::from_u64(1);
-        let __v_34: G = { let __values: [G; 3] = [__v_32, __v_33, __v_33]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
-        let __v_35: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __v_34: G = G::from_u64(1);
+        let __v_35: G = { let __values: [G; 3] = [__v_33, __v_34, __v_34]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
-        let __v_40: G = G::from_u64(1);
+        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __v_40: G = __r_arr[0];
         let __v_41: G = G::from_u64(1);
-        let __v_42: G = { let __values: [G; 3] = [__v_40, __v_41, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
-        let __v_43: G = __r_arr[0];
-        let __v_44: G = __r_arr[1];
-        let __v_45: G = __r_arr[2];
-        let __v_46: G = __r_arr[3];
-        let __v_47: G = __r_arr[4];
-        let __v_48: G = __r_arr[5];
-        let __v_49: G = __r_arr[6];
-        let __v_50: G = __r_arr[7];
-        let __v_51: G = __r_arr[8];
-        let __v_52: G = __r_arr[9];
-        let __v_53: G = __r_arr[10];
-        let __v_54: G = __r_arr[11];
-        let __v_55: G = __r_arr[12];
-        let __v_56: G = __r_arr[13];
-        let __v_57: G = __r_arr[14];
-        let __v_58: G = __r_arr[15];
-        let __v_59: G = __r_arr[16];
-        let __v_60: G = __r_arr[17];
-        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
-        let __v_61: G = __r_arr[0];
-        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
+        let __v_42: G = G::from_u64(1);
+        let __v_43: G = { let __values: [G; 3] = [__v_41, __v_42, __v_42]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_44: G = __r_arr[0];
+        let __v_45: G = __r_arr[1];
+        let __v_46: G = __r_arr[2];
+        let __v_47: G = __r_arr[3];
+        let __v_48: G = __r_arr[4];
+        let __v_49: G = __r_arr[5];
+        let __v_50: G = __r_arr[6];
+        let __v_51: G = __r_arr[7];
+        let __v_52: G = __r_arr[8];
+        let __v_53: G = __r_arr[9];
+        let __v_54: G = __r_arr[10];
+        let __v_55: G = __r_arr[11];
+        let __v_56: G = __r_arr[12];
+        let __v_57: G = __r_arr[13];
+        let __v_58: G = __r_arr[14];
+        let __v_59: G = __r_arr[15];
+        let __v_60: G = __r_arr[16];
+        let __v_61: G = __r_arr[17];
+        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_62: G = __r_arr[0];
-        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_59, __v_6, __v_7, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_63: G = __r_arr[0];
-        let __v_64: G = __r_arr[1];
-        let __v_65: G = G::from_u64(1);
+        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_60, __v_6, __v_7, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+        let __v_64: G = __r_arr[0];
+        let __v_65: G = __r_arr[1];
         let __v_66: G = G::from_u64(1);
-        let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
-        let __v_68: G = __r_arr[0];
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __v_67: G = G::from_u64(1);
+        let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
-        let __v_71: G = (__v_31 + __v_28);
-        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_70, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __v_71: G = __r_arr[0];
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_71, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_72: G = __r_arr[0];
-        let __v_73: G = (__v_72 - __v_31);
-        let __v_74: G = G::from_bool((__v_73 == G::ZERO));
-        let __v_75: G = G::from_u64(1);
-        if (__v_74 != __v_75) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_74.as_canonical_u64(), rhs: __v_75.as_canonical_u64() });
+        let __v_73: G = __r_arr[1];
+        let __v_74: G = (__v_32 + __v_28);
+        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
+        let __v_75: G = __r_arr[0];
+        let __v_76: G = (__v_75 - __v_32);
+        let __v_77: G = G::from_bool((__v_76 == G::ZERO));
+        let __v_78: G = G::from_u64(1);
+        if (__v_77 != __v_78) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
         }
         let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-        let __v_76: G = __r_arr[0];
-        let __v_77: G = (__v_76 - __v_29);
-        let __v_78: G = G::from_bool((__v_77 == G::ZERO));
-        let __v_79: G = G::from_u64(1);
-        if (__v_78 != __v_79) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_78.as_canonical_u64(), rhs: __v_79.as_canonical_u64() });
+        let __v_79: G = __r_arr[0];
+        let __v_80: G = (__v_79 - __v_29);
+        let __v_81: G = G::from_bool((__v_80 == G::ZERO));
+        let __v_82: G = G::from_u64(1);
+        if (__v_81 != __v_82) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
         }
         let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-        let __v_80: G = __r_arr[0];
-        let __v_81: G = G::from_u64(1);
-        if (__v_80 != __v_81) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
+        let __v_83: G = __r_arr[0];
+        let __v_84: G = G::from_u64(1);
+        if (__v_83 != __v_84) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_83.as_canonical_u64(), rhs: __v_84.as_canonical_u64() });
         }
-        let __v_82: G = G::from_u64(1);
-        let __v_83: G = G::from_u64(1);
-        let __v_84: G = { let __values: [G; 3] = [__v_82, __v_83, __v_83]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_70, __v_84, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_71, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_72, __v_73, __v_8, __v_62, __v_63, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_74, __v_64, __v_6, __v_9, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_85: G = __r_arr[0];
         let __ret: [G; OUT_149] = [__v_85];
         record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -16037,8 +16038,8 @@ fn aiur_fn_195(
   })
 }
 
-const INPUT_SIZE_196: usize = 39;
-const IN_196: usize = 39;
+const INPUT_SIZE_196: usize = 36;
+const IN_196: usize = 36;
 const OUT_196: usize = 1;
 fn aiur_fn_196(
   inp: [G; IN_196],
@@ -16083,91 +16084,70 @@ fn aiur_fn_196(
     let __v_33: G = inp[33];
     let __v_34: G = inp[34];
     let __v_35: G = inp[35];
-    let __v_36: G = inp[36];
-    let __v_37: G = inp[37];
-    let __v_38: G = inp[38];
     match __v_0.as_canonical_u64() {
       _ => {
         match __v_0.as_canonical_u64() {
           _ => {
-            let __v_39: G = (__v_0 - __v_38);
-            let __v_40: G = G::from_bool((__v_39 == G::ZERO));
-            let __v_41: G = G::from_u64(1);
-            if (__v_40 != __v_41) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_40.as_canonical_u64(), rhs: __v_41.as_canonical_u64() });
-            }
-            let __v_42: G = (__v_4 - __v_36);
-            let __v_43: G = G::from_bool((__v_42 == G::ZERO));
-            let __v_44: G = G::from_u64(1);
-            if (__v_43 != __v_44) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_43.as_canonical_u64(), rhs: __v_44.as_canonical_u64() });
-            }
-            let __v_45: G = (__v_5 - __v_37);
-            let __v_46: G = G::from_bool((__v_45 == G::ZERO));
-            let __v_47: G = G::from_u64(1);
-            if (__v_46 != __v_47) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_46.as_canonical_u64(), rhs: __v_47.as_canonical_u64() });
-            }
             match __v_12.as_canonical_u64() {
               _ => {
                 let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-                let __v_48: G = __r_arr[0];
+                let __v_36: G = __r_arr[0];
                 let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-                let __v_49: G = __r_arr[0];
+                let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
                     let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+                    let __v_38: G = __r_arr[0];
+                    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+                    let __v_39: G = __r_arr[0];
+                    let __v_40: G = __r_arr[1];
+                    let __v_41: G = __r_arr[2];
+                    let __v_42: G = __r_arr[3];
+                    let __v_43: G = __r_arr[4];
+                    let __v_44: G = __r_arr[5];
+                    let __v_45: G = __r_arr[6];
+                    let __v_46: G = __r_arr[7];
+                    let __v_47: G = __r_arr[8];
+                    let __v_48: G = G::from_u64(0);
+                    let __v_49: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
-                    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_7, __v_12, __v_50, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
-                    let __v_51: G = __r_arr[0];
-                    let __v_52: G = __r_arr[1];
-                    let __v_53: G = __r_arr[2];
-                    let __v_54: G = __r_arr[3];
-                    let __v_55: G = __r_arr[4];
-                    let __v_56: G = __r_arr[5];
-                    let __v_57: G = __r_arr[6];
-                    let __v_58: G = __r_arr[7];
-                    let __v_59: G = __r_arr[8];
-                    let __v_60: G = G::from_u64(0);
-                    let __v_61: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_60, __v_61, __v_35, __v_51, __v_52, __v_53, __v_54]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
-                    let __v_62: G = __r_arr[0];
-                    let __v_63: G = __r_arr[1];
-                    let __v_64: G = G::from_u64(0);
-                    let __v_65: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_48, __v_49, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_64, __v_62, __v_63, __v_65, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-                    let __v_66: G = __r_arr[0];
+                    let __v_51: G = __r_arr[1];
+                    let __v_52: G = G::from_u64(0);
+                    let __v_53: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_53, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                    let __v_54: G = __r_arr[0];
                     let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                    let __v_67: G = __r_arr[0];
-                    let __v_68: G = G::from_u64(1);
-                    if (__v_67 != __v_68) {
-                      return Err(ExecError::AssertEqMismatch { lhs: __v_67.as_canonical_u64(), rhs: __v_68.as_canonical_u64() });
+                    let __v_55: G = __r_arr[0];
+                    let __v_56: G = G::from_u64(1);
+                    if (__v_55 != __v_56) {
+                      return Err(ExecError::AssertEqMismatch { lhs: __v_55.as_canonical_u64(), rhs: __v_56.as_canonical_u64() });
                     }
                     let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                    let __v_69: G = __r_arr[0];
+                    let __v_57: G = __r_arr[0];
                     let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
-                    let __v_70: G = __r_arr[0];
-                    let __v_71: G = (__v_69 - __v_70);
-                    let __v_72: G = G::from_bool((__v_71 == G::ZERO));
-                    let __v_73: G = G::from_u64(1);
-                    if (__v_72 != __v_73) {
-                      return Err(ExecError::AssertEqMismatch { lhs: __v_72.as_canonical_u64(), rhs: __v_73.as_canonical_u64() });
+                    let __v_58: G = __r_arr[0];
+                    let __v_59: G = (__v_57 - __v_58);
+                    let __v_60: G = G::from_bool((__v_59 == G::ZERO));
+                    let __v_61: G = G::from_u64(1);
+                    if (__v_60 != __v_61) {
+                      return Err(ExecError::AssertEqMismatch { lhs: __v_60.as_canonical_u64(), rhs: __v_61.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
-                    let __v_74: G = __r_arr[0];
+                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
+                    let __v_62: G = __r_arr[0];
                     let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-                    let __v_75: G = __r_arr[0];
-                    let __v_76: G = (__v_74 - __v_75);
-                    let __v_77: G = G::from_bool((__v_76 == G::ZERO));
-                    let __v_78: G = G::from_u64(1);
-                    if (__v_77 != __v_78) {
-                      return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
+                    let __v_63: G = __r_arr[0];
+                    let __v_64: G = (__v_62 - __v_63);
+                    let __v_65: G = G::from_bool((__v_64 == G::ZERO));
+                    let __v_66: G = G::from_u64(1);
+                    if (__v_65 != __v_66) {
+                      return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
-                    let __v_79: G = __r_arr[0];
-                    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_59, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_50, __v_48, __v_49, __v_17, __v_57, __v_58, __v_79, __v_0, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-                    let __v_80: G = __r_arr[0];
-                    let __ret: [G; OUT_196] = [__v_80];
+                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
+                    let __v_67: G = __r_arr[0];
+                    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_36, __v_37, __v_17, __v_45, __v_46, __v_67, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+                    let __v_68: G = __r_arr[0];
+                    let __ret: [G; OUT_196] = [__v_68];
                     record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
@@ -16495,8 +16475,8 @@ fn aiur_fn_203(
   })
 }
 
-const INPUT_SIZE_204: usize = 67;
-const IN_204: usize = 67;
+const INPUT_SIZE_204: usize = 64;
+const IN_204: usize = 64;
 const OUT_204: usize = 0;
 fn aiur_fn_204(
   inp: [G; IN_204],
@@ -16569,428 +16549,425 @@ fn aiur_fn_204(
     let __v_61: G = inp[61];
     let __v_62: G = inp[62];
     let __v_63: G = inp[63];
-    let __v_64: G = inp[64];
-    let __v_65: G = inp[65];
-    let __v_66: G = inp[66];
-    let __v_67: G = G::from_u64(0);
-    let __v_68: G = G::from_u64(0);
-    let __io_pair: (G, G) = { let __key: [G; 1] = [__v_68]; let __info = io_buffer.get_info(__v_67, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
-    let __v_69: G = __io_pair.0;
-    let __v_70: G = __io_pair.1;
-    let __r_arr: [G; OUT_61] = { let __args: [G; IN_61] = [__v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[61].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_61] = unsafe { *(result.output.as_ptr() as *const [G; OUT_61]) }; __ret } else { aiur_fn_61(__args, record, io_buffer, __cu)? } };
-    let __v_71: G = __r_arr[0];
-    let __v_72: G = __r_arr[1];
-    let __v_73: G = __r_arr[2];
-    let __v_74: G = __r_arr[3];
-    let __v_75: G = __r_arr[4];
-    let __v_76: G = __r_arr[5];
-    let __v_77: G = __r_arr[6];
-    let __v_78: G = __r_arr[7];
-    let __v_79: G = __r_arr[8];
-    let __v_80: G = __r_arr[9];
-    let __v_81: G = __r_arr[10];
-    let __v_82: G = __r_arr[11];
-    let __v_83: G = __r_arr[12];
-    let __v_84: G = __r_arr[13];
-    let __v_85: G = __r_arr[14];
-    let __v_86: G = __r_arr[15];
-    let __v_87: G = __r_arr[16];
-    let __v_88: G = __r_arr[17];
-    let __v_89: G = __r_arr[18];
-    let __v_90: G = __r_arr[19];
-    let __v_91: G = __r_arr[20];
-    let __v_92: G = __r_arr[21];
-    let __v_93: G = __r_arr[22];
-    let __v_94: G = __r_arr[23];
-    let __v_95: G = G::from_u64(1);
-    let __v_96: G = G::from_u64(0);
-    let __io_pair: (G, G) = { let __key: [G; 1] = [__v_96]; let __info = io_buffer.get_info(__v_95, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
-    let __v_97: G = __io_pair.0;
-    let __v_98: G = __io_pair.1;
-    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
-    let __v_99: G = __r_arr[0];
-    let __v_100: G = __r_arr[1];
-    let __v_101: G = __r_arr[2];
-    let __v_102: G = __r_arr[3];
-    let __v_103: G = __r_arr[4];
-    let __v_104: G = __r_arr[5];
-    let __v_105: G = __r_arr[6];
-    let __v_106: G = __r_arr[7];
-    let __v_107: G = __r_arr[8];
-    let __v_108: G = __r_arr[9];
-    let __v_109: G = __r_arr[10];
-    let __v_110: G = __r_arr[11];
-    let __v_111: G = __r_arr[12];
-    let __v_112: G = G::from_u64(2);
-    let __v_113: G = G::from_u64(0);
-    let __io_pair: (G, G) = { let __key: [G; 1] = [__v_113]; let __info = io_buffer.get_info(__v_112, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
-    let __v_114: G = __io_pair.0;
-    let __v_115: G = __io_pair.1;
-    let __v_116: G = G::from_u64(2);
-    let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_116, __v_114, __v_115]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
-    let __v_117: G = __r_arr[0];
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_117]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-    let __v_118: G = __r_arr[0];
-    let __v_119: G = __r_arr[1];
-    let __v_120: G = (__v_69 + __v_70);
-    if (__v_94 != __v_120) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_94.as_canonical_u64(), rhs: __v_120.as_canonical_u64() });
-    }
-    let __v_121: G = G::from_u64(1);
-    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_121, __v_97, __v_98]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
-    let __v_122: G = __r_arr[0];
-    let __v_123: G = __r_arr[1];
-    let __v_124: G = __r_arr[2];
-    let __v_125: G = __r_arr[3];
-    let __v_126: G = __r_arr[4];
-    let __v_127: G = __r_arr[5];
-    let __v_128: G = __r_arr[6];
-    let __v_129: G = __r_arr[7];
-    let __v_130: G = __r_arr[8];
-    let __v_131: G = __r_arr[9];
-    let __v_132: G = __r_arr[10];
-    let __v_133: G = __r_arr[11];
-    let __v_134: G = __r_arr[12];
-    let __v_135: G = __r_arr[13];
-    let __v_136: G = __r_arr[14];
-    let __v_137: G = __r_arr[15];
-    let __v_138: G = __r_arr[16];
-    let __v_139: G = __r_arr[17];
-    let __v_140: G = __r_arr[18];
-    let __v_141: G = __r_arr[19];
-    let __v_142: G = __r_arr[20];
-    let __v_143: G = __r_arr[21];
-    let __v_144: G = __r_arr[22];
-    let __v_145: G = __r_arr[23];
-    let __v_146: G = __r_arr[24];
-    let __v_147: G = __r_arr[25];
-    let __v_148: G = __r_arr[26];
-    let __v_149: G = __r_arr[27];
-    let __v_150: G = __r_arr[28];
-    let __v_151: G = __r_arr[29];
-    let __v_152: G = __r_arr[30];
-    let __v_153: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
-    let __v_154: G = __r_arr[0];
-    let __v_155: G = __r_arr[1];
-    let __v_156: G = __r_arr[2];
-    let __v_157: G = __r_arr[3];
-    let __v_158: G = __r_arr[4];
-    let __v_159: G = __r_arr[5];
-    let __v_160: G = __r_arr[6];
-    let __v_161: G = __r_arr[7];
-    let __v_162: G = __r_arr[8];
-    let __v_163: G = __r_arr[9];
-    let __v_164: G = __r_arr[10];
-    let __v_165: G = __r_arr[11];
-    let __v_166: G = __r_arr[12];
-    let __v_167: G = __r_arr[13];
-    let __v_168: G = __r_arr[14];
-    let __v_169: G = __r_arr[15];
-    let __v_170: G = __r_arr[16];
-    let __v_171: G = __r_arr[17];
-    let __v_172: G = __r_arr[18];
-    let __v_173: G = __r_arr[19];
-    let __v_174: G = __r_arr[20];
-    let __v_175: G = __r_arr[21];
-    let __v_176: G = __r_arr[22];
-    let __v_177: G = __r_arr[23];
-    let __v_178: G = __r_arr[24];
-    let __v_179: G = __r_arr[25];
-    let __v_180: G = __r_arr[26];
-    let __v_181: G = __r_arr[27];
-    let __v_182: G = __r_arr[28];
-    let __v_183: G = __r_arr[29];
-    let __v_184: G = __r_arr[30];
-    let __v_185: G = __r_arr[31];
-    if (__v_154 != __v_0) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_154.as_canonical_u64(), rhs: __v_0.as_canonical_u64() });
-    }
-    if (__v_155 != __v_1) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_155.as_canonical_u64(), rhs: __v_1.as_canonical_u64() });
-    }
-    if (__v_156 != __v_2) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_156.as_canonical_u64(), rhs: __v_2.as_canonical_u64() });
-    }
-    if (__v_157 != __v_3) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_157.as_canonical_u64(), rhs: __v_3.as_canonical_u64() });
-    }
-    if (__v_158 != __v_4) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_158.as_canonical_u64(), rhs: __v_4.as_canonical_u64() });
-    }
-    if (__v_159 != __v_5) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_159.as_canonical_u64(), rhs: __v_5.as_canonical_u64() });
-    }
-    if (__v_160 != __v_6) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_160.as_canonical_u64(), rhs: __v_6.as_canonical_u64() });
-    }
-    if (__v_161 != __v_7) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_161.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
-    }
-    if (__v_162 != __v_8) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_162.as_canonical_u64(), rhs: __v_8.as_canonical_u64() });
-    }
-    if (__v_163 != __v_9) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_163.as_canonical_u64(), rhs: __v_9.as_canonical_u64() });
-    }
-    if (__v_164 != __v_10) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_164.as_canonical_u64(), rhs: __v_10.as_canonical_u64() });
-    }
-    if (__v_165 != __v_11) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_165.as_canonical_u64(), rhs: __v_11.as_canonical_u64() });
-    }
-    if (__v_166 != __v_12) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_166.as_canonical_u64(), rhs: __v_12.as_canonical_u64() });
-    }
-    if (__v_167 != __v_13) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_167.as_canonical_u64(), rhs: __v_13.as_canonical_u64() });
-    }
-    if (__v_168 != __v_14) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_168.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
-    }
-    if (__v_169 != __v_15) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_169.as_canonical_u64(), rhs: __v_15.as_canonical_u64() });
-    }
-    if (__v_170 != __v_16) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_170.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
-    }
-    if (__v_171 != __v_17) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_171.as_canonical_u64(), rhs: __v_17.as_canonical_u64() });
-    }
-    if (__v_172 != __v_18) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_172.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
-    }
-    if (__v_173 != __v_19) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_173.as_canonical_u64(), rhs: __v_19.as_canonical_u64() });
-    }
-    if (__v_174 != __v_20) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_174.as_canonical_u64(), rhs: __v_20.as_canonical_u64() });
-    }
-    if (__v_175 != __v_21) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_175.as_canonical_u64(), rhs: __v_21.as_canonical_u64() });
-    }
-    if (__v_176 != __v_22) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_176.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-    }
-    if (__v_177 != __v_23) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_177.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
-    }
-    if (__v_178 != __v_24) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_178.as_canonical_u64(), rhs: __v_24.as_canonical_u64() });
-    }
-    if (__v_179 != __v_25) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_179.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
-    }
-    if (__v_180 != __v_26) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_180.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
-    }
-    if (__v_181 != __v_27) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_181.as_canonical_u64(), rhs: __v_27.as_canonical_u64() });
-    }
-    if (__v_182 != __v_28) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_182.as_canonical_u64(), rhs: __v_28.as_canonical_u64() });
-    }
-    if (__v_183 != __v_29) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_183.as_canonical_u64(), rhs: __v_29.as_canonical_u64() });
-    }
-    if (__v_184 != __v_30) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_184.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
-    }
-    if (__v_185 != __v_31) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_185.as_canonical_u64(), rhs: __v_31.as_canonical_u64() });
-    }
-    let __v_186: G = (__v_97 + __v_98);
-    if (__v_111 != __v_186) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_111.as_canonical_u64(), rhs: __v_186.as_canonical_u64() });
-    }
-    let __r_arr: [G; OUT_62] = { let __args: [G; IN_62] = [__v_117]; let __cu = unconstrained; if let Some(result) = record.function_queries[62].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_62] = unsafe { *(result.output.as_ptr() as *const [G; OUT_62]) }; __ret } else { aiur_fn_62(__args, record, io_buffer, __cu)? } };
-    let __v_187: G = __r_arr[0];
-    let __v_188: G = __r_arr[1];
-    let __v_189: G = __r_arr[2];
-    let __v_190: G = __r_arr[3];
-    let __v_191: G = __r_arr[4];
-    let __v_192: G = __r_arr[5];
-    let __v_193: G = __r_arr[6];
-    let __v_194: G = __r_arr[7];
-    let __v_195: G = __r_arr[8];
-    let __v_196: G = __r_arr[9];
-    let __v_197: G = __r_arr[10];
-    let __v_198: G = __r_arr[11];
-    let __v_199: G = __r_arr[12];
-    let __v_200: G = __r_arr[13];
-    let __v_201: G = __r_arr[14];
-    let __v_202: G = __r_arr[15];
-    let __v_203: G = __r_arr[16];
-    let __v_204: G = __r_arr[17];
-    let __v_205: G = __r_arr[18];
-    let __v_206: G = __r_arr[19];
-    let __v_207: G = __r_arr[20];
-    let __v_208: G = __r_arr[21];
-    let __v_209: G = __r_arr[22];
-    let __v_210: G = __r_arr[23];
-    let __v_211: G = __r_arr[24];
-    let __v_212: G = __r_arr[25];
-    let __v_213: G = __r_arr[26];
-    let __v_214: G = __r_arr[27];
-    let __v_215: G = __r_arr[28];
-    let __v_216: G = __r_arr[29];
-    let __v_217: G = __r_arr[30];
-    let __v_218: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
-    let __v_219: G = __r_arr[0];
-    let __v_220: G = __r_arr[1];
-    let __v_221: G = __r_arr[2];
-    let __v_222: G = __r_arr[3];
-    let __v_223: G = __r_arr[4];
-    let __v_224: G = __r_arr[5];
-    let __v_225: G = __r_arr[6];
-    let __v_226: G = __r_arr[7];
-    let __v_227: G = __r_arr[8];
-    let __v_228: G = __r_arr[9];
-    let __v_229: G = __r_arr[10];
-    let __v_230: G = __r_arr[11];
-    let __v_231: G = __r_arr[12];
-    let __v_232: G = __r_arr[13];
-    let __v_233: G = __r_arr[14];
-    let __v_234: G = __r_arr[15];
-    let __v_235: G = __r_arr[16];
-    let __v_236: G = __r_arr[17];
-    let __v_237: G = __r_arr[18];
-    let __v_238: G = __r_arr[19];
-    let __v_239: G = __r_arr[20];
-    let __v_240: G = __r_arr[21];
-    let __v_241: G = __r_arr[22];
-    let __v_242: G = __r_arr[23];
-    let __v_243: G = __r_arr[24];
-    let __v_244: G = __r_arr[25];
-    let __v_245: G = __r_arr[26];
-    let __v_246: G = __r_arr[27];
-    let __v_247: G = __r_arr[28];
-    let __v_248: G = __r_arr[29];
-    let __v_249: G = __r_arr[30];
-    let __v_250: G = __r_arr[31];
-    if (__v_219 != __v_32) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_219.as_canonical_u64(), rhs: __v_32.as_canonical_u64() });
-    }
-    if (__v_220 != __v_33) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_220.as_canonical_u64(), rhs: __v_33.as_canonical_u64() });
-    }
-    if (__v_221 != __v_34) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_221.as_canonical_u64(), rhs: __v_34.as_canonical_u64() });
-    }
-    if (__v_222 != __v_35) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_222.as_canonical_u64(), rhs: __v_35.as_canonical_u64() });
-    }
-    if (__v_223 != __v_36) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_223.as_canonical_u64(), rhs: __v_36.as_canonical_u64() });
-    }
-    if (__v_224 != __v_37) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_224.as_canonical_u64(), rhs: __v_37.as_canonical_u64() });
-    }
-    if (__v_225 != __v_38) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_225.as_canonical_u64(), rhs: __v_38.as_canonical_u64() });
-    }
-    if (__v_226 != __v_39) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_226.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
-    }
-    if (__v_227 != __v_40) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_227.as_canonical_u64(), rhs: __v_40.as_canonical_u64() });
-    }
-    if (__v_228 != __v_41) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_228.as_canonical_u64(), rhs: __v_41.as_canonical_u64() });
-    }
-    if (__v_229 != __v_42) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_229.as_canonical_u64(), rhs: __v_42.as_canonical_u64() });
-    }
-    if (__v_230 != __v_43) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_230.as_canonical_u64(), rhs: __v_43.as_canonical_u64() });
-    }
-    if (__v_231 != __v_44) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_231.as_canonical_u64(), rhs: __v_44.as_canonical_u64() });
-    }
-    if (__v_232 != __v_45) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_232.as_canonical_u64(), rhs: __v_45.as_canonical_u64() });
-    }
-    if (__v_233 != __v_46) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_233.as_canonical_u64(), rhs: __v_46.as_canonical_u64() });
-    }
-    if (__v_234 != __v_47) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_234.as_canonical_u64(), rhs: __v_47.as_canonical_u64() });
-    }
-    if (__v_235 != __v_48) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_235.as_canonical_u64(), rhs: __v_48.as_canonical_u64() });
-    }
-    if (__v_236 != __v_49) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_236.as_canonical_u64(), rhs: __v_49.as_canonical_u64() });
-    }
-    if (__v_237 != __v_50) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_237.as_canonical_u64(), rhs: __v_50.as_canonical_u64() });
-    }
-    if (__v_238 != __v_51) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_238.as_canonical_u64(), rhs: __v_51.as_canonical_u64() });
-    }
-    if (__v_239 != __v_52) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_239.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
-    }
-    if (__v_240 != __v_53) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_240.as_canonical_u64(), rhs: __v_53.as_canonical_u64() });
-    }
-    if (__v_241 != __v_54) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_241.as_canonical_u64(), rhs: __v_54.as_canonical_u64() });
-    }
-    if (__v_242 != __v_55) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_242.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
-    }
-    if (__v_243 != __v_56) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_243.as_canonical_u64(), rhs: __v_56.as_canonical_u64() });
-    }
-    if (__v_244 != __v_57) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_244.as_canonical_u64(), rhs: __v_57.as_canonical_u64() });
-    }
-    if (__v_245 != __v_58) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_245.as_canonical_u64(), rhs: __v_58.as_canonical_u64() });
-    }
-    if (__v_246 != __v_59) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_246.as_canonical_u64(), rhs: __v_59.as_canonical_u64() });
-    }
-    if (__v_247 != __v_60) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_247.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
-    }
-    if (__v_248 != __v_61) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_248.as_canonical_u64(), rhs: __v_61.as_canonical_u64() });
-    }
-    if (__v_249 != __v_62) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_249.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
-    }
-    if (__v_250 != __v_63) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_63.as_canonical_u64() });
-    }
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_119.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_251: G = __loaded[0];
-    let __v_252: G = __loaded[1];
-    let __v_253: G = __loaded[2];
+    let __v_64: G = G::from_u64(0);
+    let __v_65: G = G::from_u64(0);
+    let __io_pair: (G, G) = { let __key: [G; 1] = [__v_65]; let __info = io_buffer.get_info(__v_64, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
+    let __v_66: G = __io_pair.0;
+    let __v_67: G = __io_pair.1;
+    let __r_arr: [G; OUT_61] = { let __args: [G; IN_61] = [__v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[61].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_61] = unsafe { *(result.output.as_ptr() as *const [G; OUT_61]) }; __ret } else { aiur_fn_61(__args, record, io_buffer, __cu)? } };
+    let __v_68: G = __r_arr[0];
+    let __v_69: G = __r_arr[1];
+    let __v_70: G = __r_arr[2];
+    let __v_71: G = __r_arr[3];
+    let __v_72: G = __r_arr[4];
+    let __v_73: G = __r_arr[5];
+    let __v_74: G = __r_arr[6];
+    let __v_75: G = __r_arr[7];
+    let __v_76: G = __r_arr[8];
+    let __v_77: G = __r_arr[9];
+    let __v_78: G = __r_arr[10];
+    let __v_79: G = __r_arr[11];
+    let __v_80: G = __r_arr[12];
+    let __v_81: G = __r_arr[13];
+    let __v_82: G = __r_arr[14];
+    let __v_83: G = __r_arr[15];
+    let __v_84: G = __r_arr[16];
+    let __v_85: G = __r_arr[17];
+    let __v_86: G = __r_arr[18];
+    let __v_87: G = __r_arr[19];
+    let __v_88: G = __r_arr[20];
+    let __v_89: G = __r_arr[21];
+    let __v_90: G = __r_arr[22];
+    let __v_91: G = __r_arr[23];
+    let __v_92: G = G::from_u64(1);
+    let __v_93: G = G::from_u64(0);
+    let __io_pair: (G, G) = { let __key: [G; 1] = [__v_93]; let __info = io_buffer.get_info(__v_92, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
+    let __v_94: G = __io_pair.0;
+    let __v_95: G = __io_pair.1;
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_96: G = __r_arr[0];
+    let __v_97: G = __r_arr[1];
+    let __v_98: G = __r_arr[2];
+    let __v_99: G = __r_arr[3];
+    let __v_100: G = __r_arr[4];
+    let __v_101: G = __r_arr[5];
+    let __v_102: G = __r_arr[6];
+    let __v_103: G = __r_arr[7];
+    let __v_104: G = __r_arr[8];
+    let __v_105: G = __r_arr[9];
+    let __v_106: G = __r_arr[10];
+    let __v_107: G = __r_arr[11];
+    let __v_108: G = __r_arr[12];
+    let __v_109: G = G::from_u64(2);
+    let __v_110: G = G::from_u64(0);
+    let __io_pair: (G, G) = { let __key: [G; 1] = [__v_110]; let __info = io_buffer.get_info(__v_109, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
+    let __v_111: G = __io_pair.0;
+    let __v_112: G = __io_pair.1;
+    let __v_113: G = G::from_u64(2);
+    let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
+    let __v_114: G = __r_arr[0];
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_115: G = __r_arr[0];
+    let __v_116: G = __r_arr[1];
+    let __v_117: G = (__v_66 + __v_67);
+    if (__v_91 != __v_117) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_91.as_canonical_u64(), rhs: __v_117.as_canonical_u64() });
+    }
+    let __v_118: G = G::from_u64(1);
+    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
+    let __v_119: G = __r_arr[0];
+    let __v_120: G = __r_arr[1];
+    let __v_121: G = __r_arr[2];
+    let __v_122: G = __r_arr[3];
+    let __v_123: G = __r_arr[4];
+    let __v_124: G = __r_arr[5];
+    let __v_125: G = __r_arr[6];
+    let __v_126: G = __r_arr[7];
+    let __v_127: G = __r_arr[8];
+    let __v_128: G = __r_arr[9];
+    let __v_129: G = __r_arr[10];
+    let __v_130: G = __r_arr[11];
+    let __v_131: G = __r_arr[12];
+    let __v_132: G = __r_arr[13];
+    let __v_133: G = __r_arr[14];
+    let __v_134: G = __r_arr[15];
+    let __v_135: G = __r_arr[16];
+    let __v_136: G = __r_arr[17];
+    let __v_137: G = __r_arr[18];
+    let __v_138: G = __r_arr[19];
+    let __v_139: G = __r_arr[20];
+    let __v_140: G = __r_arr[21];
+    let __v_141: G = __r_arr[22];
+    let __v_142: G = __r_arr[23];
+    let __v_143: G = __r_arr[24];
+    let __v_144: G = __r_arr[25];
+    let __v_145: G = __r_arr[26];
+    let __v_146: G = __r_arr[27];
+    let __v_147: G = __r_arr[28];
+    let __v_148: G = __r_arr[29];
+    let __v_149: G = __r_arr[30];
+    let __v_150: G = __r_arr[31];
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __v_151: G = __r_arr[0];
+    let __v_152: G = __r_arr[1];
+    let __v_153: G = __r_arr[2];
+    let __v_154: G = __r_arr[3];
+    let __v_155: G = __r_arr[4];
+    let __v_156: G = __r_arr[5];
+    let __v_157: G = __r_arr[6];
+    let __v_158: G = __r_arr[7];
+    let __v_159: G = __r_arr[8];
+    let __v_160: G = __r_arr[9];
+    let __v_161: G = __r_arr[10];
+    let __v_162: G = __r_arr[11];
+    let __v_163: G = __r_arr[12];
+    let __v_164: G = __r_arr[13];
+    let __v_165: G = __r_arr[14];
+    let __v_166: G = __r_arr[15];
+    let __v_167: G = __r_arr[16];
+    let __v_168: G = __r_arr[17];
+    let __v_169: G = __r_arr[18];
+    let __v_170: G = __r_arr[19];
+    let __v_171: G = __r_arr[20];
+    let __v_172: G = __r_arr[21];
+    let __v_173: G = __r_arr[22];
+    let __v_174: G = __r_arr[23];
+    let __v_175: G = __r_arr[24];
+    let __v_176: G = __r_arr[25];
+    let __v_177: G = __r_arr[26];
+    let __v_178: G = __r_arr[27];
+    let __v_179: G = __r_arr[28];
+    let __v_180: G = __r_arr[29];
+    let __v_181: G = __r_arr[30];
+    let __v_182: G = __r_arr[31];
+    if (__v_151 != __v_0) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_151.as_canonical_u64(), rhs: __v_0.as_canonical_u64() });
+    }
+    if (__v_152 != __v_1) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_152.as_canonical_u64(), rhs: __v_1.as_canonical_u64() });
+    }
+    if (__v_153 != __v_2) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_153.as_canonical_u64(), rhs: __v_2.as_canonical_u64() });
+    }
+    if (__v_154 != __v_3) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_154.as_canonical_u64(), rhs: __v_3.as_canonical_u64() });
+    }
+    if (__v_155 != __v_4) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_155.as_canonical_u64(), rhs: __v_4.as_canonical_u64() });
+    }
+    if (__v_156 != __v_5) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_156.as_canonical_u64(), rhs: __v_5.as_canonical_u64() });
+    }
+    if (__v_157 != __v_6) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_157.as_canonical_u64(), rhs: __v_6.as_canonical_u64() });
+    }
+    if (__v_158 != __v_7) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_158.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
+    }
+    if (__v_159 != __v_8) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_159.as_canonical_u64(), rhs: __v_8.as_canonical_u64() });
+    }
+    if (__v_160 != __v_9) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_160.as_canonical_u64(), rhs: __v_9.as_canonical_u64() });
+    }
+    if (__v_161 != __v_10) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_161.as_canonical_u64(), rhs: __v_10.as_canonical_u64() });
+    }
+    if (__v_162 != __v_11) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_162.as_canonical_u64(), rhs: __v_11.as_canonical_u64() });
+    }
+    if (__v_163 != __v_12) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_163.as_canonical_u64(), rhs: __v_12.as_canonical_u64() });
+    }
+    if (__v_164 != __v_13) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_164.as_canonical_u64(), rhs: __v_13.as_canonical_u64() });
+    }
+    if (__v_165 != __v_14) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_165.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
+    }
+    if (__v_166 != __v_15) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_166.as_canonical_u64(), rhs: __v_15.as_canonical_u64() });
+    }
+    if (__v_167 != __v_16) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_167.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
+    }
+    if (__v_168 != __v_17) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_168.as_canonical_u64(), rhs: __v_17.as_canonical_u64() });
+    }
+    if (__v_169 != __v_18) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_169.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
+    }
+    if (__v_170 != __v_19) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_170.as_canonical_u64(), rhs: __v_19.as_canonical_u64() });
+    }
+    if (__v_171 != __v_20) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_171.as_canonical_u64(), rhs: __v_20.as_canonical_u64() });
+    }
+    if (__v_172 != __v_21) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_172.as_canonical_u64(), rhs: __v_21.as_canonical_u64() });
+    }
+    if (__v_173 != __v_22) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_173.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+    }
+    if (__v_174 != __v_23) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_174.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
+    }
+    if (__v_175 != __v_24) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_175.as_canonical_u64(), rhs: __v_24.as_canonical_u64() });
+    }
+    if (__v_176 != __v_25) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_176.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
+    }
+    if (__v_177 != __v_26) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_177.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
+    }
+    if (__v_178 != __v_27) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_178.as_canonical_u64(), rhs: __v_27.as_canonical_u64() });
+    }
+    if (__v_179 != __v_28) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_179.as_canonical_u64(), rhs: __v_28.as_canonical_u64() });
+    }
+    if (__v_180 != __v_29) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_180.as_canonical_u64(), rhs: __v_29.as_canonical_u64() });
+    }
+    if (__v_181 != __v_30) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_181.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
+    }
+    if (__v_182 != __v_31) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_182.as_canonical_u64(), rhs: __v_31.as_canonical_u64() });
+    }
+    let __v_183: G = (__v_94 + __v_95);
+    if (__v_108 != __v_183) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_108.as_canonical_u64(), rhs: __v_183.as_canonical_u64() });
+    }
+    let __r_arr: [G; OUT_62] = { let __args: [G; IN_62] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[62].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_62] = unsafe { *(result.output.as_ptr() as *const [G; OUT_62]) }; __ret } else { aiur_fn_62(__args, record, io_buffer, __cu)? } };
+    let __v_184: G = __r_arr[0];
+    let __v_185: G = __r_arr[1];
+    let __v_186: G = __r_arr[2];
+    let __v_187: G = __r_arr[3];
+    let __v_188: G = __r_arr[4];
+    let __v_189: G = __r_arr[5];
+    let __v_190: G = __r_arr[6];
+    let __v_191: G = __r_arr[7];
+    let __v_192: G = __r_arr[8];
+    let __v_193: G = __r_arr[9];
+    let __v_194: G = __r_arr[10];
+    let __v_195: G = __r_arr[11];
+    let __v_196: G = __r_arr[12];
+    let __v_197: G = __r_arr[13];
+    let __v_198: G = __r_arr[14];
+    let __v_199: G = __r_arr[15];
+    let __v_200: G = __r_arr[16];
+    let __v_201: G = __r_arr[17];
+    let __v_202: G = __r_arr[18];
+    let __v_203: G = __r_arr[19];
+    let __v_204: G = __r_arr[20];
+    let __v_205: G = __r_arr[21];
+    let __v_206: G = __r_arr[22];
+    let __v_207: G = __r_arr[23];
+    let __v_208: G = __r_arr[24];
+    let __v_209: G = __r_arr[25];
+    let __v_210: G = __r_arr[26];
+    let __v_211: G = __r_arr[27];
+    let __v_212: G = __r_arr[28];
+    let __v_213: G = __r_arr[29];
+    let __v_214: G = __r_arr[30];
+    let __v_215: G = __r_arr[31];
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __v_216: G = __r_arr[0];
+    let __v_217: G = __r_arr[1];
+    let __v_218: G = __r_arr[2];
+    let __v_219: G = __r_arr[3];
+    let __v_220: G = __r_arr[4];
+    let __v_221: G = __r_arr[5];
+    let __v_222: G = __r_arr[6];
+    let __v_223: G = __r_arr[7];
+    let __v_224: G = __r_arr[8];
+    let __v_225: G = __r_arr[9];
+    let __v_226: G = __r_arr[10];
+    let __v_227: G = __r_arr[11];
+    let __v_228: G = __r_arr[12];
+    let __v_229: G = __r_arr[13];
+    let __v_230: G = __r_arr[14];
+    let __v_231: G = __r_arr[15];
+    let __v_232: G = __r_arr[16];
+    let __v_233: G = __r_arr[17];
+    let __v_234: G = __r_arr[18];
+    let __v_235: G = __r_arr[19];
+    let __v_236: G = __r_arr[20];
+    let __v_237: G = __r_arr[21];
+    let __v_238: G = __r_arr[22];
+    let __v_239: G = __r_arr[23];
+    let __v_240: G = __r_arr[24];
+    let __v_241: G = __r_arr[25];
+    let __v_242: G = __r_arr[26];
+    let __v_243: G = __r_arr[27];
+    let __v_244: G = __r_arr[28];
+    let __v_245: G = __r_arr[29];
+    let __v_246: G = __r_arr[30];
+    let __v_247: G = __r_arr[31];
+    if (__v_216 != __v_32) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_216.as_canonical_u64(), rhs: __v_32.as_canonical_u64() });
+    }
+    if (__v_217 != __v_33) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_217.as_canonical_u64(), rhs: __v_33.as_canonical_u64() });
+    }
+    if (__v_218 != __v_34) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_218.as_canonical_u64(), rhs: __v_34.as_canonical_u64() });
+    }
+    if (__v_219 != __v_35) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_219.as_canonical_u64(), rhs: __v_35.as_canonical_u64() });
+    }
+    if (__v_220 != __v_36) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_220.as_canonical_u64(), rhs: __v_36.as_canonical_u64() });
+    }
+    if (__v_221 != __v_37) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_221.as_canonical_u64(), rhs: __v_37.as_canonical_u64() });
+    }
+    if (__v_222 != __v_38) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_222.as_canonical_u64(), rhs: __v_38.as_canonical_u64() });
+    }
+    if (__v_223 != __v_39) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_223.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
+    }
+    if (__v_224 != __v_40) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_224.as_canonical_u64(), rhs: __v_40.as_canonical_u64() });
+    }
+    if (__v_225 != __v_41) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_225.as_canonical_u64(), rhs: __v_41.as_canonical_u64() });
+    }
+    if (__v_226 != __v_42) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_226.as_canonical_u64(), rhs: __v_42.as_canonical_u64() });
+    }
+    if (__v_227 != __v_43) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_227.as_canonical_u64(), rhs: __v_43.as_canonical_u64() });
+    }
+    if (__v_228 != __v_44) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_228.as_canonical_u64(), rhs: __v_44.as_canonical_u64() });
+    }
+    if (__v_229 != __v_45) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_229.as_canonical_u64(), rhs: __v_45.as_canonical_u64() });
+    }
+    if (__v_230 != __v_46) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_230.as_canonical_u64(), rhs: __v_46.as_canonical_u64() });
+    }
+    if (__v_231 != __v_47) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_231.as_canonical_u64(), rhs: __v_47.as_canonical_u64() });
+    }
+    if (__v_232 != __v_48) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_232.as_canonical_u64(), rhs: __v_48.as_canonical_u64() });
+    }
+    if (__v_233 != __v_49) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_233.as_canonical_u64(), rhs: __v_49.as_canonical_u64() });
+    }
+    if (__v_234 != __v_50) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_234.as_canonical_u64(), rhs: __v_50.as_canonical_u64() });
+    }
+    if (__v_235 != __v_51) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_235.as_canonical_u64(), rhs: __v_51.as_canonical_u64() });
+    }
+    if (__v_236 != __v_52) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_236.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
+    }
+    if (__v_237 != __v_53) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_237.as_canonical_u64(), rhs: __v_53.as_canonical_u64() });
+    }
+    if (__v_238 != __v_54) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_238.as_canonical_u64(), rhs: __v_54.as_canonical_u64() });
+    }
+    if (__v_239 != __v_55) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_239.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
+    }
+    if (__v_240 != __v_56) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_240.as_canonical_u64(), rhs: __v_56.as_canonical_u64() });
+    }
+    if (__v_241 != __v_57) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_241.as_canonical_u64(), rhs: __v_57.as_canonical_u64() });
+    }
+    if (__v_242 != __v_58) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_242.as_canonical_u64(), rhs: __v_58.as_canonical_u64() });
+    }
+    if (__v_243 != __v_59) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_243.as_canonical_u64(), rhs: __v_59.as_canonical_u64() });
+    }
+    if (__v_244 != __v_60) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_244.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
+    }
+    if (__v_245 != __v_61) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_245.as_canonical_u64(), rhs: __v_61.as_canonical_u64() });
+    }
+    if (__v_246 != __v_62) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_246.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
+    }
+    if (__v_247 != __v_63) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_247.as_canonical_u64(), rhs: __v_63.as_canonical_u64() });
+    }
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_116.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_248: G = __loaded[0];
+    let __v_249: G = __loaded[1];
+    let __v_250: G = __loaded[2];
+    let __v_251: G = G::from_u64(1);
+    let __v_252: G = G::from_u64(1);
+    if (__v_248 != __v_251) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_248.as_canonical_u64(), rhs: __v_251.as_canonical_u64() });
+    }
+    if (__v_249 != __v_252) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_249.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
+    }
+    if (__v_250 != __v_252) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
+    }
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+    let __v_253: G = __r_arr[0];
     let __v_254: G = G::from_u64(1);
-    let __v_255: G = G::from_u64(1);
-    if (__v_251 != __v_254) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_251.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
+    if (__v_253 != __v_254) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    if (__v_252 != __v_255) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_252.as_canonical_u64(), rhs: __v_255.as_canonical_u64() });
-    }
-    if (__v_253 != __v_255) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_255.as_canonical_u64() });
-    }
-    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
-    let __v_256: G = __r_arr[0];
-    let __v_257: G = G::from_u64(1);
-    if (__v_256 != __v_257) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_256.as_canonical_u64(), rhs: __v_257.as_canonical_u64() });
-    }
-    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_118, __v_64, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
-    let __v_258: G = __r_arr[0];
-    let __v_259: G = G::from_u64(1);
-    if (__v_258 != __v_259) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_258.as_canonical_u64(), rhs: __v_259.as_canonical_u64() });
+    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+    let __v_255: G = __r_arr[0];
+    let __v_256: G = G::from_u64(1);
+    if (__v_255 != __v_256) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
     let __ret: [G; OUT_204] = [];
     record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -113,7 +113,7 @@ a PR tree and compare them — exactly what the PR workflow does.
 
 All tools emit the same rows, and all the constant-driven ones take the same
 `--consts`/`--consts-file` grammar (`bench-recursive-verifier` instead takes
-its config as flags — `--trivial`, `--queries`, `--blowup` — with the row
+its config as flags — `--trivial`, `--queries`, `--log-blowup` — with the row
 name supplied via `--json-name`). The ooc and zkVM cells share per-constant
 **full-closure** scope, so their delta isolates in-circuit vs out-of-circuit
 overhead.


### PR DESCRIPTION
Fixes the recursive benchmark parameters to reflect the FRI parameters everywhere else.

This PR also implements query PoW on the recursive verifier and removes the FRI/Commitment parameters from the public inputs, as it is redundant. These parameters are already found within `System`, specifically inside `TwoAdicPcs`