### PR TITLE
fix: Apps.ZKVoting.Prover ignored test

### DIFF
--- a/.github/workflows/ignored.yml
+++ b/.github/workflows/ignored.yml
@@ -3,7 +3,6 @@ name: Extended CI tests
 on:
   push:
     branches: main
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ignored.yml
+++ b/.github/workflows/ignored.yml
@@ -3,6 +3,7 @@ name: Extended CI tests
 on:
   push:
     branches: main
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/Ix/Commit.lean
+++ b/Ix/Commit.lean
@@ -147,11 +147,16 @@ def commitDef (compileEnv : CompileM.CompileEnv) (leanEnv : Lean.Environment)
     | .ok env => pure env
     | .error _e => throw $ IO.userError "commitDef: addDeclCore failed"
 
-  -- 4. Also register the committed name in CompileEnv so later compilations can reference it
+  -- 4. Also register the committed name in CompileEnv so later compilations
+  --    can reference it. Both maps must carry it: `nameToNamed` is the final
+  --    named registry, but expression compilation resolves names through
+  --    `nameToAddr` (`lookupConstAddr`'s first hop) — without the latter a
+  --    reference to the commitment fails with `missingConstant`.
   let (ixCommitName, _) := (CanonM.canonName commitName).run {}
   let compileEnv'' := { compileEnv' with
     nameToNamed := compileEnv'.nameToNamed.insert ixCommitName
       { addr := payloadAddr, constMeta := .empty }
+    nameToAddr := compileEnv'.nameToAddr.insert ixCommitName payloadAddr
   }
 
   return (commitAddr, leanEnv', compileEnv'')


### PR DESCRIPTION
#509 split CompileEnv name resolution — nameToAddr became the authority consulted by lookupConstAddr, seeded in mkCompileEnv — but commitDef was not updated and kept registering commitments only in nameToNamed (the final named registry, not the resolution map). Referencing a committed constant then failed with `missingConstant`, breaking Apps.ZKVoting.Prover. Also insert into nameToAddr so committed constants resolve.

Successful run: https://github.com/argumentcomputer/ix/actions/runs/30111995374/job/89543507174