### PR TITLE
multi-stark: adopt flat quotient commitment (rev 678f8e1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=c178aaedaaea003331f0992d385266068cee32c8#c178aaedaaea003331f0992d385266068cee32c8"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=40092c160f51fdc2330b9e388873ece3fa4c12c2#40092c160f51fdc2330b9e388873ece3fa4c12c2"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "c178aaedaaea003331f0992d385266068cee32c8" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "40092c160f51fdc2330b9e388873ece3fa4c12c2" }
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"

--- a/Ix/MultiStark/Pcs.lean
+++ b/Ix/MultiStark/Pcs.lean
@@ -678,12 +678,6 @@ def pcs := ⟦
   }
 
   -- ── reduced-opening buckets ───────────────────────────────────────────────
-  fn repeat_g(v: G, n: G) -> List‹G› {
-    match n {
-      0 => store(ListNode.Nil),
-      _ => store(ListNode.Cons(v, repeat_g(v, n - 1))),
-    }
-  }
   -- 1 iff some circuit `i < rem` has log-height `log_degrees[i] + log_blowup == h`.
   fn circ_has_height(log_degrees: List‹U8›, log_blowup: G, rem: G, i: G, h: G) -> G {
     match rem {
@@ -781,29 +775,18 @@ def pcs := ⟦
     }
   }
 
-  -- The quotient batch: `qd` chunks per circuit, one opening point (ζ) each.
-  fn open_q_chunks(buckets: List‹Bucket›, idxbits: List‹G›, log_gmax: G, lh: G,
-      chunk: G, qrem: G, zeta: Ext, base_rows: List‹List‹U64››,
-      q_opened: OpenedRound, alpha: Ext) -> (List‹Bucket›, G) {
-    match qrem {
-      0 => (buckets, chunk),
-      _ =>
-        let b = ri_apply(buckets, lh, idxbits, log_gmax, zeta,
-                  lanes_to_gl(list_lookup(base_rows, chunk)), list_lookup(list_lookup(q_opened, chunk), 0), alpha);
-        open_q_chunks(b, idxbits, log_gmax, lh, chunk + 1, qrem - 1, zeta, base_rows, q_opened, alpha),
-    }
-  }
+  -- The quotient batch: ONE wide matrix per circuit (all its coefficient
+  -- slices), on the trace domain, opened at the single point ζ.
   fn open_quotient(buckets: List‹Bucket›, idxbits: List‹G›, log_gmax: G, log_blowup: G, ci: G,
-      rem: G, chunk: G, circuits: List‹SysCircuit›, log_degrees: List‹U8›, zeta: Ext,
+      rem: G, log_degrees: List‹U8›, zeta: Ext,
       base_rows: List‹List‹U64››, q_opened: OpenedRound, alpha: Ext) -> List‹Bucket› {
     match rem {
       0 => buckets,
       _ =>
-        let SysCircuit.Mk(_a, _cc, md, _ph, _pw, _w1, _w2) = list_lookup(circuits, ci);
-        let qd = quotient_degree_of(md);
         let lh = to_field(list_lookup(log_degrees, ci)) + log_blowup;
-        let (b, chunk2) = open_q_chunks(buckets, idxbits, log_gmax, lh, chunk, qd, zeta, base_rows, q_opened, alpha);
-        open_quotient(b, idxbits, log_gmax, log_blowup, ci + 1, rem - 1, chunk2, circuits, log_degrees, zeta, base_rows, q_opened, alpha),
+        let b = ri_apply(buckets, lh, idxbits, log_gmax, zeta,
+                  lanes_to_gl(list_lookup(base_rows, ci)), list_lookup(list_lookup(q_opened, ci), 0), alpha);
+        open_quotient(b, idxbits, log_gmax, log_blowup, ci + 1, rem - 1, log_degrees, zeta, base_rows, q_opened, alpha),
     }
   }
 
@@ -850,15 +833,6 @@ def pcs := ⟦
       0 => store(ListNode.Nil),
       _ => store(ListNode.Cons(to_field(list_lookup(log_degrees, i)) + log_blowup,
                                heights_all(log_degrees, log_blowup, rem - 1, i + 1))),
-    }
-  }
-  fn heights_quotient(circuits: List‹SysCircuit›, log_degrees: List‹U8›, log_blowup: G, rem: G, i: G) -> List‹G› {
-    match rem {
-      0 => store(ListNode.Nil),
-      _ =>
-        let SysCircuit.Mk(_a, _cc, md, _ph, _pw, _w1, _w2) = list_lookup(circuits, i);
-        list_concat(repeat_g(to_field(list_lookup(log_degrees, i)) + log_blowup, quotient_degree_of(md)),
-                    heights_quotient(circuits, log_degrees, log_blowup, rem - 1, i + 1)),
     }
   }
   fn heights_prep(log_degrees: List‹U8›, log_blowup: G, prep_indices: List‹OptIdx›, rem: G, i: G) -> List‹G› {
@@ -935,7 +909,7 @@ def pcs := ⟦
   fn verify_one_query(idxbits: List‹G›, qp: QueryProof, alpha: Ext,
       stage1: OpenedRound, stage2: OpenedRound, q_opened: OpenedRound,
       prep_opt: PreprocessedOpt, s1c: MerkleCap, s2c: MerkleCap, qc: MerkleCap,
-      prep_commit: MerkleCap, circuits: List‹SysCircuit›, prep_indices: List‹OptIdx›,
+      prep_commit: MerkleCap, prep_indices: List‹OptIdx›,
       log_degrees: List‹U8›, zeta: Ext, num_circuits: G, log_blowup: G, log_gmax: G,
       betas: List‹Ext›, commit_phase_commits: List‹MerkleCap›, final_poly: List‹Ext›,
       num_rounds: G) -> G {
@@ -954,9 +928,11 @@ def pcs := ⟦
     assert_eq!(mmcs_verify(s2c, rows_s2, heights_all(log_degrees, log_blowup, num_circuits, 0), idxbits, proof_s2, log_gmax), 1);
     let buckets = open_batch_2pt(buckets, idxbits, log_gmax, log_blowup, 0, num_circuits, log_degrees, zeta, rows_s2, stage2, alpha);
     let BatchOpening.Mk(rows_q, proof_q) = list_lookup(input_proof, 2);
-    assert_eq!(eq_zero(list_length(rows_q) - list_length(q_opened)), 1);
-    assert_eq!(mmcs_verify(qc, rows_q, heights_quotient(circuits, log_degrees, log_blowup, num_circuits, 0), idxbits, proof_q, log_gmax), 1);
-    let buckets = open_quotient(buckets, idxbits, log_gmax, log_blowup, 0, num_circuits, 0, circuits, log_degrees, zeta, rows_q, q_opened, alpha);
+    -- one wide quotient matrix per circuit, on the trace domain, so the
+    -- quotient batch's heights are the same per-circuit heights as the stages
+    assert_eq!(eq_zero(list_length(rows_q) - num_circuits), 1);
+    assert_eq!(mmcs_verify(qc, rows_q, heights_all(log_degrees, log_blowup, num_circuits, 0), idxbits, proof_q, log_gmax), 1);
+    let buckets = open_quotient(buckets, idxbits, log_gmax, log_blowup, 0, num_circuits, log_degrees, zeta, rows_q, q_opened, alpha);
     let buckets = open_prep_batch(buckets, input_proof, prep_commit, prep_opt, prep_indices, log_degrees, num_circuits, idxbits, log_gmax, log_blowup, zeta, alpha);
     -- a height-`log_blowup` (constant-poly) reduced opening must be zero
     let _cz = assert_blowup_zero(buckets, log_blowup);
@@ -976,7 +952,7 @@ def pcs := ⟦
   fn query_loop(input: ByteStream, output: ByteStream, query_proofs: List‹QueryProof›,
       alpha: Ext, stage1: OpenedRound, stage2: OpenedRound, q_opened: OpenedRound,
       prep_opt: PreprocessedOpt, s1c: MerkleCap, s2c: MerkleCap, qc: MerkleCap,
-      prep_commit: MerkleCap, circuits: List‹SysCircuit›, prep_indices: List‹OptIdx›,
+      prep_commit: MerkleCap, prep_indices: List‹OptIdx›,
       log_degrees: List‹U8›, zeta: Ext, num_circuits: G, log_blowup: G, log_gmax: G,
       betas: List‹Ext›, commit_phase_commits: List‹MerkleCap›, final_poly: List‹Ext›,
       num_rounds: G) -> G {
@@ -985,10 +961,10 @@ def pcs := ⟦
       ListNode.Cons(qp, rest) =>
         let (idxbits, input2, output2) = ch_sample_bits(input, output, log_gmax);
         let _q = verify_one_query(idxbits, qp, alpha, stage1, stage2, q_opened, prep_opt,
-          s1c, s2c, qc, prep_commit, circuits, prep_indices, log_degrees, zeta, num_circuits,
+          s1c, s2c, qc, prep_commit, prep_indices, log_degrees, zeta, num_circuits,
           log_blowup, log_gmax, betas, commit_phase_commits, final_poly, num_rounds);
         query_loop(input2, output2, rest, alpha, stage1, stage2, q_opened, prep_opt,
-          s1c, s2c, qc, prep_commit, circuits, prep_indices, log_degrees, zeta, num_circuits,
+          s1c, s2c, qc, prep_commit, prep_indices, log_degrees, zeta, num_circuits,
           log_blowup, log_gmax, betas, commit_phase_commits, final_poly, num_rounds),
     }
   }
@@ -999,7 +975,7 @@ def pcs := ⟦
   fn pcs_fri_verify(post_zeta_input: ByteStream, stage1: OpenedRound, stage2: OpenedRound,
       q_opened: OpenedRound, prep_opt: PreprocessedOpt, opening: FriProof,
       s1c: MerkleCap, s2c: MerkleCap, qc: MerkleCap, prep_commit: MerkleCap,
-      circuits: List‹SysCircuit›, prep_indices: List‹OptIdx›, log_degrees: List‹U8›,
+      prep_indices: List‹OptIdx›, log_degrees: List‹U8›,
       zeta: Ext, num_circuits: G, log_blowup: G, num_queries: G, commit_pow_bits: G,
       query_pow_bits: G) -> G {
     let FriProof.Mk(commit_phase_commits, pw, query_proofs, final_poly, qpw) = opening;
@@ -1030,7 +1006,7 @@ def pcs := ⟦
     -- query indices + per-query verification (log_global_max_height = #rounds + log_blowup)
     let log_gmax = num_rounds + log_blowup;
     query_loop(input, output, query_proofs, alpha, stage1, stage2, q_opened,
-      prep_opt, s1c, s2c, qc, prep_commit, circuits, prep_indices, log_degrees, zeta,
+      prep_opt, s1c, s2c, qc, prep_commit, prep_indices, log_degrees, zeta,
       num_circuits, log_blowup, log_gmax, betas, commit_phase_commits, final_poly, num_rounds)
   }
 

--- a/Ix/MultiStark/Verifier.lean
+++ b/Ix/MultiStark/Verifier.lean
@@ -43,8 +43,9 @@ The Rust verifier runs these steps:
   circuit it recomputes `composition(ζ)` by replaying the AIR constraint folder
   (`VerifierConstraintFolder` + `LookupAir::eval`) over the deserialized
   symbolic system and the opened values, recomputes `quotient(ζ)` from the
-  opened quotient chunks (barycentric `zps` weights over the split quotient
-  domains), and asserts `composition(ζ) · inv_vanishing(ζ) == quotient(ζ)`.
+  opened quotient coefficient slices (the power series
+  `Q(ζ) = Σᵢ ζ^(i·n)·cᵢ(ζ)`), and asserts
+  `composition(ζ) · inv_vanishing(ζ) == quotient(ζ)`.
   Validated end-to-end against a real factorial proof (the `recursive-verifier`
   test runner, `Tests/MultiStark.lean`): the verifier accepts the honest proof
   and rejects a tampered claim.
@@ -475,7 +476,7 @@ def verifier := ⟦
   fn verify(proof: Proof) -> G {
     match proof {
       Proof.Mk(_active, _commitments, accs, _log_degrees, _opening,
-               _quotient, _preprocessed, stage_1, stage_2) =>
+               quotient, _preprocessed, stage_1, stage_2) =>
         -- Step 1 (shape, system-independent): the per-round opened-value lists
         -- and the accumulator list all have the same length = the circuit count.
         let num_circuits = list_length(accs);
@@ -483,6 +484,8 @@ def verifier := ⟦
         assert_eq!(eq_zero(num_circuits), 0);
         assert_eq!(list_length(stage_1), num_circuits);
         assert_eq!(list_length(stage_2), num_circuits);
+        -- one wide quotient matrix per active circuit
+        assert_eq!(list_length(quotient), num_circuits);
 
         -- Step 2: accumulator balance — the last accumulator must be zero.
         assert_eq!(last_acc_is_zero(accs), 1);
@@ -495,12 +498,12 @@ def verifier := ⟦
   -- ==========================================================================
   -- Step 5: out-of-domain (OOD) evaluation.
   --
-  -- Mirrors the per-circuit loop in `verifier.rs::verify_multiple_claims`
-  -- (lines 329-434). For each circuit it recomputes the composition polynomial
+  -- Mirrors the per-circuit loop in `verifier.rs::verify_multiple_claims`.
+  -- For each circuit it recomputes the composition polynomial
   -- `composition(ζ)` from the opened values by replaying the AIR constraint
   -- folder (`VerifierConstraintFolder` + `LookupAir::eval`), recomputes the
-  -- quotient `quotient(ζ)` from the opened quotient chunks via the barycentric
-  -- weights `zps`, and asserts
+  -- quotient `quotient(ζ)` from the opened coefficient slices via the power
+  -- series `Q(ζ) = Σᵢ ζ^(i·n)·cᵢ(ζ)`, and asserts
   --   composition(ζ) · inv_vanishing(ζ) == quotient(ζ).
   --
   -- The challenges (lookup, fingerprint, α, ζ) come from `fiat_shamir` above.
@@ -672,66 +675,28 @@ def verifier := ⟦
   }
 
   -- ==========================================================================
-  -- Quotient evaluation from the opened quotient chunks.
+  -- Quotient evaluation from the opened quotient row.
   --
-  -- The trace domain is the order-2^L subgroup H (shift = 1). The quotient
-  -- domain is the disjoint coset `7·H'` of size `2^(L+log_qd)` (7 = Goldilocks
-  -- GENERATOR), split into `qd = 2^log_qd` chunk domains `Dⱼ` of size `2^L`,
-  -- shift `7·g_q^j` where `g_q = two_adic_gen(L + log_qd)`. Then
-  --   quotient(ζ) = Σⱼ zpsⱼ · from_ext_basis(chunkⱼ),
-  --   zpsⱼ = Πₖ≠ⱼ Z_{Dₖ}(ζ) / Z_{Dₖ}(first_point(Dⱼ)),
-  -- with `Z_{Dₖ}(x) = (x · shift_k⁻¹)^(2^L) - 1`.
+  -- The quotient is sliced by COEFFICIENTS — `Q(X) = Σᵢ X^(i·n)·cᵢ(X)` with
+  -- each `cᵢ` of degree < n = 2^L — and all `qd` slices of a circuit live in
+  -- one wide matrix on the trace domain, opened once at ζ. Recombination is
+  -- the plain power series
+  --   quotient(ζ) = Σᵢ ζ^(i·n) · cᵢ(ζ),
+  -- over the slice values reconstructed from the opened row
+  -- (`reconstruct_ext_row`, pairs of base coordinates → extension elements).
   -- ==========================================================================
 
-  -- base-field power `base^e` (e small: the chunk index, < qd).
-  fn g_pow(base: Goldilocks, e: G) -> Goldilocks {
-    match e {
-      0 => 1,
-      _ => gl_mul(base, g_pow(base, e - 1)),
+  -- `Σᵢ powᵢ·sliceᵢ` with `powᵢ = zeta_pow_n^i` (`pow` threads the running
+  -- power, starting at 1).
+  fn quotient_eval(slices: List‹Ext›, zeta_pow_n: Ext, pow: Ext) -> Ext {
+    match load(slices) {
+      ListNode.Nil => [0, 0],
+      ListNode.Cons(c, rest) =>
+        eg_add(eg_mul(pow, c), quotient_eval(rest, zeta_pow_n, eg_mul(pow, zeta_pow_n))),
     }
   }
 
-  -- `Z_{Dⱼ}(x) = (x · shift_j⁻¹)^(2^L) - 1`, evaluated at extension point `x`.
-  fn vanish_chunk(x: Ext, l: G, shiftinv: Goldilocks) -> Ext {
-    eg_sub(ext_exp_pow2(eg_mul(x, [shiftinv, 0]), l), [1, 0])
-  }
-
-  -- `zpsₜ = Πⱼ≠ₜ Z_{Dⱼ}(ζ) / Z_{Dⱼ}(shift_t)`. Iterates j over `[jidx, jidx+rem)`.
-  fn zps_prod(acc: Ext, zeta: Ext, l: G, g_q: Goldilocks, shift_t: Goldilocks, jidx: G, rem: G, t: G) -> Ext {
-    match rem {
-      0 => acc,
-      _ =>
-        let shiftinv = gl_inverse(gl_mul(7, g_pow(g_q, jidx)));
-        -- skip the j = t factor (the chunk's own domain); branch in tail
-        -- position so the inner match is not a non-tail match.
-        match eq_zero(jidx - t) {
-          1 => zps_prod(acc, zeta, l, g_q, shift_t, jidx + 1, rem - 1, t),
-          _ =>
-            let factor = eg_mul(vanish_chunk(zeta, l, shiftinv),
-                                 eg_inverse(vanish_chunk([shift_t, 0], l, shiftinv)));
-            zps_prod(eg_mul(acc, factor), zeta, l, g_q, shift_t, jidx + 1, rem - 1, t),
-        },
-    }
-  }
-
-  -- `quotient(ζ) = Σₜ zpsₜ · from_ext_basis(chunkₜ)`, iterating the `qd` chunks
-  -- (`q_opened[idx][0] = [c0, c1]`).
-  fn quotient_sum(acc: Ext, zeta: Ext, l: G, qd: G, g_q: Goldilocks,
-      q_opened: OpenedRound, idx: G, rem: G, t: G) -> Ext {
-    match rem {
-      0 => acc,
-      _ =>
-        let shift_t = gl_mul(7, g_pow(g_q, t));
-        let zps_t = zps_prod([1, 0], zeta, l, g_q, shift_t, 0, qd, t);
-        let ch = list_lookup(q_opened, idx);
-        let row = list_lookup(ch, 0);
-        let qv = from_ext_basis(list_lookup(row, 0), list_lookup(row, 1));
-        quotient_sum(eg_add(acc, eg_mul(zps_t, qv)), zeta, l, qd, g_q,
-                     q_opened, idx + 1, rem - 1, t + 1),
-    }
-  }
-
-  -- `quotient_degree = (max(md, 2) - 1).next_power_of_two()` and its log2.
+  -- `quotient_degree = (max(md, 2) - 1).next_power_of_two()`.
   -- Tabulated for `max_constraint_degree ≤ 17` (covers all current circuits);
   -- larger degrees fall through to the `_` arm.
   fn quotient_degree_of(md: G) -> G {
@@ -742,16 +707,6 @@ def verifier := ⟦
       6 => 8, 7 => 8, 8 => 8, 9 => 8,
       10 => 16, 11 => 16, 12 => 16, 13 => 16, 14 => 16, 15 => 16, 16 => 16, 17 => 16,
       _ => 32,
-    }
-  }
-  fn log_qd_of(md: G) -> G {
-    match md {
-      0 => 0, 1 => 0, 2 => 0,
-      3 => 1,
-      4 => 2, 5 => 2,
-      6 => 3, 7 => 3, 8 => 3, 9 => 3,
-      10 => 4, 11 => 4, 12 => 4, 13 => 4, 14 => 4, 15 => 4, 16 => 4, 17 => 4,
-      _ => 5,
     }
   }
 
@@ -772,11 +727,11 @@ def verifier := ⟦
 
   -- Per-circuit OOD loop: for each circuit, recompute composition(ζ) and
   -- quotient(ζ) and assert `composition · inv_vanishing == quotient`. Threads
-  -- the running lookup accumulator `accp` and the quotient-chunk offset `lastq`.
+  -- the running lookup accumulator `accp`.
   fn ood_loop(circuits: List‹SysCircuit›, prep_indices: List‹OptIdx›,
       log_degrees: List‹U8›, accs: List‹Ext›,
       stage1: OpenedRound, stage2: OpenedRound, prep_opt: PreprocessedOpt,
-      q_opened: OpenedRound, i: G, accp: Ext, lastq: G,
+      q_opened: OpenedRound, i: G, accp: Ext,
       lch: Ext, fch: Ext, alpha: Ext, zeta: Ext) -> G {
     match load(circuits) {
       ListNode.Nil => 1,
@@ -785,7 +740,6 @@ def verifier := ⟦
         let SysLookupAir.Mk(air, lookups) = lair;
         let l = to_field(list_lookup(log_degrees, i));
         let qd = quotient_degree_of(md);
-        let log_qd = log_qd_of(md);
         let naccp = list_lookup(accs, i);
         let s1 = list_lookup(stage1, i);
         let main = list_lookup(s1, 0);
@@ -797,11 +751,16 @@ def verifier := ⟦
         let (isf, isl, ist, invv) = trace_selectors(zeta, l);
         let comp = ood_composition(air, lookups, main, main_next, s2row, s2next,
                                    prep, isf, isl, ist, lch, fch, accp, naccp, alpha);
-        let g_q = two_adic_gen(l + log_qd);
-        let quot = quotient_sum([0, 0], zeta, l, qd, g_q, q_opened, lastq, qd, 0);
+        -- circuit i's wide quotient row, its base-coordinate pairs folded back
+        -- into the `qd` slice values (Rust: `quotient_row.chunks_exact(D)`)
+        let slices = reconstruct_ext_row(list_lookup(list_lookup(q_opened, i), 0));
+        -- shape: `quotient_opened_values[pos][0].len() == quotient_degree · D`
+        -- (Rust `check_shapes`)
+        assert_eq!(eq_zero(list_length(slices) - qd), 1);
+        let quot = quotient_eval(slices, ext_exp_pow2(zeta, l), [1, 0]);
         assert_eq!(eg_eq(eg_mul(comp, invv), quot), 1);
         ood_loop(rest, prep_indices, log_degrees, accs, stage1, stage2, prep_opt,
-                 q_opened, i + 1, naccp, lastq + qd, lch, fch, alpha, zeta),
+                 q_opened, i + 1, naccp, lch, fch, alpha, zeta),
     }
   }
 
@@ -863,9 +822,9 @@ def verifier := ⟦
         let acc0 = claims_acc([0, 0], claims, lch, fch);
         -- Step 5: OOD composition/quotient identity for every active circuit.
         let _ood = ood_loop(acirc, aprep, log_degrees, accs, stage1, stage2,
-                 prep_opt, q_opened, 0, acc0, 0, lch, fch, alpha, zeta);
+                 prep_opt, q_opened, 0, acc0, lch, fch, alpha, zeta);
         pcs_fri_verify(post_zeta_input, stage1, stage2, q_opened, prep_opt, opening,
-          s1c, s2c, qc, prep_cap, acirc, aprep, log_degrees, zeta,
+          s1c, s2c, qc, prep_cap, aprep, log_degrees, zeta,
           list_length(acirc), log_blowup, num_queries, commit_pow_bits,
           query_pow_bits),
     }

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4341,7 +4341,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4499,10 +4499,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -7574,7 +7574,7 @@ fn aiur_fn_93(
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = { let __values: [G; 10] = [__v_28, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_21]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __ret: [G; OUT_93] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
     record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -10592,7 +10592,7 @@ fn aiur_fn_113(
     let __v_36: G = __r_arr[30];
     let __v_37: G = __r_arr[31];
     let __v_38: G = __r_arr[32];
-    let __r_arr: [G; OUT_220] = { let __args: [G; IN_220] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[220].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_220] = unsafe { *(result.output.as_ptr() as *const [G; OUT_220]) }; __ret } else { aiur_fn_220(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10741,7 +10741,7 @@ fn aiur_fn_116(
     let __v_7: G = inp[7];
     let __v_8: G = G::from_u64(1);
     let __v_9: G = (__v_1 + __v_8);
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = G::from_u64(1);
     let __v_12: G = G::from_u64(1);
@@ -10792,7 +10792,7 @@ fn aiur_fn_117(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_u64(7);
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = G::from_u64(1);
     let __v_5: G = G::from_u64(1);
@@ -10977,9 +10977,9 @@ fn aiur_fn_120(
         let __v_21: G = __r_arr[7];
         let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __ret: [G; OUT_120] = [__v_24];
         record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -11132,7 +11132,7 @@ fn aiur_fn_124(
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
@@ -11177,12 +11177,12 @@ fn aiur_fn_125(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
         let __v_15: G = __r_arr[1];
         let __v_16: G = __r_arr[2];
@@ -11241,12 +11241,12 @@ fn aiur_fn_126(
         let __v_16: G = __loaded[9];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
             let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
             let __v_19: G = __r_arr[1];
-            let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
             let __v_21: G = __r_arr[1];
             let __v_22: G = __r_arr[2];
@@ -11290,8 +11290,8 @@ fn aiur_fn_126(
   })
 }
 
-const INPUT_SIZE_127: usize = 2;
-const IN_127: usize = 2;
+const INPUT_SIZE_127: usize = 5;
+const IN_127: usize = 5;
 const OUT_127: usize = 1;
 fn aiur_fn_127(
   inp: [G; IN_127],
@@ -11302,32 +11302,48 @@ fn aiur_fn_127(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_2.as_canonical_u64() {
       0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_127] = [__v_4];
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_127] = [__v_5];
         record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(0);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = (__v_1 - __v_3);
-        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
-        let __v_6: G = { let __values: [G; 3] = [__v_2, __v_0, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_127] = [__v_6];
-        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __v_6: G = (__v_1 - __v_4);
+        let __v_7: G = (__v_5 + __v_6);
+        let __v_8: G = G::from_bool((__v_7 == G::ZERO));
+        match __v_8.as_canonical_u64() {
+          1u64 => {
+            let __v_9: G = G::from_u64(1);
+            let __ret: [G; OUT_127] = [__v_9];
+            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_2 - __v_9);
+            let __v_11: G = G::from_u64(1);
+            let __v_12: G = (__v_3 + __v_11);
+            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+            let __v_13: G = __r_arr[0];
+            let __ret: [G; OUT_127] = [__v_13];
+            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_128: usize = 5;
-const IN_128: usize = 5;
+const INPUT_SIZE_128: usize = 4;
+const IN_128: usize = 4;
 const OUT_128: usize = 1;
 fn aiur_fn_128(
   inp: [G; IN_128],
@@ -11340,79 +11356,27 @@ fn aiur_fn_128(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_128] = [__v_5];
-        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_1 - __v_4);
-        let __v_7: G = (__v_5 + __v_6);
-        let __v_8: G = G::from_bool((__v_7 == G::ZERO));
-        match __v_8.as_canonical_u64() {
-          1u64 => {
-            let __v_9: G = G::from_u64(1);
-            let __ret: [G; OUT_128] = [__v_9];
-            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_2 - __v_9);
-            let __v_11: G = G::from_u64(1);
-            let __v_12: G = (__v_3 + __v_11);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
-            let __v_13: G = __r_arr[0];
-            let __ret: [G; OUT_128] = [__v_13];
-            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_129: usize = 4;
-const IN_129: usize = 4;
-const OUT_129: usize = 1;
-fn aiur_fn_129(
-  inp: [G; IN_129],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_129], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 7] = [__v_4, __v_5, __v_5, __v_5, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_129] = [__v_6];
-        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_128] = [__v_6];
+        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_3 - __v_6);
-            let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_129] = [__v_8];
-            record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_128] = [__v_8];
+            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11423,11 +11387,11 @@ fn aiur_fn_129(
             let __v_10: G = G::from_u64(0);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 - __v_11);
-            let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = { let __values: [G; 7] = [__v_6, __v_3, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_129] = [__v_14];
-            record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_128] = [__v_14];
+            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -11436,15 +11400,15 @@ fn aiur_fn_129(
   })
 }
 
-const INPUT_SIZE_130: usize = 8;
-const IN_130: usize = 8;
-const OUT_130: usize = 1;
-fn aiur_fn_130(
-  inp: [G; IN_130],
+const INPUT_SIZE_129: usize = 8;
+const IN_129: usize = 8;
+const OUT_129: usize = 1;
+fn aiur_fn_129(
+  inp: [G; IN_129],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_130], ExecError> {
+) -> Result<[G; OUT_129], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11467,8 +11431,8 @@ fn aiur_fn_130(
         let __v_15: G = G::from_u64(1);
         let __v_16: G = G::from_u64(1);
         let __v_17: G = { let __values: [G; 7] = [__v_15, __v_16, __v_16, __v_16, __v_16, __v_16, __v_16]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_130] = [__v_17];
-        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_129] = [__v_17];
+        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11485,17 +11449,17 @@ fn aiur_fn_130(
                 let __v_20: G = __r_arr[3];
                 let __v_21: G = G::from_u64(0);
                 let __v_22: G = { let __values: [G; 7] = [__v_21, __v_9, __v_19, __v_20, __v_17, __v_18, __v_14]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_130] = [__v_22];
-                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_129] = [__v_22];
+                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_17: G = G::from_u64(0);
-                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
                 let __v_18: G = __r_arr[0];
                 let __v_19: G = { let __values: [G; 7] = [__v_17, __v_9, __v_10, __v_11, __v_12, __v_13, __v_18]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_130] = [__v_19];
-                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_129] = [__v_19];
+                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11509,15 +11473,15 @@ fn aiur_fn_130(
   })
 }
 
-const INPUT_SIZE_131: usize = 2;
-const IN_131: usize = 2;
-const OUT_131: usize = 1;
-fn aiur_fn_131(
-  inp: [G; IN_131],
+const INPUT_SIZE_130: usize = 2;
+const IN_130: usize = 2;
+const OUT_130: usize = 1;
+fn aiur_fn_130(
+  inp: [G; IN_130],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_131], ExecError> {
+) -> Result<[G; OUT_130], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11532,8 +11496,8 @@ fn aiur_fn_131(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_9: G = G::from_u64(1);
-        let __ret: [G; OUT_131] = [__v_9];
-        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_130] = [__v_9];
+        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11552,15 +11516,15 @@ fn aiur_fn_131(
                   return Err(ExecError::AssertEqMismatch { lhs: __v_13.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
                 }
                 let __v_15: G = G::from_u64(1);
-                let __ret: [G; OUT_131] = [__v_15];
-                record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_130] = [__v_15];
+                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_131] = [__v_11];
-                record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_130] = [__v_11];
+                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11574,8 +11538,40 @@ fn aiur_fn_131(
   })
 }
 
-const INPUT_SIZE_132: usize = 2;
-const IN_132: usize = 2;
+const INPUT_SIZE_131: usize = 2;
+const IN_131: usize = 2;
+const OUT_131: usize = 1;
+fn aiur_fn_131(
+  inp: [G; IN_131],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_131], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(0);
+        let __ret: [G; OUT_131] = [__v_2];
+        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __ret: [G; OUT_131] = [__v_2];
+        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_132: usize = 10;
+const IN_132: usize = 10;
 const OUT_132: usize = 1;
 fn aiur_fn_132(
   inp: [G; IN_132],
@@ -11586,28 +11582,46 @@ fn aiur_fn_132(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(0);
-        let __ret: [G; OUT_132] = [__v_2];
-        record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __ret: [G; OUT_132] = [__v_2];
-        record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = (__v_3 - __v_1);
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
+    let __v_16: G = __r_arr[0];
+    let __v_17: G = __r_arr[1];
+    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+    let __v_18: G = __r_arr[0];
+    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __v_20: G = (__v_18 - __v_19);
+    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+    let __v_22: G = G::from_u64(1);
+    if (__v_21 != __v_22) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
     }
+    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __ret: [G; OUT_132] = [__v_23];
+    record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_133: usize = 10;
-const IN_133: usize = 10;
+const INPUT_SIZE_133: usize = 11;
+const IN_133: usize = 11;
 const OUT_133: usize = 1;
 fn aiur_fn_133(
   inp: [G; IN_133],
@@ -11626,38 +11640,31 @@ fn aiur_fn_133(
     let __v_7: G = inp[7];
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
-    let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+    let __v_10: G = inp[10];
+    let __v_11: G = G::from_u64(0);
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_13: G = G::from_u64(1);
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __v_15: G = __r_arr[1];
-    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
-    let __v_16: G = __r_arr[0];
-    let __v_17: G = __r_arr[1];
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-    let __v_18: G = __r_arr[0];
-    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __v_15: G = __r_arr[0];
+    let __v_16: G = G::from_u64(0);
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_17: G = __r_arr[0];
+    let __v_18: G = __r_arr[1];
+    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
     let __v_19: G = __r_arr[0];
-    let __v_20: G = (__v_18 - __v_19);
-    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-    let __v_22: G = G::from_u64(1);
-    if (__v_21 != __v_22) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-    }
-    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __ret: [G; OUT_133] = [__v_23];
+    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __ret: [G; OUT_133] = [__v_20];
     record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_134: usize = 11;
-const IN_134: usize = 11;
+const INPUT_SIZE_134: usize = 13;
+const IN_134: usize = 13;
 const OUT_134: usize = 1;
 fn aiur_fn_134(
   inp: [G; IN_134],
@@ -11677,25 +11684,37 @@ fn aiur_fn_134(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
-    let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
-    let __v_15: G = __r_arr[0];
-    let __v_16: G = G::from_u64(0);
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_17: G = __r_arr[0];
-    let __v_18: G = __r_arr[1];
-    let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __ret: [G; OUT_134] = [__v_20];
-    record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    match __v_5.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_134] = [__v_0];
+        record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = G::from_u64(1);
+        let __v_20: G = (__v_4 + __v_19);
+        let __v_21: G = G::from_u64(1);
+        let __v_22: G = (__v_5 - __v_21);
+        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __ret: [G; OUT_134] = [__v_23];
+        record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
@@ -11729,24 +11748,27 @@ fn aiur_fn_135(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
-        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = G::from_u64(1);
-        let __v_20: G = (__v_4 + __v_19);
+        let __v_18: G = G::from_u64(0);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
         let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_5 - __v_21);
-        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-        let __v_23: G = __r_arr[0];
-        let __ret: [G; OUT_135] = [__v_23];
+        let __v_22: G = (__v_4 + __v_21);
+        let __v_23: G = G::from_u64(1);
+        let __v_24: G = (__v_5 - __v_23);
+        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __ret: [G; OUT_135] = [__v_25];
         record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -11754,9 +11776,9 @@ fn aiur_fn_135(
   })
 }
 
-const INPUT_SIZE_136: usize = 12;
-const IN_136: usize = 12;
-const OUT_136: usize = 2;
+const INPUT_SIZE_136: usize = 15;
+const IN_136: usize = 15;
+const OUT_136: usize = 1;
 fn aiur_fn_136(
   inp: [G; IN_136],
   record: &mut QueryRecord,
@@ -11776,34 +11798,59 @@ fn aiur_fn_136(
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
     match __v_5.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_136] = [__v_0, __v_4];
+        let __ret: [G; OUT_136] = [__v_0];
         record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __v_15: G = G::from_u64(0);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_3, __v_1, __v_2, __v_6, __v_7, __v_13, __v_16, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = G::from_u64(1);
-        let __v_19: G = (__v_4 + __v_18);
-        let __v_20: G = G::from_u64(1);
-        let __v_21: G = (__v_5 - __v_20);
-        let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_17, __v_1, __v_2, __v_3, __v_19, __v_21, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-        let __v_22: G = __r_arr[0];
-        let __v_23: G = __r_arr[1];
-        let __ret: [G; OUT_136] = [__v_22, __v_23];
-        record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __v_16: G = __r_arr[1];
+        match __v_15.as_canonical_u64() {
+          0u64 => {
+            let __v_17: G = G::from_u64(1);
+            let __v_18: G = (__v_4 + __v_17);
+            let __v_19: G = G::from_u64(1);
+            let __v_20: G = (__v_5 - __v_19);
+            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __ret: [G; OUT_136] = [__v_21];
+            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_17: G = __r_arr[0];
+            let __v_18: G = (__v_17 + __v_3);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+            let __v_22: G = __r_arr[0];
+            let __v_23: G = G::from_u64(1);
+            let __v_24: G = (__v_4 + __v_23);
+            let __v_25: G = G::from_u64(1);
+            let __v_26: G = (__v_5 - __v_25);
+            let __v_27: G = G::from_u64(1);
+            let __v_28: G = (__v_6 + __v_27);
+            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_136] = [__v_29];
+            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
+          },
+        }
       },
     }
   })
@@ -11834,54 +11881,57 @@ fn aiur_fn_137(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    match __v_5.as_canonical_u64() {
+    match __v_3.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_137] = [__v_0];
         record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        let __v_17: G = __r_arr[2];
-        let __v_18: G = __r_arr[3];
-        let __v_19: G = __r_arr[4];
-        let __v_20: G = __r_arr[5];
-        let __v_21: G = __r_arr[6];
-        let __v_22: G = __r_arr[7];
-        let __v_23: G = __r_arr[8];
-        let __v_24: G = __r_arr[9];
-        let __v_25: G = __r_arr[10];
-        let __v_26: G = __r_arr[11];
-        match __v_15.as_canonical_u64() {
+      1u64 => {
+        let __v_15: G = G::from_u64(3);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __v_17: G = __r_arr[1];
+        match __v_16.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
-            let __v_27: G = __r_arr[0];
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-            let __v_28: G = __r_arr[0];
-            let __v_29: G = (__v_28 + __v_3);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_2, __v_29, __v_6, __v_27, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_30: G = __r_arr[0];
-            let __v_31: G = __r_arr[1];
-            let __v_32: G = G::from_u64(1);
-            let __v_33: G = (__v_4 + __v_32);
-            let __v_34: G = G::from_u64(1);
-            let __v_35: G = (__v_5 - __v_34);
-            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_30, __v_1, __v_2, __v_3, __v_33, __v_35, __v_31, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-            let __v_36: G = __r_arr[0];
-            let __ret: [G; OUT_137] = [__v_36];
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __v_18: G = __r_arr[0];
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __v_20: G = (__v_18 - __v_19);
+            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+            let __v_22: G = G::from_u64(1);
+            if (__v_21 != __v_22) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+            }
+            let __v_23: G = G::from_u64(0);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __v_24: G = __r_arr[0];
+            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+            let __v_25: G = __r_arr[0];
+            let __v_26: G = G::from_u64(1);
+            if (__v_25 != __v_26) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
+            }
+            let __v_27: G = G::from_u64(0);
+            let __v_28: G = G::from_u64(0);
+            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_137] = [__v_29];
             record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
     }
   })
 }
 
-const INPUT_SIZE_138: usize = 15;
-const IN_138: usize = 15;
+const INPUT_SIZE_138: usize = 4;
+const IN_138: usize = 4;
 const OUT_138: usize = 1;
 fn aiur_fn_138(
   inp: [G; IN_138],
@@ -11894,74 +11944,37 @@ fn aiur_fn_138(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    match __v_5.as_canonical_u64() {
+    match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_138] = [__v_0];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_138] = [__v_6];
         record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        match __v_15.as_canonical_u64() {
-          0u64 => {
-            let __v_17: G = G::from_u64(1);
-            let __v_18: G = (__v_4 + __v_17);
-            let __v_19: G = G::from_u64(1);
-            let __v_20: G = (__v_5 - __v_19);
-            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __ret: [G; OUT_138] = [__v_21];
-            record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-            let __v_17: G = __r_arr[0];
-            let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-            let __v_22: G = __r_arr[0];
-            let __v_23: G = G::from_u64(1);
-            let __v_24: G = (__v_4 + __v_23);
-            let __v_25: G = G::from_u64(1);
-            let __v_26: G = (__v_5 - __v_25);
-            let __v_27: G = G::from_u64(1);
-            let __v_28: G = (__v_6 + __v_27);
-            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_138] = [__v_29];
-            record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-          },
-        }
+        let __v_4: G = G::from_u64(0);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_5 + __v_1);
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_2 - __v_7);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_3 + __v_9);
+        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_138] = [__v_12];
+        record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_139: usize = 15;
-const IN_139: usize = 15;
+const INPUT_SIZE_139: usize = 5;
+const IN_139: usize = 5;
 const OUT_139: usize = 1;
 fn aiur_fn_139(
   inp: [G; IN_139],
@@ -11975,199 +11988,17 @@ fn aiur_fn_139(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_139] = [__v_0];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_139] = [__v_7];
         record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      1u64 => {
-        let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        match __v_16.as_canonical_u64() {
-          _ => {
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-            let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __v_20: G = (__v_18 - __v_19);
-            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-            let __v_22: G = G::from_u64(1);
-            if (__v_21 != __v_22) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-            }
-            let __v_23: G = G::from_u64(0);
-            let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
-            let __v_24: G = __r_arr[0];
-            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __v_26: G = G::from_u64(1);
-            if (__v_25 != __v_26) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
-            }
-            let __v_27: G = G::from_u64(0);
-            let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_139] = [__v_29];
-            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_140: usize = 4;
-const IN_140: usize = 4;
-const OUT_140: usize = 1;
-fn aiur_fn_140(
-  inp: [G; IN_140],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_140], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_140] = [__v_6];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_5 + __v_1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_2 - __v_7);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_3 + __v_9);
-        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_140] = [__v_12];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_141: usize = 5;
-const IN_141: usize = 5;
-const OUT_141: usize = 1;
-fn aiur_fn_141(
-  inp: [G; IN_141],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_141], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_141] = [__v_7];
-        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        let __v_7: G = __r_arr[2];
-        let __v_8: G = __r_arr[3];
-        let __v_9: G = __r_arr[4];
-        let __v_10: G = __r_arr[5];
-        let __v_11: G = __r_arr[6];
-        let __v_12: G = __r_arr[7];
-        let __v_13: G = __r_arr[8];
-        let __v_14: G = __r_arr[9];
-        let __v_15: G = __r_arr[10];
-        let __v_16: G = __r_arr[11];
-        match __v_5.as_canonical_u64() {
-          _ => {
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-            let __v_17: G = __r_arr[0];
-            let __v_18: G = (__v_17 + __v_2);
-            let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = G::from_u64(1);
-            let __v_22: G = (__v_3 - __v_21);
-            let __v_23: G = G::from_u64(1);
-            let __v_24: G = (__v_4 + __v_23);
-            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_0, __v_1, __v_2, __v_22, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_20, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
-            let __v_26: G = __r_arr[0];
-            let __ret: [G; OUT_141] = [__v_26];
-            record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_142: usize = 5;
-const IN_142: usize = 5;
-const OUT_142: usize = 1;
-fn aiur_fn_142(
-  inp: [G; IN_142],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_142], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_142] = [__v_7];
-        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         match __v_5.as_canonical_u64() {
@@ -12176,26 +12007,26 @@ fn aiur_fn_142(
             let __v_8: G = (__v_3 - __v_7);
             let __v_9: G = G::from_u64(1);
             let __v_10: G = (__v_4 + __v_9);
-            let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
             let __v_11: G = __r_arr[0];
-            let __ret: [G; OUT_142] = [__v_11];
-            record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_139] = [__v_11];
+            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
             let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = (__v_8 + __v_1);
             let __v_10: G = G::from_u64(1);
             let __v_11: G = (__v_3 - __v_10);
             let __v_12: G = G::from_u64(1);
             let __v_13: G = (__v_4 + __v_12);
-            let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
             let __v_14: G = __r_arr[0];
             let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_142] = [__v_15];
-            record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_139] = [__v_15];
+            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -12207,15 +12038,15 @@ fn aiur_fn_142(
   })
 }
 
-const INPUT_SIZE_143: usize = 5;
-const IN_143: usize = 5;
-const OUT_143: usize = 4;
-fn aiur_fn_143(
-  inp: [G; IN_143],
+const INPUT_SIZE_140: usize = 5;
+const IN_140: usize = 5;
+const OUT_140: usize = 4;
+fn aiur_fn_140(
+  inp: [G; IN_140],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_143], ExecError> {
+) -> Result<[G; OUT_140], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12224,28 +12055,28 @@ fn aiur_fn_143(
     let __v_4: G = inp[4];
     match __v_0.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_143] = [__v_1, __v_2, __v_3, __v_4];
-        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_140] = [__v_1, __v_2, __v_3, __v_4];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __ret: [G; OUT_143] = [__v_3, __v_4, __v_1, __v_2];
-        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_140] = [__v_3, __v_4, __v_1, __v_2];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_144: usize = 4;
-const IN_144: usize = 4;
-const OUT_144: usize = 1;
-fn aiur_fn_144(
-  inp: [G; IN_144],
+const INPUT_SIZE_141: usize = 4;
+const IN_141: usize = 4;
+const OUT_141: usize = 1;
+fn aiur_fn_141(
+  inp: [G; IN_141],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_144], ExecError> {
+) -> Result<[G; OUT_141], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12298,21 +12129,21 @@ fn aiur_fn_144(
     let __v_44: G = { let __values: [G; 10] = [__v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_43]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_45: G = { let __values: [G; 10] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_44]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_46: G = { let __values: [G; 10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_45]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_144] = [__v_46];
-    record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_141] = [__v_46];
+    record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_145: usize = 6;
-const IN_145: usize = 6;
-const OUT_145: usize = 3;
-fn aiur_fn_145(
-  inp: [G; IN_145],
+const INPUT_SIZE_142: usize = 6;
+const IN_142: usize = 6;
+const OUT_142: usize = 3;
+fn aiur_fn_142(
+  inp: [G; IN_142],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_145], ExecError> {
+) -> Result<[G; OUT_142], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12330,8 +12161,8 @@ fn aiur_fn_145(
     let __v_12: G = __loaded[6];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_145] = [__v_0, __v_1, __v_5];
-        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
+        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12342,7 +12173,7 @@ fn aiur_fn_145(
             match __v_14.as_canonical_u64() {
               1u64 => {
                 let __v_15: G = G::from_u64(1);
-                let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
                 let __v_16: G = __r_arr[0];
                 let __v_17: G = __r_arr[1];
                 let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_16, __v_17, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -12351,13 +12182,13 @@ fn aiur_fn_145(
                 let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 let __v_21: G = __r_arr[1];
-                let __ret: [G; OUT_145] = [__v_20, __v_21, __v_12];
-                record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_142] = [__v_20, __v_21, __v_12];
+                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __ret: [G; OUT_145] = [__v_0, __v_1, __v_5];
-                record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
+                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -12371,15 +12202,15 @@ fn aiur_fn_145(
   })
 }
 
-const INPUT_SIZE_146: usize = 9;
-const IN_146: usize = 9;
-const OUT_146: usize = 2;
-fn aiur_fn_146(
-  inp: [G; IN_146],
+const INPUT_SIZE_143: usize = 9;
+const IN_143: usize = 9;
+const OUT_143: usize = 2;
+fn aiur_fn_143(
+  inp: [G; IN_143],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_146], ExecError> {
+) -> Result<[G; OUT_143], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12404,14 +12235,14 @@ fn aiur_fn_146(
         if (__v_15 != __v_16) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_15.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_146] = [__v_0, __v_1];
-        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_143] = [__v_0, __v_1];
+        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12439,10 +12270,10 @@ fn aiur_fn_146(
                         let __v_24: G = G::from_u64(1);
                         let __v_25: G = (__v_6 - __v_24);
                         let __v_26: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                         let __v_27: G = __r_arr[0];
                         let __v_28: G = __r_arr[1];
-                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
                         let __v_29: G = __r_arr[0];
                         let __v_30: G = __r_arr[1];
                         let __v_31: G = __r_arr[2];
@@ -12450,18 +12281,18 @@ fn aiur_fn_146(
                         let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
                         let __v_33: G = __r_arr[0];
                         let __v_34: G = __r_arr[1];
-                        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = __r_arr[1];
                         let __v_37: G = __r_arr[2];
-                        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
                         let __v_39: G = G::from_u64(1);
                         if (__v_38 != __v_39) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_38.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
                         }
                         let __v_40: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                         let __v_41: G = __r_arr[0];
                         let __v_42: G = G::from_u64(1);
                         let __v_43: G = G::from_u64(1);
@@ -12478,11 +12309,11 @@ fn aiur_fn_146(
                         if (__v_51 != __v_52) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_51.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
                         }
-                        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
                         let __v_53: G = __r_arr[0];
                         let __v_54: G = __r_arr[1];
-                        let __ret: [G; OUT_146] = [__v_53, __v_54];
-                        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_143] = [__v_53, __v_54];
+                        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                       _ => {
@@ -12509,15 +12340,15 @@ fn aiur_fn_146(
   })
 }
 
-const INPUT_SIZE_147: usize = 26;
-const IN_147: usize = 26;
-const OUT_147: usize = 1;
-fn aiur_fn_147(
-  inp: [G; IN_147],
+const INPUT_SIZE_144: usize = 25;
+const IN_144: usize = 25;
+const OUT_144: usize = 1;
+fn aiur_fn_144(
+  inp: [G; IN_144],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_147], ExecError> {
+) -> Result<[G; OUT_144], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12544,156 +12375,152 @@ fn aiur_fn_147(
     let __v_22: G = inp[22];
     let __v_23: G = inp[23];
     let __v_24: G = inp[24];
-    let __v_25: G = inp[25];
     match __v_1.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_16, __v_20, __v_19, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
-        let __v_26: G = __r_arr[0];
-        let __v_27: G = G::from_u64(0);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_1, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_28: G = __r_arr[0];
-        let __v_29: G = __r_arr[1];
-        match __v_28.as_canonical_u64() {
+        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __v_26: G = G::from_u64(0);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_27: G = __r_arr[0];
+        let __v_28: G = __r_arr[1];
+        match __v_27.as_canonical_u64() {
           _ => {
-            let __v_30: G = G::from_u64(0);
-            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_26, __v_0, __v_21, __v_20, __v_30, __v_19, __v_16, __v_17, __v_18, __v_28, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-            let __v_31: G = __r_arr[0];
-            let __v_32: G = G::from_u64(1);
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_1, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-            let __v_33: G = __r_arr[0];
-            let __v_34: G = __r_arr[1];
-            match __v_33.as_canonical_u64() {
+            let __v_29: G = G::from_u64(0);
+            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+            let __v_30: G = __r_arr[0];
+            let __v_31: G = G::from_u64(1);
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __v_32: G = __r_arr[0];
+            let __v_33: G = __r_arr[1];
+            match __v_32.as_canonical_u64() {
               _ => {
-                let __v_35: G = G::from_u64(0);
-                let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_31, __v_0, __v_21, __v_20, __v_35, __v_19, __v_16, __v_17, __v_18, __v_33, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-                let __v_36: G = __r_arr[0];
-                let __v_37: G = G::from_u64(2);
-                let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-                let __v_38: G = __r_arr[0];
-                let __v_39: G = __r_arr[1];
-                match __v_38.as_canonical_u64() {
+                let __v_34: G = G::from_u64(0);
+                let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+                let __v_35: G = __r_arr[0];
+                let __v_36: G = G::from_u64(2);
+                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                let __v_37: G = __r_arr[0];
+                let __v_38: G = __r_arr[1];
+                match __v_37.as_canonical_u64() {
                   _ => {
-                    let __v_40: G = G::from_u64(0);
-                    let __v_41: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_36, __v_0, __v_21, __v_20, __v_40, __v_19, __v_41, __v_14, __v_16, __v_17, __v_18, __v_38, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                    let __v_39: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+                    let __v_40: G = __r_arr[0];
+                    let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                    let __v_41: G = __r_arr[0];
+                    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
                     let __v_42: G = __r_arr[0];
-                    let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_42, __v_1, __v_13, __v_8, __v_9, __v_15, __v_16, __v_19, __v_0, __v_21, __v_20, __v_17, __v_18, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
-                    let __v_43: G = __r_arr[0];
-                    let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_43, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
-                    let __v_44: G = __r_arr[0];
-                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_43.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-                    let __v_45: G = __loaded[0];
-                    let __v_46: G = __loaded[1];
-                    let __v_47: G = __loaded[2];
-                    let __v_48: G = __loaded[3];
-                    let __v_49: G = __loaded[4];
-                    let __v_50: G = __loaded[5];
-                    let __v_51: G = __loaded[6];
-                    match __v_45.as_canonical_u64() {
+                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+                    let __v_43: G = __loaded[0];
+                    let __v_44: G = __loaded[1];
+                    let __v_45: G = __loaded[2];
+                    let __v_46: G = __loaded[3];
+                    let __v_47: G = __loaded[4];
+                    let __v_48: G = __loaded[5];
+                    let __v_49: G = __loaded[6];
+                    match __v_43.as_canonical_u64() {
                       0u64 => {
-                        match __v_46.as_canonical_u64() {
+                        match __v_44.as_canonical_u64() {
                           _ => {
-                            let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_49, __v_50, __v_22, __v_23, __v_2, __v_0, __v_21, __v_51, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                            let __v_50: G = __r_arr[0];
+                            let __v_51: G = __r_arr[1];
+                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
                             let __v_52: G = __r_arr[0];
-                            let __v_53: G = __r_arr[1];
-                            let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
-                            let __v_54: G = __r_arr[0];
-                            let __v_55: G = (__v_54 - __v_25);
-                            let __v_56: G = G::from_bool((__v_55 == G::ZERO));
-                            let __v_57: G = G::from_u64(1);
-                            if (__v_56 != __v_57) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_56.as_canonical_u64(), rhs: __v_57.as_canonical_u64() });
+                            let __v_53: G = (__v_52 - __v_24);
+                            let __v_54: G = G::from_bool((__v_53 == G::ZERO));
+                            let __v_55: G = G::from_u64(1);
+                            if (__v_54 != __v_55) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                            let __v_56: G = __r_arr[0];
+                            let __v_57: G = G::from_u64(3);
+                            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
                             let __v_58: G = __r_arr[0];
-                            let __v_59: G = G::from_u64(3);
-                            let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-                            let __v_60: G = __r_arr[0];
-                            let __v_61: G = (__v_59 + __v_60);
-                            let __v_62: G = (__v_58 - __v_61);
-                            let __v_63: G = G::from_bool((__v_62 == G::ZERO));
-                            let __v_64: G = G::from_u64(1);
-                            if (__v_63 != __v_64) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_63.as_canonical_u64(), rhs: __v_64.as_canonical_u64() });
+                            let __v_59: G = (__v_57 + __v_58);
+                            let __v_60: G = (__v_56 - __v_59);
+                            let __v_61: G = G::from_bool((__v_60 == G::ZERO));
+                            let __v_62: G = G::from_u64(1);
+                            if (__v_61 != __v_62) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_65: G = __r_arr[0];
-                            let __v_66: G = (__v_65 - __v_19);
-                            let __v_67: G = G::from_bool((__v_66 == G::ZERO));
-                            let __v_68: G = G::from_u64(1);
-                            if (__v_67 != __v_68) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_67.as_canonical_u64(), rhs: __v_68.as_canonical_u64() });
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __v_63: G = __r_arr[0];
+                            let __v_64: G = (__v_63 - __v_18);
+                            let __v_65: G = G::from_bool((__v_64 == G::ZERO));
+                            let __v_66: G = G::from_u64(1);
+                            if (__v_65 != __v_66) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
                             }
-                            let __v_69: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_16, __v_20, __v_19, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
-                            let __v_70: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_28, __v_70, __v_0, __v_29, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __v_67: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                            let __v_68: G = __r_arr[0];
+                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __v_69: G = __r_arr[0];
+                            let __v_70: G = G::from_u64(1);
+                            if (__v_69 != __v_70) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                             let __v_71: G = __r_arr[0];
-                            let __v_72: G = G::from_u64(1);
-                            if (__v_71 != __v_72) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_71.as_canonical_u64(), rhs: __v_72.as_canonical_u64() });
+                            let __v_72: G = (__v_71 - __v_18);
+                            let __v_73: G = G::from_bool((__v_72 == G::ZERO));
+                            let __v_74: G = G::from_u64(1);
+                            if (__v_73 != __v_74) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_73: G = __r_arr[0];
-                            let __v_74: G = (__v_73 - __v_19);
-                            let __v_75: G = G::from_bool((__v_74 == G::ZERO));
-                            let __v_76: G = G::from_u64(1);
-                            if (__v_75 != __v_76) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_75.as_canonical_u64(), rhs: __v_76.as_canonical_u64() });
+                            let __v_75: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                            let __v_76: G = __r_arr[0];
+                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __v_77: G = __r_arr[0];
+                            let __v_78: G = G::from_u64(1);
+                            if (__v_77 != __v_78) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
                             }
-                            let __v_77: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_16, __v_20, __v_19, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
-                            let __v_78: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_11, __v_33, __v_78, __v_0, __v_34, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                             let __v_79: G = __r_arr[0];
-                            let __v_80: G = G::from_u64(1);
-                            if (__v_79 != __v_80) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_79.as_canonical_u64(), rhs: __v_80.as_canonical_u64() });
+                            let __v_80: G = (__v_79 - __v_18);
+                            let __v_81: G = G::from_bool((__v_80 == G::ZERO));
+                            let __v_82: G = G::from_u64(1);
+                            if (__v_81 != __v_82) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_81: G = __r_arr[0];
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_82: G = __r_arr[0];
-                            let __v_83: G = (__v_81 - __v_82);
-                            let __v_84: G = G::from_bool((__v_83 == G::ZERO));
-                            let __v_85: G = G::from_u64(1);
-                            if (__v_84 != __v_85) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_84.as_canonical_u64(), rhs: __v_85.as_canonical_u64() });
+                            let __v_83: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                            let __v_84: G = __r_arr[0];
+                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __v_85: G = __r_arr[0];
+                            let __v_86: G = G::from_u64(1);
+                            if (__v_85 != __v_86) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64() });
                             }
-                            let __v_86: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_14, __v_16, __v_20, __v_19, __v_86]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
-                            let __v_87: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_12, __v_38, __v_87, __v_0, __v_39, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-                            let __v_88: G = __r_arr[0];
+                            let __v_87: G = (__v_44 - __v_20);
+                            let __v_88: G = G::from_bool((__v_87 == G::ZERO));
                             let __v_89: G = G::from_u64(1);
                             if (__v_88 != __v_89) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
                             }
-                            let __v_90: G = (__v_46 - __v_21);
-                            let __v_91: G = G::from_bool((__v_90 == G::ZERO));
-                            let __v_92: G = G::from_u64(1);
-                            if (__v_91 != __v_92) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_91.as_canonical_u64(), rhs: __v_92.as_canonical_u64() });
+                            let __v_90: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                            let __v_91: G = __r_arr[0];
+                            let __v_92: G = __r_arr[1];
+                            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
+                            let __v_93: G = __r_arr[0];
+                            let __v_94: G = G::from_u64(1);
+                            if (__v_93 != __v_94) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
                             }
-                            let __v_93: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_24, __v_93]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-                            let __v_94: G = __r_arr[0];
-                            let __v_95: G = __r_arr[1];
-                            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_94, __v_95, __v_52, __v_53]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
-                            let __v_96: G = __r_arr[0];
-                            let __v_97: G = G::from_u64(1);
-                            if (__v_96 != __v_97) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_96.as_canonical_u64(), rhs: __v_97.as_canonical_u64() });
-                            }
-                            let __v_98: G = G::from_u64(1);
-                            let __ret: [G; OUT_147] = [__v_98];
-                            record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __v_95: G = G::from_u64(1);
+                            let __ret: [G; OUT_144] = [__v_95];
+                            record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        return Err(ExecError::MatchNoCase(__v_45.as_canonical_u64()));
+                        return Err(ExecError::MatchNoCase(__v_43.as_canonical_u64()));
                       },
                     }
                   },
@@ -12707,15 +12534,15 @@ fn aiur_fn_147(
   })
 }
 
-const INPUT_SIZE_148: usize = 26;
-const IN_148: usize = 26;
-const OUT_148: usize = 1;
-fn aiur_fn_148(
-  inp: [G; IN_148],
+const INPUT_SIZE_145: usize = 25;
+const IN_145: usize = 25;
+const OUT_145: usize = 1;
+fn aiur_fn_145(
+  inp: [G; IN_145],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_148], ExecError> {
+) -> Result<[G; OUT_145], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12742,48 +12569,47 @@ fn aiur_fn_148(
     let __v_22: G = inp[22];
     let __v_23: G = inp[23];
     let __v_24: G = inp[24];
-    let __v_25: G = inp[25];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_26: G = __loaded[0];
-    let __v_27: G = __loaded[1];
-    let __v_28: G = __loaded[2];
-    let __v_29: G = __loaded[3];
-    match __v_26.as_canonical_u64() {
+    let __v_25: G = __loaded[0];
+    let __v_26: G = __loaded[1];
+    let __v_27: G = __loaded[2];
+    let __v_28: G = __loaded[3];
+    match __v_25.as_canonical_u64() {
       1u64 => {
-        let __v_30: G = G::from_u64(1);
-        let __ret: [G; OUT_148] = [__v_30];
-        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_29: G = G::from_u64(1);
+        let __ret: [G; OUT_145] = [__v_29];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_1, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
-        let __v_30: G = __r_arr[0];
-        let __v_31: G = __r_arr[1];
-        let __v_32: G = __r_arr[2];
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_30, __v_27, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_29: G = __r_arr[0];
+        let __v_30: G = __r_arr[1];
+        let __v_31: G = __r_arr[2];
+        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+        let __v_32: G = __r_arr[0];
+        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
         let __v_33: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_31, __v_32, __v_29, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-        let __v_34: G = __r_arr[0];
-        let __ret: [G; OUT_148] = [__v_34];
-        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_145] = [__v_33];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_26.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_25.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_149: usize = 32;
-const IN_149: usize = 32;
-const OUT_149: usize = 1;
-fn aiur_fn_149(
-  inp: [G; IN_149],
+const INPUT_SIZE_146: usize = 31;
+const IN_146: usize = 31;
+const OUT_146: usize = 1;
+fn aiur_fn_146(
+  inp: [G; IN_146],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_149], ExecError> {
+) -> Result<[G; OUT_146], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12816,128 +12642,127 @@ fn aiur_fn_149(
     let __v_28: G = inp[28];
     let __v_29: G = inp[29];
     let __v_30: G = inp[30];
-    let __v_31: G = inp[31];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-        let __v_32: G = __r_arr[0];
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __v_31: G = __r_arr[0];
+        let __v_32: G = G::from_u64(1);
         let __v_33: G = G::from_u64(1);
-        let __v_34: G = G::from_u64(1);
-        let __v_35: G = { let __values: [G; 3] = [__v_33, __v_34, __v_34]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __v_34: G = { let __values: [G; 3] = [__v_32, __v_33, __v_33]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __v_35: G = __r_arr[0];
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
-        let __v_40: G = __r_arr[0];
+        let __v_40: G = G::from_u64(1);
         let __v_41: G = G::from_u64(1);
-        let __v_42: G = G::from_u64(1);
-        let __v_43: G = { let __values: [G; 3] = [__v_41, __v_42, __v_42]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
-        let __v_44: G = __r_arr[0];
-        let __v_45: G = __r_arr[1];
-        let __v_46: G = __r_arr[2];
-        let __v_47: G = __r_arr[3];
-        let __v_48: G = __r_arr[4];
-        let __v_49: G = __r_arr[5];
-        let __v_50: G = __r_arr[6];
-        let __v_51: G = __r_arr[7];
-        let __v_52: G = __r_arr[8];
-        let __v_53: G = __r_arr[9];
-        let __v_54: G = __r_arr[10];
-        let __v_55: G = __r_arr[11];
-        let __v_56: G = __r_arr[12];
-        let __v_57: G = __r_arr[13];
-        let __v_58: G = __r_arr[14];
-        let __v_59: G = __r_arr[15];
-        let __v_60: G = __r_arr[16];
-        let __v_61: G = __r_arr[17];
-        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
+        let __v_42: G = { let __values: [G; 3] = [__v_40, __v_41, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+        let __v_43: G = __r_arr[0];
+        let __v_44: G = __r_arr[1];
+        let __v_45: G = __r_arr[2];
+        let __v_46: G = __r_arr[3];
+        let __v_47: G = __r_arr[4];
+        let __v_48: G = __r_arr[5];
+        let __v_49: G = __r_arr[6];
+        let __v_50: G = __r_arr[7];
+        let __v_51: G = __r_arr[8];
+        let __v_52: G = __r_arr[9];
+        let __v_53: G = __r_arr[10];
+        let __v_54: G = __r_arr[11];
+        let __v_55: G = __r_arr[12];
+        let __v_56: G = __r_arr[13];
+        let __v_57: G = __r_arr[14];
+        let __v_58: G = __r_arr[15];
+        let __v_59: G = __r_arr[16];
+        let __v_60: G = __r_arr[17];
+        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
+        let __v_61: G = __r_arr[0];
+        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_62: G = __r_arr[0];
-        let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
         let __v_63: G = __r_arr[0];
-        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_60, __v_6, __v_7, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
-        let __v_64: G = __r_arr[0];
-        let __v_65: G = __r_arr[1];
+        let __v_64: G = __r_arr[1];
+        let __v_65: G = G::from_u64(1);
         let __v_66: G = G::from_u64(1);
-        let __v_67: G = G::from_u64(1);
-        let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __v_68: G = __r_arr[0];
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_70, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
-        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_71, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
-        let __v_72: G = __r_arr[0];
-        let __v_73: G = __r_arr[1];
-        let __v_74: G = (__v_32 + __v_28);
-        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
-        let __v_75: G = __r_arr[0];
-        let __v_76: G = (__v_75 - __v_32);
-        let __v_77: G = G::from_bool((__v_76 == G::ZERO));
-        let __v_78: G = G::from_u64(1);
-        if (__v_77 != __v_78) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
+        let __v_72: G = __r_arr[1];
+        let __v_73: G = (__v_31 + __v_27);
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __v_74: G = __r_arr[0];
+        let __v_75: G = (__v_74 - __v_31);
+        let __v_76: G = G::from_bool((__v_75 == G::ZERO));
+        let __v_77: G = G::from_u64(1);
+        if (__v_76 != __v_77) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-        let __v_79: G = __r_arr[0];
-        let __v_80: G = (__v_79 - __v_29);
-        let __v_81: G = G::from_bool((__v_80 == G::ZERO));
-        let __v_82: G = G::from_u64(1);
-        if (__v_81 != __v_82) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __v_78: G = __r_arr[0];
+        let __v_79: G = (__v_78 - __v_28);
+        let __v_80: G = G::from_bool((__v_79 == G::ZERO));
+        let __v_81: G = G::from_u64(1);
+        if (__v_80 != __v_81) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-        let __v_83: G = __r_arr[0];
-        let __v_84: G = G::from_u64(1);
-        if (__v_83 != __v_84) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_83.as_canonical_u64(), rhs: __v_84.as_canonical_u64() });
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __v_82: G = __r_arr[0];
+        let __v_83: G = G::from_u64(1);
+        if (__v_82 != __v_83) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_82.as_canonical_u64(), rhs: __v_83.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_72, __v_73, __v_8, __v_62, __v_63, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_74, __v_64, __v_6, __v_9, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-        let __v_85: G = __r_arr[0];
-        let __ret: [G; OUT_149] = [__v_85];
-        record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+        let __v_84: G = __r_arr[0];
+        let __ret: [G; OUT_146] = [__v_84];
+        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_150: usize = 2;
-const IN_150: usize = 2;
-const OUT_150: usize = 1;
-fn aiur_fn_150(
-  inp: [G; IN_150],
+const INPUT_SIZE_147: usize = 2;
+const IN_147: usize = 2;
+const OUT_147: usize = 1;
+fn aiur_fn_147(
+  inp: [G; IN_147],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_150], ExecError> {
+) -> Result<[G; OUT_147], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_bool((__v_0 == G::ZERO));
     let __v_3: G = G::from_bool((__v_1 == G::ZERO));
     let __v_4: G = (__v_2 * __v_3);
-    let __ret: [G; OUT_150] = [__v_4];
-    record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_147] = [__v_4];
+    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_151: usize = 1;
-const IN_151: usize = 1;
-const OUT_151: usize = 1;
-fn aiur_fn_151(
-  inp: [G; IN_151],
+const INPUT_SIZE_148: usize = 1;
+const IN_148: usize = 1;
+const OUT_148: usize = 1;
+fn aiur_fn_148(
+  inp: [G; IN_148],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_151], ExecError> {
+) -> Result<[G; OUT_148], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -12948,8 +12773,8 @@ fn aiur_fn_151(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_151] = [__v_5];
-        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_148] = [__v_5];
+        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12960,17 +12785,17 @@ fn aiur_fn_151(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           1u64 => {
-            let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_151] = [__v_9];
-            record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_148] = [__v_9];
+            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_151] = [__v_9];
-            record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_148] = [__v_9];
+            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -12982,15 +12807,15 @@ fn aiur_fn_151(
   })
 }
 
-const INPUT_SIZE_152: usize = 9;
-const IN_152: usize = 9;
-const OUT_152: usize = 1;
-fn aiur_fn_152(
-  inp: [G; IN_152],
+const INPUT_SIZE_149: usize = 9;
+const IN_149: usize = 9;
+const OUT_149: usize = 1;
+fn aiur_fn_149(
+  inp: [G; IN_149],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_152], ExecError> {
+) -> Result<[G; OUT_149], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13017,21 +12842,21 @@ fn aiur_fn_152(
     let __v_22: G = { let __values: [G; 3] = [__v_11, __v_2, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_23: G = { let __values: [G; 3] = [__v_10, __v_1, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_24: G = { let __values: [G; 3] = [__v_9, __v_0, __v_23]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_152] = [__v_24];
-    record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_149] = [__v_24];
+    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_153: usize = 33;
-const IN_153: usize = 33;
-const OUT_153: usize = 1;
-fn aiur_fn_153(
-  inp: [G; IN_153],
+const INPUT_SIZE_150: usize = 33;
+const IN_150: usize = 33;
+const OUT_150: usize = 1;
+fn aiur_fn_150(
+  inp: [G; IN_150],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_153], ExecError> {
+) -> Result<[G; OUT_150], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13066,29 +12891,29 @@ fn aiur_fn_153(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __ret: [G; OUT_153] = [__v_36];
-    record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_150] = [__v_36];
+    record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_154: usize = 2;
-const IN_154: usize = 2;
-const OUT_154: usize = 1;
-fn aiur_fn_154(
-  inp: [G; IN_154],
+const INPUT_SIZE_151: usize = 2;
+const IN_151: usize = 2;
+const OUT_151: usize = 1;
+fn aiur_fn_151(
+  inp: [G; IN_151],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_154], ExecError> {
+) -> Result<[G; OUT_151], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13129,17 +12954,17 @@ fn aiur_fn_154(
     let __v_35: G = __loaded[33];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_154] = [__v_1];
-        record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_151] = [__v_1];
+        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __ret: [G; OUT_154] = [__v_37];
-        record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_151] = [__v_37];
+        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13149,15 +12974,15 @@ fn aiur_fn_154(
   })
 }
 
-const INPUT_SIZE_155: usize = 2;
-const IN_155: usize = 2;
-const OUT_155: usize = 1;
-fn aiur_fn_155(
-  inp: [G; IN_155],
+const INPUT_SIZE_152: usize = 2;
+const IN_152: usize = 2;
+const OUT_152: usize = 1;
+fn aiur_fn_152(
+  inp: [G; IN_152],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_155], ExecError> {
+) -> Result<[G; OUT_152], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13167,8 +12992,8 @@ fn aiur_fn_155(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_155] = [__v_1];
-        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_152] = [__v_1];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -13179,12 +13004,12 @@ fn aiur_fn_155(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_155] = [__v_13];
-        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_152] = [__v_13];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13194,15 +13019,15 @@ fn aiur_fn_155(
   })
 }
 
-const INPUT_SIZE_156: usize = 2;
-const IN_156: usize = 2;
-const OUT_156: usize = 3;
-fn aiur_fn_156(
-  inp: [G; IN_156],
+const INPUT_SIZE_153: usize = 2;
+const IN_153: usize = 2;
+const OUT_153: usize = 3;
+fn aiur_fn_153(
+  inp: [G; IN_153],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_156], ExecError> {
+) -> Result<[G; OUT_153], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13212,8 +13037,8 @@ fn aiur_fn_156(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_156] = [__v_3, __v_0, __v_4];
-        record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_153] = [__v_3, __v_0, __v_4];
+        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -13266,8 +13091,8 @@ fn aiur_fn_156(
         let __v_47: G = __loaded[2];
         match __v_45.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_156] = [__v_46, __v_40, __v_47];
-            record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_153] = [__v_46, __v_40, __v_47];
+            record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -13282,69 +13107,69 @@ fn aiur_fn_156(
   })
 }
 
-const INPUT_SIZE_157: usize = 2;
-const IN_157: usize = 2;
-const OUT_157: usize = 10;
-fn aiur_fn_157(
-  inp: [G; IN_157],
+const INPUT_SIZE_154: usize = 2;
+const IN_154: usize = 2;
+const OUT_154: usize = 10;
+fn aiur_fn_154(
+  inp: [G; IN_154],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_157], ExecError> {
+) -> Result<[G; OUT_154], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
     let __v_7: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
     let __v_10: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
     let __v_12: G = __r_arr[1];
     let __v_13: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
     let __v_15: G = __r_arr[1];
     let __v_16: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
     let __v_18: G = __r_arr[1];
     let __v_19: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = __r_arr[2];
-    let __ret: [G; OUT_157] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
-    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_154] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
+    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_158: usize = 2;
-const IN_158: usize = 2;
-const OUT_158: usize = 10;
-fn aiur_fn_158(
-  inp: [G; IN_158],
+const INPUT_SIZE_155: usize = 2;
+const IN_155: usize = 2;
+const OUT_155: usize = 10;
+fn aiur_fn_155(
+  inp: [G; IN_155],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_158], ExecError> {
+) -> Result<[G; OUT_155], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13359,12 +13184,12 @@ fn aiur_fn_158(
     let __v_12: G = __r_arr[0];
     match __v_12.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_158] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = __r_arr[2];
@@ -13375,27 +13200,27 @@ fn aiur_fn_158(
         let __v_20: G = __r_arr[7];
         let __v_21: G = __r_arr[8];
         let __v_22: G = __r_arr[9];
-        let __ret: [G; OUT_158] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
-        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_155] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
+        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_159: usize = 2;
-const IN_159: usize = 2;
-const OUT_159: usize = 18;
-fn aiur_fn_159(
-  inp: [G; IN_159],
+const INPUT_SIZE_156: usize = 2;
+const IN_156: usize = 2;
+const OUT_156: usize = 18;
+fn aiur_fn_156(
+  inp: [G; IN_156],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_159], ExecError> {
+) -> Result<[G; OUT_156], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13406,7 +13231,7 @@ fn aiur_fn_159(
     let __v_9: G = __r_arr[7];
     let __v_10: G = __r_arr[8];
     let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = __r_arr[1];
     let __v_14: G = __r_arr[2];
@@ -13417,21 +13242,21 @@ fn aiur_fn_159(
     let __v_19: G = __r_arr[7];
     let __v_20: G = __r_arr[8];
     let __v_21: G = __r_arr[9];
-    let __ret: [G; OUT_159] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
-    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_156] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
+    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_160: usize = 8;
-const IN_160: usize = 8;
-const OUT_160: usize = 1;
-fn aiur_fn_160(
-  inp: [G; IN_160],
+const INPUT_SIZE_157: usize = 8;
+const IN_157: usize = 8;
+const OUT_157: usize = 1;
+fn aiur_fn_157(
+  inp: [G; IN_157],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_160], ExecError> {
+) -> Result<[G; OUT_157], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13516,23 +13341,136 @@ fn aiur_fn_160(
     let __v_72: G = G::from_u64(1);
     let __v_73: G = G::from_u64(1);
     let __v_74: G = { let __values: [G; 3] = [__v_72, __v_73, __v_73]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_76: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_77: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_78: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_80: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_82: G = __r_arr[0];
-    let __ret: [G; OUT_160] = [__v_82];
+    let __ret: [G; OUT_157] = [__v_82];
+    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_158: usize = 2;
+const IN_158: usize = 2;
+const OUT_158: usize = 1;
+fn aiur_fn_158(
+  inp: [G; IN_158],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_158], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_158] = [__v_4];
+        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_2: G = __loaded[0];
+        let __v_3: G = __loaded[1];
+        let __v_4: G = __loaded[2];
+        match __v_2.as_canonical_u64() {
+          0u64 => {
+            let __v_5: G = G::from_u64(0);
+            let __v_6: G = G::from_u64(1);
+            let __v_7: G = (__v_1 - __v_6);
+            let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_158] = [__v_9];
+            record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_159: usize = 3;
+const IN_159: usize = 3;
+const OUT_159: usize = 3;
+fn aiur_fn_159(
+  inp: [G; IN_159],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_159], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __v_5: G = __r_arr[2];
+    let __v_6: G = __r_arr[3];
+    let __v_7: G = __r_arr[4];
+    let __v_8: G = __r_arr[5];
+    let __v_9: G = __r_arr[6];
+    let __v_10: G = __r_arr[7];
+    let __v_11: G = __r_arr[8];
+    let __v_12: G = __r_arr[9];
+    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+    let __v_13: G = __r_arr[0];
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __ret: [G; OUT_159] = [__v_14, __v_11, __v_12];
+    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_160: usize = 9;
+const IN_160: usize = 9;
+const OUT_160: usize = 1;
+fn aiur_fn_160(
+  inp: [G; IN_160],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_160], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = G::from_u64(1);
+    let __v_10: G = G::from_u64(1);
+    let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __v_13: G = __r_arr[0];
+    let __ret: [G; OUT_160] = [__v_13];
     record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
@@ -13550,141 +13488,28 @@ fn aiur_fn_161(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_161] = [__v_4];
-        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_2: G = __loaded[0];
-        let __v_3: G = __loaded[1];
-        let __v_4: G = __loaded[2];
-        match __v_2.as_canonical_u64() {
-          0u64 => {
-            let __v_5: G = G::from_u64(0);
-            let __v_6: G = G::from_u64(1);
-            let __v_7: G = (__v_1 - __v_6);
-            let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
-            let __v_8: G = __r_arr[0];
-            let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_161] = [__v_9];
-            record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-          },
-        }
-      },
-    }
+    let __v_2: G = G::from_u64(1);
+    let __v_3: G = G::from_u64(1);
+    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __v_6: G = __r_arr[0];
+    let __ret: [G; OUT_161] = [__v_6];
+    record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_162: usize = 3;
-const IN_162: usize = 3;
-const OUT_162: usize = 3;
+const INPUT_SIZE_162: usize = 2;
+const IN_162: usize = 2;
+const OUT_162: usize = 1;
 fn aiur_fn_162(
   inp: [G; IN_162],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_162], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __v_5: G = __r_arr[2];
-    let __v_6: G = __r_arr[3];
-    let __v_7: G = __r_arr[4];
-    let __v_8: G = __r_arr[5];
-    let __v_9: G = __r_arr[6];
-    let __v_10: G = __r_arr[7];
-    let __v_11: G = __r_arr[8];
-    let __v_12: G = __r_arr[9];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
-    let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __ret: [G; OUT_162] = [__v_14, __v_11, __v_12];
-    record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_163: usize = 9;
-const IN_163: usize = 9;
-const OUT_163: usize = 1;
-fn aiur_fn_163(
-  inp: [G; IN_163],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_163], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = G::from_u64(1);
-    let __v_10: G = G::from_u64(1);
-    let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
-    let __v_13: G = __r_arr[0];
-    let __ret: [G; OUT_163] = [__v_13];
-    record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_164: usize = 2;
-const IN_164: usize = 2;
-const OUT_164: usize = 1;
-fn aiur_fn_164(
-  inp: [G; IN_164],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_164], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_u64(1);
-    let __v_3: G = G::from_u64(1);
-    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
-    let __v_6: G = __r_arr[0];
-    let __ret: [G; OUT_164] = [__v_6];
-    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_165: usize = 2;
-const IN_165: usize = 2;
-const OUT_165: usize = 1;
-fn aiur_fn_165(
-  inp: [G; IN_165],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13701,17 +13526,17 @@ fn aiur_fn_165(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_165] = [__v_1];
-        record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_162] = [__v_1];
+        record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_165] = [__v_13];
-        record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_162] = [__v_13];
+        record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13721,15 +13546,15 @@ fn aiur_fn_165(
   })
 }
 
-const INPUT_SIZE_166: usize = 2;
-const IN_166: usize = 2;
-const OUT_166: usize = 1;
-fn aiur_fn_166(
-  inp: [G; IN_166],
+const INPUT_SIZE_163: usize = 2;
+const IN_163: usize = 2;
+const OUT_163: usize = 1;
+fn aiur_fn_163(
+  inp: [G; IN_163],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_166], ExecError> {
+) -> Result<[G; OUT_163], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13739,12 +13564,12 @@ fn aiur_fn_166(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_166] = [__v_1];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_163] = [__v_1];
+        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = __r_arr[2];
@@ -13753,14 +13578,14 @@ fn aiur_fn_166(
         let __v_10: G = __r_arr[5];
         let __v_11: G = __r_arr[6];
         let __v_12: G = __r_arr[7];
-        let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __ret: [G; OUT_166] = [__v_15];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_163] = [__v_15];
+        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13770,19 +13595,19 @@ fn aiur_fn_166(
   })
 }
 
-const INPUT_SIZE_167: usize = 2;
-const IN_167: usize = 2;
-const OUT_167: usize = 1;
-fn aiur_fn_167(
-  inp: [G; IN_167],
+const INPUT_SIZE_164: usize = 2;
+const IN_164: usize = 2;
+const OUT_164: usize = 1;
+fn aiur_fn_164(
+  inp: [G; IN_164],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_167], ExecError> {
+) -> Result<[G; OUT_164], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13791,25 +13616,25 @@ fn aiur_fn_167(
     let __v_7: G = __r_arr[5];
     let __v_8: G = __r_arr[6];
     let __v_9: G = __r_arr[7];
-    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
-    let __ret: [G; OUT_167] = [__v_11];
-    record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_164] = [__v_11];
+    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_168: usize = 1;
-const IN_168: usize = 1;
-const OUT_168: usize = 1;
-fn aiur_fn_168(
-  inp: [G; IN_168],
+const INPUT_SIZE_165: usize = 1;
+const IN_165: usize = 1;
+const OUT_165: usize = 1;
+fn aiur_fn_165(
+  inp: [G; IN_165],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_168], ExecError> {
+) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(0);
@@ -13854,21 +13679,21 @@ fn aiur_fn_168(
     let __v_40: G = { let __values: [G; 3] = [__v_5, __v_6, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_41: G = { let __values: [G; 3] = [__v_3, __v_4, __v_40]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_42: G = { let __values: [G; 3] = [__v_1, __v_2, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_168] = [__v_42];
-    record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_165] = [__v_42];
+    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_169: usize = 2;
-const IN_169: usize = 2;
-const OUT_169: usize = 1;
-fn aiur_fn_169(
-  inp: [G; IN_169],
+const INPUT_SIZE_166: usize = 2;
+const IN_166: usize = 2;
+const OUT_166: usize = 1;
+fn aiur_fn_166(
+  inp: [G; IN_166],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_169], ExecError> {
+) -> Result<[G; OUT_166], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13877,13 +13702,13 @@ fn aiur_fn_169(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 34] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_169] = [__v_4];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_166] = [__v_4];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_166] = [__v_1];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13893,15 +13718,15 @@ fn aiur_fn_169(
   })
 }
 
-const INPUT_SIZE_170: usize = 9;
-const IN_170: usize = 9;
-const OUT_170: usize = 9;
-fn aiur_fn_170(
-  inp: [G; IN_170],
+const INPUT_SIZE_167: usize = 9;
+const IN_167: usize = 9;
+const OUT_167: usize = 9;
+fn aiur_fn_167(
+  inp: [G; IN_167],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_170], ExecError> {
+) -> Result<[G; OUT_167], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13915,24 +13740,24 @@ fn aiur_fn_170(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
-    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
     let __v_19: G = G::from_u64(1);
     let __v_20: G = G::from_u64(1);
     let __v_21: G = { let __values: [G; 3] = [__v_19, __v_20, __v_20]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
     let __v_24: G = __r_arr[2];
@@ -13951,14 +13776,14 @@ fn aiur_fn_170(
     let __v_37: G = __r_arr[15];
     let __v_38: G = __r_arr[16];
     let __v_39: G = __r_arr[17];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = G::from_u64(1);
     let __v_43: G = G::from_u64(1);
     let __v_44: G = { let __values: [G; 3] = [__v_42, __v_43, __v_43]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
     let __v_46: G = __r_arr[1];
     let __v_47: G = __r_arr[2];
@@ -13977,23 +13802,23 @@ fn aiur_fn_170(
     let __v_60: G = __r_arr[15];
     let __v_61: G = __r_arr[16];
     let __v_62: G = __r_arr[17];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_63: G = __r_arr[0];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_64: G = __r_arr[0];
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_65: G = __r_arr[0];
     let __v_66: G = G::from_u64(1);
     let __v_67: G = G::from_u64(1);
     let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
-    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_70: G = __r_arr[0];
     let __v_71: G = G::from_u64(1);
     let __v_72: G = G::from_u64(1);
     let __v_73: G = { let __values: [G; 3] = [__v_71, __v_72, __v_72]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_74: G = __r_arr[0];
     let __v_75: G = __r_arr[1];
     let __v_76: G = __r_arr[2];
@@ -14012,12 +13837,12 @@ fn aiur_fn_170(
     let __v_89: G = __r_arr[15];
     let __v_90: G = __r_arr[16];
     let __v_91: G = __r_arr[17];
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_92: G = __r_arr[0];
     let __v_93: G = G::from_u64(1);
     let __v_94: G = G::from_u64(1);
     let __v_95: G = { let __values: [G; 3] = [__v_93, __v_94, __v_94]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -14052,7 +13877,284 @@ fn aiur_fn_170(
     let __v_120: G = __r_arr[0];
     let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
     let __v_121: G = __r_arr[0];
-    let __ret: [G; OUT_170] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
+    let __ret: [G; OUT_167] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
+    record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_168: usize = 3;
+const IN_168: usize = 3;
+const OUT_168: usize = 2;
+fn aiur_fn_168(
+  inp: [G; IN_168],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_168], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    match __v_2.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_168] = [__v_0, __v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_2 - __v_5);
+        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = __r_arr[1];
+        let __ret: [G; OUT_168] = [__v_7, __v_8];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_169: usize = 1;
+const IN_169: usize = 1;
+const OUT_169: usize = 1;
+fn aiur_fn_169(
+  inp: [G; IN_169],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_169], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(18446744069414584320);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(281474976710656);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(18446744069397807105);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(17293822564807737345);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(70368744161280);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(549755813888);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(17870292113338400769);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(13797081185216407910);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(1803076106186727246);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(11353340290879379826);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(455906449640507599);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(17492915097719143606);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(1532612707718625687);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16207902636198568418);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(17776499369601055404);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(6115771955107415310);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(12380578893860276750);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      18u64 => {
+        let __v_1: G = G::from_u64(9306717745644682924);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      19u64 => {
+        let __v_1: G = G::from_u64(18146160046829613826);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      20u64 => {
+        let __v_1: G = G::from_u64(3511170319078647661);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      21u64 => {
+        let __v_1: G = G::from_u64(17654865857378133588);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      22u64 => {
+        let __v_1: G = G::from_u64(5416168637041100469);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      23u64 => {
+        let __v_1: G = G::from_u64(16905767614792059275);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      24u64 => {
+        let __v_1: G = G::from_u64(9713644485405565297);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      25u64 => {
+        let __v_1: G = G::from_u64(5456943929260765144);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      26u64 => {
+        let __v_1: G = G::from_u64(17096174751763063430);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      27u64 => {
+        let __v_1: G = G::from_u64(1213594585890690845);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      28u64 => {
+        let __v_1: G = G::from_u64(6414415596519834757);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      29u64 => {
+        let __v_1: G = G::from_u64(16116352524544190054);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      30u64 => {
+        let __v_1: G = G::from_u64(9123114210336311365);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      31u64 => {
+        let __v_1: G = G::from_u64(4614640910117430873);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(1753635133440165772);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_170: usize = 3;
+const IN_170: usize = 3;
+const OUT_170: usize = 2;
+fn aiur_fn_170(
+  inp: [G; IN_170],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_170], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __v_8: G = __r_arr[1];
+    let __ret: [G; OUT_170] = [__v_7, __v_8];
     record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
@@ -14060,7 +14162,7 @@ fn aiur_fn_170(
 
 const INPUT_SIZE_171: usize = 3;
 const IN_171: usize = 3;
-const OUT_171: usize = 2;
+const OUT_171: usize = 8;
 fn aiur_fn_171(
   inp: [G; IN_171],
   record: &mut QueryRecord,
@@ -14071,287 +14173,10 @@ fn aiur_fn_171(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_171] = [__v_0, __v_1];
-        record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __v_4: G = __r_arr[1];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_2 - __v_5);
-        let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __ret: [G; OUT_171] = [__v_7, __v_8];
-        record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_172: usize = 1;
-const IN_172: usize = 1;
-const OUT_172: usize = 1;
-fn aiur_fn_172(
-  inp: [G; IN_172],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_172], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(18446744069414584320);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(281474976710656);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(18446744069397807105);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(17293822564807737345);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(70368744161280);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(549755813888);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(17870292113338400769);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(13797081185216407910);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(1803076106186727246);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(11353340290879379826);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(455906449640507599);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(17492915097719143606);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(1532612707718625687);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16207902636198568418);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(17776499369601055404);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(6115771955107415310);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(12380578893860276750);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      18u64 => {
-        let __v_1: G = G::from_u64(9306717745644682924);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      19u64 => {
-        let __v_1: G = G::from_u64(18146160046829613826);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      20u64 => {
-        let __v_1: G = G::from_u64(3511170319078647661);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      21u64 => {
-        let __v_1: G = G::from_u64(17654865857378133588);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      22u64 => {
-        let __v_1: G = G::from_u64(5416168637041100469);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      23u64 => {
-        let __v_1: G = G::from_u64(16905767614792059275);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      24u64 => {
-        let __v_1: G = G::from_u64(9713644485405565297);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      25u64 => {
-        let __v_1: G = G::from_u64(5456943929260765144);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      26u64 => {
-        let __v_1: G = G::from_u64(17096174751763063430);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      27u64 => {
-        let __v_1: G = G::from_u64(1213594585890690845);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      28u64 => {
-        let __v_1: G = G::from_u64(6414415596519834757);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      29u64 => {
-        let __v_1: G = G::from_u64(16116352524544190054);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      30u64 => {
-        let __v_1: G = G::from_u64(9123114210336311365);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      31u64 => {
-        let __v_1: G = G::from_u64(4614640910117430873);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(1753635133440165772);
-        let __ret: [G; OUT_172] = [__v_1];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_173: usize = 3;
-const IN_173: usize = 3;
-const OUT_173: usize = 2;
-fn aiur_fn_173(
-  inp: [G; IN_173],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_173], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __ret: [G; OUT_173] = [__v_7, __v_8];
-    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_174: usize = 3;
-const IN_174: usize = 3;
-const OUT_174: usize = 8;
-fn aiur_fn_174(
-  inp: [G; IN_174],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_174], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __r_arr: [G; OUT_16] = { let __args: [G; IN_16] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[16].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_16] = unsafe { *(result.output.as_ptr() as *const [G; OUT_16]) }; __ret } else { aiur_fn_16(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
@@ -14377,21 +14202,21 @@ fn aiur_fn_174(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_21: G = __r_arr[0];
     let __v_22: G = __r_arr[1];
-    let __ret: [G; OUT_174] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
-    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_171] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
+    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_175: usize = 23;
-const IN_175: usize = 23;
-const OUT_175: usize = 1;
-fn aiur_fn_175(
-  inp: [G; IN_175],
+const INPUT_SIZE_172: usize = 23;
+const IN_172: usize = 23;
+const OUT_172: usize = 1;
+fn aiur_fn_172(
+  inp: [G; IN_172],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_175], ExecError> {
+) -> Result<[G; OUT_172], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14418,33 +14243,150 @@ fn aiur_fn_175(
     let __v_22: G = inp[22];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = G::from_bool((__v_23 == G::ZERO));
         let __v_25: G = G::from_u64(0);
         if (__v_24 != __v_25) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         if (__v_26 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
-        let __v_29: G = G::from_u64(1);
-        if (__v_28 != __v_29) {
-          return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_29.as_canonical_u64() });
+        if (__v_28 != __v_23) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __v_29: G = __r_arr[0];
         let __v_30: G = G::from_u64(1);
-        let __ret: [G; OUT_175] = [__v_30];
+        if (__v_29 != __v_30) {
+          return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
+        }
+        let __v_31: G = G::from_u64(1);
+        let __ret: [G; OUT_172] = [__v_31];
+        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_173: usize = 6;
+const IN_173: usize = 6;
+const OUT_173: usize = 2;
+fn aiur_fn_173(
+  inp: [G; IN_173],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_173], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_6: G = __r_arr[0];
+    let __v_7: G = __r_arr[1];
+    let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __v_9: G = __r_arr[1];
+    let __ret: [G; OUT_173] = [__v_8, __v_9];
+    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_174: usize = 4;
+const IN_174: usize = 4;
+const OUT_174: usize = 2;
+fn aiur_fn_174(
+  inp: [G; IN_174],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_174], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = G::from_u64(0);
+    let __v_5: G = G::from_u64(1);
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_6: G = __r_arr[0];
+    let __v_7: G = __r_arr[1];
+    let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __v_9: G = __r_arr[1];
+    let __ret: [G; OUT_174] = [__v_8, __v_9];
+    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_175: usize = 1;
+const IN_175: usize = 1;
+const OUT_175: usize = 1;
+fn aiur_fn_175(
+  inp: [G; IN_175],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_175], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_175] = [__v_7];
         record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
+      },
+      0u64 => {
+        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        let __v_8: G = __loaded[3];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __v_9: G = G::from_u64(0);
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __v_10: G = __r_arr[0];
+            let __v_11: G = __r_arr[1];
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+            let __v_12: G = __r_arr[0];
+            let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_175] = [__v_13];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -14466,163 +14408,51 @@ fn aiur_fn_176(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_6: G = __r_arr[0];
-    let __v_7: G = __r_arr[1];
-    let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-    let __v_8: G = __r_arr[0];
-    let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_176] = [__v_8, __v_9];
-    record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_177: usize = 4;
-const IN_177: usize = 4;
-const OUT_177: usize = 2;
-fn aiur_fn_177(
-  inp: [G; IN_177],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_177], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = G::from_u64(0);
-    let __v_5: G = G::from_u64(1);
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_6: G = __r_arr[0];
-    let __v_7: G = __r_arr[1];
-    let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-    let __v_8: G = __r_arr[0];
-    let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_177] = [__v_8, __v_9];
-    record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_178: usize = 1;
-const IN_178: usize = 1;
-const OUT_178: usize = 1;
-fn aiur_fn_178(
-  inp: [G; IN_178],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_178], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_178] = [__v_7];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        let __v_8: G = __loaded[3];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __v_9: G = G::from_u64(0);
-            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
-            let __v_10: G = __r_arr[0];
-            let __v_11: G = __r_arr[1];
-            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
-            let __v_12: G = __r_arr[0];
-            let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_178] = [__v_13];
-            record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_179: usize = 6;
-const IN_179: usize = 6;
-const OUT_179: usize = 2;
-fn aiur_fn_179(
-  inp: [G; IN_179],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_179], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
     match __v_0.as_canonical_u64() {
       0u64 => {
         match __v_1.as_canonical_u64() {
           1u64 => {
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = __r_arr[1];
-            let __ret: [G; OUT_179] = [__v_6, __v_7];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_6, __v_7];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_5, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = __r_arr[1];
-            let __ret: [G; OUT_179] = [__v_6, __v_7];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_6, __v_7];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           2u64 => {
             let __v_6: G = G::from_u64(0);
             let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_179] = [__v_6, __v_7];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_6, __v_7];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           3u64 => {
             let __v_6: G = G::from_u64(0);
             let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_179] = [__v_6, __v_7];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_6, __v_7];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           4u64 => {
             let __v_6: G = G::from_u64(0);
             let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_179] = [__v_6, __v_7];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_6, __v_7];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           5u64 => {
             let __v_6: G = G::from_u64(0);
             let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_179] = [__v_6, __v_7];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_6, __v_7];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14633,28 +14463,28 @@ fn aiur_fn_179(
       1u64 => {
         let __v_6: G = G::from_u64(0);
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_179] = [__v_6, __v_7];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_6, __v_7];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
         let __v_6: G = G::from_u64(0);
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_179] = [__v_6, __v_7];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_6, __v_7];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_6: G = G::from_u64(0);
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_179] = [__v_6, __v_7];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_6, __v_7];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_179] = [__v_1, __v_6];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_1, __v_6];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
@@ -14663,7 +14493,7 @@ fn aiur_fn_179(
         let __v_7: G = __loaded[1];
         let __v_8: G = __loaded[2];
         let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14671,14 +14501,14 @@ fn aiur_fn_179(
         let __v_13: G = __loaded[1];
         let __v_14: G = __loaded[2];
         let __v_15: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_10, __v_11, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_179] = [__v_18, __v_19];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_18, __v_19];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
@@ -14687,7 +14517,7 @@ fn aiur_fn_179(
         let __v_7: G = __loaded[1];
         let __v_8: G = __loaded[2];
         let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14695,14 +14525,14 @@ fn aiur_fn_179(
         let __v_13: G = __loaded[1];
         let __v_14: G = __loaded[2];
         let __v_15: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
         let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_10, __v_11, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_179] = [__v_18, __v_19];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_18, __v_19];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
@@ -14711,14 +14541,14 @@ fn aiur_fn_179(
         let __v_7: G = __loaded[1];
         let __v_8: G = __loaded[2];
         let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
         let __v_13: G = __r_arr[1];
-        let __ret: [G; OUT_179] = [__v_12, __v_13];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_12, __v_13];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
@@ -14727,7 +14557,7 @@ fn aiur_fn_179(
         let __v_7: G = __loaded[1];
         let __v_8: G = __loaded[2];
         let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14735,14 +14565,14 @@ fn aiur_fn_179(
         let __v_13: G = __loaded[1];
         let __v_14: G = __loaded[2];
         let __v_15: G = __loaded[3];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_179] = [__v_18, __v_19];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_18, __v_19];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14752,15 +14582,15 @@ fn aiur_fn_179(
   })
 }
 
-const INPUT_SIZE_180: usize = 5;
-const IN_180: usize = 5;
-const OUT_180: usize = 2;
-fn aiur_fn_180(
-  inp: [G; IN_180],
+const INPUT_SIZE_177: usize = 5;
+const IN_177: usize = 5;
+const OUT_177: usize = 2;
+fn aiur_fn_177(
+  inp: [G; IN_177],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_180], ExecError> {
+) -> Result<[G; OUT_177], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14778,15 +14608,15 @@ fn aiur_fn_180(
       1u64 => {
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __ret: [G; OUT_180] = [__v_11, __v_12];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_177] = [__v_11, __v_12];
+        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_6, __v_7, __v_8, __v_9, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_0, __v_1, __v_10, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_0, __v_1, __v_10, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -14795,8 +14625,8 @@ fn aiur_fn_180(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_11, __v_12, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = __r_arr[1];
-        let __ret: [G; OUT_180] = [__v_17, __v_18];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_177] = [__v_17, __v_18];
+        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14806,15 +14636,15 @@ fn aiur_fn_180(
   })
 }
 
-const INPUT_SIZE_181: usize = 6;
-const IN_181: usize = 6;
-const OUT_181: usize = 2;
-fn aiur_fn_181(
-  inp: [G; IN_181],
+const INPUT_SIZE_178: usize = 6;
+const IN_178: usize = 6;
+const OUT_178: usize = 2;
+fn aiur_fn_178(
+  inp: [G; IN_178],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
+) -> Result<[G; OUT_178], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14831,25 +14661,25 @@ fn aiur_fn_181(
     let __v_11: G = __loaded[5];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_181] = [__v_0, __v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_178] = [__v_0, __v_1];
+        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_12: G = G::from_u64(1);
         let __v_13: G = G::from_u64(1);
         let __v_14: G = { let __values: [G; 4] = [__v_12, __v_13, __v_13, __v_13]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_7, __v_8, __v_9, __v_10, __v_5, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_7, __v_8, __v_9, __v_10, __v_5, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_1, __v_2, __v_3, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = __r_arr[1];
-        let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_17, __v_18, __v_2, __v_3, __v_11, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_17, __v_18, __v_2, __v_3, __v_11, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_181] = [__v_19, __v_20];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_178] = [__v_19, __v_20];
+        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14859,15 +14689,15 @@ fn aiur_fn_181(
   })
 }
 
-const INPUT_SIZE_182: usize = 7;
-const IN_182: usize = 7;
-const OUT_182: usize = 2;
-fn aiur_fn_182(
-  inp: [G; IN_182],
+const INPUT_SIZE_179: usize = 7;
+const IN_179: usize = 7;
+const OUT_179: usize = 2;
+fn aiur_fn_179(
+  inp: [G; IN_179],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
+) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14878,12 +14708,12 @@ fn aiur_fn_182(
     let __v_6: G = inp[6];
     match __v_6.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_182] = [__v_0, __v_1];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_0, __v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
         let __v_8: G = __r_arr[1];
         let __v_9: G = G::from_u64(1);
@@ -14894,33 +14724,33 @@ fn aiur_fn_182(
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_7, __v_8, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_1, __v_2, __v_3, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __v_17: G = G::from_u64(1);
         let __v_18: G = (__v_5 + __v_17);
         let __v_19: G = G::from_u64(1);
         let __v_20: G = (__v_6 - __v_19);
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_15, __v_16, __v_2, __v_3, __v_4, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_15, __v_16, __v_2, __v_3, __v_4, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
-        let __ret: [G; OUT_182] = [__v_21, __v_22];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_21, __v_22];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_183: usize = 15;
-const IN_183: usize = 15;
-const OUT_183: usize = 4;
-fn aiur_fn_183(
-  inp: [G; IN_183],
+const INPUT_SIZE_180: usize = 15;
+const IN_180: usize = 15;
+const OUT_180: usize = 4;
+fn aiur_fn_180(
+  inp: [G; IN_180],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
+) -> Result<[G; OUT_180], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14947,8 +14777,8 @@ fn aiur_fn_183(
     let __v_21: G = __loaded[6];
     match __v_15.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_183] = [__v_0, __v_1, __v_13, __v_14];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_180] = [__v_0, __v_1, __v_13, __v_14];
+        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14956,13 +14786,13 @@ fn aiur_fn_183(
           _ => {
             let __v_22: G = G::from_u64(1);
             let __v_23: G = (__v_5 + __v_22);
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_8, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_24: G = __r_arr[0];
             let __v_25: G = __r_arr[1];
-            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_16, __v_17, __v_18, __v_19, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_16, __v_17, __v_18, __v_19, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
             let __v_26: G = __r_arr[0];
             let __v_27: G = __r_arr[1];
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_11, __v_12, __v_20, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_11, __v_12, __v_20, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
             let __v_29: G = __r_arr[1];
             let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -14976,7 +14806,7 @@ fn aiur_fn_183(
             let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
             let __v_36: G = __r_arr[0];
             let __v_37: G = __r_arr[1];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_1, __v_2, __v_3, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = __r_arr[1];
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_26, __v_27, __v_24, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -14987,13 +14817,13 @@ fn aiur_fn_183(
             let __v_43: G = __r_arr[1];
             let __v_44: G = G::from_u64(1);
             let __v_45: G = (__v_5 + __v_44);
-            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_38, __v_39, __v_2, __v_3, __v_21, __v_45, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_38, __v_39, __v_2, __v_3, __v_21, __v_45, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
             let __v_46: G = __r_arr[0];
             let __v_47: G = __r_arr[1];
             let __v_48: G = __r_arr[2];
             let __v_49: G = __r_arr[3];
-            let __ret: [G; OUT_183] = [__v_46, __v_47, __v_48, __v_49];
-            record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_180] = [__v_46, __v_47, __v_48, __v_49];
+            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -15005,15 +14835,15 @@ fn aiur_fn_183(
   })
 }
 
-const INPUT_SIZE_184: usize = 27;
-const IN_184: usize = 27;
-const OUT_184: usize = 2;
-fn aiur_fn_184(
-  inp: [G; IN_184],
+const INPUT_SIZE_181: usize = 27;
+const IN_181: usize = 27;
+const OUT_181: usize = 2;
+fn aiur_fn_181(
+  inp: [G; IN_181],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_184], ExecError> {
+) -> Result<[G; OUT_181], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15048,18 +14878,18 @@ fn aiur_fn_184(
           _ => {
             let __v_27: G = G::from_u64(0);
             let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_27, __v_28, __v_25, __v_26, __v_1, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_27, __v_28, __v_25, __v_26, __v_1, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
             let __v_29: G = __r_arr[0];
             let __v_30: G = __r_arr[1];
             let __v_31: G = (__v_3 - __v_2);
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_29, __v_30, __v_25, __v_26, __v_6, __v_2, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_29, __v_30, __v_25, __v_26, __v_6, __v_2, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
             let __v_32: G = __r_arr[0];
             let __v_33: G = __r_arr[1];
-            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_32, __v_33, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_32, __v_33, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_34: G = __r_arr[0];
             let __v_35: G = __r_arr[1];
-            let __ret: [G; OUT_184] = [__v_34, __v_35];
-            record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_181] = [__v_34, __v_35];
+            record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -15068,19 +14898,19 @@ fn aiur_fn_184(
         match __v_1.as_canonical_u64() {
           _ => {
             let __v_27: G = G::from_u64(1);
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_6, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
             let __v_29: G = __r_arr[1];
             let __v_30: G = G::from_u64(2);
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_6, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_31: G = __r_arr[0];
             let __v_32: G = __r_arr[1];
             let __v_33: G = G::from_u64(1);
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_34: G = __r_arr[0];
             let __v_35: G = __r_arr[1];
             let __v_36: G = G::from_u64(2);
-            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_37: G = __r_arr[0];
             let __v_38: G = __r_arr[1];
             let __v_39: G = G::from_u64(0);
@@ -15093,7 +14923,7 @@ fn aiur_fn_184(
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_28, __v_29, __v_43, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
             let __v_45: G = __r_arr[0];
             let __v_46: G = __r_arr[1];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_39, __v_40, __v_25, __v_26, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_39, __v_40, __v_25, __v_26, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_47: G = __r_arr[0];
             let __v_48: G = __r_arr[1];
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_34, __v_35, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -15107,7 +14937,7 @@ fn aiur_fn_184(
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_49, __v_50, __v_53, __v_54]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
             let __v_55: G = __r_arr[0];
             let __v_56: G = __r_arr[1];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_47, __v_48, __v_25, __v_26, __v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_47, __v_48, __v_25, __v_26, __v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_57: G = __r_arr[0];
             let __v_58: G = __r_arr[1];
             let __v_59: G = G::from_u64(1);
@@ -15121,14 +14951,14 @@ fn aiur_fn_184(
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_49, __v_50, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
             let __v_65: G = __r_arr[0];
             let __v_66: G = __r_arr[1];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_57, __v_58, __v_25, __v_26, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_57, __v_58, __v_25, __v_26, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_67: G = __r_arr[0];
             let __v_68: G = __r_arr[1];
-            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_67, __v_68, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_67, __v_68, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_69: G = __r_arr[0];
             let __v_70: G = __r_arr[1];
-            let __ret: [G; OUT_184] = [__v_69, __v_70];
-            record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_181] = [__v_69, __v_70];
+            record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -15136,21 +14966,21 @@ fn aiur_fn_184(
       2u64 => {
         let __v_27: G = G::from_u64(0);
         let __v_28: G = G::from_u64(0);
-        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_27, __v_28, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_27, __v_28, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = __r_arr[1];
-        let __ret: [G; OUT_184] = [__v_29, __v_30];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_29, __v_30];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_27: G = G::from_u64(0);
         let __v_28: G = G::from_u64(0);
-        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_27, __v_28, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_27, __v_28, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = __r_arr[1];
-        let __ret: [G; OUT_184] = [__v_29, __v_30];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_29, __v_30];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15160,15 +14990,15 @@ fn aiur_fn_184(
   })
 }
 
-const INPUT_SIZE_185: usize = 23;
-const IN_185: usize = 23;
-const OUT_185: usize = 2;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_182: usize = 23;
+const IN_182: usize = 23;
+const OUT_182: usize = 2;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15195,20 +15025,20 @@ fn aiur_fn_185(
     let __v_22: G = inp[22];
     let __v_23: G = G::from_u64(0);
     let __v_24: G = G::from_u64(0);
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_5, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_25: G = __r_arr[0];
     let __v_26: G = __r_arr[1];
-    let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_1, __v_21, __v_22, __v_2, __v_23, __v_3, __v_4, __v_5, __v_13, __v_14, __v_15, __v_16, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_0, __v_1, __v_21, __v_22, __v_2, __v_23, __v_3, __v_4, __v_5, __v_13, __v_14, __v_15, __v_16, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
     let __v_27: G = __r_arr[0];
     let __v_28: G = __r_arr[1];
     let __v_29: G = __r_arr[2];
     let __v_30: G = __r_arr[3];
     let __v_31: G = G::from_u64(0);
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_5, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_32: G = __r_arr[0];
     let __v_33: G = __r_arr[1];
     let __v_34: G = G::from_u64(0);
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_6, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
     let __v_36: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_32, __v_33, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -15217,7 +15047,7 @@ fn aiur_fn_185(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_7, __v_8, __v_37, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
-    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_27, __v_28, __v_21, __v_22, __v_39, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_27, __v_28, __v_21, __v_22, __v_39, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_29, __v_30, __v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -15226,7 +15056,7 @@ fn aiur_fn_185(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_11, __v_12, __v_43, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
     let __v_46: G = __r_arr[1];
-    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_41, __v_42, __v_21, __v_22, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_41, __v_42, __v_21, __v_22, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_47: G = __r_arr[0];
     let __v_48: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_29, __v_30, __v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -15235,511 +15065,206 @@ fn aiur_fn_185(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_9, __v_10, __v_49, __v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_51: G = __r_arr[0];
     let __v_52: G = __r_arr[1];
-    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_47, __v_48, __v_21, __v_22, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_47, __v_48, __v_21, __v_22, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_53: G = __r_arr[0];
     let __v_54: G = __r_arr[1];
-    let __ret: [G; OUT_185] = [__v_53, __v_54];
-    record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_182] = [__v_53, __v_54];
+    record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_186: usize = 2;
-const IN_186: usize = 2;
-const OUT_186: usize = 1;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_183: usize = 5;
+const IN_183: usize = 5;
+const OUT_183: usize = 2;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __ret: [G; OUT_186] = [__v_2];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __ret: [G; OUT_186] = [__v_5];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_187: usize = 4;
-const IN_187: usize = 4;
-const OUT_187: usize = 2;
-fn aiur_fn_187(
-  inp: [G; IN_187],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = G::from_u64(0);
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __v_6: G = __r_arr[1];
-    let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_5, __v_6, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __v_9: G = G::from_u64(1);
-    let __v_10: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __v_12: G = __r_arr[1];
-    let __ret: [G; OUT_187] = [__v_11, __v_12];
-    record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_188: usize = 10;
-const IN_188: usize = 10;
-const OUT_188: usize = 2;
-fn aiur_fn_188(
-  inp: [G; IN_188],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    match __v_8.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_188] = [__v_0, __v_1];
-        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_5: G = __loaded[0];
+    let __v_6: G = __loaded[1];
+    let __v_7: G = __loaded[2];
+    let __v_8: G = __loaded[3];
+    match __v_5.as_canonical_u64() {
+      1u64 => {
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = G::from_u64(0);
+        let __ret: [G; OUT_183] = [__v_9, __v_10];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __v_10: G = G::from_u64(7);
-        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_5, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+      0u64 => {
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_9: G = __r_arr[0];
+        let __v_10: G = __r_arr[1];
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
-        let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_16] = { let __args: [G; IN_16] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[16].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_16] = unsafe { *(result.output.as_ptr() as *const [G; OUT_16]) }; __ret } else { aiur_fn_16(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[1];
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_7 - __v_9);
-        let __v_15: G = G::from_bool((__v_14 == G::ZERO));
-        match __v_15.as_canonical_u64() {
-          1u64 => {
-            let __v_16: G = G::from_u64(1);
-            let __v_17: G = (__v_7 + __v_16);
-            let __v_18: G = G::from_u64(1);
-            let __v_19: G = (__v_8 - __v_18);
-            let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_17, __v_19, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_188] = [__v_20, __v_21];
-            record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_2, __v_3, __v_4, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
-            let __v_16: G = __r_arr[0];
-            let __v_17: G = __r_arr[1];
-            let __v_18: G = G::from_u64(0);
-            let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_6, __v_18, __v_4, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __v_20: G = __r_arr[1];
-            let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __v_22: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_16, __v_17, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_23: G = __r_arr[0];
-            let __v_24: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __v_26: G = __r_arr[1];
-            let __v_27: G = G::from_u64(1);
-            let __v_28: G = (__v_7 + __v_27);
-            let __v_29: G = G::from_u64(1);
-            let __v_30: G = (__v_8 - __v_29);
-            let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_25, __v_26, __v_2, __v_3, __v_4, __v_5, __v_6, __v_28, __v_30, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
-            let __v_31: G = __r_arr[0];
-            let __v_32: G = __r_arr[1];
-            let __ret: [G; OUT_188] = [__v_31, __v_32];
-            record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_189: usize = 11;
-const IN_189: usize = 11;
-const OUT_189: usize = 2;
-fn aiur_fn_189(
-  inp: [G; IN_189],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    match __v_9.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_189] = [__v_0, __v_1];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_14: G = __r_arr[1];
+        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __v_16: G = __r_arr[1];
+        let __ret: [G; OUT_183] = [__v_15, __v_16];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_11: G = G::from_u64(7);
-        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_6, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = G::from_u64(1);
-        let __v_15: G = G::from_u64(0);
-        let __v_16: G = G::from_u64(0);
-        let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_14, __v_15, __v_2, __v_3, __v_4, __v_6, __v_13, __v_16, __v_5, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = __r_arr[1];
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_19: G = __r_arr[0];
-        let __v_20: G = G::from_u64(0);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_21: G = __r_arr[0];
-        let __v_22: G = G::from_u64(0);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_23: G = __r_arr[0];
-        let __v_24: G = __r_arr[1];
-        let __v_25: G = G::from_u64(1);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_21, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_26: G = __r_arr[0];
-        let __v_27: G = __r_arr[1];
-        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_23, __v_24, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
-        let __v_28: G = __r_arr[0];
-        let __v_29: G = __r_arr[1];
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_17, __v_18, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_30: G = __r_arr[0];
-        let __v_31: G = __r_arr[1];
-        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-        let __v_32: G = __r_arr[0];
-        let __v_33: G = __r_arr[1];
-        let __v_34: G = G::from_u64(1);
-        let __v_35: G = (__v_8 + __v_34);
-        let __v_36: G = G::from_u64(1);
-        let __v_37: G = (__v_9 - __v_36);
-        let __v_38: G = G::from_u64(1);
-        let __v_39: G = (__v_10 + __v_38);
-        let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_32, __v_33, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35, __v_37, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
-        let __v_40: G = __r_arr[0];
-        let __v_41: G = __r_arr[1];
-        let __ret: [G; OUT_189] = [__v_40, __v_41];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_190: usize = 1;
-const IN_190: usize = 1;
-const OUT_190: usize = 1;
-fn aiur_fn_190(
-  inp: [G; IN_190],
+const INPUT_SIZE_184: usize = 1;
+const IN_184: usize = 1;
+const OUT_184: usize = 1;
+fn aiur_fn_184(
+  inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_190], ExecError> {
+) -> Result<[G; OUT_184], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     match __v_0.as_canonical_u64() {
       0u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       10u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       11u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       12u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       13u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       14u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       15u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       16u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       17u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_190] = [__v_1];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_191: usize = 1;
-const IN_191: usize = 1;
-const OUT_191: usize = 1;
-fn aiur_fn_191(
-  inp: [G; IN_191],
+const INPUT_SIZE_185: usize = 4;
+const IN_185: usize = 4;
+const OUT_185: usize = 1;
+fn aiur_fn_185(
+  inp: [G; IN_185],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_191], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(0);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(0);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(0);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(3);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(3);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(3);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(3);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(5);
-        let __ret: [G; OUT_191] = [__v_1];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_192: usize = 4;
-const IN_192: usize = 4;
-const OUT_192: usize = 1;
-fn aiur_fn_192(
-  inp: [G; IN_192],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15750,8 +15275,8 @@ fn aiur_fn_192(
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 4] = [__v_4, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_192] = [__v_6];
-        record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_6];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -15760,18 +15285,18 @@ fn aiur_fn_192(
             let __v_4: G = G::from_u64(1);
             let __v_5: G = G::from_u64(1);
             let __v_6: G = { let __values: [G; 4] = [__v_4, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_192] = [__v_6];
-            record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_6];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
-            let __ret: [G; OUT_192] = [__v_6];
-            record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_6];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -15786,15 +15311,15 @@ fn aiur_fn_192(
   })
 }
 
-const INPUT_SIZE_193: usize = 21;
-const IN_193: usize = 21;
-const OUT_193: usize = 1;
-fn aiur_fn_193(
-  inp: [G; IN_193],
+const INPUT_SIZE_186: usize = 20;
+const IN_186: usize = 20;
+const OUT_186: usize = 1;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_193], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15816,105 +15341,115 @@ fn aiur_fn_193(
     let __v_17: G = inp[17];
     let __v_18: G = inp[18];
     let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
     let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
-    let __v_21: G = __loaded[0];
-    let __v_22: G = __loaded[1];
-    let __v_23: G = __loaded[2];
-    let __v_24: G = __loaded[3];
-    let __v_25: G = __loaded[4];
-    let __v_26: G = __loaded[5];
-    let __v_27: G = __loaded[6];
-    let __v_28: G = __loaded[7];
-    let __v_29: G = __loaded[8];
-    let __v_30: G = __loaded[9];
-    let __v_31: G = __loaded[10];
-    let __v_32: G = __loaded[11];
-    let __v_33: G = __loaded[12];
-    let __v_34: G = __loaded[13];
-    match __v_21.as_canonical_u64() {
+    let __v_20: G = __loaded[0];
+    let __v_21: G = __loaded[1];
+    let __v_22: G = __loaded[2];
+    let __v_23: G = __loaded[3];
+    let __v_24: G = __loaded[4];
+    let __v_25: G = __loaded[5];
+    let __v_26: G = __loaded[6];
+    let __v_27: G = __loaded[7];
+    let __v_28: G = __loaded[8];
+    let __v_29: G = __loaded[9];
+    let __v_30: G = __loaded[10];
+    let __v_31: G = __loaded[11];
+    let __v_32: G = __loaded[12];
+    let __v_33: G = __loaded[13];
+    match __v_20.as_canonical_u64() {
       1u64 => {
-        let __v_35: G = G::from_u64(1);
-        let __ret: [G; OUT_193] = [__v_35];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_34: G = G::from_u64(1);
+        let __ret: [G; OUT_186] = [__v_34];
+        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        match __v_22.as_canonical_u64() {
+        match __v_21.as_canonical_u64() {
           _ => {
-            match __v_22.as_canonical_u64() {
+            match __v_21.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                let __v_34: G = __r_arr[0];
+                let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
                 let __v_35: G = __r_arr[0];
-                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
-                let __v_37: G = __r_arr[0];
-                let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                let __v_37: G = __r_arr[1];
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                 let __v_38: G = __r_arr[0];
-                let __v_39: G = __r_arr[1];
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                let __v_39: G = G::from_u64(0);
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_38, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                 let __v_40: G = __r_arr[0];
-                let __v_41: G = G::from_u64(0);
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_40, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                let __v_41: G = G::from_u64(1);
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_38, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                 let __v_42: G = __r_arr[0];
-                let __v_43: G = G::from_u64(1);
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-                let __v_44: G = __r_arr[0];
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                let __v_43: G = __r_arr[0];
+                let __v_44: G = G::from_u64(0);
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_43, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                 let __v_45: G = __r_arr[0];
-                let __v_46: G = G::from_u64(0);
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-                let __v_47: G = __r_arr[0];
-                let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+                let __v_46: G = __r_arr[0];
+                let __v_47: G = G::from_u64(1);
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_43, __v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                 let __v_48: G = __r_arr[0];
-                let __v_49: G = G::from_u64(1);
-                let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_45, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+                let __v_49: G = __r_arr[0];
+                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                 let __v_50: G = __r_arr[0];
-                let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
-                let __v_51: G = __r_arr[0];
-                let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                let __v_51: G = __r_arr[1];
+                let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_6, __v_7, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
                 let __v_52: G = __r_arr[0];
-                let __v_53: G = __r_arr[1];
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_6, __v_7, __v_52, __v_53]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
-                let __v_54: G = __r_arr[0];
-                let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_19, __v_20, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-                let __v_55: G = __r_arr[0];
-                let __v_56: G = __r_arr[1];
-                let __v_57: G = __r_arr[2];
-                let __v_58: G = __r_arr[3];
-                let __v_59: G = __r_arr[4];
-                let __v_60: G = __r_arr[5];
-                let __v_61: G = __r_arr[6];
-                let __v_62: G = __r_arr[7];
-                let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_42, __v_44, __v_48, __v_51, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_13, __v_14, __v_15, __v_16, __v_10, __v_11, __v_38, __v_39, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_18, __v_19, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+                let __v_53: G = __r_arr[0];
+                let __v_54: G = __r_arr[1];
+                let __v_55: G = __r_arr[2];
+                let __v_56: G = __r_arr[3];
+                let __v_57: G = __r_arr[4];
+                let __v_58: G = __r_arr[5];
+                let __v_59: G = __r_arr[6];
+                let __v_60: G = __r_arr[7];
+                let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_40, __v_42, __v_46, __v_49, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_36, __v_37, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+                let __v_61: G = __r_arr[0];
+                let __v_62: G = __r_arr[1];
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                 let __v_63: G = __r_arr[0];
-                let __v_64: G = __r_arr[1];
-                let __v_65: G = (__v_35 + __v_37);
-                let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_65]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+                let __v_64: G = G::from_u64(0);
+                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                let __v_65: G = __r_arr[0];
+                let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_65]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
                 let __v_66: G = __r_arr[0];
-                let __v_67: G = G::from_u64(0);
-                let __v_68: G = G::from_u64(0);
-                let __v_69: G = G::from_u64(0);
-                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_67, __v_68, __v_19, __v_20, __v_35, __v_36, __v_66, __v_8, __v_12, __v_36, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
-                let __v_70: G = __r_arr[0];
-                let __v_71: G = __r_arr[1];
-                let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_63, __v_64, __v_61, __v_62]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-                let __v_72: G = __r_arr[0];
-                let __v_73: G = __r_arr[1];
-                let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_72, __v_73, __v_70, __v_71]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
-                let __v_74: G = __r_arr[0];
-                let __v_75: G = G::from_u64(1);
-                if (__v_74 != __v_75) {
-                  return Err(ExecError::AssertEqMismatch { lhs: __v_74.as_canonical_u64(), rhs: __v_75.as_canonical_u64() });
-                }
+                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_18, __v_19, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                let __v_67: G = __r_arr[0];
+                let __v_68: G = __r_arr[1];
+                let __v_69: G = G::from_u64(1);
+                let __v_70: G = G::from_u64(0);
+                let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_66, __v_67, __v_68, __v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+                let __v_71: G = __r_arr[0];
+                let __v_72: G = __r_arr[1];
+                let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                let __v_73: G = __r_arr[0];
+                let __v_74: G = (__v_73 - __v_35);
+                let __v_75: G = G::from_bool((__v_74 == G::ZERO));
                 let __v_76: G = G::from_u64(1);
-                let __v_77: G = (__v_9 + __v_76);
-                let __v_78: G = (__v_12 + __v_36);
-                let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_34, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_77, __v_38, __v_39, __v_78, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                if (__v_75 != __v_76) {
+                  return Err(ExecError::AssertEqMismatch { lhs: __v_75.as_canonical_u64(), rhs: __v_76.as_canonical_u64() });
+                }
+                let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_61, __v_62, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+                let __v_77: G = __r_arr[0];
+                let __v_78: G = __r_arr[1];
+                let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_77, __v_78, __v_71, __v_72]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
                 let __v_79: G = __r_arr[0];
-                let __ret: [G; OUT_193] = [__v_79];
-                record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __v_80: G = G::from_u64(1);
+                if (__v_79 != __v_80) {
+                  return Err(ExecError::AssertEqMismatch { lhs: __v_79.as_canonical_u64(), rhs: __v_80.as_canonical_u64() });
+                }
+                let __v_81: G = G::from_u64(1);
+                let __v_82: G = (__v_9 + __v_81);
+                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_33, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_82, __v_36, __v_37, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                let __v_83: G = __r_arr[0];
+                let __ret: [G; OUT_186] = [__v_83];
+                record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15922,21 +15457,21 @@ fn aiur_fn_193(
         }
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_21.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_20.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_194: usize = 3;
-const IN_194: usize = 3;
-const OUT_194: usize = 2;
-fn aiur_fn_194(
-  inp: [G; IN_194],
+const INPUT_SIZE_187: usize = 3;
+const IN_187: usize = 3;
+const OUT_187: usize = 2;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_194], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15956,15 +15491,15 @@ fn aiur_fn_194(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_194] = [__v_13, __v_14];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_13, __v_14];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = G::from_u64(0);
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -15973,8 +15508,8 @@ fn aiur_fn_194(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_194] = [__v_19, __v_20];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_19, __v_20];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15984,15 +15519,15 @@ fn aiur_fn_194(
   })
 }
 
-const INPUT_SIZE_195: usize = 7;
-const IN_195: usize = 7;
-const OUT_195: usize = 2;
-fn aiur_fn_195(
-  inp: [G; IN_195],
+const INPUT_SIZE_188: usize = 7;
+const IN_188: usize = 7;
+const OUT_188: usize = 2;
+fn aiur_fn_188(
+  inp: [G; IN_188],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_195], ExecError> {
+) -> Result<[G; OUT_188], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16007,12 +15542,12 @@ fn aiur_fn_195(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_195] = [__v_0, __v_1];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_188] = [__v_0, __v_1];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_3, __v_4, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -16024,11 +15559,11 @@ fn aiur_fn_195(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_195] = [__v_18, __v_19];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_188] = [__v_18, __v_19];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16038,15 +15573,15 @@ fn aiur_fn_195(
   })
 }
 
-const INPUT_SIZE_196: usize = 36;
-const IN_196: usize = 36;
-const OUT_196: usize = 1;
-fn aiur_fn_196(
-  inp: [G; IN_196],
+const INPUT_SIZE_189: usize = 36;
+const IN_189: usize = 36;
+const OUT_189: usize = 1;
+fn aiur_fn_189(
+  inp: [G; IN_189],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
+) -> Result<[G; OUT_189], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16090,15 +15625,15 @@ fn aiur_fn_196(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
-                    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
                     let __v_38: G = __r_arr[0];
-                    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
                     let __v_39: G = __r_arr[0];
                     let __v_40: G = __r_arr[1];
                     let __v_41: G = __r_arr[2];
@@ -16110,45 +15645,44 @@ fn aiur_fn_196(
                     let __v_47: G = __r_arr[8];
                     let __v_48: G = G::from_u64(0);
                     let __v_49: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
                     let __v_51: G = __r_arr[1];
                     let __v_52: G = G::from_u64(0);
-                    let __v_53: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_53, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                    let __v_53: G = __r_arr[0];
+                    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
                     let __v_54: G = __r_arr[0];
-                    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                    let __v_55: G = __r_arr[0];
-                    let __v_56: G = G::from_u64(1);
-                    if (__v_55 != __v_56) {
-                      return Err(ExecError::AssertEqMismatch { lhs: __v_55.as_canonical_u64(), rhs: __v_56.as_canonical_u64() });
+                    let __v_55: G = G::from_u64(1);
+                    if (__v_54 != __v_55) {
+                      return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                    let __v_56: G = __r_arr[0];
+                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
                     let __v_57: G = __r_arr[0];
-                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
-                    let __v_58: G = __r_arr[0];
-                    let __v_59: G = (__v_57 - __v_58);
-                    let __v_60: G = G::from_bool((__v_59 == G::ZERO));
-                    let __v_61: G = G::from_u64(1);
-                    if (__v_60 != __v_61) {
-                      return Err(ExecError::AssertEqMismatch { lhs: __v_60.as_canonical_u64(), rhs: __v_61.as_canonical_u64() });
+                    let __v_58: G = (__v_56 - __v_57);
+                    let __v_59: G = G::from_bool((__v_58 == G::ZERO));
+                    let __v_60: G = G::from_u64(1);
+                    if (__v_59 != __v_60) {
+                      return Err(ExecError::AssertEqMismatch { lhs: __v_59.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+                    let __v_61: G = __r_arr[0];
+                    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                     let __v_62: G = __r_arr[0];
-                    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-                    let __v_63: G = __r_arr[0];
-                    let __v_64: G = (__v_62 - __v_63);
-                    let __v_65: G = G::from_bool((__v_64 == G::ZERO));
-                    let __v_66: G = G::from_u64(1);
-                    if (__v_65 != __v_66) {
-                      return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
+                    let __v_63: G = (__v_61 - __v_62);
+                    let __v_64: G = G::from_bool((__v_63 == G::ZERO));
+                    let __v_65: G = G::from_u64(1);
+                    if (__v_64 != __v_65) {
+                      return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+                    let __v_66: G = __r_arr[0];
+                    let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
                     let __v_67: G = __r_arr[0];
-                    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_36, __v_37, __v_17, __v_45, __v_46, __v_67, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-                    let __v_68: G = __r_arr[0];
-                    let __ret: [G; OUT_196] = [__v_68];
-                    record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_189] = [__v_67];
+                    record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -16161,15 +15695,15 @@ fn aiur_fn_196(
   })
 }
 
-const INPUT_SIZE_197: usize = 1;
-const IN_197: usize = 1;
-const OUT_197: usize = 1;
-fn aiur_fn_197(
-  inp: [G; IN_197],
+const INPUT_SIZE_190: usize = 1;
+const IN_190: usize = 1;
+const OUT_190: usize = 1;
+fn aiur_fn_190(
+  inp: [G; IN_190],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
+) -> Result<[G; OUT_190], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16179,8 +15713,8 @@ fn aiur_fn_197(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_197] = [__v_4];
-        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_190] = [__v_4];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -16191,10 +15725,10 @@ fn aiur_fn_197(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_197] = [__v_8];
-        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_190] = [__v_8];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16204,15 +15738,15 @@ fn aiur_fn_197(
   })
 }
 
-const INPUT_SIZE_198: usize = 2;
-const IN_198: usize = 2;
-const OUT_198: usize = 1;
-fn aiur_fn_198(
-  inp: [G; IN_198],
+const INPUT_SIZE_191: usize = 2;
+const IN_191: usize = 2;
+const OUT_191: usize = 1;
+fn aiur_fn_191(
+  inp: [G; IN_191],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_198], ExecError> {
+) -> Result<[G; OUT_191], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16236,8 +15770,8 @@ fn aiur_fn_198(
         let __v_16: G = G::from_u64(1);
         let __v_17: G = G::from_u64(1);
         let __v_18: G = { let __values: [G; 14] = [__v_16, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17]; let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_198] = [__v_18];
-        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_191] = [__v_18];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -16249,19 +15783,19 @@ fn aiur_fn_198(
           0u64 => {
             match __v_17.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_15, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_15, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_19: G = __r_arr[0];
-                let __ret: [G; OUT_198] = [__v_19];
-                record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_191] = [__v_19];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_19: G = G::from_u64(0);
-                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_15, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_15, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 let __v_21: G = { let __values: [G; 14] = [__v_19, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_20]; let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_198] = [__v_21];
-                record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_191] = [__v_21];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -16278,15 +15812,15 @@ fn aiur_fn_198(
   })
 }
 
-const INPUT_SIZE_199: usize = 2;
-const IN_199: usize = 2;
-const OUT_199: usize = 1;
-fn aiur_fn_199(
-  inp: [G; IN_199],
+const INPUT_SIZE_192: usize = 2;
+const IN_192: usize = 2;
+const OUT_192: usize = 1;
+fn aiur_fn_192(
+  inp: [G; IN_192],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_199], ExecError> {
+) -> Result<[G; OUT_192], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16300,8 +15834,8 @@ fn aiur_fn_199(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_199] = [__v_8];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_192] = [__v_8];
+        record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -16313,19 +15847,19 @@ fn aiur_fn_199(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_199] = [__v_9];
-                record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_192] = [__v_9];
+                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_199] = [__v_11];
-                record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_192] = [__v_11];
+                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -16342,38 +15876,38 @@ fn aiur_fn_199(
   })
 }
 
-const INPUT_SIZE_200: usize = 1;
-const IN_200: usize = 1;
-const OUT_200: usize = 2;
-fn aiur_fn_200(
-  inp: [G; IN_200],
+const INPUT_SIZE_193: usize = 1;
+const IN_193: usize = 1;
+const OUT_193: usize = 2;
+fn aiur_fn_193(
+  inp: [G; IN_193],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_200], ExecError> {
+) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_200] = [__v_3, __v_4];
-    record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_193] = [__v_3, __v_4];
+    record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_201: usize = 2;
-const IN_201: usize = 2;
-const OUT_201: usize = 2;
-fn aiur_fn_201(
-  inp: [G; IN_201],
+const INPUT_SIZE_194: usize = 2;
+const IN_194: usize = 2;
+const OUT_194: usize = 2;
+fn aiur_fn_194(
+  inp: [G; IN_194],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_201], ExecError> {
+) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16382,61 +15916,61 @@ fn aiur_fn_201(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_201] = [__v_4, __v_0];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_194] = [__v_4, __v_0];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
         let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = __r_arr[1];
         let __v_8: G = G::from_u64(0);
         let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_201] = [__v_9, __v_7];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_194] = [__v_9, __v_7];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_202: usize = 1;
-const IN_202: usize = 1;
-const OUT_202: usize = 2;
-fn aiur_fn_202(
-  inp: [G; IN_202],
+const INPUT_SIZE_195: usize = 1;
+const IN_195: usize = 1;
+const OUT_195: usize = 2;
+fn aiur_fn_195(
+  inp: [G; IN_195],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_202], ExecError> {
+) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_202] = [__v_3, __v_4];
-    record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_195] = [__v_3, __v_4];
+    record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_203: usize = 2;
-const IN_203: usize = 2;
-const OUT_203: usize = 2;
-fn aiur_fn_203(
-  inp: [G; IN_203],
+const INPUT_SIZE_196: usize = 2;
+const IN_196: usize = 2;
+const OUT_196: usize = 2;
+fn aiur_fn_196(
+  inp: [G; IN_196],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_203], ExecError> {
+) -> Result<[G; OUT_196], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16445,8 +15979,8 @@ fn aiur_fn_203(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_203] = [__v_4, __v_0];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_4, __v_0];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16462,28 +15996,28 @@ fn aiur_fn_203(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_203] = [__v_16, __v_14];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_16, __v_14];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_204: usize = 64;
-const IN_204: usize = 64;
-const OUT_204: usize = 0;
-fn aiur_fn_204(
-  inp: [G; IN_204],
+const INPUT_SIZE_197: usize = 64;
+const IN_197: usize = 64;
+const OUT_197: usize = 0;
+fn aiur_fn_197(
+  inp: [G; IN_197],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_204], ExecError> {
+) -> Result<[G; OUT_197], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16606,7 +16140,7 @@ fn aiur_fn_204(
     let __v_113: G = G::from_u64(2);
     let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = __r_arr[1];
     let __v_117: G = (__v_66 + __v_67);
@@ -16957,33 +16491,33 @@ fn aiur_fn_204(
     if (__v_250 != __v_252) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_253: G = __r_arr[0];
     let __v_254: G = G::from_u64(1);
     if (__v_253 != __v_254) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
     let __v_255: G = __r_arr[0];
     let __v_256: G = G::from_u64(1);
     if (__v_255 != __v_256) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
-    let __ret: [G; OUT_204] = [];
-    record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_197] = [];
+    record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_205: usize = 1;
-const IN_205: usize = 1;
-const OUT_205: usize = 1;
-fn aiur_fn_205(
-  inp: [G; IN_205],
+const INPUT_SIZE_198: usize = 1;
+const IN_198: usize = 1;
+const OUT_198: usize = 1;
+fn aiur_fn_198(
+  inp: [G; IN_198],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_205], ExecError> {
+) -> Result<[G; OUT_198], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16993,17 +16527,17 @@ fn aiur_fn_205(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_205] = [__v_4];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_198] = [__v_4];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = G::from_u64(1);
         let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_205] = [__v_6];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_198] = [__v_6];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17013,15 +16547,15 @@ fn aiur_fn_205(
   })
 }
 
-const INPUT_SIZE_206: usize = 1;
-const IN_206: usize = 1;
-const OUT_206: usize = 1;
-fn aiur_fn_206(
-  inp: [G; IN_206],
+const INPUT_SIZE_199: usize = 1;
+const IN_199: usize = 1;
+const OUT_199: usize = 1;
+fn aiur_fn_199(
+  inp: [G; IN_199],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_206], ExecError> {
+) -> Result<[G; OUT_199], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -17031,14 +16565,14 @@ fn aiur_fn_206(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_206] = [__v_4];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_206] = [__v_4];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17048,19 +16582,19 @@ fn aiur_fn_206(
   })
 }
 
-const INPUT_SIZE_207: usize = 2;
-const IN_207: usize = 2;
-const OUT_207: usize = 2;
-fn aiur_fn_207(
-  inp: [G; IN_207],
+const INPUT_SIZE_200: usize = 2;
+const IN_200: usize = 2;
+const OUT_200: usize = 2;
+fn aiur_fn_200(
+  inp: [G; IN_200],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_207], ExecError> {
+) -> Result<[G; OUT_200], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_222] = { let __args: [G; IN_222] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[222].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_222] = unsafe { *(result.output.as_ptr() as *const [G; OUT_222]) }; __ret } else { aiur_fn_222(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -17069,8 +16603,8 @@ fn aiur_fn_207(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_207] = [__v_4, __v_5];
-        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_4, __v_5];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17080,15 +16614,15 @@ fn aiur_fn_207(
   })
 }
 
-const INPUT_SIZE_208: usize = 1;
-const IN_208: usize = 1;
-const OUT_208: usize = 8;
-fn aiur_fn_208(
-  inp: [G; IN_208],
+const INPUT_SIZE_201: usize = 1;
+const IN_201: usize = 1;
+const OUT_201: usize = 8;
+fn aiur_fn_201(
+  inp: [G; IN_201],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_208], ExecError> {
+) -> Result<[G; OUT_201], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -17112,12 +16646,12 @@ fn aiur_fn_208(
         let __v_16: G = G::from_u64(0);
         let __v_17: G = G::from_u64(0);
         let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_208] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
-        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
         let __v_13: G = __r_arr[2];
@@ -17135,8 +16669,8 @@ fn aiur_fn_208(
         let __v_24: G = __r_arr[5];
         let __v_25: G = __r_arr[6];
         let __v_26: G = __r_arr[7];
-        let __ret: [G; OUT_208] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
-        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17146,61 +16680,19 @@ fn aiur_fn_208(
   })
 }
 
-const INPUT_SIZE_209: usize = 2;
-const IN_209: usize = 2;
-const OUT_209: usize = 12;
-fn aiur_fn_209(
-  inp: [G; IN_209],
+const INPUT_SIZE_202: usize = 2;
+const IN_202: usize = 2;
+const OUT_202: usize = 1;
+fn aiur_fn_202(
+  inp: [G; IN_202],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_209], ExecError> {
+) -> Result<[G; OUT_202], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_221] = { let __args: [G; IN_221] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[221].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_221] = unsafe { *(result.output.as_ptr() as *const [G; OUT_221]) }; __ret } else { aiur_fn_221(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    let __v_6: G = __loaded[3];
-    let __v_7: G = __loaded[4];
-    let __v_8: G = __loaded[5];
-    let __v_9: G = __loaded[6];
-    let __v_10: G = __loaded[7];
-    let __v_11: G = __loaded[8];
-    let __v_12: G = __loaded[9];
-    let __v_13: G = __loaded[10];
-    let __v_14: G = __loaded[11];
-    let __v_15: G = __loaded[12];
-    let __v_16: G = __loaded[13];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_209] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_210: usize = 2;
-const IN_210: usize = 2;
-const OUT_210: usize = 1;
-fn aiur_fn_210(
-  inp: [G; IN_210],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_210], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -17208,8 +16700,8 @@ fn aiur_fn_210(
     let __v_5: G = __loaded[2];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_210] = [__v_4];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_202] = [__v_4];
+        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17219,15 +16711,15 @@ fn aiur_fn_210(
   })
 }
 
-const INPUT_SIZE_211: usize = 1;
-const IN_211: usize = 1;
-const OUT_211: usize = 1;
-fn aiur_fn_211(
-  inp: [G; IN_211],
+const INPUT_SIZE_203: usize = 1;
+const IN_203: usize = 1;
+const OUT_203: usize = 1;
+fn aiur_fn_203(
+  inp: [G; IN_203],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_211], ExecError> {
+) -> Result<[G; OUT_203], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
@@ -17239,17 +16731,17 @@ fn aiur_fn_211(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_211] = [__v_6];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_203] = [__v_6];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = G::from_u64(1);
         let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_211] = [__v_8];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_203] = [__v_8];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17259,15 +16751,15 @@ fn aiur_fn_211(
   })
 }
 
-const INPUT_SIZE_212: usize = 1;
-const IN_212: usize = 1;
-const OUT_212: usize = 1;
-fn aiur_fn_212(
-  inp: [G; IN_212],
+const INPUT_SIZE_204: usize = 1;
+const IN_204: usize = 1;
+const OUT_204: usize = 1;
+fn aiur_fn_204(
+  inp: [G; IN_204],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_212], ExecError> {
+) -> Result<[G; OUT_204], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -17278,17 +16770,17 @@ fn aiur_fn_212(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_212] = [__v_5];
-        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_204] = [__v_5];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = G::from_u64(1);
         let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_212] = [__v_7];
-        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_204] = [__v_7];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17298,15 +16790,15 @@ fn aiur_fn_212(
   })
 }
 
-const INPUT_SIZE_213: usize = 2;
-const IN_213: usize = 2;
-const OUT_213: usize = 1;
-fn aiur_fn_213(
-  inp: [G; IN_213],
+const INPUT_SIZE_205: usize = 2;
+const IN_205: usize = 2;
+const OUT_205: usize = 1;
+fn aiur_fn_205(
+  inp: [G; IN_205],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_213], ExecError> {
+) -> Result<[G; OUT_205], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17323,17 +16815,17 @@ fn aiur_fn_213(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_213] = [__v_1];
-        record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_1];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_213] = [__v_14];
-        record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_14];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17343,15 +16835,15 @@ fn aiur_fn_213(
   })
 }
 
-const INPUT_SIZE_214: usize = 1;
-const IN_214: usize = 1;
-const OUT_214: usize = 8;
-fn aiur_fn_214(
-  inp: [G; IN_214],
+const INPUT_SIZE_206: usize = 1;
+const IN_206: usize = 1;
+const OUT_206: usize = 8;
+fn aiur_fn_206(
+  inp: [G; IN_206],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_214], ExecError> {
+) -> Result<[G; OUT_206], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -17368,12 +16860,12 @@ fn aiur_fn_214(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_214] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = __r_arr[1];
         let __v_6: G = __r_arr[2];
@@ -17391,8 +16883,8 @@ fn aiur_fn_214(
         let __v_17: G = __r_arr[5];
         let __v_18: G = __r_arr[6];
         let __v_19: G = __r_arr[7];
-        let __ret: [G; OUT_214] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
-        record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_206] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17402,15 +16894,15 @@ fn aiur_fn_214(
   })
 }
 
-const INPUT_SIZE_215: usize = 2;
-const IN_215: usize = 2;
-const OUT_215: usize = 1;
-fn aiur_fn_215(
-  inp: [G; IN_215],
+const INPUT_SIZE_207: usize = 2;
+const IN_207: usize = 2;
+const OUT_207: usize = 1;
+fn aiur_fn_207(
+  inp: [G; IN_207],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_215], ExecError> {
+) -> Result<[G; OUT_207], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17420,17 +16912,17 @@ fn aiur_fn_215(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_215] = [__v_1];
-        record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_207] = [__v_1];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_215] = [__v_7];
-        record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_207] = [__v_7];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17440,28 +16932,28 @@ fn aiur_fn_215(
   })
 }
 
-const INPUT_SIZE_216: usize = 2;
-const IN_216: usize = 2;
-const OUT_216: usize = 1;
-fn aiur_fn_216(
-  inp: [G; IN_216],
+const INPUT_SIZE_208: usize = 2;
+const IN_208: usize = 2;
+const OUT_208: usize = 1;
+fn aiur_fn_208(
+  inp: [G; IN_208],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_216], ExecError> {
+) -> Result<[G; OUT_208], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_216] = [__v_0];
-        record.function_queries[216].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_208] = [__v_0];
+        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17469,8 +16961,8 @@ fn aiur_fn_216(
         let __v_7: G = __loaded[2];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_216] = [__v_7];
-            record.function_queries[216].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_208] = [__v_7];
+            record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -17482,15 +16974,15 @@ fn aiur_fn_216(
   })
 }
 
-const INPUT_SIZE_217: usize = 1;
-const IN_217: usize = 1;
-const OUT_217: usize = 1;
-fn aiur_fn_217(
-  inp: [G; IN_217],
+const INPUT_SIZE_209: usize = 1;
+const IN_209: usize = 1;
+const OUT_209: usize = 1;
+fn aiur_fn_209(
+  inp: [G; IN_209],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_217], ExecError> {
+) -> Result<[G; OUT_209], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
@@ -17504,17 +16996,17 @@ fn aiur_fn_217(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_217] = [__v_8];
-        record.function_queries[217].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_209] = [__v_8];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
         let __v_9: G = G::from_u64(1);
         let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_217] = [__v_10];
-        record.function_queries[217].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_209] = [__v_10];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17524,15 +17016,15 @@ fn aiur_fn_217(
   })
 }
 
-const INPUT_SIZE_218: usize = 1;
-const IN_218: usize = 1;
-const OUT_218: usize = 1;
-fn aiur_fn_218(
-  inp: [G; IN_218],
+const INPUT_SIZE_210: usize = 1;
+const IN_210: usize = 1;
+const OUT_210: usize = 1;
+fn aiur_fn_210(
+  inp: [G; IN_210],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_218], ExecError> {
+) -> Result<[G; OUT_210], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -17549,17 +17041,17 @@ fn aiur_fn_218(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_218] = [__v_11];
-        record.function_queries[218].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_11];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_u64(1);
         let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_218] = [__v_13];
-        record.function_queries[218].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_13];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17569,15 +17061,15 @@ fn aiur_fn_218(
   })
 }
 
-const INPUT_SIZE_219: usize = 1;
-const IN_219: usize = 1;
-const OUT_219: usize = 1;
-fn aiur_fn_219(
-  inp: [G; IN_219],
+const INPUT_SIZE_211: usize = 1;
+const IN_211: usize = 1;
+const OUT_211: usize = 1;
+fn aiur_fn_211(
+  inp: [G; IN_211],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_219], ExecError> {
+) -> Result<[G; OUT_211], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
@@ -17598,17 +17090,17 @@ fn aiur_fn_219(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_15: G = G::from_u64(0);
-        let __ret: [G; OUT_219] = [__v_15];
-        record.function_queries[219].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_211] = [__v_15];
+        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = G::from_u64(1);
         let __v_17: G = (__v_15 + __v_16);
-        let __ret: [G; OUT_219] = [__v_17];
-        record.function_queries[219].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_211] = [__v_17];
+        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17618,19 +17110,19 @@ fn aiur_fn_219(
   })
 }
 
-const INPUT_SIZE_220: usize = 2;
-const IN_220: usize = 2;
-const OUT_220: usize = 32;
-fn aiur_fn_220(
-  inp: [G; IN_220],
+const INPUT_SIZE_212: usize = 2;
+const IN_212: usize = 2;
+const OUT_212: usize = 32;
+fn aiur_fn_212(
+  inp: [G; IN_212],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_220], ExecError> {
+) -> Result<[G; OUT_212], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_223] = { let __args: [G; IN_223] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[223].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_223] = unsafe { *(result.output.as_ptr() as *const [G; OUT_223]) }; __ret } else { aiur_fn_223(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -17669,8 +17161,8 @@ fn aiur_fn_220(
     let __v_36: G = __loaded[33];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_220] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
-        record.function_queries[220].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_212] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
+        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17680,81 +17172,28 @@ fn aiur_fn_220(
   })
 }
 
-const INPUT_SIZE_221: usize = 2;
-const IN_221: usize = 2;
-const OUT_221: usize = 1;
-fn aiur_fn_221(
-  inp: [G; IN_221],
+const INPUT_SIZE_213: usize = 2;
+const IN_213: usize = 2;
+const OUT_213: usize = 1;
+fn aiur_fn_213(
+  inp: [G; IN_213],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_221], ExecError> {
+) -> Result<[G; OUT_213], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_221] = [__v_0];
-        record.function_queries[221].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_213] = [__v_0];
+        record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_221] = { let __args: [G; IN_221] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[221].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_221] = unsafe { *(result.output.as_ptr() as *const [G; OUT_221]) }; __ret } else { aiur_fn_221(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        let __v_8: G = __loaded[3];
-        let __v_9: G = __loaded[4];
-        let __v_10: G = __loaded[5];
-        let __v_11: G = __loaded[6];
-        let __v_12: G = __loaded[7];
-        let __v_13: G = __loaded[8];
-        let __v_14: G = __loaded[9];
-        let __v_15: G = __loaded[10];
-        let __v_16: G = __loaded[11];
-        let __v_17: G = __loaded[12];
-        let __v_18: G = __loaded[13];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_221] = [__v_18];
-            record.function_queries[221].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_222: usize = 2;
-const IN_222: usize = 2;
-const OUT_222: usize = 1;
-fn aiur_fn_222(
-  inp: [G; IN_222],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_222], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_222] = [__v_0];
-        record.function_queries[222].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_222] = { let __args: [G; IN_222] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[222].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_222] = unsafe { *(result.output.as_ptr() as *const [G; OUT_222]) }; __ret } else { aiur_fn_222(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17763,8 +17202,8 @@ fn aiur_fn_222(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_222] = [__v_8];
-            record.function_queries[222].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_213] = [__v_8];
+            record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -17776,28 +17215,28 @@ fn aiur_fn_222(
   })
 }
 
-const INPUT_SIZE_223: usize = 2;
-const IN_223: usize = 2;
-const OUT_223: usize = 1;
-fn aiur_fn_223(
-  inp: [G; IN_223],
+const INPUT_SIZE_214: usize = 2;
+const IN_214: usize = 2;
+const OUT_214: usize = 1;
+fn aiur_fn_214(
+  inp: [G; IN_214],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_223], ExecError> {
+) -> Result<[G; OUT_214], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_223] = [__v_0];
-        record.function_queries[223].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_214] = [__v_0];
+        record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_223] = { let __args: [G; IN_223] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[223].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_223] = unsafe { *(result.output.as_ptr() as *const [G; OUT_223]) }; __ret } else { aiur_fn_223(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17836,8 +17275,8 @@ fn aiur_fn_223(
         let __v_38: G = __loaded[33];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_223] = [__v_38];
-            record.function_queries[223].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_214] = [__v_38];
+            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -18929,51 +18368,6 @@ pub(crate) fn execute_generated(
     214u64 => {
       let __inp: [G; IN_214] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_214(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    215u64 => {
-      let __inp: [G; IN_215] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_215(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    216u64 => {
-      let __inp: [G; IN_216] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_216(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    217u64 => {
-      let __inp: [G; IN_217] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_217(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    218u64 => {
-      let __inp: [G; IN_218] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_218(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    219u64 => {
-      let __inp: [G; IN_219] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_219(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    220u64 => {
-      let __inp: [G; IN_220] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_220(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    221u64 => {
-      let __inp: [G; IN_221] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_221(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    222u64 => {
-      let __inp: [G; IN_222] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_222(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    223u64 => {
-      let __inp: [G; IN_223] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_223(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {


### PR DESCRIPTION
Bump multi-stark to 678f8e1c96b3d67eaddaa9aa8d03cd7695f97081, which commits each circuit's quotient coefficient slices as one wide matrix on the trace domain (opened once at ζ) instead of one matrix per slice on the split sub-cosets.

Port the recursive verifier to the new proof shape:
- OOD: quotient(ζ) is now the power series Σᵢ ζ^(i·n)·cᵢ(ζ) over the slice values reconstructed from the single opened row, replacing the sub-domain Lagrange recombination (zps products over vanishing polynomials). Adds the check_shapes width assert (qd slices per row) and the one-matrix-per-circuit round-length check in verify().
- PCS: the quotient FRI batch is one matrix per circuit at the same per-circuit heights as the stages; the per-chunk open loop and the chunk-expanded height list are gone, and the verifying-key circuit list no longer threads through the PCS phase.
- Delete the dead zps machinery (g_pow, vanish_chunk, zps_prod, quotient_sum, log_qd_of, open_q_chunks, heights_quotient, repeat_g).

Regenerate crates/ixvm-codegen/src/aiur_multi_stark.rs (215 aiur fns).

Verified: multi-stark self-tests and the recursive-verifier end-to-end suite pass (honest proof accepted, codegen/interpreter parity holds, tampered proof and tampered claim rejected).