### PR TITLE
Ixon text format (.ixon): AST-level parser + canonical printer in Rus…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "indexmap",
  "ix-common",
  "memmap2",
+ "nom",
  "num-bigint",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
 multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "40092c160f51fdc2330b9e388873ece3fa4c12c2" }
+nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"

--- a/Ix.lean
+++ b/Ix.lean
@@ -4,6 +4,7 @@ module
 public import Ix.Environment
 public import Ix.CanonM
 public import Ix.Ixon
+public import Ix.IxonSyntax
 public import Ix.Sharing
 public import Ix.Meta
 public import Ix.GraphM

--- a/Ix/IxonSyntax.lean
+++ b/Ix/IxonSyntax.lean
@@ -1,0 +1,20 @@
+/-
+  Ixon text format (`.ixon`): parser and canonical pretty-printer.
+
+  The textual syntax denotes the *named Ix level* — a Lean-resembling
+  closed grammar over `Ix.Expr`-shaped trees — never the pack-level
+  tables (sharing/refs/univs are derived by the one canonical compile
+  pipeline). See `plans/ixon-syntax.md` for the design and
+  requirements (R1–R8), and `crates/ixon/src/syntax/` for the Rust
+  twin this module mirrors behaviorally.
+
+  This is the AST-level layer: text ↔ AST both ways, with structured
+  errors and metered parsing. The `Constant` ↔ AST stages
+  (resolve/ingress and the metadata-arena printer walk) build on top.
+-/
+module
+
+public import Ix.IxonSyntax.AST
+public import Ix.IxonSyntax.Error
+public import Ix.IxonSyntax.Parser
+public import Ix.IxonSyntax.Print

--- a/Ix/IxonSyntax/AST.lean
+++ b/Ix/IxonSyntax/AST.lean
@@ -1,0 +1,387 @@
+/-
+  Surface AST for the Ixon text format (`.ixon`).
+
+  Behavioral mirror of `crates/ixon/src/syntax/ast.rs` — same shapes,
+  same invariants. The AST is the hub shared by the parser and the
+  pretty-printer: it denotes the *named Ix level* (Ix.Expr minus
+  fvar/mvar/mdata) plus source spans and the three reference forms
+  (`Name`, `#hash`, `Name#hash`). Nothing here knows about the pack
+  format: no tables, no de Bruijn indices, no blob addresses.
+
+  Every node carries a byte-offset `Span`. Roundtrip tests compare at
+  the text level (`print ∘ parse ∘ print = print`), never by AST
+  equality (spans differ across a roundtrip).
+-/
+module
+
+public import Lean.Expr
+
+public section
+
+namespace Ixon.Syntax
+
+/-- Grammar version this implementation speaks (R7). The `ixon <n>`
+    header is optional: absent means version 1, forever; grammar
+    versions ≥ 2 must declare themselves, and canonical version-1
+    output omits the header. Mirrors Rust `syntax::VERSION`. -/
+def VERSION : Nat := 1
+
+/-- Parser resource caps (R2: gas for admission). Mirrors Rust
+    `syntax::Limits`, including the defaults. -/
+structure Limits where
+  /-- Maximum input length in bytes (checked before any work). -/
+  maxBytes : Nat := 1 <<< 20
+  /-- Maximum AST node count (checked after parse; no ε-productions,
+      so `maxBytes` already bounds it). -/
+  maxNodes : Nat := 1 <<< 20
+  /-- Maximum nesting depth (checked during descent). -/
+  maxDepth : Nat := 512
+  deriving BEq, Repr, Inhabited
+
+/-- Byte-offset span into the source: `start` inclusive, `stop`
+    exclusive. -/
+structure Span where
+  start : Nat := 0
+  stop : Nat := 0
+  deriving BEq, Repr, Inhabited
+
+/-- Smallest span covering both. -/
+def Span.to (a b : Span) : Span :=
+  ⟨min a.start b.start, max a.stop b.stop⟩
+
+/-- One surface name component. Mirrors Rust
+    `ix_common::env::NameComponent`. -/
+inductive NameComponent where
+  | str (s : String)
+  | num (n : Nat)
+  deriving BEq, Repr, Inhabited
+
+/-- A surface (dotted) name: raw components, no hashing. Numeric
+    components are legal only in non-leading position. -/
+structure SName where
+  parts : Array NameComponent
+  span : Span := {}
+  deriving BEq, Repr, Inhabited
+
+/-- A `#hex` reference: 4–64 lowercase hex digits (exactly 64 in
+    import position). -/
+structure HashRef where
+  hex : String
+  span : Span := {}
+  deriving BEq, Repr, Inhabited
+
+/-- Universe-level expression. -/
+inductive UnivExpr where
+  | nat (n : Nat) (span : Span)
+  | var (c : NameComponent) (span : Span)
+  | add (u : UnivExpr) (n : Nat) (span : Span)
+  | max (a b : UnivExpr) (span : Span)
+  | imax (a b : UnivExpr) (span : Span)
+  deriving BEq, Repr, Inhabited
+
+def UnivExpr.span : UnivExpr → Span
+  | .nat _ s | .var _ s | .add _ _ s | .max _ _ s | .imax _ _ s => s
+
+/-- Constant reference: `Name`, `#hash`, or pinned `Name#hash`.
+    Invariant: at least one of `name`/`hash` present; `levels = none`
+    is the bare zero-default form, `some vs` the explicit `.{…}` form
+    (`vs` nonempty). -/
+structure ConstRef where
+  name : Option SName := none
+  hash : Option HashRef := none
+  levels : Option (Array UnivExpr) := none
+  span : Span := {}
+  deriving BEq, Repr, Inhabited
+
+/-- `Prop` | `Type u?` | `Sort u` — surface distinction kept for exact
+    printing. -/
+inductive SortKind where
+  | prop
+  | type (u : Option UnivExpr)
+  | sort (u : UnivExpr)
+  deriving BEq, Repr, Inhabited
+
+/-- A binder name: identifier component or `_`. -/
+inductive BinderName where
+  | ident (c : NameComponent) (span : Span)
+  | anon (span : Span)
+  deriving BEq, Repr, Inhabited
+
+def BinderName.span : BinderName → Span
+  | .ident _ s | .anon s => s
+
+mutual
+
+/-- Surface term. Mirrors Rust `syntax::ast::Term`. -/
+inductive Term where
+  | ref (r : ConstRef)
+  | sort (k : SortKind) (span : Span)
+  /-- Application spine `f a b c` (`args` nonempty); the canonical
+      printer flattens nested spines. -/
+  | app (head : Term) (args : Array Term) (span : Span)
+  | lam (binders : Array BinderGroup) (body : Term) (span : Span)
+  | pi (binders : Array BinderGroup) (body : Term) (span : Span)
+  | arrow (dom cod : Term) (span : Span)
+  /-- `let` (`nonDep = false`) / `have` (`nonDep = true`) —
+      address-relevant. -/
+  | letE (nonDep : Bool) (name : BinderName) (ty val body : Term)
+      (span : Span)
+  | natLit (n : Nat) (span : Span)
+  | strLit (s : String) (span : Span)
+  | proj (typeRef : ConstRef) (idx : Nat) (val : Term) (span : Span)
+
+/-- One bracketed binder group; bracket shape is `Lean.BinderInfo` —
+    metadata only, never address-relevant. Unnamed instance `[T]` has
+    empty `names`. -/
+inductive BinderGroup where
+  | mk (info : Lean.BinderInfo) (names : Array BinderName) (ty : Term)
+      (span : Span)
+
+end
+
+instance : Inhabited Term := ⟨.sort .prop {}⟩
+
+instance : Inhabited BinderGroup :=
+  ⟨.mk .default #[] (.sort .prop {}) {}⟩
+
+def BinderGroup.info : BinderGroup → Lean.BinderInfo
+  | .mk i _ _ _ => i
+
+def BinderGroup.names : BinderGroup → Array BinderName
+  | .mk _ n _ _ => n
+
+def BinderGroup.ty : BinderGroup → Term
+  | .mk _ _ t _ => t
+
+def BinderGroup.span : BinderGroup → Span
+  | .mk _ _ _ s => s
+
+def Term.span : Term → Span
+  | .ref r => r.span
+  | .sort _ s | .natLit _ s | .strLit _ s => s
+  | .app _ _ s | .lam _ _ s | .pi _ _ s | .arrow _ _ s
+  | .letE _ _ _ _ _ s | .proj _ _ _ s => s
+
+/-- `def` / `theorem` / `opaque` — address-relevant. -/
+inductive DefKw where
+  | defn
+  | thm
+  | opaq
+  deriving BEq, Repr, Inhabited
+
+/-- Declaration modifiers — address-relevant (`DefinitionSafety`). -/
+structure Modifiers where
+  isUnsafe : Bool := false
+  isPartial : Bool := false
+  deriving BEq, Repr, Inhabited
+
+/-- Universe parameter binder in `.{u, v}` declaration position. -/
+structure UParam where
+  name : NameComponent
+  span : Span := {}
+  deriving BEq, Repr, Inhabited
+
+/-- `def Name.{u} : T := v`. -/
+structure DefDecl where
+  kw : DefKw
+  mods : Modifiers := {}
+  name : Option SName := none
+  uparams : Array UParam := #[]
+  ty : Term
+  value : Term
+  span : Span := {}
+  deriving Inhabited
+
+/-- `axiom Name.{u} : T`. -/
+structure AxiomDecl where
+  isUnsafe : Bool := false
+  name : Option SName := none
+  uparams : Array UParam := #[]
+  ty : Term
+  span : Span := {}
+  deriving Inhabited
+
+/-- The four quotient primitives. -/
+inductive QuotKindKw where
+  | type
+  | ctor
+  | lift
+  | ind
+  deriving BEq, Repr, Inhabited
+
+/-- `quot type|ctor|lift|ind Name.{u} : T`. -/
+structure QuotDecl where
+  kind : QuotKindKw
+  name : Option SName := none
+  uparams : Array UParam := #[]
+  ty : Term
+  span : Span := {}
+  deriving Inhabited
+
+/-- Constructor inside `inductive … where`. -/
+structure CtorDecl where
+  name : Option SName := none
+  params : Nat
+  fields : Nat
+  ty : Term
+  span : Span := {}
+  deriving Inhabited
+
+/-- `inductive Name.{u} (params := n) (indices := m) : T where …`. -/
+structure IndDecl where
+  isUnsafe : Bool := false
+  name : Option SName := none
+  uparams : Array UParam := #[]
+  params : Nat
+  indices : Nat
+  ty : Term
+  ctors : Array CtorDecl := #[]
+  span : Span := {}
+  deriving Inhabited
+
+/-- Recursor rule `| rule (fields := n) := rhs`. -/
+structure RuleDecl where
+  fields : Nat
+  rhs : Term
+  span : Span := {}
+  deriving Inhabited
+
+/-- `recursor Name.{u} (params := …) … : T where …`. -/
+structure RecrDecl where
+  isUnsafe : Bool := false
+  name : Option SName := none
+  uparams : Array UParam := #[]
+  params : Nat
+  indices : Nat
+  motives : Nat
+  minors : Nat
+  k : Bool := false
+  ty : Term
+  rules : Array RuleDecl := #[]
+  span : Span := {}
+  deriving Inhabited
+
+/-- The four projection-constant kinds. -/
+inductive PrjKind where
+  | dprj
+  | iprj
+  | cprj
+  | rprj
+  deriving BEq, Repr, Inhabited
+
+/-- Projection constant `cprj Name := #block i c` etc.; `cidx` present
+    iff `kind = cprj`. -/
+structure PrjDecl where
+  kind : PrjKind
+  name : Option SName := none
+  block : HashRef
+  idx : Nat
+  cidx : Option Nat := none
+  span : Span := {}
+  deriving Inhabited
+
+/-- Top-level declaration. `muts` members are restricted to
+    `defn`/`indc`/`recr`. -/
+inductive Decl where
+  | defn (d : DefDecl)
+  | axio (d : AxiomDecl)
+  | quot (d : QuotDecl)
+  | indc (d : IndDecl)
+  | recr (d : RecrDecl)
+  | muts (members : Array Decl) (span : Span)
+  | prj (d : PrjDecl)
+  deriving Inhabited
+
+def Decl.span : Decl → Span
+  | .defn d => d.span
+  | .axio d => d.span
+  | .quot d => d.span
+  | .indc d => d.span
+  | .recr d => d.span
+  | .muts _ s => s
+  | .prj d => d.span
+
+/-- `import Foo.Bar#hash` (mount under prefix) / `import #hash` (mount
+    at root); import hashes are always full 64-hex. -/
+structure ImportDecl where
+  prefixName : Option SName := none
+  hash : HashRef
+  span : Span := {}
+  deriving Inhabited
+
+/-- The file's main expression: a trailing `⊢ value : type` item. The
+    annotation is mandatory (it is the constant's `typ` — inference
+    would be elaboration, R4); the turnstile is load-bearing (without
+    it a preceding declaration's final term absorbs an atom-headed
+    value as an application argument). Compiles like an anonymous
+    `def : T := v` (defn-kind, safe, monomorphic) and marks the result
+    as the file's `main` constant. -/
+structure MainExpr where
+  value : Term
+  ty : Term
+  span : Span := {}
+  deriving Inhabited
+
+/-- A parsed `.ixon` file. -/
+structure File where
+  version : Nat
+  imports : Array ImportDecl := #[]
+  decls : Array Decl := #[]
+  main : Option MainExpr := none
+  span : Span := {}
+  deriving Inhabited
+
+/-! ## Node counting (the `maxNodes` limit, R2) -/
+
+mutual
+
+partial def countTermNodes : Term → Nat
+  | .ref r => countRefNodes r
+  | .sort k _ =>
+    match k with
+    | .type (some u) | .sort u => 1 + countUnivNodes u
+    | _ => 1
+  | .app h args _ =>
+    args.foldl (fun acc a => acc + countTermNodes a) (1 + countTermNodes h)
+  | .lam bs body _ | .pi bs body _ =>
+    bs.foldl (fun acc b => acc + 1 + countTermNodes b.ty)
+      (1 + countTermNodes body)
+  | .arrow d c _ => 1 + countTermNodes d + countTermNodes c
+  | .letE _ _ t v b _ =>
+    1 + countTermNodes t + countTermNodes v + countTermNodes b
+  | .natLit .. | .strLit .. => 1
+  | .proj tr _ v _ => 1 + countRefNodes tr + countTermNodes v
+
+partial def countRefNodes (r : ConstRef) : Nat :=
+  match r.levels with
+  | some ls => ls.foldl (fun acc l => acc + countUnivNodes l) 1
+  | none => 1
+
+partial def countUnivNodes : UnivExpr → Nat
+  | .nat .. | .var .. => 1
+  | .add a _ _ => 1 + countUnivNodes a
+  | .max a b _ | .imax a b _ => 1 + countUnivNodes a + countUnivNodes b
+
+end
+
+partial def countDeclNodes : Decl → Nat
+  | .defn d => 1 + countTermNodes d.ty + countTermNodes d.value
+  | .axio d => 1 + countTermNodes d.ty
+  | .quot d => 1 + countTermNodes d.ty
+  | .indc d =>
+    d.ctors.foldl (fun acc c => acc + 1 + countTermNodes c.ty)
+      (1 + countTermNodes d.ty)
+  | .recr d =>
+    d.rules.foldl (fun acc r => acc + 1 + countTermNodes r.rhs)
+      (1 + countTermNodes d.ty)
+  | .muts ms _ => ms.foldl (fun acc m => acc + countDeclNodes m) 1
+  | .prj _ => 1
+
+def countFileNodes (f : File) : Nat :=
+  let base := f.decls.foldl (fun acc d => acc + countDeclNodes d)
+    (1 + f.imports.size)
+  match f.main with
+  | some m => base + 1 + countTermNodes m.value + countTermNodes m.ty
+  | none => base
+
+end Ixon.Syntax

--- a/Ix/IxonSyntax/Error.lean
+++ b/Ix/IxonSyntax/Error.lean
@@ -1,0 +1,101 @@
+/-
+  Structured errors for the Ixon text format (R8: errors are data).
+
+  Behavioral mirror of `crates/ixon/src/syntax/error.rs`: same variant
+  set, same rendering, same line/column convention (1-based; column
+  counted in Unicode scalar values). The variant set is part of the
+  cross-language parity surface.
+-/
+module
+
+public import Ix.IxonSyntax.AST
+
+public section
+
+namespace Ixon.Syntax
+
+/-- Which parser limit was exceeded. -/
+inductive Cap where
+  | bytes
+  | nodes
+  | depth
+  deriving BEq, Repr, Inhabited
+
+/-- Structured error kind (parse-stage variants; the resolve stage
+    extends this later). Mirrors Rust `syntax::ErrorKind`. -/
+inductive ErrorKind where
+  | unexpectedToken (expected found : String)
+  | unknownVersion (found supported : Nat)
+  | capExceeded (which : Cap) (limit : Nat)
+  | invalidHash (reason : String)
+  | importHashLength (found : Nat)
+  | invalidEscape
+  | unterminatedString
+  | unterminatedQuotedName
+  | unterminatedComment
+  | natOutOfRange
+  | placeholder
+  | emptyLevels
+  | badMutualMember
+  | mainExprNotLast
+  deriving BEq, Repr, Inhabited
+
+/-- A positioned, structured syntax error. -/
+structure SyntaxError where
+  kind : ErrorKind
+  span : Span
+  /-- 1-based line of `span.start`. -/
+  line : Nat
+  /-- 1-based column (in Unicode scalar values) of `span.start`. -/
+  col : Nat
+  deriving BEq, Repr, Inhabited
+
+/-- Derive (1-based line, 1-based char column) for a byte offset. -/
+def lineCol (src : String) (pos : Nat) : Nat × Nat :=
+  go src.toList 0 1 1
+where
+  go : List Char → Nat → Nat → Nat → Nat × Nat
+    | [], _, line, col => (line, col)
+    | c :: cs, i, line, col =>
+      if i ≥ pos then (line, col)
+      else if c == '\n' then go cs (i + c.utf8Size) (line + 1) 1
+      else go cs (i + c.utf8Size) line (col + 1)
+
+/-- Build an error, deriving line/column from `src`. -/
+def SyntaxError.new (kind : ErrorKind) (span : Span) (src : String)
+    : SyntaxError :=
+  let (line, col) := lineCol src (min span.start src.utf8ByteSize)
+  { kind, span, line, col }
+
+def ErrorKind.render : ErrorKind → String
+  | .unexpectedToken expected found =>
+    s!"expected {expected}, found {found}"
+  | .unknownVersion found supported =>
+    s!"unknown ixon version {found} (this parser speaks {supported})"
+  | .capExceeded which limit =>
+    let w := match which with
+      | .bytes => "byte"
+      | .nodes => "node"
+      | .depth => "depth"
+    s!"{w} limit exceeded (max {limit})"
+  | .invalidHash reason => s!"invalid #hash reference: {reason}"
+  | .importHashLength found =>
+    s!"import hashes must be exactly 64 hex digits, found {found}"
+  | .invalidEscape => "invalid string escape"
+  | .unterminatedString => "unterminated string literal"
+  | .unterminatedQuotedName => "unterminated «…» name component"
+  | .unterminatedComment => "unterminated block comment"
+  | .natOutOfRange => "numeric literal out of range for this position"
+  | .placeholder => "`_` is not a term (the grammar has no holes)"
+  | .emptyLevels => "`.{}` must list at least one universe"
+  | .badMutualMember =>
+    "only def/theorem/opaque, inductive, and recursor declarations "
+      ++ "may appear in a mutual block"
+  | .mainExprNotLast =>
+    "a main expression (`⊢ value : type`) must be the last item "
+      ++ "in the file"
+
+instance : ToString SyntaxError where
+  toString e := s!"{e.line}:{e.col}: {e.kind.render}"
+
+end Ixon.Syntax

--- a/Ix/IxonSyntax/Parser.lean
+++ b/Ix/IxonSyntax/Parser.lean
@@ -1,0 +1,1347 @@
+/-
+  Recursive-descent parser for the Ixon text format.
+
+  Behavioral mirror of `crates/ixon/src/syntax/parse.rs`: same grammar,
+  same reserved words, same error kinds/messages/positions, same
+  metering semantics. Structure differs (handwritten descent here, nom
+  there) — parity is enforced by the shared corpus, not structurally.
+
+  Representation: the source is decoded once into a char array with a
+  parallel cumulative byte-offset table. Parsing walks char indices;
+  all emitted spans and error positions are byte offsets, matching the
+  Rust implementation exactly.
+
+  Whitespace is exactly `{' ', '\t', '\r', '\n'}` — an explicit set,
+  not a Unicode class (Unicode whitespace drifts by version; both
+  implementations use this list).
+-/
+module
+
+public import Ix.IxonSyntax.AST
+public import Ix.IxonSyntax.Error
+
+public section
+
+namespace Ixon.Syntax
+namespace Parser
+
+/-- Reserved words: rejected as bare name components everywhere
+    (escape as `«def»`). Every declaration-STARTING word must be
+    reserved — otherwise a preceding declaration's final term absorbs
+    it as an application argument in multi-decl files. Mirrors Rust
+    `RESERVED`. -/
+def RESERVED : List String :=
+  [ "import", "def", "theorem", "opaque", "axiom", "quot", "inductive",
+    "recursor", "mutual", "end", "unsafe", "partial", "fun", "let",
+    "have", "where", "proj", "Prop", "Type", "Sort", "dprj", "iprj",
+    "cprj", "rprj" ]
+
+def isReserved (s : String) : Bool := RESERVED.contains s
+
+/-- Lean's `isLetterLike` ranges (self-contained; parity-locked with
+    the Rust port, cross-checked against core in M4). -/
+def isLetterLike (c : Char) : Bool :=
+  let v := c.val
+  (0x3b1 ≤ v && v ≤ 0x3c9 && v != 0x3bb)                    -- greek lower (no λ)
+  || (0x391 ≤ v && v ≤ 0x3a9 && v != 0x3a0 && v != 0x3a3)   -- greek upper (no Π Σ)
+  || (0x3ca ≤ v && v ≤ 0x3fb)                               -- accented greek
+  || (0x1f00 ≤ v && v ≤ 0x1ffe)                             -- polytonic greek
+  || (0x2100 ≤ v && v ≤ 0x214f)                             -- letterlike symbols
+  || (0x1d49c ≤ v && v ≤ 0x1d59f)                           -- script/fraktur/etc.
+
+def isSubScript (c : Char) : Bool :=
+  let v := c.val
+  (0x2080 ≤ v && v ≤ 0x209c) || (0x1d62 ≤ v && v ≤ 0x1d6a) || v == 0x2c7c
+
+def isIdFirst (c : Char) : Bool :=
+  c.isAlpha || c == '_' || isLetterLike c
+
+def isIdRest (c : Char) : Bool :=
+  c.isAlphanum || c == '_' || c == '\'' || c == '!' || c == '?'
+  || isSubScript c || isLetterLike c
+
+/-- The whitespace set (explicit; see module docstring). -/
+def isWs (c : Char) : Bool :=
+  c == ' ' || c == '\t' || c == '\r' || c == '\n'
+
+/-- Parser context: decoded chars plus cumulative byte offsets
+    (`byteOff[i]` = byte offset of `chars[i]`; `byteOff[chars.size]` =
+    total byte size). -/
+structure Ctx where
+  chars : Array Char
+  byteOff : Array Nat
+  limits : Limits
+
+def Ctx.ofString (src : String) (limits : Limits) : Ctx := Id.run do
+  let chars := src.toList.toArray
+  let mut byteOff := Array.mkEmpty (chars.size + 1)
+  let mut o := 0
+  for c in chars do
+    byteOff := byteOff.push o
+    o := o + c.utf8Size
+  byteOff := byteOff.push o
+  return { chars, byteOff, limits }
+
+/-- Internal parse error. `pos` is a CHAR index (converted to bytes at
+    the boundary); `special` carries structured kinds with byte spans;
+    `fatal` mirrors Rust's committed `Failure`. -/
+structure PErr where
+  pos : Nat := 0
+  expected : String := ""
+  special : Option (ErrorKind × Span) := none
+  fatal : Bool := false
+  deriving Inhabited
+
+structure St where
+  idx : Nat := 0
+  depth : Nat := 0
+  deriving Inhabited
+
+abbrev M := ReaderT Ctx (EStateM PErr St)
+
+instance : Inhabited (M α) := ⟨fun _ s => .error default s⟩
+
+/-- Byte offset of char index `i`. -/
+def off (i : Nat) : M Nat := do
+  let ctx ← read
+  return ctx.byteOff[min i (ctx.byteOff.size - 1)]!
+
+def sp (fromIdx toIdx : Nat) : M Span := do
+  return ⟨← off fromIdx, ← off toIdx⟩
+
+def curIdx : M Nat := do return (← get).idx
+
+def setIdx (i : Nat) : M Unit := modify fun s => { s with idx := i }
+
+def peekAt (i : Nat) : M (Option Char) := do
+  return (← read).chars[i]?
+
+def peek : M (Option Char) := do peekAt (← get).idx
+
+/-- Backtrackable expectation failure at char index `i`. -/
+def failExp (i : Nat) (what : String) : M α :=
+  throw { pos := i, expected := what }
+
+/-- Committed structured failure. -/
+def failFatal (kind : ErrorKind) (span : Span) : M α :=
+  throw { pos := 0, special := some (kind, span), fatal := true }
+
+/-- Convert backtrackable errors into committed ones (Rust `cut`). -/
+def cut (p : M α) : M α :=
+  tryCatch p fun e => throw { e with fatal := true }
+
+/-- Run `p`; on a backtrackable error restore state and return `none`
+    (fatal errors propagate). The workhorse mirroring Rust's
+    `Err(Error) => fallback`. -/
+def attempt? (p : M α) : M (Option α) := do
+  let st ← get
+  tryCatch (some <$> p) fun e => do
+    if e.fatal then throw e
+    set st
+    return none
+
+/-- Depth guard (R2). -/
+def withDepth (p : M α) : M α := do
+  let ctx ← read
+  let st ← get
+  if st.depth ≥ ctx.limits.maxDepth then
+    let o ← off st.idx
+    failFatal (.capExceeded .depth ctx.limits.maxDepth) ⟨o, o⟩
+  else
+    modify fun s => { s with depth := s.depth + 1 }
+    tryCatch
+      (do
+        let a ← p
+        modify fun s => { s with depth := s.depth - 1 }
+        return a)
+      (fun e => do
+        modify fun s => { s with depth := s.depth - 1 }
+        throw e)
+
+/-- Does `lit` occur at char index `i`? Returns the index after it. -/
+def litAt (ctx : Ctx) (i : Nat) (lit : List Char) : Option Nat :=
+  match lit with
+  | [] => some i
+  | c :: cs =>
+    match ctx.chars[i]? with
+    | some c' => if c == c' then litAt ctx (i + 1) cs else none
+    | none => none
+
+/-- Skip whitespace, `--` line comments, nested `/- -/` block
+    comments. -/
+partial def ws : M Unit := do
+  let ctx ← read
+  let s ← get
+  let mut i := s.idx
+  let mut go := true
+  while go do
+    match ctx.chars[i]? with
+    | some c =>
+      if isWs c then
+        i := i + 1
+      else if (litAt ctx i ['-', '-']).isSome then
+        i := i + 2
+        while ctx.chars[i]?.isSome && ctx.chars[i]! != '\n' do
+          i := i + 1
+        if ctx.chars[i]?.isSome then i := i + 1
+      else if (litAt ctx i ['/', '-']).isSome then
+        let openIdx := i
+        let mut depth := 1
+        i := i + 2
+        while depth > 0 do
+          if (litAt ctx i ['/', '-']).isSome then
+            depth := depth + 1
+            i := i + 2
+          else if (litAt ctx i ['-', '/']).isSome then
+            depth := depth - 1
+            i := i + 2
+          else
+            match ctx.chars[i]? with
+            | some _ => i := i + 1
+            | none =>
+              let o ← off openIdx
+              setIdx i
+              failFatal .unterminatedComment ⟨o, o + 2⟩
+      else
+        go := false
+    | none => go := false
+  setIdx i
+
+/-- Lex one identifier component at `i` (no whitespace skip). -/
+def identRaw (ctx : Ctx) (i : Nat) : Option (String × Nat) := Id.run do
+  match ctx.chars[i]? with
+  | some c0 =>
+    if !isIdFirst c0 then return none
+    let mut j := i + 1
+    while ctx.chars[j]?.any isIdRest do
+      j := j + 1
+    let s := (ctx.chars.extract i j).foldl (·.push ·) ""
+    return some (s, j)
+  | none => return none
+
+/-- Lex one ascii-digit run at `i`. -/
+def digitsRaw (ctx : Ctx) (i : Nat) : Option (String × Nat) := Id.run do
+  let mut j := i
+  while ctx.chars[j]?.any Char.isDigit do
+    j := j + 1
+  if j == i then return none
+  return some ((ctx.chars.extract i j).foldl (·.push ·) "", j)
+
+/-- `«…»` quoted component starting at `i` (expects `«` there). -/
+def quotedComponent (i : Nat) : M (String × Nat) := do
+  let ctx ← read
+  if ctx.chars[i]? != some '«' then failExp i "name"
+  else Id.run do
+    let mut j := i + 1
+    while ctx.chars[j]?.isSome && ctx.chars[j]! != '»' do
+      j := j + 1
+    return do
+      match ctx.chars[j]? with
+      | none =>
+        let o ← off i
+        failFatal .unterminatedQuotedName ⟨o, o + 2⟩
+      | some _ =>
+        if j == i + 1 then failExp i "nonempty «…» component"
+        else
+          let s := (ctx.chars.extract (i + 1) j).foldl (·.push ·) ""
+          return (s, j + 1)
+
+/-- Keyword or contextual word: a full identifier component equal to
+    `w`. Consumes leading whitespace. -/
+def kw (w : String) : M Span := do
+  ws
+  let ctx ← read
+  let i ← curIdx
+  match identRaw ctx i with
+  | some (c, j) =>
+    if c == w then do
+      let span ← sp i j
+      setIdx j
+      return span
+    else failExp i w
+  | none => failExp i w
+
+/-- Peek the next identifier word (after ws) without consuming. -/
+def peekWord : M (Option String) := do
+  ws
+  let ctx ← read
+  return (identRaw ctx (← curIdx)).map (·.1)
+
+/-- Punctuation token; `":"` refuses to match the prefix of `":="`,
+    and `"|"` the prefix of `"|-"` (the ASCII main-expression
+    turnstile) — so ctor/rule bars never absorb it. -/
+def sym (s : String) : M Span := do
+  ws
+  let ctx ← read
+  let i ← curIdx
+  if s == ":" && (litAt ctx i [':', '=']).isSome then failExp i ":"
+  else if s == "|" && (litAt ctx i ['|', '-']).isSome then failExp i "|"
+  else
+    match litAt ctx i s.toList with
+    | some j => do
+      let span ← sp i j
+      setIdx j
+      return span
+    | none => failExp i s
+
+/-- `⊢` or `|-` — the main-expression marker. -/
+def turnstileTok : M Span := do
+  ws
+  let ctx ← read
+  let i ← curIdx
+  if ctx.chars[i]? == some '⊢' then do
+    let span ← sp i (i + 1)
+    setIdx (i + 1)
+    return span
+  else
+    match litAt ctx i ['|', '-'] with
+    | some j => do
+      let span ← sp i j
+      setIdx j
+      return span
+    | none => failExp i "⊢"
+
+/-- `→` or `->`. -/
+def arrowTok : M Span := do
+  ws
+  let ctx ← read
+  let i ← curIdx
+  match ctx.chars[i]? with
+  | some '→' => do
+    let span ← sp i (i + 1)
+    setIdx (i + 1)
+    return span
+  | _ =>
+    match litAt ctx i ['-', '>'] with
+    | some j => do
+      let span ← sp i j
+      setIdx j
+      return span
+    | none => failExp i "→"
+
+/-- Dotted surface name. Leading component: identifier or `«…»`;
+    continuations may also be bare digit runs (numeric components).
+    Stops before `.{` and before a reserved continuation. -/
+partial def nameP : M SName := do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  let (first, afterFirst) ←
+    match identRaw ctx start with
+    | some (c, j) =>
+      if isReserved c then failExp start "name"
+      else pure (NameComponent.str c, j)
+    | none =>
+      if ctx.chars[start]? == some '«' then do
+        let (s, j) ← quotedComponent start
+        pure (NameComponent.str s, j)
+      else failExp start "name"
+  let mut parts := #[first]
+  let mut i := afterFirst
+  let mut go := true
+  while go do
+    if ctx.chars[i]? == some '.' && ctx.chars[i+1]? != some '{' then
+      let r := i + 1
+      match identRaw ctx r with
+      | some (c, j) =>
+        if isReserved c then go := false -- leave `.def` unconsumed
+        else
+          parts := parts.push (.str c)
+          i := j
+      | none =>
+        if ctx.chars[r]? == some '«' then
+          let (s, j) ← quotedComponent r
+          parts := parts.push (.str s)
+          i := j
+        else
+          match digitsRaw ctx r with
+          | some (d, j) =>
+            parts := parts.push (.num d.toNat!)
+            i := j
+          | none => go := false -- trailing `.` stays unconsumed
+    else
+      go := false
+  setIdx i
+  return { parts, span := ← sp start i }
+
+def isHexAny (c : Char) : Bool :=
+  c.isDigit || ('a' ≤ c && c ≤ 'f') || ('A' ≤ c && c ≤ 'F')
+
+/-- `#hex` reference at the CURRENT index, no leading-whitespace skip
+    (callers control adjacency). 4–64 lowercase hex digits. -/
+def hashRaw : M HashRef := do
+  let ctx ← read
+  let start ← curIdx
+  if ctx.chars[start]? != some '#' then failExp start "#hash"
+  else Id.run do
+    let mut j := start + 1
+    while ctx.chars[j]?.any isHexAny do
+      j := j + 1
+    let run := (ctx.chars.extract (start + 1) j).foldl (·.push ·) ""
+    return do
+      let span ← sp start j
+      match run.toList.find? Char.isUpper with
+      | some bad =>
+        failFatal
+          (.invalidHash s!"uppercase digit '{bad}' (addresses are lowercase)")
+          span
+      | none =>
+        if ctx.chars[j]?.any isIdRest then
+          failFatal (.invalidHash "invalid character in hash") span
+        else if run.length < 4 then
+          failFatal
+            (.invalidHash s!"too short ({run.length} digits, minimum 4)")
+            span
+        else if run.length > 64 then
+          failFatal
+            (.invalidHash s!"too long ({run.length} digits, maximum 64)")
+            span
+        else do
+          setIdx j
+          return { hex := run, span }
+
+def digitInRadix (radix : Nat) (c : Char) : Bool :=
+  if radix == 16 then isHexAny c
+  else if radix == 10 then c.isDigit
+  else if radix == 8 then '0' ≤ c && c ≤ '7'
+  else c == '0' || c == '1'
+
+def digitVal (c : Char) : Nat :=
+  if c.isDigit then c.toNat - '0'.toNat
+  else if 'a' ≤ c && c ≤ 'f' then c.toNat - 'a'.toNat + 10
+  else c.toNat - 'A'.toNat + 10
+
+/-- Nat literal: decimal, `0x`, `0b`, `0o`. Arbitrary precision. -/
+def natlit : M (Nat × Span) := do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  let (radix, digitsStart) :=
+    match litAt ctx start ['0', 'x'] with
+    | some j => (16, j)
+    | none =>
+      match litAt ctx start ['0', 'b'] with
+      | some j => (2, j)
+      | none =>
+        match litAt ctx start ['0', 'o'] with
+        | some j => (8, j)
+        | none => (10, start)
+  Id.run do
+    let mut j := digitsStart
+    while ctx.chars[j]?.any (digitInRadix radix) do
+      j := j + 1
+    if j == digitsStart then return failExp start "number"
+    let n := (ctx.chars.extract digitsStart j).foldl
+      (fun acc c => acc * radix + digitVal c) 0
+    return do
+      let span ← sp start j
+      setIdx j
+      return (n, span)
+
+/-- Nat literal bounded to `u64` (mirrors Rust's `nat_u64`). -/
+def natU64 : M (Nat × Span) := do
+  let (n, span) ← natlit
+  if n < 2 ^ 64 then return (n, span)
+  else failFatal .natOutOfRange span
+
+def hexEscape (n : Nat) (escStartOff : Nat) : M Char := do
+  let ctx ← read
+  let i ← curIdx
+  Id.run do
+    let mut ok := true
+    let mut v := 0
+    for k in [0:n] do
+      match ctx.chars[i + k]? with
+      | some c => if isHexAny c then v := v * 16 + digitVal c else ok := false
+      | none => ok := false
+    let val := v
+    let good := ok
+    return do
+      if !good then
+        failFatal .invalidEscape ⟨escStartOff, ← off i⟩
+      else if !val.isValidChar then
+        failFatal .invalidEscape ⟨escStartOff, (← off i) + n⟩
+      else do
+        setIdx (i + n)
+        return Char.ofNat val
+
+/-- String literal with Lean escapes. -/
+partial def strlit : M (String × Span) := do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  if ctx.chars[start]? != some '"' then failExp start "string literal"
+  else do
+    setIdx (start + 1)
+    let mut out := ""
+    let mut go := true
+    while go do
+      let i ← curIdx
+      match ctx.chars[i]? with
+      | none =>
+        let o ← off start
+        failFatal .unterminatedString ⟨o, ctx.byteOff[ctx.byteOff.size - 1]!⟩
+      | some '"' =>
+        setIdx (i + 1)
+        go := false
+      | some '\\' =>
+        let escStart ← off i
+        match ctx.chars[i+1]? with
+        | none => failFatal .invalidEscape ⟨escStart, escStart + 1⟩
+        | some e =>
+          setIdx (i + 2)
+          match e with
+          | 'n' => out := out.push '\n'
+          | 't' => out := out.push '\t'
+          | 'r' => out := out.push '\r'
+          | '\\' => out := out.push '\\'
+          | '"' => out := out.push '"'
+          | '\'' => out := out.push '\''
+          | 'x' => out := out.push (← hexEscape 2 escStart)
+          | 'u' => out := out.push (← hexEscape 4 escStart)
+          | _ => failFatal .invalidEscape ⟨escStart, ← off (i + 2)⟩
+      | some c =>
+        setIdx (i + 1)
+        out := out.push c
+    let stop ← curIdx
+    return (out, ← sp start stop)
+
+mutual
+
+/-- Universe expression: `uatom ("+" nat)?`. -/
+partial def univ : M UnivExpr := do
+  let a ← uatom
+  ws
+  let ctx ← read
+  let i ← curIdx
+  if ctx.chars[i]? == some '+' then do
+    setIdx (i + 1)
+    let (n, nsp) ← cut natU64
+    return .add a n (a.span.to nsp)
+  else
+    return a
+
+/-- Universe atom: literal, var, parens, contextual `max`/`imax`. -/
+partial def uatom : M UnivExpr := withDepth do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  match ctx.chars[start]? with
+  | some c =>
+    if c.isDigit then do
+      let (n, span) ← natU64
+      return .nat n span
+    else if c == '(' then do
+      setIdx (start + 1)
+      let u ← cut univ
+      let _ ← cut (sym ")")
+      return u
+    else if c == '«' then do
+      let (s, j) ← quotedComponent start
+      setIdx j
+      return .var (.str s) (← sp start j)
+    else
+      match identRaw ctx start with
+      | some ("max", j) => do
+        setIdx j
+        let a ← cut uatom
+        let b ← cut uatom
+        return .max a b ⟨← off start, b.span.stop⟩
+      | some ("imax", j) => do
+        setIdx j
+        let a ← cut uatom
+        let b ← cut uatom
+        return .imax a b ⟨← off start, b.span.stop⟩
+      | some (c', j) =>
+        if isReserved c' then failExp start "universe"
+        else do
+          setIdx j
+          return .var (.str c') (← sp start j)
+      | none => failExp start "universe"
+  | none => failExp start "universe"
+
+end
+
+/-- Adjacent `.{u, v}` level list (no whitespace before `.{`). -/
+partial def levelsAdj : M (Option (Array UnivExpr)) := do
+  let ctx ← read
+  let openIdx ← curIdx
+  if (litAt ctx openIdx ['.', '{']).isNone then return none
+  else do
+    setIdx (openIdx + 2)
+    ws
+    let j ← curIdx
+    if ctx.chars[j]? == some '}' then
+      failFatal .emptyLevels (← sp openIdx (j + 1))
+    else do
+      setIdx (openIdx + 2)
+      let first ← cut univ
+      let mut levels := #[first]
+      let mut go := true
+      while go do
+        ws
+        let i ← curIdx
+        match ctx.chars[i]? with
+        | some ',' =>
+          setIdx (i + 1)
+          levels := levels.push (← cut univ)
+        | some '}' =>
+          setIdx (i + 1)
+          go := false
+        | _ => cut (failExp i "`,` or `}`")
+      return some levels
+
+/-- Constant reference: `Name`, `#hash`, `Name#hash`, with optional
+    adjacent `.{levels}`. -/
+partial def cref : M ConstRef := do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  if ctx.chars[start]? == some '#' then do
+    let h ← hashRaw
+    let levels ← levelsAdj
+    return { hash := some h, levels, span := ← sp start (← curIdx) }
+  else do
+    let n ← nameP
+    let hash ←
+      if ctx.chars[(← curIdx)]? == some '#' then some <$> hashRaw
+      else pure none
+    let levels ← levelsAdj
+    return { name := some n, hash, levels, span := ← sp start (← curIdx) }
+
+/-- Greedy optional universe argument for `Type`/`Sort`: a numeral, a
+    simple identifier or `«…»` component (not dotted/hashed), or a
+    parenthesized universe. -/
+partial def uargOpt : M (Option UnivExpr) := do
+  let saved ← get
+  ws
+  let ctx ← read
+  let j ← curIdx
+  match ctx.chars[j]? with
+  | some c =>
+    if c.isDigit then do
+      let (n, span) ← natU64
+      return some (.nat n span)
+    else if c == '(' then do
+      match ← attempt? (do
+          setIdx (j + 1)
+          let u ← univ
+          let _ ← sym ")"
+          pure u) with
+      | some u => return some u
+      | none =>
+        set saved
+        return none
+    else if c == '«' then do
+      let (s, k) ← quotedComponent j
+      if ctx.chars[k]? == some '#' || ctx.chars[k]? == some '.' then do
+        set saved
+        return none
+      else do
+        setIdx k
+        return some (.var (.str s) (← sp j k))
+    else
+      match identRaw ctx j with
+      | some (w, k) =>
+        let simple := !isReserved w && w != "max" && w != "imax"
+          && w != "_" && ctx.chars[k]? != some '#'
+          && ctx.chars[k]? != some '.'
+        if simple then do
+          setIdx k
+          return some (.var (.str w) (← sp j k))
+        else do
+          set saved
+          return none
+      | none =>
+        set saved
+        return none
+  | none =>
+    set saved
+    return none
+
+/-- Binder name: identifier component or `_`. -/
+def binderNameP : M BinderName := do
+  ws
+  let ctx ← read
+  let i ← curIdx
+  match identRaw ctx i with
+  | some (c, j) => do
+    let span ← sp i j
+    if c == "_" then do
+      setIdx j
+      return .anon span
+    else if isReserved c then failExp i "binder name"
+    else do
+      setIdx j
+      return .ident (.str c) span
+  | none =>
+    if ctx.chars[i]? == some '«' then do
+      let (s, j) ← quotedComponent i
+      setIdx j
+      return .ident (.str s) (← sp i j)
+    else failExp i "binder name"
+
+mutual
+
+/-- Application atom. -/
+partial def atom : M Term := withDepth do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  match ctx.chars[start]? with
+  | none => failExp start "term"
+  | some c =>
+    if c == '(' then do
+      setIdx (start + 1)
+      let t ← cut term
+      let _ ← cut (sym ")")
+      return t
+    else if c == '"' then do
+      let (s, span) ← strlit
+      return .strLit s span
+    else if c == '#' || c == '«' then do
+      return .ref (← cref)
+    else if c.isDigit then do
+      let (n, span) ← natlit
+      return .natLit n span
+    else if isIdFirst c then do
+      let some (word, _) := identRaw ctx start | failExp start "term"
+      match word with
+      | "_" => failFatal .placeholder (← sp start (start + 1))
+      | "Prop" => do
+        let span ← kw "Prop"
+        return .sort .prop span
+      | "Type" => do
+        let ksp ← kw "Type"
+        let u ← uargOpt
+        let span := match u with
+          | some x => ksp.to x.span
+          | none => ksp
+        return .sort (.type u) span
+      | "Sort" => do
+        let ksp ← kw "Sort"
+        match ← uargOpt with
+        | some u => return .sort (.sort u) (ksp.to u.span)
+        | none => cut (failExp (← curIdx) "universe")
+      | "proj" => do
+        let ksp ← kw "proj"
+        let typeRef ← cut cref
+        let (idx, _) ← cut natU64
+        let v ← cut atom
+        return .proj typeRef idx v (ksp.to v.span)
+      | w =>
+        if isReserved w then failExp start "term"
+        else return .ref (← cref)
+    else failExp start "term"
+
+/-- Application spine: `atom+`, flat. -/
+partial def appP : M Term := do
+  let head ← atom
+  let mut args := #[]
+  let mut go := true
+  while go do
+    match ← attempt? atom with
+    | some t => args := args.push t
+    | none => go := false
+  if args.isEmpty then return head
+  else return .app head args (head.span.to args.back!.span)
+
+/-- One bracketed binder group. `(…)` is tentative (backtrackable
+    before the `:`); `{…}`, `[…]`, `⦃…⦄` commit. -/
+partial def binderGroup : M BinderGroup := do
+  ws
+  let ctx ← read
+  let start ← curIdx
+  let bracket : Option (Char × String × Lean.BinderInfo) :=
+    match ctx.chars[start]? with
+    | some '(' => some ('(', ")", .default)
+    | some '{' => some ('{', "}", .implicit)
+    | some '[' => some ('[', "]", .instImplicit)
+    | some '⦃' => some ('⦃', "⦄", .strictImplicit)
+    | _ => none
+  match bracket with
+  | none => failExp start "binder"
+  | some (openC, closeS, info) => do
+    setIdx (start + 1)
+    if openC == '[' then do
+      match ← attempt? binderNamesColon with
+      | some names => do
+        let ty ← cut term
+        let _ ← cut (sym closeS)
+        return .mk info names ty (← sp start (← curIdx))
+      | none => do
+        let ty ← cut term
+        let _ ← cut (sym closeS)
+        return .mk info #[] ty (← sp start (← curIdx))
+    else do
+      let names ←
+        if openC == '(' then binderNamesColon
+        else cut binderNamesColon
+      let ty ← cut term
+      let _ ← cut (sym closeS)
+      return .mk info names ty (← sp start (← curIdx))
+
+/-- `ident+ :` — the committing prefix of a named binder group. -/
+partial def binderNamesColon : M (Array BinderName) := do
+  let first ← binderNameP
+  let mut names := #[first]
+  let mut go := true
+  while go do
+    match ← attempt? binderNameP with
+    | some n => names := names.push n
+    | none => go := false
+  let _ ← sym ":"
+  return names
+
+partial def binderGroups1 : M (Array BinderGroup) := do
+  let first ← binderGroup
+  let mut groups := #[first]
+  let mut go := true
+  while go do
+    match ← attempt? binderGroup with
+    | some g => groups := groups.push g
+    | none => go := false
+  return groups
+
+/-- `fun binder+ => term`. -/
+partial def lamTerm : M Term := do
+  let ksp ← kw "fun"
+  let groups ← cut binderGroups1
+  let _ ← cut (sym "=>")
+  let body ← cut term
+  return .lam groups body (ksp.to body.span)
+
+/-- `let x : T := v; b` / `have x : T := v; b`. -/
+partial def letTerm (nonDep : Bool) : M Term := do
+  let ksp ← kw (if nonDep then "have" else "let")
+  let name ← cut binderNameP
+  let _ ← cut (sym ":")
+  let ty ← cut term
+  let _ ← cut (sym ":=")
+  let val ← cut term
+  let _ ← cut (sym ";")
+  let body ← cut term
+  return .letE nonDep name ty val body (ksp.to body.span)
+
+/-- Dependent domain: `binder+ → term` (committed once the first
+    group parses). -/
+partial def piTerm : M Term := do
+  ws
+  let start ← curIdx
+  let groups ← binderGroups1
+  let _ ← cut arrowTok
+  let body ← cut term
+  return .pi groups body ⟨← off start, body.span.stop⟩
+
+/-- Arrow layer: dependent domain, or application with optional `→`. -/
+partial def piOrArrow : M Term := do
+  ws
+  let ctx ← read
+  let j ← curIdx
+  let starter := ctx.chars[j]?
+  if starter == some '(' || starter == some '{' || starter == some '['
+      || starter == some '⦃' then
+    match ← attempt? piTerm with
+    | some t => return t
+    | none => appArrow
+  else
+    appArrow
+
+partial def appArrow : M Term := do
+  let lhs ← appP
+  match ← attempt? arrowTok with
+  | some _ => do
+    let cod ← cut term
+    return .arrow lhs cod (lhs.span.to cod.span)
+  | none => return lhs
+
+/-- Term entry point. -/
+partial def term : M Term := withDepth do
+  match ← peekWord with
+  | some "fun" => lamTerm
+  | some "let" => letTerm false
+  | some "have" => letTerm true
+  | _ => piOrArrow
+
+end
+
+/-- `.{u, v}` universe-parameter binders on a declaration. -/
+partial def uparams : M (Array UParam) := do
+  let ctx ← read
+  if (litAt ctx (← curIdx) ['.', '{']).isNone then return #[]
+  else do
+    setIdx ((← curIdx) + 2)
+    let mut out := #[]
+    let mut go := true
+    while go do
+      ws
+      let start ← curIdx
+      let comp ←
+        match identRaw ctx start with
+        | some (c, j) =>
+          if isReserved c || c == "_" then
+            cut (failExp start "universe parameter")
+          else do
+            setIdx j
+            pure (NameComponent.str c)
+        | none =>
+          if ctx.chars[start]? == some '«' then do
+            let (s, j) ← quotedComponent start
+            setIdx j
+            pure (NameComponent.str s)
+          else cut (failExp start "universe parameter")
+      out := out.push { name := comp, span := ← sp start (← curIdx) }
+      ws
+      let i ← curIdx
+      match ctx.chars[i]? with
+      | some ',' => setIdx (i + 1)
+      | some '}' =>
+        setIdx (i + 1)
+        go := false
+      | _ => cut (failExp i "`,` or `}`")
+    return out
+
+/-- Optional declaration name + optional universe parameters. -/
+partial def declName : M (Option SName × Array UParam) := do
+  ws
+  let ctx ← read
+  let j ← curIdx
+  if (litAt ctx j ['.', '{']).isSome then do
+    return (none, ← uparams)
+  else if ctx.chars[j]? == some '«'
+      || (identRaw ctx j).any (fun (c, _) => !isReserved c) then do
+    let n ← nameP
+    let ups ← uparams
+    return (some n, ups)
+  else
+    return (none, #[])
+
+/-- `(<key> := <nat>)` count annotation. -/
+partial def annot (key : String) (label : String) : M Nat := do
+  ws
+  let ctx ← read
+  let i ← curIdx
+  if ctx.chars[i]? != some '(' then failExp i label
+  else do
+    setIdx (i + 1)
+    match ← attempt? (kw key) with
+    | none => do
+      setIdx i
+      failExp i label
+    | some _ => do
+      let _ ← cut (sym ":=")
+      let (v, _) ← cut natU64
+      let _ ← cut (sym ")")
+      return v
+
+/-- Optional `(k := true|false)` on a recursor. -/
+partial def kAnnot : M Bool := do
+  let saved ← get
+  ws
+  let ctx ← read
+  let j ← curIdx
+  if ctx.chars[j]? != some '(' then do
+    set saved
+    return false
+  else do
+    setIdx (j + 1)
+    match ← attempt? (kw "k") with
+    | none => do
+      set saved
+      return false
+    | some _ => do
+      let _ ← cut (sym ":=")
+      let v ← match ← peekWord with
+        | some "true" => do let _ ← kw "true"; pure true
+        | some "false" => do let _ ← kw "false"; pure false
+        | _ => cut (failExp (← curIdx) "true or false")
+      let _ ← cut (sym ")")
+      return v
+
+def defDecl (kwKind : DefKw) (kwWord : String) (mods : Modifiers)
+    (startIdx : Nat) : M Decl := do
+  let _ ← kw kwWord
+  if mods.isPartial && kwKind != .defn then
+    cut (failExp startIdx "def after partial")
+  else do
+    let (name, ups) ← cut declName
+    let _ ← cut (sym ":")
+    let ty ← cut term
+    let _ ← cut (sym ":=")
+    let value ← cut term
+    return .defn
+      { kw := kwKind, mods, name, uparams := ups, ty, value
+        span := ← sp startIdx (← curIdx) }
+
+def axiomDecl (mods : Modifiers) (startIdx : Nat) : M Decl := do
+  let _ ← kw "axiom"
+  if mods.isPartial then cut (failExp startIdx "def after partial")
+  else do
+    let (name, ups) ← cut declName
+    let _ ← cut (sym ":")
+    let ty ← cut term
+    return .axio
+      { isUnsafe := mods.isUnsafe, name, uparams := ups, ty
+        span := ← sp startIdx (← curIdx) }
+
+def quotDecl (startIdx : Nat) : M Decl := do
+  let _ ← kw "quot"
+  let kind ← match ← peekWord with
+    | some "type" => do let _ ← kw "type"; pure QuotKindKw.type
+    | some "ctor" => do let _ ← kw "ctor"; pure QuotKindKw.ctor
+    | some "lift" => do let _ ← kw "lift"; pure QuotKindKw.lift
+    | some "ind" => do let _ ← kw "ind"; pure QuotKindKw.ind
+    | _ => cut (failExp (← curIdx) "quotient kind (type|ctor|lift|ind)")
+  let (name, ups) ← cut declName
+  let _ ← cut (sym ":")
+  let ty ← cut term
+  return .quot
+    { kind, name, uparams := ups, ty, span := ← sp startIdx (← curIdx) }
+
+partial def ctorBlock : M (Array CtorDecl) := do
+  if (← peekWord) != some "where" then return #[]
+  else do
+    let _ ← kw "where"
+    let mut ctors := #[]
+    let mut go := true
+    while go do
+      match ← attempt? (sym "|") with
+      | some barSp => do
+        let (name, ups) ← cut declName
+        if let some up := ups[0]? then
+          failFatal
+            (.unexpectedToken "(params := _)"
+              "universe parameters (constructors inherit the inductive's)")
+            up.span
+        else do
+          let params ← cut (annot "params" "(params := _)")
+          let fields ← cut (annot "fields" "(fields := _)")
+          let _ ← cut (sym ":")
+          let ty ← cut term
+          ctors := ctors.push
+            { name, params, fields, ty
+              span := barSp.to ⟨← off (← curIdx), ← off (← curIdx)⟩ }
+      | none => go := false
+    if ctors.isEmpty then cut (failExp (← curIdx) "|")
+    else return ctors
+
+def indDecl (mods : Modifiers) (startIdx : Nat) : M Decl := do
+  let _ ← kw "inductive"
+  if mods.isPartial then cut (failExp startIdx "def after partial")
+  else do
+    let (name, ups) ← cut declName
+    let params ← cut (annot "params" "(params := _)")
+    let indices ← cut (annot "indices" "(indices := _)")
+    let _ ← cut (sym ":")
+    let ty ← cut term
+    let ctors ← ctorBlock
+    return .indc
+      { isUnsafe := mods.isUnsafe, name, uparams := ups, params, indices
+        ty, ctors, span := ← sp startIdx (← curIdx) }
+
+partial def ruleBlock : M (Array RuleDecl) := do
+  if (← peekWord) != some "where" then return #[]
+  else do
+    let _ ← kw "where"
+    let mut rules := #[]
+    let mut go := true
+    while go do
+      match ← attempt? (sym "|") with
+      | some barSp => do
+        let _ ← cut (kw "rule")
+        let fields ← cut (annot "fields" "(fields := _)")
+        let _ ← cut (sym ":=")
+        let rhs ← cut term
+        rules := rules.push
+          { fields, rhs
+            span := barSp.to ⟨← off (← curIdx), ← off (← curIdx)⟩ }
+      | none => go := false
+    if rules.isEmpty then cut (failExp (← curIdx) "|")
+    else return rules
+
+def recrDecl (mods : Modifiers) (startIdx : Nat) : M Decl := do
+  let _ ← kw "recursor"
+  if mods.isPartial then cut (failExp startIdx "def after partial")
+  else do
+    let (name, ups) ← cut declName
+    let params ← cut (annot "params" "(params := _)")
+    let indices ← cut (annot "indices" "(indices := _)")
+    let motives ← cut (annot "motives" "(motives := _)")
+    let minors ← cut (annot "minors" "(minors := _)")
+    let k ← kAnnot
+    let _ ← cut (sym ":")
+    let ty ← cut term
+    let rules ← ruleBlock
+    return .recr
+      { isUnsafe := mods.isUnsafe, name, uparams := ups, params, indices
+        motives, minors, k, ty, rules, span := ← sp startIdx (← curIdx) }
+
+def prjDecl (kind : PrjKind) (word : String) (startIdx : Nat) : M Decl := do
+  let _ ← kw word
+  let (name, ups) ← cut declName
+  if let some up := ups[0]? then
+    failFatal (.unexpectedToken ":=" "universe parameters") up.span
+  else do
+    let _ ← cut (sym ":=")
+    ws
+    let block ← cut hashRaw
+    let (idx, _) ← cut natU64
+    let cidx ←
+      if kind == .cprj then some <$> Prod.fst <$> cut natU64
+      else pure none
+    return .prj
+      { kind, name, block, idx, cidx, span := ← sp startIdx (← curIdx) }
+
+mutual
+
+/-- One declaration. -/
+partial def decl : M Decl := do
+  ws
+  let startIdx ← curIdx
+  let mut mods : Modifiers := {}
+  let mut going := true
+  while going do
+    match ← peekWord with
+    | some "unsafe" =>
+      if mods.isUnsafe then going := false
+      else do
+        let _ ← kw "unsafe"
+        mods := { mods with isUnsafe := true }
+    | some "partial" =>
+      if mods.isPartial then going := false
+      else do
+        let _ ← kw "partial"
+        mods := { mods with isPartial := true }
+    | _ => going := false
+  if mods.isUnsafe && mods.isPartial then
+    cut (failExp startIdx "either unsafe or partial (not both)")
+  else do
+    let hasMods := mods.isUnsafe || mods.isPartial
+    match ← peekWord with
+    | some "def" => defDecl .defn "def" mods startIdx
+    | some "theorem" => defDecl .thm "theorem" mods startIdx
+    | some "opaque" => defDecl .opaq "opaque" mods startIdx
+    | some "axiom" => axiomDecl mods startIdx
+    | some "inductive" => indDecl mods startIdx
+    | some "recursor" => recrDecl mods startIdx
+    | some "quot" =>
+      if hasMods then failExp (← curIdx) "declaration"
+      else quotDecl startIdx
+    | some "mutual" =>
+      if hasMods then failExp (← curIdx) "declaration"
+      else mutualDecl startIdx
+    | some "dprj" =>
+      if hasMods then failExp (← curIdx) "declaration"
+      else prjDecl .dprj "dprj" startIdx
+    | some "iprj" =>
+      if hasMods then failExp (← curIdx) "declaration"
+      else prjDecl .iprj "iprj" startIdx
+    | some "cprj" =>
+      if hasMods then failExp (← curIdx) "declaration"
+      else prjDecl .cprj "cprj" startIdx
+    | some "rprj" =>
+      if hasMods then failExp (← curIdx) "declaration"
+      else prjDecl .rprj "rprj" startIdx
+    | _ => failExp (← curIdx) "declaration"
+
+partial def mutualDecl (startIdx : Nat) : M Decl := do
+  let _ ← kw "mutual"
+  let mut members := #[]
+  let mut go := true
+  while go do
+    if (← peekWord) == some "end" then
+      if members.isEmpty then cut (failExp (← curIdx) "declaration")
+      else do
+        let _ ← kw "end"
+        go := false
+    else do
+      let d ← cut decl
+      match d with
+      | .defn _ | .indc _ | .recr _ => members := members.push d
+      | other => failFatal .badMutualMember other.span
+  return .muts members (← sp startIdx (← curIdx))
+
+end
+
+/-- `import Foo.Bar#hash` / `import #hash`. -/
+partial def importDecl : M ImportDecl := do
+  ws
+  let startIdx ← curIdx
+  let _ ← kw "import"
+  ws
+  let ctx ← read
+  let (prefixName, hash) ←
+    if ctx.chars[(← curIdx)]? == some '#' then do
+      let h ← cut hashRaw
+      pure (none, h)
+    else do
+      let n ← cut nameP
+      if ctx.chars[(← curIdx)]? != some '#' then
+        cut (failExp (← curIdx) "#hash")
+      else do
+        let h ← cut hashRaw
+        pure (some n, h)
+  if hash.hex.length != 64 then
+    failFatal (.importHashLength hash.hex.length) hash.span
+  else
+    return { prefixName, hash, span := ← sp startIdx (← curIdx) }
+
+/-- The `value : type` interior — deterministic on its own: no term
+    production consumes a bare `:`, so the value spine stops at the
+    annotation. Only the decl→main *boundary* needs the turnstile. -/
+partial def mainExprTail (startIdx : Nat) : M MainExpr := do
+  let value ← cut term
+  let _ ← cut (sym ":")
+  let ty ← cut term
+  let stopIdx ← curIdx
+  ws
+  let ctx ← read
+  if (ctx.chars[(← curIdx)]?).isSome then
+    let o ← off (← curIdx)
+    failFatal .mainExprNotLast ⟨o, o⟩
+  else
+    return { value, ty, span := ← sp startIdx stopIdx }
+
+/-- The trailing `⊢ value : type` main expression. The turnstile stops
+    a preceding declaration's application spine (found by property
+    testing); it is required after declarations and optional only when
+    the main expression is the file's sole item. -/
+partial def mainExprP : M MainExpr := do
+  ws
+  let startIdx ← curIdx
+  let _ ← turnstileTok
+  mainExprTail startIdx
+
+/-- Whole file: `ixon <version>` header, imports, declarations,
+    optional main expression, EOF. -/
+partial def file : M File := do
+  ws
+  let startIdx ← curIdx
+  -- Optional version header: absent means version 1, forever
+  -- (grammar versions ≥ 2 must declare themselves). A leading `ixon`
+  -- followed by a numeral is always the header (a constant literally
+  -- named `ixon` applied to a literal at file start needs parens);
+  -- followed by anything else it is content.
+  let version ←
+    if (← peekWord) == some "ixon" then do
+      let saved ← get
+      let _ ← kw "ixon"
+      ws
+      let ctx ← read
+      if (ctx.chars[(← curIdx)]?).any Char.isDigit then do
+        let (version, vsp) ← natU64
+        if version != VERSION then
+          failFatal (.unknownVersion version VERSION) vsp
+        else pure version
+      else do
+        set saved
+        pure VERSION
+    else pure VERSION
+  do
+    let mut imports := #[]
+    let mut go := true
+    while go do
+      if (← peekWord) == some "import" then
+        imports := imports.push (← importDecl)
+      else go := false
+    let mut decls := #[]
+    let mut mainE : Option MainExpr := none
+    go := true
+    while go do
+      ws
+      let ctx ← read
+      let i ← curIdx
+      if ctx.chars[i]?.isNone then go := false
+      else if ctx.chars[i]? == some '⊢'
+          || (litAt ctx i ['|', '-']).isSome then do
+        mainE := some (← mainExprP)
+        go := false
+      else
+        -- Bare `value : type` (no turnstile) is accepted only as the
+        -- file's SOLE item: with no preceding declaration term there
+        -- is no boundary to absorb into, and the interior is
+        -- deterministic. After declarations the turnstile is required
+        -- (the bare form errors on the orphaned `:` — never a silent
+        -- re-split).
+        let keywordItem := match identRaw ctx i with
+          | some (w, _) =>
+            ["def", "theorem", "opaque", "axiom", "inductive",
+             "recursor", "quot", "mutual", "unsafe", "partial", "dprj",
+             "iprj", "cprj", "rprj", "import"].contains w
+          | none => false
+        if !keywordItem && decls.isEmpty then do
+          mainE := some (← mainExprTail i)
+          go := false
+        else decls := decls.push (← decl)
+    return { version, imports, decls, main := mainE
+             span := ← sp startIdx (← curIdx) }
+
+/-- Short description of what sits at char index `pos`. -/
+def foundSnippet (ctx : Ctx) (pos : Nat) : String := Id.run do
+  match ctx.chars[pos]? with
+  | none => return "end of input"
+  | some c0 =>
+    if isIdFirst c0 || c0.isDigit then
+      let mut j := pos
+      while ctx.chars[j]?.any (fun c => isIdRest c || c.isDigit) do
+        j := j + 1
+      let word := (ctx.chars.extract pos (min j (pos + 24))).foldl
+        (·.push ·) ""
+      return s!"`{word}`"
+    else
+      return s!"`{c0}`"
+
+def convert (src : String) (ctx : Ctx) (e : PErr) : SyntaxError :=
+  match e.special with
+  | some (kind, span) => SyntaxError.new kind span src
+  | none =>
+    let bytePos := ctx.byteOff[min e.pos (ctx.byteOff.size - 1)]!
+    let expected := if e.expected.isEmpty then "valid syntax" else e.expected
+    SyntaxError.new
+      (.unexpectedToken expected (foundSnippet ctx e.pos))
+      ⟨bytePos, bytePos⟩ src
+
+end Parser
+
+open Parser in
+/-- Parse a whole `.ixon` file. -/
+def parseFile (src : String) (limits : Limits := {})
+    : Except SyntaxError File :=
+  if src.utf8ByteSize > limits.maxBytes then
+    .error <| SyntaxError.new
+      (.capExceeded .bytes limits.maxBytes) ⟨0, 0⟩ src
+  else
+    let ctx := Ctx.ofString src limits
+    match (Parser.file.run ctx).run {} with
+    | .ok f _ =>
+      if countFileNodes f > limits.maxNodes then
+        .error <| SyntaxError.new
+          (.capExceeded .nodes limits.maxNodes) ⟨0, 0⟩ src
+      else .ok f
+    | .error e _ => .error (convert src ctx e)
+
+open Parser in
+/-- Parse a standalone term (whole input). -/
+def parseTerm (src : String) (limits : Limits := {})
+    : Except SyntaxError Term :=
+  if src.utf8ByteSize > limits.maxBytes then
+    .error <| SyntaxError.new
+      (.capExceeded .bytes limits.maxBytes) ⟨0, 0⟩ src
+  else
+    let ctx := Ctx.ofString src limits
+    let p : M Term := do
+      let t ← term
+      ws
+      let ctx' ← read
+      if ctx'.chars[(← curIdx)]?.isSome then
+        failExp (← curIdx) "end of input"
+      else return t
+    match (p.run ctx).run {} with
+    | .ok t _ =>
+      if countTermNodes t > limits.maxNodes then
+        .error <| SyntaxError.new
+          (.capExceeded .nodes limits.maxNodes) ⟨0, 0⟩ src
+      else .ok t
+    | .error e _ => .error (convert src ctx e)
+
+end Ixon.Syntax

--- a/Ix/IxonSyntax/Print.lean
+++ b/Ix/IxonSyntax/Print.lean
@@ -1,0 +1,406 @@
+/-
+  Canonical pretty-printer for the Ixon text format.
+
+  Behavioral mirror of `crates/ixon/src/syntax/print.rs`: same doc
+  engine (Wadler-style, group-local fitting on cached flat widths),
+  same WIDTH/INDENT, same precedence and escaping rules — byte-for-byte
+  identical output for equal ASTs, which is what makes the printed
+  corpus a cross-language parity surface.
+-/
+module
+
+public import Ix.IxonSyntax.AST
+public import Ix.IxonSyntax.Parser
+
+public section
+
+namespace Ixon.Syntax
+namespace Print
+
+/-- Canonical layout width, in columns (chars). Part of the canonical
+    form; must equal Rust `syntax::print::WIDTH`. -/
+def WIDTH : Nat := 100
+
+/-- Canonical indent step. -/
+def INDENT : Nat := 2
+
+/-! ## Doc engine -/
+
+mutual
+
+/-- Layout document; `width` caches the flattened width (`none` when a
+    hard newline is inside), so grouping decisions are O(1). -/
+inductive Doc where
+  | mk (width : Option Nat) (kind : DocKind)
+
+inductive DocKind where
+  | text (s : String)
+  | cat (ds : Array Doc)
+  /-- Space when flat, newline when broken. -/
+  | line
+  /-- Always a newline. -/
+  | hard
+  | group (d : Doc)
+  | nest (d : Doc)
+
+end
+
+instance : Inhabited Doc := ⟨.mk (some 0) (.text "")⟩
+
+def Doc.width : Doc → Option Nat
+  | .mk w _ => w
+
+def Doc.kind : Doc → DocKind
+  | .mk _ k => k
+
+def text (s : String) : Doc := .mk (some s.length) (.text s)
+
+def cat (ds : Array Doc) : Doc :=
+  let width := ds.foldl (init := some 0) fun acc d =>
+    match acc, d.width with
+    | some a, some w => some (a + w)
+    | _, _ => none
+  .mk width (.cat ds)
+
+def line : Doc := .mk (some 1) .line
+
+def hard : Doc := .mk none .hard
+
+def group (d : Doc) : Doc := .mk d.width (.group d)
+
+def nest (d : Doc) : Doc := .mk d.width (.nest d)
+
+/-- Render with group-local fitting; iterative, mirrors the Rust
+    renderer exactly (including traversal order). Mode: `true` =
+    flat. -/
+partial def render (doc : Doc) (width : Nat) : String := Id.run do
+  let mut out := ""
+  let mut col := 0
+  let mut stack : Array (Nat × Bool × Doc) := #[(0, false, doc)]
+  while stack.size > 0 do
+    let (ind, flat, d) := stack.back!
+    stack := stack.pop
+    match d.kind with
+    | .text s =>
+      out := out ++ s
+      col := col + s.length
+    | .cat ds =>
+      for c in ds.reverse do
+        stack := stack.push (ind, flat, c)
+    | .line =>
+      if flat then
+        out := out.push ' '
+        col := col + 1
+      else
+        out := out.push '\n' |>.pushn ' ' ind
+        col := ind
+    | .hard =>
+      out := out.push '\n' |>.pushn ' ' ind
+      col := ind
+    | .nest c => stack := stack.push (ind + INDENT, flat, c)
+    | .group c =>
+      let f := match c.width with
+        | some w => col + w ≤ width
+        | none => false
+      stack := stack.push (ind, f, c)
+  return out
+
+/-! ## Lexical spelling -/
+
+open Parser (isIdFirst isIdRest isReserved)
+
+/-- Can `s` print as a bare identifier component? -/
+def isBareComponent (s : String) : Bool :=
+  match s.toList with
+  | [] => false
+  | c0 :: rest =>
+    isIdFirst c0 && rest.all isIdRest && !isReserved s
+
+/-- Bare when possible, `«…»` otherwise; `num` components print as
+    bare digits. -/
+def componentStr : NameComponent → String
+  | .str s => if isBareComponent s then s else s!"«{s}»"
+  | .num n => toString n
+
+def snameStr (n : SName) : String :=
+  ".".intercalate (n.parts.toList.map componentStr)
+
+def hashStr (h : HashRef) : String := s!"#{h.hex}"
+
+def hexDigit (n : Nat) : Char :=
+  if n < 10 then Char.ofNat ('0'.toNat + n)
+  else Char.ofNat ('a'.toNat + n - 10)
+
+/-- Lean-style string escaping (matches Rust `escape_string`). -/
+def escapeString (s : String) : String := Id.run do
+  let mut out := "\""
+  for c in s.toList do
+    if c == '"' then out := out ++ "\\\""
+    else if c == '\\' then out := out ++ "\\\\"
+    else if c == '\n' then out := out ++ "\\n"
+    else if c == '\t' then out := out ++ "\\t"
+    else if c == '\r' then out := out ++ "\\r"
+    else if c.toNat < 0x20 || c.toNat == 0x7f then
+      out := out ++ "\\x" |>.push (hexDigit (c.toNat / 16))
+        |>.push (hexDigit (c.toNat % 16))
+    else out := out.push c
+  return out.push '"'
+
+/-! ## Universes -/
+
+/-- `max`/`imax` are operators in universe positions; parameters
+    spelled that way must escape. -/
+def uvarStr : NameComponent → String
+  | .str s => if s == "max" || s == "imax" then s!"«{s}»" else componentStr (.str s)
+  | c => componentStr c
+
+/-- Fold nested `add`s (the grammar admits a single `+ n`). -/
+def foldAdd : UnivExpr → Nat → UnivExpr × Nat
+  | .add inner n _, acc => foldAdd inner (acc + n)
+  | u, acc => (u, acc)
+
+/-- `atomCtx`: position admits only a universe atom — compounds
+    parenthesize. -/
+partial def univStr (u : UnivExpr) (atomCtx : Bool) : String :=
+  match u with
+  | .nat n _ => toString n
+  | .var c _ => uvarStr c
+  | .add a n _ =>
+    let (base, total) := foldAdd a n
+    let s := s!"{univStr base false} + {total}"
+    if atomCtx then s!"({s})" else s
+  | .max a b _ =>
+    let s := s!"max {univStr a true} {univStr b true}"
+    if atomCtx then s!"({s})" else s
+  | .imax a b _ =>
+    let s := s!"imax {univStr a true} {univStr b true}"
+    if atomCtx then s!"({s})" else s
+
+def crefStr (c : ConstRef) : String := Id.run do
+  let mut s := ""
+  if let some n := c.name then
+    s := s ++ snameStr n
+  if let some h := c.hash then
+    s := s ++ hashStr h
+  if let some ls := c.levels then
+    s := s ++ ".{" ++ ", ".intercalate (ls.toList.map (univStr · false)) ++ "}"
+  return s
+
+/-! ## Terms -/
+
+/-- Precedence: 0 = fun/let, 1 = arrows, 2 = loose atoms (spines,
+    `Type u`/`Sort u`, `proj`), 3 = closed atoms. `Type`/`Sort` sit at
+    2 even argument-less so a spine argument can never be captured as
+    their universe argument. -/
+def termPrec : Term → Nat
+  | .lam .. | .letE .. => 0
+  | .pi .. | .arrow .. => 1
+  | .sort .prop _ | .ref _ | .natLit .. | .strLit .. => 3
+  | .app .. | .proj .. | .sort .. => 2
+
+def binderNameStr : BinderName → String
+  | .ident c _ => componentStr c
+  | .anon _ => "_"
+
+mutual
+
+partial def termDoc (t : Term) (minPrec : Nat) : Doc :=
+  let d := termDocBare t
+  if termPrec t < minPrec then cat #[text "(", d, text ")"]
+  else d
+
+partial def termDocBare : Term → Doc
+  | .ref c => text (crefStr c)
+  | .sort k _ =>
+    match k with
+    | .prop => text "Prop"
+    | .type none => text "Type"
+    | .type (some u) => text s!"Type {univStr u true}"
+    | .sort u => text s!"Sort {univStr u true}"
+  | .natLit n _ => text (toString n)
+  | .strLit s _ => text (escapeString s)
+  | .app head args _ => Id.run do
+    -- Flatten nested spines: `(f a) b` prints `f a b`.
+    let mut h := head
+    let mut all := args
+    let mut go := true
+    while go do
+      match h with
+      | .app h2 a2 _ =>
+        all := a2 ++ all
+        h := h2
+      | _ => go := false
+    let mut ds := #[termDoc h 3]
+    for a in all do
+      ds := ds.push line
+      ds := ds.push (termDoc a 3)
+    return group (nest (cat ds))
+  | .lam binders body _ => Id.run do
+    let mut ds := #[text "fun"]
+    for b in binders do
+      ds := ds.push (text " ")
+      ds := ds.push (binderDoc b)
+    ds := ds.push (text " =>")
+    ds := ds.push (group (nest (cat #[line, termDoc body 0])))
+    return cat ds
+  | .pi binders body _ => Id.run do
+    let mut ds := #[]
+    for b in binders do
+      ds := ds.push (binderDoc b)
+      ds := ds.push (text " ")
+    ds := ds.push (text "→")
+    ds := ds.push (group (nest (cat #[line, termDoc body 1])))
+    return cat ds
+  | .arrow dom cod _ =>
+    cat #[termDoc dom 2, text " →",
+      group (nest (cat #[line, termDoc cod 1]))]
+  | .letE nonDep name ty val body _ =>
+    let kwS := if nonDep then "have" else "let"
+    cat #[text s!"{kwS} {binderNameStr name} : ", termDoc ty 0,
+      text " :=", group (nest (cat #[line, termDoc val 0])), text ";",
+      hard, termDoc body 0]
+  | .proj typeRef idx val _ =>
+    cat #[text s!"proj {crefStr typeRef} {idx} ", termDoc val 3]
+
+partial def binderDoc (b : BinderGroup) : Doc :=
+  let (openS, closeS) := match b.info with
+    | .default => ("(", ")")
+    | .implicit => ("{", "}")
+    | .strictImplicit => ("⦃", "⦄")
+    | .instImplicit => ("[", "]")
+  let inner :=
+    if b.names.isEmpty then #[termDoc b.ty 0]
+    else
+      #[text (" ".intercalate (b.names.toList.map binderNameStr) ++ " : "),
+        termDoc b.ty 0]
+  group (cat (#[text openS] ++ inner ++ #[text closeS]))
+
+end
+
+/-! ## Declarations -/
+
+def uparamsStr (ups : Array UParam) : String :=
+  if ups.isEmpty then ""
+  else ".{" ++ ", ".intercalate (ups.toList.map (uvarStr ·.name)) ++ "}"
+
+/-- Header prefix: keyword, optional name, uparams. -/
+def headStr (kwS : String) (name : Option SName) (ups : Array UParam)
+    : String :=
+  match name with
+  | some n => s!"{kwS} {snameStr n}{uparamsStr ups}"
+  | none =>
+    if ups.isEmpty then kwS else s!"{kwS} {uparamsStr ups}"
+
+def sigDoc (head : String) (ty : Term) : Doc :=
+  cat #[text head, text " :", group (nest (cat #[line, termDoc ty 0]))]
+
+partial def declDoc : Decl → Doc
+  | .defn x =>
+    let kwS := (if x.mods.isUnsafe then "unsafe " else "")
+      ++ (if x.mods.isPartial then "partial " else "")
+      ++ (match x.kw with
+          | .defn => "def"
+          | .thm => "theorem"
+          | .opaq => "opaque")
+    cat #[sigDoc (headStr kwS x.name x.uparams) x.ty, text " :=",
+      group (nest (cat #[line, termDoc x.value 0]))]
+  | .axio x =>
+    let kwS := if x.isUnsafe then "unsafe axiom" else "axiom"
+    sigDoc (headStr kwS x.name x.uparams) x.ty
+  | .quot x =>
+    let kind := match x.kind with
+      | .type => "type"
+      | .ctor => "ctor"
+      | .lift => "lift"
+      | .ind => "ind"
+    sigDoc (headStr s!"quot {kind}" x.name x.uparams) x.ty
+  | .indc x => Id.run do
+    let kwS := if x.isUnsafe then "unsafe inductive" else "inductive"
+    let head := headStr kwS x.name x.uparams
+      ++ s!" (params := {x.params}) (indices := {x.indices})"
+    let mut ds := #[sigDoc head x.ty]
+    if !x.ctors.isEmpty then
+      ds := ds.push (text " where")
+      let mut items := #[]
+      for c in x.ctors do
+        items := items.push hard
+        let chead := headStr "|" c.name #[]
+          ++ s!" (params := {c.params}) (fields := {c.fields})"
+        items := items.push (sigDoc chead c.ty)
+      ds := ds.push (nest (cat items))
+    return cat ds
+  | .recr x => Id.run do
+    let kwS := if x.isUnsafe then "unsafe recursor" else "recursor"
+    let mut head := headStr kwS x.name x.uparams
+      ++ s!" (params := {x.params}) (indices := {x.indices})"
+      ++ s!" (motives := {x.motives}) (minors := {x.minors})"
+    if x.k then head := head ++ " (k := true)"
+    let mut ds := #[sigDoc head x.ty]
+    if !x.rules.isEmpty then
+      ds := ds.push (text " where")
+      let mut items := #[]
+      for r in x.rules do
+        items := items.push hard
+        items := items.push (cat #[
+          text s!"| rule (fields := {r.fields}) :=",
+          group (nest (cat #[line, termDoc r.rhs 0]))])
+      ds := ds.push (nest (cat items))
+    return cat ds
+  | .muts members _ => Id.run do
+    let mut items := #[]
+    for m in members do
+      items := items.push hard
+      items := items.push (declDoc m)
+    return cat #[text "mutual", nest (cat items), hard, text "end"]
+  | .prj x =>
+    let kwS := match x.kind with
+      | .dprj => "dprj"
+      | .iprj => "iprj"
+      | .cprj => "cprj"
+      | .rprj => "rprj"
+    let base := s!"{headStr kwS x.name #[]} := {hashStr x.block} {x.idx}"
+    text (match x.cidx with
+      | some c => s!"{base} {c}"
+      | none => base)
+
+def importStr (i : ImportDecl) : String :=
+  match i.prefixName with
+  | some p => s!"import {snameStr p}{hashStr i.hash}"
+  | none => s!"import {hashStr i.hash}"
+
+end Print
+
+/-! ## Public API -/
+
+/-- Print a term (canonical form, no trailing newline). -/
+def printTerm (t : Term) : String :=
+  Print.render (Print.group (Print.termDoc t 0)) Print.WIDTH
+
+/-- Print one declaration (canonical form, no trailing newline). -/
+def printDecl (d : Decl) : String :=
+  Print.render (Print.declDoc d) Print.WIDTH
+
+/-- Print a whole file in canonical form: sections (imports block,
+    declarations, optional trailing main expression) separated by
+    blank lines, trailing newline. The version header is emitted only
+    for versions ≥ 2 — absent means version 1, forever. The main
+    expression's value prints at precedence 2 — `fun`/`let`/arrows
+    parenthesize, so `⊢ (fun (x : A) => x) : A → A` rather than the
+    visually ambiguous bare form (both reparse identically). -/
+def printFile (f : File) : String := Id.run do
+  let mut sections : Array String := #[]
+  if f.version != 1 then
+    sections := sections.push s!"ixon {f.version}"
+  if !f.imports.isEmpty then
+    sections := sections.push
+      ("\n".intercalate (f.imports.toList.map Print.importStr))
+  for d in f.decls do
+    sections := sections.push (printDecl d)
+  if let some m := f.main then
+    let doc := Print.cat #[Print.text "⊢ ", Print.termDoc m.value 2,
+      Print.text " :",
+      Print.group (Print.nest (Print.cat #[Print.line, Print.termDoc m.ty 0]))]
+    sections := sections.push (Print.render doc Print.WIDTH)
+  return "\n\n".intercalate sections.toList ++ "\n"
+
+end Ixon.Syntax

--- a/Tests/Gen/IxonSyntax.lean
+++ b/Tests/Gen/IxonSyntax.lean
@@ -1,0 +1,432 @@
+/-
+  SlimCheck generators for the Ixon text-format surface AST.
+
+  Mirror of the Rust quickcheck generators
+  (`crates/ixon/src/syntax/props.rs`): the same pools, the same
+  validity invariants (nonempty spines, name-or-hash references,
+  leading `Str` name components, `partial` only on `def`, `cidx` iff
+  `cprj`, mutual members restricted), and the same shrinking shapes
+  (subterms + minimal `Prop` replacements; element dropping at the
+  decl/file level).
+
+  `Repr` for `Term`/`File` goes through the canonical printer, so
+  shrunk counterexamples display as actual `.ixon` text.
+-/
+module
+
+public import LSpec
+public import Tests.Gen.Basic
+public import Ix.IxonSyntax
+
+public section
+
+open LSpec SlimCheck Gen Ixon.Syntax
+
+namespace Tests.Gen.IxonSyntax
+
+/-- Counterexamples display as syntax, not structure dumps. -/
+instance : Repr Term := ⟨fun t _ => printTerm t⟩
+
+instance : Repr File := ⟨fun f _ => printFile f⟩
+
+/-! ## Generators -/
+
+/-- Component pool: bare identifiers, unicode, primes/`!?`, reserved
+    words and digit-strings (which must print `«…»`-escaped), and a
+    spaced string (ditto). Identical to the Rust `STR_POOL`. -/
+def strPool : Array String :=
+  #["x", "y", "foo", "bar'", "h!?", "α", "ℕ", "add_comm", "Nat",
+    "Except", "def", "weird name", "123", "max"]
+
+def genStrComponent : Gen NameComponent :=
+  .str <$> elements strPool
+
+def genComponent : Gen NameComponent :=
+  frequency [
+    (1, .num <$> choose Nat 0 999),
+    (4, genStrComponent)
+  ]
+
+def genSName : Gen SName := do
+  let n ← choose Nat 0 2
+  let mut parts := #[← genStrComponent]
+  for _ in [0:n] do
+    parts := parts.push (← genComponent)
+  return { parts }
+
+def hexChars : Array Char :=
+  #['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c',
+    'd', 'e', 'f']
+
+def genHex (len : Nat) : Gen String := do
+  let mut s := ""
+  for _ in [0:len] do
+    s := s.push (← elements hexChars)
+  return s
+
+def genHash : Gen HashRef := do
+  return { hex := ← genHex (4 + (← choose Nat 0 11)) }
+
+/-- Universe variables: `Str` only; includes `"max"` (must print
+    escaped in universe positions). -/
+def genUvar : Gen NameComponent :=
+  .str <$> elements #["u", "v", "w", "max", "weird name"]
+
+def genUniv : Nat → Gen UnivExpr
+  | 0 =>
+    frequency [
+      (1, (.nat · {}) <$> choose Nat 0 3),
+      (1, (.var · {}) <$> genUvar)
+    ]
+  | d + 1 =>
+    frequency [
+      (1, (.nat · {}) <$> choose Nat 0 3),
+      (1, (.var · {}) <$> genUvar),
+      (1, do return .add (← genUniv d) (1 + (← choose Nat 0 2)) {}),
+      (1, do return .max (← genUniv d) (← genUniv d) {}),
+      (1, do return .imax (← genUniv d) (← genUniv d) {})
+    ]
+
+def genCref : Gen ConstRef := do
+  let name ← frequency [(3, some <$> genSName), (1, pure none)]
+  let hash ←
+    if name.isNone then some <$> genHash
+    else frequency [(1, some <$> genHash), (3, pure none)]
+  let levels ← frequency [
+    (1, do
+      let n ← choose Nat 1 2
+      let mut ls := #[]
+      for _ in [0:n] do
+        ls := ls.push (← genUniv 1)
+      pure (some ls)),
+    (3, pure none)
+  ]
+  return { name, hash, levels }
+
+def genBinderName : Gen BinderName :=
+  frequency [
+    (1, pure (.anon {})),
+    (5, (.ident · {}) <$> genStrComponent)
+  ]
+
+def genSort : Gen SortKind :=
+  frequency [
+    (1, pure .prop),
+    (1, pure (.type none)),
+    (1, .type <$> some <$> genUniv 1),
+    (1, .sort <$> genUniv 1)
+  ]
+
+/-- Interesting string-literal contents (escape coverage) plus the
+    pool. -/
+def genLitString : Gen String :=
+  frequency [
+    (3, elements #["", "hi", "line\nbreak", "q\"uote", "tab\there\\"]),
+    (1, do
+      let n ← choose Nat 0 12
+      let mut s := ""
+      for _ in [0:n] do
+        let c ← frequency [
+          (3, elements #['"', '\\', '\n', '\t', 'a', ' ', '«', '»', '¤']),
+          (2, Char.ofNat <$> choose Nat 0x20 0x7e),
+          (1, Char.ofNat <$> choose Nat 0xa0 0x2fff)
+        ]
+        s := s.push c
+      pure s)
+  ]
+
+mutual
+
+partial def genBinder (depth : Nat) : Gen BinderGroup := do
+  let info ← elements #[Lean.BinderInfo.default, .implicit,
+    .strictImplicit, .instImplicit]
+  let names ←
+    if info == Lean.BinderInfo.instImplicit && (← choose Nat 0 1) == 0 then
+      pure #[]
+    else do
+      let n ← choose Nat 1 2
+      let mut ns := #[]
+      for _ in [0:n] do
+        ns := ns.push (← genBinderName)
+      pure ns
+  return .mk info names (← genTerm depth) {}
+
+partial def genTerm (depth : Nat) : Gen Term := do
+  if depth == 0 then
+    frequency [
+      (1, (.natLit · {}) <$> choose Nat 0 1000000),
+      (1, (.strLit · {}) <$> genLitString),
+      (1, (.sort · {}) <$> genSort),
+      (3, .ref <$> genCref)
+    ]
+  else
+    let d := depth - 1
+    frequency [
+      (1, (.sort · {}) <$> genSort),
+      (2, do
+        let n ← choose Nat 1 3
+        let mut args := #[]
+        for _ in [0:n] do
+          args := args.push (← genTerm d)
+        return .app (← genTerm d) args {}),
+      (2, do
+        let n ← choose Nat 1 2
+        let mut bs := #[]
+        for _ in [0:n] do
+          bs := bs.push (← genBinder d)
+        return .lam bs (← genTerm d) {}),
+      (1, do
+        let n ← choose Nat 1 2
+        let mut bs := #[]
+        for _ in [0:n] do
+          bs := bs.push (← genBinder d)
+        return .pi bs (← genTerm d) {}),
+      (1, do return .arrow (← genTerm d) (← genTerm d) {}),
+      (1, do
+        return .letE ((← choose Nat 0 1) == 0) (← genBinderName)
+          (← genTerm d) (← genTerm d) (← genTerm d) {}),
+      (1, do return .proj (← genCref) (← choose Nat 0 7) (← genTerm d) {}),
+      (1, .ref <$> genCref)
+    ]
+
+end
+
+def genUParams : Gen (Array UParam) := do
+  let n ← choose Nat 0 2
+  let mut out := #[]
+  for _ in [0:n] do
+    out := out.push { name := ← genUvar }
+  return out
+
+def genName? : Gen (Option SName) :=
+  frequency [(3, some <$> genSName), (1, pure none)]
+
+/-- The parser rejects `partial` on non-`def` and unsafe+partial. -/
+def genModifiers (kw : DefKw) : Gen Modifiers := do
+  match ← choose Nat 0 3 with
+  | 0 => return { isUnsafe := true }
+  | 1 => if kw == .defn then return { isPartial := true } else return {}
+  | _ => return {}
+
+def genDefDecl (depth : Nat) : Gen DefDecl := do
+  let kw ← elements #[DefKw.defn, .thm, .opaq]
+  return { kw, mods := ← genModifiers kw, name := ← genName?
+           uparams := ← genUParams, ty := ← genTerm depth
+           value := ← genTerm depth }
+
+def genIndDecl (depth : Nat) : Gen IndDecl := do
+  let nCtors ← choose Nat 0 2
+  let mut ctors := #[]
+  for _ in [0:nCtors] do
+    ctors := ctors.push
+      { name := ← genName?, params := ← choose Nat 0 3
+        fields := ← choose Nat 0 3, ty := ← genTerm depth }
+  return { isUnsafe := (← choose Nat 0 1) == 0, name := ← genName?
+           uparams := ← genUParams, params := ← choose Nat 0 3
+           indices := ← choose Nat 0 3, ty := ← genTerm depth, ctors }
+
+def genRecrDecl (depth : Nat) : Gen RecrDecl := do
+  let nRules ← choose Nat 0 2
+  let mut rules := #[]
+  for _ in [0:nRules] do
+    rules := rules.push
+      { fields := ← choose Nat 0 3, rhs := ← genTerm depth }
+  return { isUnsafe := (← choose Nat 0 1) == 0, name := ← genName?
+           uparams := ← genUParams, params := ← choose Nat 0 3
+           indices := ← choose Nat 0 3, motives := 1 + (← choose Nat 0 1)
+           minors := ← choose Nat 0 3, k := (← choose Nat 0 1) == 0
+           ty := ← genTerm depth, rules }
+
+def genDecl (depth : Nat) : Gen Decl := do
+  match ← choose Nat 0 7 with
+  | 0 | 1 => .defn <$> genDefDecl depth
+  | 2 =>
+    return .axio { isUnsafe := (← choose Nat 0 1) == 0
+                   name := ← genName?, uparams := ← genUParams
+                   ty := ← genTerm depth }
+  | 3 =>
+    return .quot { kind := ← elements #[QuotKindKw.type, .ctor, .lift, .ind]
+                   name := ← genName?, uparams := ← genUParams
+                   ty := ← genTerm depth }
+  | 4 => .indc <$> genIndDecl depth
+  | 5 => .recr <$> genRecrDecl depth
+  | 6 => do
+    let n ← choose Nat 1 2
+    let mut members := #[]
+    for _ in [0:n] do
+      let m ← match ← choose Nat 0 2 with
+        | 0 => Decl.indc <$> genIndDecl depth
+        | 1 => Decl.recr <$> genRecrDecl depth
+        | _ => Decl.defn <$> genDefDecl depth
+      members := members.push m
+    return .muts members {}
+  | _ => do
+    let kind ← elements #[PrjKind.dprj, .iprj, .cprj, .rprj]
+    let cidx ←
+      if kind == .cprj then some <$> choose Nat 0 7 else pure none
+    return .prj { kind, name := ← genName?, block := ← genHash
+                  idx := ← choose Nat 0 7, cidx }
+
+def genImport : Gen ImportDecl := do
+  return { prefixName := ← frequency [(1, some <$> genSName), (1, pure none)]
+           hash := { hex := ← genHex 64 } }
+
+def genFile : Gen File := do
+  let nImports ← choose Nat 0 2
+  let mut imports := #[]
+  for _ in [0:nImports] do
+    imports := imports.push (← genImport)
+  let nDecls ← choose Nat 0 3
+  let mut decls := #[]
+  for _ in [0:nDecls] do
+    decls := decls.push (← genDecl 2)
+  let main ←
+    if (← choose Nat 0 2) == 0 then
+      pure (some { value := ← genTerm 2, ty := ← genTerm 2 : MainExpr })
+    else pure none
+  return { version := VERSION, imports, decls, main }
+
+/-! ## Shrinking (mirrors `props.rs` shrinkers) -/
+
+def propLeaf : Term := .sort .prop {}
+
+def isPropLeaf : Term → Bool
+  | .sort .prop _ => true
+  | _ => false
+
+/-- Immediate subterms plus minimal replacements — every candidate is
+    strictly smaller or the `Prop` leaf (which shrinks to nothing), so
+    shrinking terminates. -/
+def shrinkTerm (t : Term) : List Term := Id.run do
+  let mut out : List Term := []
+  if !isPropLeaf t then out := [propLeaf]
+  match t with
+  | .app head args _ =>
+    out := out ++ [head] ++ args.toList
+    if args.size > 1 then
+      for i in [0:args.size] do
+        out := out ++ [.app head (args.eraseIdxIfInBounds i) {}]
+  | .lam bs body _ | .pi bs body _ =>
+    out := out ++ [body] ++ (bs.toList.map (·.ty))
+  | .arrow d c _ => out := out ++ [d, c]
+  | .letE _ _ ty val body _ => out := out ++ [ty, val, body]
+  | .proj _ _ v _ => out := out ++ [v]
+  | .ref r =>
+    if r.levels.isSome then
+      out := out ++ [.ref { r with levels := none }]
+    if r.name.isSome && r.hash.isSome then
+      out := out ++ [.ref { r with hash := none }]
+  | .strLit s _ =>
+    if !s.isEmpty then out := out ++ [.strLit "" {}]
+  | _ => pure ()
+  return out
+
+instance : Shrinkable Term := ⟨shrinkTerm⟩
+
+def shrinkDecl (d : Decl) : List Decl := Id.run do
+  let mut out : List Decl := []
+  match d with
+  | .defn x =>
+    out := (shrinkTerm x.ty).map (fun ty => .defn { x with ty })
+      ++ (shrinkTerm x.value).map (fun value => .defn { x with value })
+  | .axio x => out := (shrinkTerm x.ty).map (fun ty => .axio { x with ty })
+  | .quot x => out := (shrinkTerm x.ty).map (fun ty => .quot { x with ty })
+  | .indc x =>
+    for i in [0:x.ctors.size] do
+      out := out ++ [.indc { x with ctors := x.ctors.eraseIdxIfInBounds i }]
+    out := out ++ (shrinkTerm x.ty).map (fun ty => .indc { x with ty })
+  | .recr x =>
+    for i in [0:x.rules.size] do
+      out := out ++ [.recr { x with rules := x.rules.eraseIdxIfInBounds i }]
+    out := out ++ (shrinkTerm x.ty).map (fun ty => .recr { x with ty })
+  | .muts members _ =>
+    out := members.toList
+    if members.size > 1 then
+      for i in [0:members.size] do
+        out := out ++ [.muts (members.eraseIdxIfInBounds i) {}]
+  | .prj _ => pure ()
+  return out
+
+instance : Shrinkable Decl := ⟨shrinkDecl⟩
+
+instance : Shrinkable File where
+  shrink f := Id.run do
+    let mut out : List File := []
+    if f.main.isSome then
+      out := out ++ [{ f with main := none }]
+    if let some m := f.main then
+      out := out ++ (shrinkTerm m.value).map
+        (fun v => { f with main := some { m with value := v } })
+      out := out ++ (shrinkTerm m.ty).map
+        (fun t => { f with main := some { m with ty := t } })
+    for i in [0:f.imports.size] do
+      out := out ++ [{ f with imports := f.imports.eraseIdxIfInBounds i }]
+    for i in [0:f.decls.size] do
+      out := out ++ [{ f with decls := f.decls.eraseIdxIfInBounds i }]
+    for i in [0:f.decls.size] do
+      for s in shrinkDecl f.decls[i]! do
+        out := out ++ [{ f with decls := f.decls.set! i s }]
+    return out
+
+/-! ## SampleableExt instances -/
+
+instance : SampleableExt Term :=
+  SampleableExt.mkSelfContained (genTerm 4)
+
+instance : SampleableExt File :=
+  SampleableExt.mkSelfContained genFile
+
+/-- Fuzz input: strings biased toward syntax-relevant characters
+    (delimiters, escapes, digits, unicode) — a sharper boundary walk
+    than uniform random strings. -/
+structure Fuzz where
+  s : String
+  deriving Repr
+
+def fuzzChars : Array Char :=
+  #['(', ')', '{', '}', '[', ']', '⦃', '⦄', '#', '«', '»', '"', '\\',
+    '.', ',', ':', ';', '=', '>', '→', '|', '+', '_', ' ', '\n', '\t',
+    'a', 'x', 'f', '0', '1', '9', 'α', 'd', 'e', 'u', 'n', '-', '/']
+
+def genFuzz : Gen Fuzz := do
+  let n ← choose Nat 0 60
+  let mut s := ""
+  for _ in [0:n] do
+    let c ← frequency [
+      (6, elements fuzzChars),
+      (1, Char.ofNat <$> choose Nat 0x20 0x7e),
+      (1, Char.ofNat <$> choose Nat 0xa0 0x2fff)
+    ]
+    s := s.push c
+  return ⟨s⟩
+
+instance : Shrinkable Fuzz where
+  shrink f :=
+    if f.s.isEmpty then []
+    else
+      let l := f.s.toList
+      [⟨String.ofList (l.take (l.length / 2))⟩,
+       ⟨String.ofList (l.drop (l.length / 2))⟩,
+       ⟨String.ofList l.tail⟩]
+
+instance : SampleableExt Fuzz := SampleableExt.mkSelfContained genFuzz
+
+/-- A batch of (position, pool-index) char mutations for the
+    near-valid fuzz property. -/
+structure Muts where
+  muts : List (Nat × Nat)
+  deriving Repr, Inhabited
+
+def genMuts : Gen Muts := do
+  let n ← choose Nat 0 6
+  let mut out : List (Nat × Nat) := []
+  for _ in [0:n] do
+    out := (← choose Nat 0 100000, ← choose Nat 0 1000) :: out
+  return ⟨out⟩
+
+instance : Shrinkable Muts where
+  shrink m := if m.muts.isEmpty then [] else [⟨m.muts.tail⟩]
+
+instance : SampleableExt Muts := SampleableExt.mkSelfContained genMuts
+
+end Tests.Gen.IxonSyntax

--- a/Tests/Ix/IxonSyntax.lean
+++ b/Tests/Ix/IxonSyntax.lean
@@ -1,0 +1,425 @@
+/-
+  Tests for the Ixon text-format parser and printer.
+
+  Direct port of the Rust unit suite (`crates/ixon/src/syntax/mod.rs`
+  tests) — same corpus strings, same expected canonical output. Until
+  the FFI parity externs land (plan M4), these shared goldens are the
+  cross-language behavioral check: both implementations must print
+  byte-identical canonical text for these inputs.
+
+  Also includes SlimCheck properties mirroring the Rust quickcheck
+  suite (`crates/ixon/src/syntax/props.rs`): printer fixpoint over
+  arbitrary valid ASTs, node-count/byte bound, and totality on fuzzed
+  and mutated input. Generators/shrinkers live in
+  `Tests/Gen/IxonSyntax.lean`. (Parse determinism, a Rust property,
+  is definitional here — the parsers are pure functions.)
+-/
+module
+
+public import LSpec
+public import Ix.IxonSyntax
+public import Tests.Gen.IxonSyntax
+
+open LSpec Ixon.Syntax
+
+namespace Tests.IxonSyntax
+
+/-- Text-level roundtrip: parse, print, reparse, reprint; the two
+    prints must agree. Returns the canonical form. -/
+def roundtripTerm (src : String) : Except String String := do
+  let t1 ← (parseTerm src).mapError fun e => s!"parse failed on {repr src}: {e}"
+  let p1 := printTerm t1
+  let t2 ← (parseTerm p1).mapError fun e => s!"reparse failed on {repr p1}: {e}"
+  let p2 := printTerm t2
+  if p1 == p2 then return p1
+  else throw s!"not a fixpoint for {repr src}: {repr p1} vs {repr p2}"
+
+def roundtripFile (src : String) : Except String String := do
+  let f1 ← (parseFile src).mapError fun e => s!"parse failed: {e}\n---\n{src}"
+  let p1 := printFile f1
+  let f2 ← (parseFile p1).mapError fun e => s!"reparse failed: {e}\n---\n{p1}"
+  let p2 := printFile f2
+  if p1 != p2 then throw s!"printer not a fixpoint:\n--- p1\n{p1}\n--- p2\n{p2}"
+  else if f1.decls.size != f2.decls.size then throw "decl count changed"
+  else return p1
+
+/-- Render an `Except String` check as a test. -/
+def checkExcept (name : String) : Except String α → TestSeq
+  | .ok _ => test name true
+  | .error e => test s!"{name}: {e}" false
+
+/-- Does the result satisfy the predicate? (`test` needs applied Bool
+    functions, not literal `match` bodies, for `Testable`.) -/
+def isOk (r : Except ε α) (p : α → Bool) : Bool :=
+  match r with
+  | .ok a => p a
+  | .error _ => false
+
+/-- Does the parse print to exactly `s`? -/
+def printsTo (r : Except SyntaxError Term) (s : String) : Bool :=
+  isOk r (printTerm · == s)
+
+/-- Does the roundtrip yield exactly `expect`? -/
+def rtEq (src expect : String) : Bool :=
+  match roundtripTerm src with
+  | .ok p => p == expect
+  | .error _ => false
+
+def errKind (r : Except SyntaxError α) (p : ErrorKind → Bool) : Bool :=
+  match r with
+  | .error e => p e.kind
+  | .ok _ => false
+
+def errLine (r : Except SyntaxError α) (n : Nat) : Bool :=
+  match r with
+  | .error e => e.line == n
+  | .ok _ => false
+
+/-- The term corpus — identical to the Rust `term_roundtrips` list. -/
+def termCorpus : List String := [
+  "Nat",
+  "Nat.add",
+  "Nat.add x y",
+  "f (g x) y",
+  "(f x) y z",
+  "fun (x : Nat) => x",
+  "fun (x y : Nat) (z : Bool) => f x z",
+  "fun {α : Type u} (a : α) => a",
+  "fun [inst : Monad m] => inst",
+  "fun ⦃p : Prop⦄ => p",
+  "(x : Nat) → Vec x",
+  "(x y : Nat) (z : Bool) → f x y z",
+  "Nat → Bool",
+  "Nat → Bool → Prop",
+  "(Nat → Bool) → Prop",
+  "let x : Nat := 5; f x",
+  "have h : And p q := trivial; h",
+  "let f : Nat → Nat := fun (x : Nat) => x; f 3",
+  "Prop",
+  "Type",
+  "Type 1",
+  "Type u",
+  "Type (max u v)",
+  "Sort (u + 1)",
+  "Sort (imax u v)",
+  "List.{0} Nat",
+  "Except.ok.{0, 0} PatchError String s",
+  "Nat.add_comm#deadbeef",
+  "#deadbeef",
+  "#deadbeef.{u} x",
+  "proj Prod 0 p",
+  "proj #abcd1234 1 (mk x y)",
+  "42",
+  "0xff",
+  "\"hello\"",
+  "\"line\\nbreak \\\"quoted\\\"\"",
+  "«weird name».foo",
+  "Nat.«0».bar",
+  "f Nat.0.bar",
+  "α.«β»",
+  "f _x y'",
+  "x!? y"
+]
+
+def termRoundtrips : TestSeq :=
+  termCorpus.foldl (init := .done) fun acc src =>
+    acc ++ checkExcept s!"roundtrip {repr src}" (roundtripTerm src)
+
+def isPinnedRef : Term → Bool
+  | .ref r => r.hash.isSome
+  | _ => false
+
+def isUnaryApp : Term → Bool
+  | .app _ args _ => args.size == 1
+  | _ => false
+
+def isLet (nonDep : Bool) : Term → Bool
+  | .letE nd .. => nd == nonDep
+  | _ => false
+
+def adjacencyIsSignificant : TestSeq :=
+  let pinned := parseTerm "f#abcd"
+  let applied := parseTerm "f #abcd"
+  test "f#abcd is a pinned ref" (isOk pinned isPinnedRef)
+  ++ test "f #abcd is an application" (isOk applied isUnaryApp)
+  ++ test "pinned prints f#abcd" (printsTo pinned "f#abcd")
+  ++ test "applied prints f #abcd" (printsTo applied "f #abcd")
+
+def typeArgumentIsGreedy : TestSeq :=
+  test "f Type 1 takes 1 as universe arg"
+    (isOk (parseTerm "f Type 1") isUnaryApp)
+  ++ test "f (Type) 1 canonical" (rtEq "f (Type) 1" "f (Type) 1")
+  ++ test "f Type 1 canonical" (rtEq "f Type 1" "f (Type 1)")
+
+def letVsHave : TestSeq :=
+  test "let is dependent"
+    (isOk (parseTerm "let x : N := v; x") (isLet false))
+  ++ test "have is non-dependent"
+    (isOk (parseTerm "have x : N := v; x") (isLet true))
+
+/-- The acceptance fixture: hand-formatted input normalizes to the
+    SAME canonical bytes the Rust printer emits (shared golden). -/
+def acceptanceFixture : TestSeq :=
+  let src := "ixon 1\n"
+    ++ "import #9c41aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9c41\n"
+    ++ "\n"
+    ++ "def : String → Except PatchError String :=\n"
+    ++ "  fun (s : String) => Except.ok PatchError String s\n"
+  let canonical :=
+    "import #9c41aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9c41\n"
+    ++ "\n"
+    ++ "def : String → Except PatchError String := "
+    ++ "fun (s : String) => Except.ok PatchError String s\n"
+  match roundtripFile src with
+  | .error e => test s!"acceptance fixture: {e}" false
+  | .ok printed =>
+    test "acceptance fixture prints the shared canonical golden"
+      (printed == canonical)
+
+def kitchenSink : TestSeq :=
+  let src := "ixon 1
+
+import #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+import Std.V2#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+def id.{u} : (α : Sort u) → α → α := fun (α : Sort u) (a : α) => a
+
+theorem trivial : True := True.intro
+
+unsafe opaque magic : Nat := 0
+
+partial def loop : Nat → Nat := fun (n : Nat) => loop n
+
+axiom choice.{u} : (α : Sort u) → Nonempty α → α
+
+quot type Quot.{u} : (α : Sort u) → (α → α → Prop) → Sort u
+
+inductive Nat' (params := 0) (indices := 0) : Type where
+  | zero (params := 0) (fields := 0) : Nat'
+  | succ (params := 0) (fields := 1) : Nat' → Nat'
+
+recursor Nat'.rec.{u} (params := 0) (indices := 0) (motives := 1) (minors := 2) :
+    (motive : Nat' → Sort u) → motive Nat'.zero →
+    ((n : Nat') → motive n → motive (Nat'.succ n)) → (t : Nat') → motive t where
+  | rule (fields := 0) := z
+  | rule (fields := 1) := fun (n : Nat') (ih : motive n) => s n ih
+
+mutual
+def even : Nat → Bool := fun (n : Nat) => odd n
+def odd : Nat → Bool := fun (n : Nat) => even n
+end
+
+dprj even := #cccccccccccccccccccccccccccccccc 0
+cprj Nat'.succ := #dddd 0 1
+
+⊢ even (succ zero) : Bool
+"
+  checkExcept "kitchen sink roundtrip" (roundtripFile src)
+  ++ test "kitchen sink has a main expression"
+    (isOk (parseFile src) (·.main.isSome))
+
+def rtFileEq (src expect : String) : Bool :=
+  match roundtripFile src with
+  | .ok p => p == expect
+  | .error _ => false
+
+def mainExpression : TestSeq :=
+  test "minimal main-only file is canonical (no header)"
+    (rtFileEq "⊢ 1 : Nat\n" "⊢ 1 : Nat\n")
+  ++ test "explicit ixon 1 header accepted and canonically omitted"
+    (rtFileEq "ixon 1\n⊢ 1 : Nat\n" "⊢ 1 : Nat\n")
+  ++ test "ASCII turnstile normalizes to ⊢"
+    (rtFileEq "|- 1 : Nat\n" "⊢ 1 : Nat\n")
+  ++ test "low-precedence values parenthesize canonically"
+    (rtFileEq "⊢ fun (x : Nat) => x : Nat → Nat\n"
+      "⊢ (fun (x : Nat) => x) : Nat → Nat\n")
+  ++ test "the annotation is mandatory"
+    (errKind (parseFile "⊢ 1\n") fun k =>
+      match k with
+      | .unexpectedToken .. => true
+      | _ => false)
+  ++ test "bare form accepted as the file's sole item"
+    (rtFileEq "1 : Nat\n" "⊢ 1 : Nat\n")
+  ++ test "bare form after imports"
+    (rtFileEq
+      ("import "
+        ++ "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        ++ "fun (x : Nat) => x : Nat → Nat\n")
+      ("import "
+        ++ "#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\n"
+        ++ "⊢ (fun (x : Nat) => x) : Nat → Nat\n"))
+  ++ test "leading ixon without a numeral is content"
+    (rtFileEq "ixon : Nat\n" "⊢ ixon : Nat\n")
+  ++ test "the fully minimal wire: one bare judgment"
+    (rtFileEq
+      ("fun (s : String) => Except.ok PatchError String s : "
+        ++ "String -> Except PatchError String\n")
+      ("⊢ (fun (s : String) => Except.ok PatchError String s) : "
+        ++ "String → Except PatchError String\n"))
+  ++ test "after a declaration the turnstile is required"
+    (errKind (parseFile "ixon 1\ndef x : N := v\n1 : Nat\n") fun k =>
+      match k with
+      | .unexpectedToken .. => true
+      | _ => false)
+  ++ test "at most one main expression"
+    (errKind (parseFile "ixon 1\n⊢ 1 : Nat ⊢ 2 : Nat\n")
+      (· == .mainExprNotLast))
+  ++ test "main expression must be last"
+    (errKind (parseFile "ixon 1\n⊢ 1 : Nat def x : A := b\n")
+      (· == .mainExprNotLast))
+
+def mainAfterTermFinalDecl : TestSeq :=
+  -- Regression (found by quickcheck on the Rust side): the turnstile
+  -- stops the preceding declaration's application spine.
+  checkExcept "main after where-less inductive"
+    (roundtripFile
+      "ixon 1\ninductive N (params := 0) (indices := 0) : Prop\n\n⊢ Prop : Prop\n")
+  ++ checkExcept "|- after a ctor block is not eaten by the bar"
+    (roundtripFile
+      ("ixon 1\ninductive N (params := 0) (indices := 0) : Prop where\n"
+        ++ "  | c (params := 0) (fields := 0) : N\n|- c : N\n"))
+
+def versionGate : TestSeq :=
+  test "ixon 2 rejected"
+    (errKind (parseFile "ixon 2\n") fun k => k == .unknownVersion 2 1)
+
+def importHashLength : TestSeq :=
+  test "short import hash rejected"
+    (errKind (parseFile "ixon 1\nimport #abcd\n")
+      fun k => k == .importHashLength 4)
+
+def errorShapes : TestSeq :=
+  test "missing => positioned"
+    (errKind (parseTerm "fun (x : Nat) x") fun k =>
+      match k with
+      | .unexpectedToken expected _ => (expected.splitOn "=>").length > 1
+      | _ => false)
+  ++ test "uppercase hash rejected"
+    (errKind (parseTerm "#DEAD") fun k =>
+      match k with
+      | .invalidHash _ => true
+      | _ => false)
+  ++ test "placeholder is not a term"
+    (errKind (parseTerm "f _") (· == .placeholder))
+  ++ test "(x : Nat) without arrow is committed"
+    (errKind (parseTerm "(x : Nat)") fun k =>
+      match k with
+      | .unexpectedToken expected _ => (expected.splitOn "→").length > 1
+      | _ => false)
+  ++ test "empty levels"
+    (errKind (parseTerm "Nat.{}") (· == .emptyLevels))
+  ++ test "line/col are 1-based"
+    (errLine (parseFile "ixon 1\ndef x : Nat :=\n") 3)
+
+def depthCap : TestSeq :=
+  let limits : Limits := { maxDepth := 16 }
+  let deep := "".pushn '(' 64 ++ "x" ++ "".pushn ')' 64
+  test "depth cap is a structured error"
+    (errKind (parseTerm deep limits) fun k =>
+      match k with
+      | .capExceeded .depth _ => true
+      | _ => false)
+
+def byteCap : TestSeq :=
+  let limits : Limits := { maxBytes := 8 }
+  test "byte cap is a structured error"
+    (errKind (parseTerm "f x y z w" limits) fun k =>
+      match k with
+      | .capExceeded .bytes _ => true
+      | _ => false)
+
+def commentsAndWhitespace : TestSeq :=
+  test "comments are skipped"
+    (printsTo (parseTerm "f -- line comment\n  /- block /- nested -/ -/ x")
+      "f x")
+  ++ test "unterminated block comment"
+    (errKind (parseTerm "f /- open") (· == .unterminatedComment))
+
+def reservedComponentsEscape : TestSeq :=
+  test "Nat.«def» roundtrips"
+    (printsTo (parseTerm "Nat.«def»") "Nat.«def»")
+  ++ test "«123» stays Str"
+    (printsTo (parseTerm "Foo.«123»") "Foo.«123»")
+  ++ test "bare 123 is Num"
+    (printsTo (parseTerm "Foo.123") "Foo.123")
+
+/-! ## Properties (mirror `props.rs`) -/
+
+open Tests.Gen.IxonSyntax
+
+/-- `print ∘ parse ∘ print = print` at the term level. -/
+def termFixpoint (t : Term) : Bool :=
+  let p1 := printTerm t
+  match parseTerm p1 with
+  | .ok t2 => printTerm t2 == p1
+  | .error _ => false
+
+/-- `print ∘ parse ∘ print = print` at the file level. -/
+def fileFixpoint (f : File) : Bool :=
+  let p1 := printFile f
+  match parseFile p1 with
+  | .ok f2 => printFile f2 == p1
+  | .error _ => false
+
+/-- The metering claim on `Limits`: no ε-productions, so the parsed
+    node count is bounded by the printed byte length. -/
+def nodeCountBounded (t : Term) : Bool :=
+  let p := printTerm t
+  match parseTerm p with
+  | .ok t2 => countTermNodes t2 ≤ p.utf8ByteSize
+  | .error _ => false
+
+/-- Force evaluation of a parse result (totality: a value or a
+    structured error, never a runtime crash). -/
+def forced (r : Except SyntaxError α) : Bool :=
+  match r with
+  | .ok _ => true
+  | .error _ => true
+
+/-- Totality on fuzzed input, both entry points. -/
+def parseTotal (f : Fuzz) : Bool :=
+  forced (parseTerm f.s) && forced (parseFile f.s)
+
+/-- Caps are respected and total, even when tiny. -/
+def tinyLimitsTotal (f : Fuzz) : Bool :=
+  let tiny : Limits := { maxBytes := 64, maxNodes := 16, maxDepth := 4 }
+  forced (parseTerm f.s tiny) && forced (parseFile f.s tiny)
+
+/-- Near-valid fuzz: mutate chars of canonical output (drawn from the
+    syntax-relevant pool), reparse, require totality. -/
+def mutatedTotal (t : Term) (m : Muts) : Bool :=
+  let chars := (printTerm t).toList.toArray
+  if chars.isEmpty then true
+  else
+    let mutated := m.muts.foldl (init := chars) fun cs (pos, ci) =>
+      cs.set! (pos % cs.size) fuzzChars[ci % fuzzChars.size]!
+    let s := String.ofList mutated.toList
+    forced (parseTerm s) && forced (parseFile s)
+
+end Tests.IxonSyntax
+
+open Tests.IxonSyntax Tests.Gen.IxonSyntax in
+public def Tests.IxonSyntax.suite : List LSpec.TestSeq := [
+  termRoundtrips,
+  adjacencyIsSignificant,
+  typeArgumentIsGreedy,
+  letVsHave,
+  acceptanceFixture,
+  kitchenSink,
+  mainExpression,
+  mainAfterTermFinalDecl,
+  versionGate,
+  importHashLength,
+  errorShapes,
+  depthCap,
+  byteCap,
+  commentsAndWhitespace,
+  reservedComponentsEscape,
+  checkIO "term print∘parse∘print fixpoint" (∀ t : Term, termFixpoint t),
+  checkIO "file print∘parse∘print fixpoint" (∀ f : File, fileFixpoint f),
+  checkIO "node count ≤ printed bytes" (∀ t : Term, nodeCountBounded t),
+  checkIO "parse total on fuzz strings" (∀ f : Fuzz, parseTotal f),
+  checkIO "parse total under tiny limits" (∀ f : Fuzz, tinyLimitsTotal f),
+  checkIO "mutated canonical text total"
+    (∀ (t : Term) (m : Muts), mutatedTotal t m)
+]

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -2,6 +2,7 @@ import Tests.Aiur
 import Tests.ByteArray
 import Tests.Ix.Ixon
 import Tests.Ix.IxonCorpus
+import Tests.Ix.IxonSyntax
 import Tests.Ix.IxVM
 import Tests.Ix.Claim
 import Tests.Ix.Merkle
@@ -66,6 +67,7 @@ def primarySuites : Std.HashMap String (List LSpec.TestSeq) := .ofList [
   ("ffi", Tests.FFI.suite),
   ("byte-array", Tests.ByteArray.suite),
   ("ixon", Tests.Ixon.suite),
+  ("ixon-syntax", Tests.IxonSyntax.suite),
   ("claim", Tests.Claim.suite),
   ("merkle", Tests.Merkle.suite),
   ("assumption-tree", Tests.AssumptionTree.suite),

--- a/crates/ixon/Cargo.toml
+++ b/crates/ixon/Cargo.toml
@@ -11,6 +11,7 @@ dashmap = { workspace = true }
 indexmap = { workspace = true }
 ix-common = { workspace = true }
 memmap2 = { workspace = true }
+nom = { workspace = true }
 num-bigint = { workspace = true }
 rustc-hash = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/ixon/src/lib.rs
+++ b/crates/ixon/src/lib.rs
@@ -21,6 +21,7 @@ pub mod metadata;
 pub mod proof;
 pub mod serialize;
 pub mod sharing;
+pub mod syntax;
 pub mod tag;
 pub mod univ;
 

--- a/crates/ixon/src/syntax/ast.rs
+++ b/crates/ixon/src/syntax/ast.rs
@@ -1,0 +1,463 @@
+//! Surface AST for the Ixon text format (`.ixon`).
+//!
+//! The AST is the hub shared by the parser and the pretty-printer. It
+//! mirrors the *named* Ix level (`ix_common::env::Expr`) minus
+//! `fvar`/`mvar`/`mdata`, plus source spans and the three reference
+//! forms (`Name`, `#hash`, `Name#hash`). Nothing here knows about the
+//! pack format: no tables, no de Bruijn indices, no blob addresses.
+//!
+//! Every node carries a byte-offset [`Span`]. Spans participate in
+//! derived `PartialEq`; roundtrip tests therefore compare at the text
+//! level (`print ∘ parse ∘ print = print`), not by AST equality.
+
+use bignat::Nat;
+use ix_common::env::{BinderInfo, NameComponent};
+
+/// Byte-offset span into the source text: `start` inclusive, `end`
+/// exclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Span {
+  pub start: usize,
+  pub end: usize,
+}
+
+impl Span {
+  pub fn new(start: usize, end: usize) -> Self {
+    Span { start, end }
+  }
+
+  /// Smallest span covering both `self` and `other`.
+  pub fn to(&self, other: Span) -> Span {
+    Span { start: self.start.min(other.start), end: self.end.max(other.end) }
+  }
+}
+
+/// A surface (dotted) name: raw components, no hashing. Numeric
+/// components are legal only in non-leading position (a leading digit
+/// run lexes as a nat literal); names with a leading numeric component
+/// are unspellable by name and use `#addr` instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SName {
+  pub parts: Vec<NameComponent>,
+  pub span: Span,
+}
+
+/// A `#hex` reference: 4–64 lowercase hex digits (exactly 64 in import
+/// position). Stored as the raw hex string; address resolution belongs
+/// to the resolve stage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HashRef {
+  pub hex: String,
+  pub span: Span,
+}
+
+/// Universe-level expression.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnivExpr {
+  /// Literal level: `0`, `1`, …
+  Nat(u64, Span),
+  /// Universe parameter by name (single component).
+  Var(NameComponent, Span),
+  /// `u + n`.
+  Add(Box<UnivExpr>, u64, Span),
+  /// `max u v`.
+  Max(Box<UnivExpr>, Box<UnivExpr>, Span),
+  /// `imax u v`.
+  IMax(Box<UnivExpr>, Box<UnivExpr>, Span),
+}
+
+impl UnivExpr {
+  pub fn span(&self) -> Span {
+    match self {
+      UnivExpr::Nat(_, s)
+      | UnivExpr::Var(_, s)
+      | UnivExpr::Add(_, _, s)
+      | UnivExpr::Max(_, _, s)
+      | UnivExpr::IMax(_, _, s) => *s,
+    }
+  }
+}
+
+/// A constant reference: `Name`, `#hash`, or the pinned `Name#hash`.
+/// Invariant: at least one of `name`/`hash` is present. `levels: None`
+/// is the bare form (zero-default, arity read from the resolved
+/// constant); `Some(vs)` is the explicit `.{…}` form, `vs` nonempty.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConstRef {
+  pub name: Option<SName>,
+  pub hash: Option<HashRef>,
+  pub levels: Option<Vec<UnivExpr>>,
+  pub span: Span,
+}
+
+/// `Prop` | `Type u?` | `Sort u` — the surface distinction is kept for
+/// exact printing; the resolve stage normalizes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SortKind {
+  Prop,
+  Type(Option<UnivExpr>),
+  Sort(UnivExpr),
+}
+
+/// A binder name: an identifier component or `_` (fresh anonymous).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinderName {
+  Ident(NameComponent, Span),
+  Anon(Span),
+}
+
+impl BinderName {
+  pub fn span(&self) -> Span {
+    match self {
+      BinderName::Ident(_, s) | BinderName::Anon(s) => *s,
+    }
+  }
+}
+
+/// One bracketed binder group, e.g. `(x y : A)`, `{α : Type u}`,
+/// `[inst : C]`, `⦃p : P⦄`. The bracket shape is recorded as
+/// [`BinderInfo`] — metadata only, never address-relevant. For the
+/// unnamed instance form `[C]`, `names` is empty.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BinderGroup {
+  pub info: BinderInfo,
+  pub names: Vec<BinderName>,
+  pub ty: Term,
+  pub span: Span,
+}
+
+/// Surface term.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Term {
+  /// Reference (bound variable or constant — resolved later).
+  Ref(ConstRef),
+  /// `Prop` / `Type u` / `Sort u`.
+  Sort(SortKind, Span),
+  /// Application spine `f a b c` (`args` nonempty). The canonical
+  /// printer flattens nested spines.
+  App { head: Box<Term>, args: Vec<Term>, span: Span },
+  /// `fun (x : A) (y : B) => e`.
+  Fun { binders: Vec<BinderGroup>, body: Box<Term>, span: Span },
+  /// Dependent function type `(x : A) (y : B) → C`.
+  Pi { binders: Vec<BinderGroup>, body: Box<Term>, span: Span },
+  /// Non-dependent function type `A → B`.
+  Arrow { dom: Box<Term>, cod: Box<Term>, span: Span },
+  /// `let x : T := v; b` (`non_dep = false`) or
+  /// `have x : T := v; b` (`non_dep = true`) — address-relevant.
+  Let {
+    non_dep: bool,
+    name: BinderName,
+    ty: Box<Term>,
+    val: Box<Term>,
+    body: Box<Term>,
+    span: Span,
+  },
+  /// Nat literal.
+  NatLit(Nat, Span),
+  /// String literal (decoded value; escapes re-applied on print).
+  StrLit(String, Span),
+  /// `proj S i e` structure projection.
+  Proj { type_ref: ConstRef, idx: u64, val: Box<Term>, span: Span },
+}
+
+impl Term {
+  pub fn span(&self) -> Span {
+    match self {
+      Term::Ref(r) => r.span,
+      Term::Sort(_, s) | Term::NatLit(_, s) | Term::StrLit(_, s) => *s,
+      Term::App { span, .. }
+      | Term::Fun { span, .. }
+      | Term::Pi { span, .. }
+      | Term::Arrow { span, .. }
+      | Term::Let { span, .. }
+      | Term::Proj { span, .. } => *span,
+    }
+  }
+}
+
+/// Universe parameter binder in `.{u, v}` declaration position.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UParam {
+  pub name: NameComponent,
+  pub span: Span,
+}
+
+/// `def` / `theorem` / `opaque` — address-relevant (`Ixon.DefKind`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefKw {
+  Def,
+  Theorem,
+  Opaque,
+}
+
+/// Declaration modifiers — address-relevant (`DefinitionSafety`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Modifiers {
+  pub unsafe_: bool,
+  pub partial_: bool,
+}
+
+/// `def`-like declaration: `def Name.{u} : T := v`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DefDecl {
+  pub kw: DefKw,
+  pub mods: Modifiers,
+  pub name: Option<SName>,
+  pub uparams: Vec<UParam>,
+  pub ty: Term,
+  pub value: Term,
+  pub span: Span,
+}
+
+/// `axiom Name.{u} : T`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AxiomDecl {
+  pub unsafe_: bool,
+  pub name: Option<SName>,
+  pub uparams: Vec<UParam>,
+  pub ty: Term,
+  pub span: Span,
+}
+
+/// The four quotient primitives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuotKindKw {
+  Type,
+  Ctor,
+  Lift,
+  Ind,
+}
+
+/// `quot type|ctor|lift|ind Name.{u} : T`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct QuotDecl {
+  pub kind: QuotKindKw,
+  pub name: Option<SName>,
+  pub uparams: Vec<UParam>,
+  pub ty: Term,
+  pub span: Span,
+}
+
+/// Constructor inside an `inductive … where` block.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CtorDecl {
+  pub name: Option<SName>,
+  pub params: u64,
+  pub fields: u64,
+  pub ty: Term,
+  pub span: Span,
+}
+
+/// `inductive Name.{u} (params := n) (indices := m) : T where …`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IndDecl {
+  pub unsafe_: bool,
+  pub name: Option<SName>,
+  pub uparams: Vec<UParam>,
+  pub params: u64,
+  pub indices: u64,
+  pub ty: Term,
+  pub ctors: Vec<CtorDecl>,
+  pub span: Span,
+}
+
+/// Recursor rule: `| rule (fields := n) := rhs`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuleDecl {
+  pub fields: u64,
+  pub rhs: Term,
+  pub span: Span,
+}
+
+/// `recursor Name.{u} (params := …) … : T where …`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecrDecl {
+  pub unsafe_: bool,
+  pub name: Option<SName>,
+  pub uparams: Vec<UParam>,
+  pub params: u64,
+  pub indices: u64,
+  pub motives: u64,
+  pub minors: u64,
+  pub k: bool,
+  pub ty: Term,
+  pub rules: Vec<RuleDecl>,
+  pub span: Span,
+}
+
+/// The four projection-constant kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrjKind {
+  DPrj,
+  IPrj,
+  CPrj,
+  RPrj,
+}
+
+/// Projection constant: `cprj Name := #block i c` etc. — a `{idx,
+/// block}` pointer into a muts block; the one decl form with no
+/// expressions. `cidx` is present iff `kind == CPrj`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrjDecl {
+  pub kind: PrjKind,
+  pub name: Option<SName>,
+  pub block: HashRef,
+  pub idx: u64,
+  pub cidx: Option<u64>,
+  pub span: Span,
+}
+
+/// Top-level declaration.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decl {
+  Def(DefDecl),
+  Axiom(AxiomDecl),
+  Quot(QuotDecl),
+  Ind(IndDecl),
+  Recr(RecrDecl),
+  /// `mutual … end`; members restricted to `Def`/`Ind`/`Recr`.
+  Mutual(Vec<Decl>, Span),
+  Prj(PrjDecl),
+}
+
+impl Decl {
+  pub fn span(&self) -> Span {
+    match self {
+      Decl::Def(d) => d.span,
+      Decl::Axiom(d) => d.span,
+      Decl::Quot(d) => d.span,
+      Decl::Ind(d) => d.span,
+      Decl::Recr(d) => d.span,
+      Decl::Mutual(_, s) => *s,
+      Decl::Prj(d) => d.span,
+    }
+  }
+}
+
+/// `import Foo.Bar#hash` (mount under prefix) or `import #hash` (mount
+/// at root). Import hashes are always full 64-hex.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportDecl {
+  pub prefix: Option<SName>,
+  pub hash: HashRef,
+  pub span: Span,
+}
+
+/// The file's main expression: a trailing `value : type` item. The
+/// annotation is mandatory (it is the constant's `typ` — inference
+/// would be elaboration, R4). Compiles like an anonymous
+/// `def : T := v` (defn-kind, safe, monomorphic) and marks the result
+/// as the file's `main` constant. At most one, and it must be the
+/// last item (consecutive bare expressions absorb each other).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MainExpr {
+  pub value: Term,
+  pub ty: Term,
+  pub span: Span,
+}
+
+/// A parsed `.ixon` file: `ixon <version>` header, imports, decls,
+/// optional trailing main expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct File {
+  pub version: u64,
+  pub imports: Vec<ImportDecl>,
+  pub decls: Vec<Decl>,
+  pub main: Option<MainExpr>,
+  pub span: Span,
+}
+
+/// Node counting for the `max_nodes` limit (R2). Every counted node
+/// consumes at least one source byte, so `max_bytes` already bounds
+/// this; the explicit count is the number the resolve/compile stages
+/// meter against.
+pub fn count_term_nodes(t: &Term) -> usize {
+  let mut n = 1;
+  match t {
+    Term::Ref(r) => n += count_ref_nodes(r) - 1,
+    Term::Sort(k, _) => {
+      if let SortKind::Type(Some(u)) | SortKind::Sort(u) = k {
+        n += count_univ_nodes(u);
+      }
+    },
+    Term::App { head, args, .. } => {
+      n += count_term_nodes(head);
+      for a in args {
+        n += count_term_nodes(a);
+      }
+    },
+    Term::Fun { binders, body, .. } | Term::Pi { binders, body, .. } => {
+      for b in binders {
+        n += 1 + count_term_nodes(&b.ty);
+      }
+      n += count_term_nodes(body);
+    },
+    Term::Arrow { dom, cod, .. } => {
+      n += count_term_nodes(dom) + count_term_nodes(cod);
+    },
+    Term::Let { ty, val, body, .. } => {
+      n +=
+        count_term_nodes(ty) + count_term_nodes(val) + count_term_nodes(body);
+    },
+    Term::NatLit(..) | Term::StrLit(..) => {},
+    Term::Proj { type_ref, val, .. } => {
+      n += count_ref_nodes(type_ref) + count_term_nodes(val);
+    },
+  }
+  n
+}
+
+fn count_ref_nodes(r: &ConstRef) -> usize {
+  let mut n = 1;
+  if let Some(ls) = &r.levels {
+    for l in ls {
+      n += count_univ_nodes(l);
+    }
+  }
+  n
+}
+
+fn count_univ_nodes(u: &UnivExpr) -> usize {
+  match u {
+    UnivExpr::Nat(..) | UnivExpr::Var(..) => 1,
+    UnivExpr::Add(a, _, _) => 1 + count_univ_nodes(a),
+    UnivExpr::Max(a, b, _) | UnivExpr::IMax(a, b, _) => {
+      1 + count_univ_nodes(a) + count_univ_nodes(b)
+    },
+  }
+}
+
+/// Total node count for a declaration.
+pub fn count_decl_nodes(d: &Decl) -> usize {
+  match d {
+    Decl::Def(x) => 1 + count_term_nodes(&x.ty) + count_term_nodes(&x.value),
+    Decl::Axiom(x) => 1 + count_term_nodes(&x.ty),
+    Decl::Quot(x) => 1 + count_term_nodes(&x.ty),
+    Decl::Ind(x) => {
+      let mut n = 1 + count_term_nodes(&x.ty);
+      for c in &x.ctors {
+        n += 1 + count_term_nodes(&c.ty);
+      }
+      n
+    },
+    Decl::Recr(x) => {
+      let mut n = 1 + count_term_nodes(&x.ty);
+      for r in &x.rules {
+        n += 1 + count_term_nodes(&r.rhs);
+      }
+      n
+    },
+    Decl::Mutual(ds, _) => 1 + ds.iter().map(count_decl_nodes).sum::<usize>(),
+    Decl::Prj(_) => 1,
+  }
+}
+
+/// Total node count for a file.
+pub fn count_file_nodes(f: &File) -> usize {
+  1 + f.imports.len()
+    + f.decls.iter().map(count_decl_nodes).sum::<usize>()
+    + f
+      .main
+      .as_ref()
+      .map_or(0, |m| 1 + count_term_nodes(&m.value) + count_term_nodes(&m.ty))
+}

--- a/crates/ixon/src/syntax/error.rs
+++ b/crates/ixon/src/syntax/error.rs
@@ -1,0 +1,157 @@
+//! Structured errors for the Ixon text format (R8: errors are data).
+//!
+//! Every error carries a byte [`Span`]; line/column are derived from
+//! the source at construction time (1-based, column counted in
+//! Unicode scalar values). The variant set is mirrored by the Lean
+//! implementation and is part of the cross-language parity surface.
+
+use crate::syntax::ast::Span;
+
+/// Which parser limit was exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cap {
+  Bytes,
+  Nodes,
+  Depth,
+}
+
+/// Structured error kind. Parse-stage variants only; the resolve
+/// stage (unknown names, import realization, …) extends this enum
+/// later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorKind {
+  /// The workhorse: what the parser wanted vs. what it saw.
+  UnexpectedToken { expected: String, found: String },
+  /// Header version this parser does not speak.
+  UnknownVersion { found: u64, supported: u64 },
+  /// A parser limit was hit (R2 metering).
+  CapExceeded { which: Cap, limit: usize },
+  /// Malformed `#hex` reference (bad char, bad length, uppercase).
+  InvalidHash { reason: String },
+  /// Import hashes must be exactly 64 hex digits.
+  ImportHashLength { found: usize },
+  /// Malformed string escape.
+  InvalidEscape,
+  /// Unterminated string literal.
+  UnterminatedString,
+  /// Unterminated `«…»` name component.
+  UnterminatedQuotedName,
+  /// Unterminated `/- … -/` block comment.
+  UnterminatedComment,
+  /// Numeric literal out of range for its position (e.g. a count
+  /// annotation beyond `u64`).
+  NatOutOfRange,
+  /// `_` used where a term is required (R4: no holes).
+  Placeholder,
+  /// Explicit `.{}` with no levels.
+  EmptyLevels,
+  /// A declaration form not permitted here (e.g. `axiom` inside
+  /// `mutual`).
+  BadMutualMember,
+  /// A `⊢ value : type` main expression must be the last item in the
+  /// file (and there can be only one).
+  MainExprNotLast,
+}
+
+/// A positioned, structured syntax error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SyntaxError {
+  pub kind: ErrorKind,
+  pub span: Span,
+  /// 1-based line of `span.start`.
+  pub line: u32,
+  /// 1-based column (in Unicode scalar values) of `span.start`.
+  pub col: u32,
+}
+
+impl SyntaxError {
+  /// Build an error, deriving line/column from `src`.
+  pub fn new(kind: ErrorKind, span: Span, src: &str) -> Self {
+    let (line, col) = line_col(src, span.start);
+    SyntaxError { kind, span, line, col }
+  }
+}
+
+/// Derive (1-based line, 1-based char column) for a byte offset.
+pub fn line_col(src: &str, pos: usize) -> (u32, u32) {
+  let pos = pos.min(src.len());
+  let mut line = 1u32;
+  let mut col = 1u32;
+  for (i, c) in src.char_indices() {
+    if i >= pos {
+      break;
+    }
+    if c == '\n' {
+      line += 1;
+      col = 1;
+    } else {
+      col += 1;
+    }
+  }
+  (line, col)
+}
+
+impl std::fmt::Display for SyntaxError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}:{}: ", self.line, self.col)?;
+    match &self.kind {
+      ErrorKind::UnexpectedToken { expected, found } => {
+        write!(f, "expected {expected}, found {found}")
+      },
+      ErrorKind::UnknownVersion { found, supported } => write!(
+        f,
+        "unknown ixon version {found} (this parser speaks {supported})"
+      ),
+      ErrorKind::CapExceeded { which, limit } => {
+        let w = match which {
+          Cap::Bytes => "byte",
+          Cap::Nodes => "node",
+          Cap::Depth => "depth",
+        };
+        write!(f, "{w} limit exceeded (max {limit})")
+      },
+      ErrorKind::InvalidHash { reason } => {
+        write!(f, "invalid #hash reference: {reason}")
+      },
+      ErrorKind::ImportHashLength { found } => {
+        write!(f, "import hashes must be exactly 64 hex digits, found {found}")
+      },
+      ErrorKind::InvalidEscape => write!(f, "invalid string escape"),
+      ErrorKind::UnterminatedString => {
+        write!(f, "unterminated string literal")
+      },
+      ErrorKind::UnterminatedQuotedName => {
+        write!(f, "unterminated «…» name component")
+      },
+      ErrorKind::UnterminatedComment => {
+        write!(f, "unterminated block comment")
+      },
+      ErrorKind::NatOutOfRange => {
+        write!(f, "numeric literal out of range for this position")
+      },
+      ErrorKind::Placeholder => {
+        write!(f, "`_` is not a term (the grammar has no holes)")
+      },
+      ErrorKind::EmptyLevels => {
+        write!(f, "`.{{}}` must list at least one universe")
+      },
+      ErrorKind::BadMutualMember => {
+        write!(
+          f,
+          "only def/theorem/opaque, inductive, and recursor \
+                   declarations may appear in a mutual block"
+        )
+      },
+      ErrorKind::MainExprNotLast => {
+        write!(
+          f,
+          "a main expression (`⊢ value : type`) must be the last \
+                   item in the file"
+        )
+      },
+    }
+  }
+}
+
+impl std::error::Error for SyntaxError {}

--- a/crates/ixon/src/syntax/mod.rs
+++ b/crates/ixon/src/syntax/mod.rs
@@ -1,0 +1,403 @@
+//! Ixon text format (`.ixon`): parser and canonical pretty-printer.
+//!
+//! The textual syntax denotes the *named Ix level* — a Lean-resembling
+//! closed grammar over `Ix.Expr`-shaped trees — never the pack-level
+//! tables (sharing/refs/univs are derived by the one canonical compile
+//! pipeline). See `plans/ixon-syntax.md` for the design and
+//! requirements (R1–R8).
+//!
+//! This module is the AST-level layer: text ↔ [`ast`] both ways, with
+//! structured errors and metered parsing. The `Constant` ↔ AST stages
+//! (resolve/ingress and the metadata-arena printer walk) build on top.
+//!
+//! Layering:
+//! - [`ast`] — the surface AST, spans, node counting
+//! - [`parse`] — `nom` parser: `&str → File/Term`
+//! - [`print`] — canonical printer: `File/Term → String`
+//! - [`error`] — structured, positioned errors (R8)
+
+pub mod ast;
+pub mod error;
+pub mod parse;
+pub mod print;
+
+pub use ast::{Decl, File, Span, Term};
+pub use error::{Cap, ErrorKind, SyntaxError};
+pub use parse::{parse_file, parse_term};
+pub use print::{print_decl, print_file, print_term};
+
+/// Grammar version this implementation speaks (R7). The `ixon <n>`
+/// header is optional: absent means version 1, forever; grammar
+/// versions ≥ 2 must declare themselves, and canonical version-1
+/// output omits the header.
+pub const VERSION: u64 = 1;
+
+/// Parser resource caps (R2: gas for admission — parse cost is
+/// chargeable up front). Defaults are deliberately generous for
+/// interactive use; doors pass their own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Limits {
+  /// Maximum input length in bytes (checked before any work).
+  pub max_bytes: usize,
+  /// Maximum AST node count (checked after parse; the grammar has no
+  /// ε-productions, so `max_bytes` already bounds it — this is the
+  /// number downstream stages meter against).
+  pub max_nodes: usize,
+  /// Maximum nesting depth (checked during descent; guards the stack).
+  pub max_depth: usize,
+}
+
+impl Default for Limits {
+  fn default() -> Self {
+    Limits { max_bytes: 1 << 20, max_nodes: 1 << 20, max_depth: 512 }
+  }
+}
+
+#[cfg(test)]
+mod props;
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::syntax::error::Cap;
+
+  fn lims() -> Limits {
+    Limits::default()
+  }
+
+  /// Text-level roundtrip fixpoint: `print (parse (print (parse s)))`
+  /// equals `print (parse s)`.
+  fn roundtrip_term(src: &str) -> String {
+    let t1 = parse_term(src, &lims())
+      .unwrap_or_else(|e| panic!("parse failed on {src:?}: {e}"));
+    let p1 = print_term(&t1);
+    let t2 = parse_term(&p1, &lims())
+      .unwrap_or_else(|e| panic!("reparse failed on {p1:?}: {e}"));
+    let p2 = print_term(&t2);
+    assert_eq!(p1, p2, "printer not a fixpoint for {src:?}");
+    p1
+  }
+
+  fn roundtrip_file(src: &str) -> String {
+    let f1 = parse_file(src, &lims())
+      .unwrap_or_else(|e| panic!("parse failed: {e}\n---\n{src}"));
+    let p1 = print_file(&f1);
+    let f2 = parse_file(&p1, &lims())
+      .unwrap_or_else(|e| panic!("reparse failed: {e}\n---\n{p1}"));
+    let p2 = print_file(&f2);
+    assert_eq!(p1, p2, "printer not a fixpoint");
+    assert_eq!(f1.decls.len(), f2.decls.len());
+    p1
+  }
+
+  #[test]
+  fn term_roundtrips() {
+    for src in [
+      "Nat",
+      "Nat.add",
+      "Nat.add x y",
+      "f (g x) y",
+      "(f x) y z",
+      "fun (x : Nat) => x",
+      "fun (x y : Nat) (z : Bool) => f x z",
+      "fun {α : Type u} (a : α) => a",
+      "fun [inst : Monad m] => inst",
+      "fun ⦃p : Prop⦄ => p",
+      "(x : Nat) → Vec x",
+      "(x y : Nat) (z : Bool) → f x y z",
+      "Nat → Bool",
+      "Nat → Bool → Prop",
+      "(Nat → Bool) → Prop",
+      "let x : Nat := 5; f x",
+      "have h : And p q := trivial; h",
+      "let f : Nat → Nat := fun (x : Nat) => x; f 3",
+      "Prop",
+      "Type",
+      "Type 1",
+      "Type u",
+      "Type (max u v)",
+      "Sort (u + 1)",
+      "Sort (imax u v)",
+      "List.{0} Nat",
+      "Except.ok.{0, 0} PatchError String s",
+      "Nat.add_comm#deadbeef",
+      "#deadbeef",
+      "#deadbeef.{u} x",
+      "proj Prod 0 p",
+      "proj #abcd1234 1 (mk x y)",
+      "42",
+      "0xff",
+      "\"hello\"",
+      "\"line\\nbreak \\\"quoted\\\"\"",
+      "«weird name».foo",
+      "Nat.«0».bar",
+      "f Nat.0.bar",
+      "α.«β»",
+      "f _x y'",
+      "x!? y",
+    ] {
+      roundtrip_term(src);
+    }
+  }
+
+  #[test]
+  fn adjacency_is_significant() {
+    // `f#abcd` is one pinned reference; `f #abcd` is an application.
+    let pinned = parse_term("f#abcd", &lims()).unwrap();
+    assert!(matches!(&pinned, Term::Ref(r) if r.hash.is_some()));
+    let applied = parse_term("f #abcd", &lims()).unwrap();
+    assert!(matches!(&applied, Term::App { args, .. } if args.len() == 1));
+    assert_eq!(print_term(&pinned), "f#abcd");
+    assert_eq!(print_term(&applied), "f #abcd");
+  }
+
+  #[test]
+  fn type_argument_is_greedy() {
+    // `f Type 1` reads the 1 as Type's universe argument…
+    let t = parse_term("f Type 1", &lims()).unwrap();
+    let Term::App { args, .. } = &t else { panic!("expected app") };
+    assert_eq!(args.len(), 1);
+    // …so the printer parenthesizes Sort atoms in argument position.
+    assert_eq!(roundtrip_term("f (Type) 1"), "f (Type) 1");
+    assert_eq!(roundtrip_term("f Type 1"), "f (Type 1)");
+  }
+
+  #[test]
+  fn let_vs_have_is_address_relevant() {
+    let l = parse_term("let x : N := v; x", &lims()).unwrap();
+    let h = parse_term("have x : N := v; x", &lims()).unwrap();
+    assert!(matches!(l, Term::Let { non_dep: false, .. }));
+    assert!(matches!(h, Term::Let { non_dep: true, .. }));
+  }
+
+  #[test]
+  fn acceptance_fixture_file() {
+    // Hand-formatted input…
+    let src = "\
+ixon 1
+import #9c41aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9c41
+
+def : String → Except PatchError String :=
+  fun (s : String) => Except.ok PatchError String s
+";
+    // …normalizes to the canonical form (no version header — absent
+    // means version 1; the def fits in WIDTH columns, so it stays
+    // flat).
+    let canonical = "\
+import #9c41aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9c41
+
+def : String → Except PatchError String := \
+fun (s : String) => Except.ok PatchError String s
+";
+    let printed = roundtrip_file(src);
+    assert_eq!(printed, canonical);
+  }
+
+  #[test]
+  fn kitchen_sink_file() {
+    let src = r#"ixon 1
+
+import #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+import Std.V2#bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+def id.{u} : (α : Sort u) → α → α := fun (α : Sort u) (a : α) => a
+
+theorem trivial : True := True.intro
+
+unsafe opaque magic : Nat := 0
+
+partial def loop : Nat → Nat := fun (n : Nat) => loop n
+
+axiom choice.{u} : (α : Sort u) → Nonempty α → α
+
+quot type Quot.{u} : (α : Sort u) → (α → α → Prop) → Sort u
+
+inductive Nat' (params := 0) (indices := 0) : Type where
+  | zero (params := 0) (fields := 0) : Nat'
+  | succ (params := 0) (fields := 1) : Nat' → Nat'
+
+recursor Nat'.rec.{u} (params := 0) (indices := 0) (motives := 1) (minors := 2) :
+    (motive : Nat' → Sort u) → motive Nat'.zero →
+    ((n : Nat') → motive n → motive (Nat'.succ n)) → (t : Nat') → motive t where
+  | rule (fields := 0) := z
+  | rule (fields := 1) := fun (n : Nat') (ih : motive n) => s n ih
+
+mutual
+def even : Nat → Bool := fun (n : Nat) => odd n
+def odd : Nat → Bool := fun (n : Nat) => even n
+end
+
+dprj even := #cccccccccccccccccccccccccccccccc 0
+cprj Nat'.succ := #dddd 0 1
+
+⊢ even (succ zero) : Bool
+"#;
+    let f = parse_file(src, &lims()).expect("kitchen sink parses");
+    assert!(f.main.is_some());
+    roundtrip_file(src);
+  }
+
+  #[test]
+  fn main_expression() {
+    // Minimal main-only file is already canonical (no header).
+    assert_eq!(roundtrip_file("⊢ 1 : Nat\n"), "⊢ 1 : Nat\n");
+    // An explicit `ixon 1` header is accepted and canonically omitted.
+    assert_eq!(roundtrip_file("ixon 1\n⊢ 1 : Nat\n"), "⊢ 1 : Nat\n");
+    // The ASCII turnstile normalizes to `⊢`.
+    assert_eq!(roundtrip_file("|- 1 : Nat\n"), "⊢ 1 : Nat\n");
+    // Low-precedence values parenthesize canonically (both spellings
+    // reparse identically) — shared golden with the Lean suite.
+    assert_eq!(
+      roundtrip_file("⊢ fun (x : Nat) => x : Nat → Nat\n"),
+      "⊢ (fun (x : Nat) => x) : Nat → Nat\n"
+    );
+    // The annotation is mandatory.
+    let e = parse_file("⊢ 1\n", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::UnexpectedToken { .. }));
+    // Bare form (no turnstile) is accepted as the file's SOLE item —
+    // the door wire, now ceremony-free — and normalizes to `⊢`.
+    assert_eq!(roundtrip_file("1 : Nat\n"), "⊢ 1 : Nat\n");
+    assert_eq!(
+      roundtrip_file(
+        "import \
+         #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
+         fun (x : Nat) => x : Nat → Nat\n"
+      ),
+      "import \
+       #aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\n\
+       ⊢ (fun (x : Nat) => x) : Nat → Nat\n"
+    );
+    // Leading `ixon` NOT followed by a numeral is content, not a
+    // header (a constant may be named `ixon`).
+    assert_eq!(roundtrip_file("ixon : Nat\n"), "⊢ ixon : Nat\n");
+    // The fully minimal wire: no header, no imports (resolution uses
+    // the application's default env), no turnstile — one judgment.
+    assert_eq!(
+      roundtrip_file(
+        "fun (s : String) => Except.ok PatchError String s : \
+         String -> Except PatchError String\n"
+      ),
+      "⊢ (fun (s : String) => Except.ok PatchError String s) : \
+       String → Except PatchError String\n"
+    );
+    // After a declaration the turnstile is required: the bare form
+    // errors (the decl's value absorbs the atom, orphaning the `:`) —
+    // never a silent re-split.
+    let e =
+      parse_file("ixon 1\ndef x : N := v\n1 : Nat\n", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::UnexpectedToken { .. }));
+    // At most one, and it must be last.
+    let e = parse_file("⊢ 1 : Nat ⊢ 2 : Nat\n", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::MainExprNotLast));
+    let e = parse_file("⊢ 1 : Nat def x : A := b\n", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::MainExprNotLast));
+  }
+
+  #[test]
+  fn main_after_term_final_decl() {
+    // Regression (found by quickcheck): the turnstile stops the
+    // preceding declaration's application spine — without it, `⊢ Prop`
+    // would be absorbed as an argument of the inductive's type.
+    let printed = roundtrip_file(
+      "ixon 1\ninductive N (params := 0) (indices := 0) : Prop\n\n⊢ Prop : Prop\n",
+    );
+    let f = parse_file(&printed, &lims()).unwrap();
+    assert_eq!(f.decls.len(), 1);
+    assert!(f.main.is_some());
+    // Same shape after a where-block: `|` in ctor loops must not eat
+    // the `|-` spelling.
+    roundtrip_file(
+      "ixon 1\ninductive N (params := 0) (indices := 0) : Prop where\n  \
+       | c (params := 0) (fields := 0) : N\n|- c : N\n",
+    );
+  }
+
+  #[test]
+  fn version_gate() {
+    let e = parse_file("ixon 2\n", &lims()).unwrap_err();
+    assert!(matches!(
+      e.kind,
+      ErrorKind::UnknownVersion { found: 2, supported: 1 }
+    ));
+  }
+
+  #[test]
+  fn import_hash_must_be_full() {
+    let e = parse_file("ixon 1\nimport #abcd\n", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::ImportHashLength { found: 4 }));
+  }
+
+  #[test]
+  fn error_shapes() {
+    // Unexpected token, positioned.
+    let e = parse_term("fun (x : Nat) x", &lims()).unwrap_err();
+    let ErrorKind::UnexpectedToken { expected, .. } = &e.kind else {
+      panic!("expected UnexpectedToken, got {:?}", e.kind)
+    };
+    assert!(expected.contains("=>"), "expected mentions `=>`: {expected}");
+
+    // Uppercase hash digits are rejected with a reason.
+    let e = parse_term("#DEAD", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::InvalidHash { .. }));
+
+    // Placeholders are not terms.
+    let e = parse_term("f _", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::Placeholder));
+
+    // `(x : A)` without an arrow is committed as a binder.
+    let e = parse_term("(x : Nat)", &lims()).unwrap_err();
+    let ErrorKind::UnexpectedToken { expected, .. } = &e.kind else {
+      panic!("expected UnexpectedToken, got {:?}", e.kind)
+    };
+    assert!(expected.contains('→'), "expected mentions arrow: {expected}");
+
+    // Empty explicit levels.
+    let e = parse_term("Nat.{}", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::EmptyLevels));
+
+    // Line/col are 1-based and positioned.
+    let e = parse_file("ixon 1\ndef x : Nat :=\n", &lims()).unwrap_err();
+    assert_eq!(e.line, 3);
+  }
+
+  #[test]
+  fn depth_cap() {
+    let mut limits = lims();
+    limits.max_depth = 16;
+    let deep = format!("{}x{}", "(".repeat(64), ")".repeat(64));
+    let e = parse_term(&deep, &limits).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::CapExceeded { which: Cap::Depth, .. }));
+  }
+
+  #[test]
+  fn byte_cap() {
+    let mut limits = lims();
+    limits.max_bytes = 8;
+    let e = parse_term("f x y z w", &limits).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::CapExceeded { which: Cap::Bytes, .. }));
+  }
+
+  #[test]
+  fn comments_and_whitespace() {
+    let t =
+      parse_term("f -- line comment\n  /- block /- nested -/ -/ x", &lims())
+        .unwrap();
+    assert_eq!(print_term(&t), "f x");
+    let e = parse_term("f /- open", &lims()).unwrap_err();
+    assert!(matches!(e.kind, ErrorKind::UnterminatedComment));
+  }
+
+  #[test]
+  fn reserved_components_escape() {
+    // `def` as a component must be escaped; bare it terminates the
+    // name.
+    let t = parse_term("Nat.«def»", &lims()).unwrap();
+    assert_eq!(print_term(&t), "Nat.«def»");
+    // «123» stays a Str component, distinct from bare-digit Num.
+    let s = parse_term("Foo.«123»", &lims()).unwrap();
+    let n = parse_term("Foo.123", &lims()).unwrap();
+    assert_eq!(print_term(&s), "Foo.«123»");
+    assert_eq!(print_term(&n), "Foo.123");
+    assert_ne!(s, n);
+  }
+}

--- a/crates/ixon/src/syntax/parse.rs
+++ b/crates/ixon/src/syntax/parse.rs
@@ -1,0 +1,1727 @@
+//! `nom` parser for the Ixon text format.
+//!
+//! Total, deterministic, metered (R2): every input yields a [`File`]/
+//! [`Term`] or a structured [`SyntaxError`]; byte/node/depth caps are
+//! parser parameters checked before and during the work they bound.
+//! Recursive descent over `&str` with single-token lookahead; the one
+//! reinterpretation point is `(x y : A)`-as-binder-group vs.
+//! parenthesized term, decided by a bounded committed attempt (each
+//! token is scanned at most twice — linear time).
+//!
+//! Errors ride a custom nom error ([`PErr`]) that keeps the *furthest*
+//! failure position and merges expectations there, plus a `special`
+//! channel for structured kinds (caps, bad escapes, …) that must not
+//! be washed out by backtracking.
+
+use std::cell::Cell;
+
+use bignat::Nat;
+use ix_common::env::{BinderInfo, NameComponent};
+use nom::{Err as NErr, IResult};
+use num_bigint::BigUint;
+
+use crate::syntax::Limits;
+use crate::syntax::VERSION;
+use crate::syntax::ast::{
+  AxiomDecl, BinderGroup, BinderName, ConstRef, CtorDecl, Decl, DefDecl, DefKw,
+  File, HashRef, ImportDecl, IndDecl, MainExpr, Modifiers, PrjDecl, PrjKind,
+  QuotDecl, QuotKindKw, RecrDecl, RuleDecl, SName, SortKind, Span, Term,
+  UParam, UnivExpr, count_file_nodes, count_term_nodes,
+};
+use crate::syntax::error::{Cap, ErrorKind, SyntaxError};
+
+/// Reserved words: rejected as bare name components everywhere in the
+/// grammar (escape as `«def»` if a real name needs one). Contextual
+/// words (`params`, `rule`, `max`, `type`, …) are matched positionally
+/// and stay usable as names.
+pub const RESERVED: &[&str] = &[
+  "import",
+  "def",
+  "theorem",
+  "opaque",
+  "axiom",
+  "quot",
+  "inductive",
+  "recursor",
+  "mutual",
+  "end",
+  "unsafe",
+  "partial",
+  "fun",
+  "let",
+  "have",
+  "where",
+  "proj",
+  "Prop",
+  "Type",
+  "Sort",
+  // Declaration-starting words must be reserved: a preceding
+  // declaration's final term would otherwise absorb them as
+  // application arguments in multi-decl files.
+  "dprj",
+  "iprj",
+  "cprj",
+  "rprj",
+];
+
+/// Is `s` a reserved word?
+pub fn is_reserved(s: &str) -> bool {
+  RESERVED.contains(&s)
+}
+
+/// Lean's `isLetterLike` character ranges. Must stay in sync with the
+/// Lean lexer (parity-tested; see plans/ixon-syntax.md §1).
+pub fn is_letter_like(c: char) -> bool {
+  let v = c as u32;
+  ((0x3b1..=0x3c9).contains(&v) && v != 0x3bb)                   // greek lower (no λ)
+    || ((0x391..=0x3a9).contains(&v) && v != 0x3a0 && v != 0x3a3) // greek upper (no Π Σ)
+    || (0x3ca..=0x3fb).contains(&v)                               // accented greek
+    || (0x1f00..=0x1ffe).contains(&v)                             // polytonic greek
+    || (0x2100..=0x214f).contains(&v)                             // letterlike symbols
+    || (0x1d49c..=0x1d59f).contains(&v) // script/fraktur/double-struck
+}
+
+/// Lean's `isSubScriptAlnum` ranges.
+pub fn is_sub_script(c: char) -> bool {
+  let v = c as u32;
+  (0x2080..=0x209c).contains(&v)
+    || (0x1d62..=0x1d6a).contains(&v)
+    || v == 0x2c7c
+}
+
+/// First character of an identifier component.
+pub fn is_id_first(c: char) -> bool {
+  c.is_ascii_alphabetic() || c == '_' || is_letter_like(c)
+}
+
+/// Continuation character of an identifier component.
+pub fn is_id_rest(c: char) -> bool {
+  c.is_ascii_alphanumeric()
+    || c == '_'
+    || c == '\''
+    || c == '!'
+    || c == '?'
+    || is_sub_script(c)
+    || is_letter_like(c)
+}
+
+/// Internal parse error: furthest-failure tracking plus a structured
+/// override channel. `rem` is the *remaining input length* at the
+/// failure (position = `src.len() - rem`), so merging can pick the
+/// deeper failure without knowing the source.
+#[derive(Debug, Clone)]
+pub struct PErr {
+  rem: usize,
+  expected: Vec<&'static str>,
+  special: Option<(ErrorKind, Span)>,
+}
+
+impl PErr {
+  fn merge(mut self, other: Self) -> Self {
+    if self.special.is_some() {
+      return self;
+    }
+    if other.special.is_some() {
+      return other;
+    }
+    match self.rem.cmp(&other.rem) {
+      std::cmp::Ordering::Less => self,
+      std::cmp::Ordering::Greater => other,
+      std::cmp::Ordering::Equal => {
+        for e in other.expected {
+          if !self.expected.contains(&e) {
+            self.expected.push(e);
+          }
+        }
+        self
+      },
+    }
+  }
+}
+
+impl<'a> nom::error::ParseError<&'a str> for PErr {
+  fn from_error_kind(input: &'a str, _kind: nom::error::ErrorKind) -> Self {
+    PErr { rem: input.len(), expected: vec![], special: None }
+  }
+
+  fn append(
+    _input: &'a str,
+    _kind: nom::error::ErrorKind,
+    other: Self,
+  ) -> Self {
+    other
+  }
+
+  fn or(self, other: Self) -> Self {
+    self.merge(other)
+  }
+}
+
+type R<'a, T> = IResult<&'a str, T, PErr>;
+
+/// Convert a backtrackable `Error` into a committed `Failure` (nom's
+/// `cut`, method-friendly).
+fn cut<T>(r: R<'_, T>) -> R<'_, T> {
+  r.map_err(|e| match e {
+    NErr::Error(x) => NErr::Failure(x),
+    o => o,
+  })
+}
+
+/// RAII depth-guard: decrements on scope exit.
+struct Guard<'p>(&'p Cell<usize>);
+
+impl Drop for Guard<'_> {
+  fn drop(&mut self) {
+    self.0.set(self.0.get() - 1);
+  }
+}
+
+struct P<'a> {
+  src: &'a str,
+  limits: &'a Limits,
+  depth: Cell<usize>,
+}
+
+impl<'a> P<'a> {
+  fn off(&self, i: &str) -> usize {
+    self.src.len() - i.len()
+  }
+
+  /// Span from the start of `from` to the start of `to` (both suffixes
+  /// of `src`).
+  fn sp(&self, from: &str, to: &str) -> Span {
+    Span::new(self.off(from), self.off(to))
+  }
+
+  fn fail<T>(&self, i: &'a str, what: &'static str) -> R<'a, T> {
+    Err(NErr::Error(PErr { rem: i.len(), expected: vec![what], special: None }))
+  }
+
+  fn fatal<T>(&self, kind: ErrorKind, span: Span) -> R<'a, T> {
+    Err(NErr::Failure(PErr {
+      rem: 0,
+      expected: vec![],
+      special: Some((kind, span)),
+    }))
+  }
+
+  fn enter(&self, i: &'a str) -> Result<Guard<'_>, NErr<PErr>> {
+    let d = self.depth.get();
+    if d >= self.limits.max_depth {
+      let p = self.off(i);
+      return Err(NErr::Failure(PErr {
+        rem: 0,
+        expected: vec![],
+        special: Some((
+          ErrorKind::CapExceeded {
+            which: Cap::Depth,
+            limit: self.limits.max_depth,
+          },
+          Span::new(p, p),
+        )),
+      }));
+    }
+    self.depth.set(d + 1);
+    Ok(Guard(&self.depth))
+  }
+
+  /// Skip whitespace, `--` line comments, and nested `/- -/` block
+  /// comments. Whitespace is the explicit set `{' ', '\t', '\r',
+  /// '\n'}` — NOT the Unicode class, which drifts by Unicode version
+  /// and would break cross-language parity (the Lean twin uses the
+  /// same list).
+  fn ws(&self, mut i: &'a str) -> Result<&'a str, NErr<PErr>> {
+    loop {
+      i = i.trim_start_matches([' ', '\t', '\r', '\n']);
+      if let Some(r) = i.strip_prefix("--") {
+        i = match r.find('\n') {
+          Some(n) => &r[n + 1..],
+          None => "",
+        };
+      } else if i.starts_with("/-") {
+        i = self.block_comment(i)?;
+      } else {
+        return Ok(i);
+      }
+    }
+  }
+
+  fn block_comment(&self, i0: &'a str) -> Result<&'a str, NErr<PErr>> {
+    let open = self.off(i0);
+    let mut depth = 0usize;
+    let mut i = i0;
+    loop {
+      if let Some(r) = i.strip_prefix("/-") {
+        depth += 1;
+        i = r;
+      } else if let Some(r) = i.strip_prefix("-/") {
+        depth -= 1;
+        i = r;
+        if depth == 0 {
+          return Ok(i);
+        }
+      } else {
+        match i.chars().next() {
+          Some(c) => i = &i[c.len_utf8()..],
+          None => {
+            return Err(NErr::Failure(PErr {
+              rem: 0,
+              expected: vec![],
+              special: Some((
+                ErrorKind::UnterminatedComment,
+                Span::new(open, open + 2),
+              )),
+            }));
+          },
+        }
+      }
+    }
+  }
+
+  /// Lex one identifier component, no whitespace skip.
+  fn ident_raw(i: &'a str) -> Option<(&'a str, &'a str)> {
+    let mut chars = i.chars();
+    let c0 = chars.next()?;
+    if !is_id_first(c0) {
+      return None;
+    }
+    let mut end = c0.len_utf8();
+    for c in chars {
+      if is_id_rest(c) {
+        end += c.len_utf8();
+      } else {
+        break;
+      }
+    }
+    Some((&i[..end], &i[end..]))
+  }
+
+  /// Lex one ascii-digit run, no whitespace skip.
+  fn digits_raw(i: &'a str) -> Option<(&'a str, &'a str)> {
+    let end = i.find(|c: char| !c.is_ascii_digit()).unwrap_or(i.len());
+    if end == 0 { None } else { Some((&i[..end], &i[end..])) }
+  }
+
+  /// `«…»` quoted name component (any chars except `»`, nonempty).
+  fn quoted_component(&self, i: &'a str) -> R<'a, String> {
+    let start = i;
+    let Some(r) = i.strip_prefix('«') else {
+      return self.fail(i, "name");
+    };
+    match r.find('»') {
+      Some(0) => self.fail(i, "nonempty «…» component"),
+      Some(n) => {
+        let content = r[..n].to_string();
+        Ok((&r[n + '»'.len_utf8()..], content))
+      },
+      None => self.fatal(
+        ErrorKind::UnterminatedQuotedName,
+        Span::new(self.off(start), self.off(start) + '«'.len_utf8()),
+      ),
+    }
+  }
+
+  /// Keyword or contextual word: a full identifier component equal to
+  /// `w`.
+  fn kw(&self, i: &'a str, w: &'static str) -> R<'a, Span> {
+    let i = self.ws(i)?;
+    match Self::ident_raw(i) {
+      Some((c, r)) if c == w => Ok((r, self.sp(i, r))),
+      _ => self.fail(i, w),
+    }
+  }
+
+  /// Peek the next identifier word (after ws) without consuming.
+  fn peek_word(
+    &self,
+    i: &'a str,
+  ) -> Result<(&'a str, Option<&'a str>), NErr<PErr>> {
+    let j = self.ws(i)?;
+    Ok((j, Self::ident_raw(j).map(|x| x.0)))
+  }
+
+  /// Punctuation token. `":"` deliberately refuses to match the
+  /// prefix of `":="`, and `"|"` the prefix of `"|-"` (the ASCII main
+  /// expression turnstile) — so ctor/rule bars never absorb it.
+  fn sym(&self, i: &'a str, s: &'static str) -> R<'a, Span> {
+    let i = self.ws(i)?;
+    if s == ":" && i.starts_with(":=") {
+      return self.fail(i, ":");
+    }
+    if s == "|" && i.starts_with("|-") {
+      return self.fail(i, "|");
+    }
+    match i.strip_prefix(s) {
+      Some(r) => Ok((r, self.sp(i, r))),
+      None => self.fail(i, s),
+    }
+  }
+
+  /// `⊢` or `|-` — the main expression marker.
+  fn turnstile_tok(&self, i: &'a str) -> R<'a, Span> {
+    let i = self.ws(i)?;
+    if let Some(r) = i.strip_prefix('⊢') {
+      return Ok((r, self.sp(i, r)));
+    }
+    if let Some(r) = i.strip_prefix("|-") {
+      return Ok((r, self.sp(i, r)));
+    }
+    self.fail(i, "⊢")
+  }
+
+  /// `→` or `->`.
+  fn arrow_tok(&self, i: &'a str) -> R<'a, Span> {
+    let i = self.ws(i)?;
+    if let Some(r) = i.strip_prefix('→') {
+      return Ok((r, self.sp(i, r)));
+    }
+    if let Some(r) = i.strip_prefix("->") {
+      return Ok((r, self.sp(i, r)));
+    }
+    self.fail(i, "→")
+  }
+
+  /// Dotted surface name. Leading component: identifier or `«…»`;
+  /// continuations may also be bare digit runs (numeric components).
+  /// Stops before `.{` (levels/uparams) and before a reserved
+  /// continuation component.
+  fn name(&self, i: &'a str) -> R<'a, SName> {
+    let i = self.ws(i)?;
+    let start = i;
+    let (mut rest, first) = if let Some((c, r)) = Self::ident_raw(i) {
+      if is_reserved(c) {
+        return self.fail(i, "name");
+      }
+      (r, NameComponent::Str(c.to_string()))
+    } else if i.starts_with('«') {
+      let (r, s) = self.quoted_component(i)?;
+      (r, NameComponent::Str(s))
+    } else {
+      return self.fail(i, "name");
+    };
+    let mut parts = vec![first];
+    while let Some(r) = rest.strip_prefix('.') {
+      if r.starts_with('{') {
+        break; // `.{…}` levels
+      }
+      if let Some((c, r2)) = Self::ident_raw(r) {
+        if is_reserved(c) {
+          break; // leave `.def` unconsumed; escape as «def»
+        }
+        parts.push(NameComponent::Str(c.to_string()));
+        rest = r2;
+      } else if r.starts_with('«') {
+        let (r2, s) = self.quoted_component(r)?;
+        parts.push(NameComponent::Str(s));
+        rest = r2;
+      } else if let Some((d, r2)) = Self::digits_raw(r) {
+        parts.push(NameComponent::Num(nat_from_decimal(d)));
+        rest = r2;
+      } else {
+        break; // trailing `.` stays unconsumed
+      }
+    }
+    Ok((rest, SName { parts, span: self.sp(start, rest) }))
+  }
+
+  /// `#hex` reference, NO leading whitespace skip (callers control
+  /// adjacency). 4–64 lowercase hex digits.
+  fn hash_raw(&self, i: &'a str) -> R<'a, HashRef> {
+    let start = i;
+    let Some(r) = i.strip_prefix('#') else {
+      return self.fail(i, "#hash");
+    };
+    let end = r.find(|c: char| !c.is_ascii_hexdigit()).unwrap_or(r.len());
+    let run = &r[..end];
+    let after = &r[end..];
+    let span = self.sp(start, after);
+    if let Some(bad) = run.chars().find(|c| c.is_ascii_uppercase()) {
+      return self.fatal(
+        ErrorKind::InvalidHash {
+          reason: format!("uppercase digit '{bad}' (addresses are lowercase)"),
+        },
+        span,
+      );
+    }
+    if after.chars().next().is_some_and(is_id_rest) {
+      return self.fatal(
+        ErrorKind::InvalidHash { reason: "invalid character in hash".into() },
+        span,
+      );
+    }
+    if run.len() < 4 {
+      return self.fatal(
+        ErrorKind::InvalidHash {
+          reason: format!("too short ({} digits, minimum 4)", run.len()),
+        },
+        span,
+      );
+    }
+    if run.len() > 64 {
+      return self.fatal(
+        ErrorKind::InvalidHash {
+          reason: format!("too long ({} digits, maximum 64)", run.len()),
+        },
+        span,
+      );
+    }
+    Ok((after, HashRef { hex: run.to_string(), span }))
+  }
+
+  /// Nat literal: decimal, `0x`, `0b`, or `0o`. Arbitrary precision.
+  fn natlit(&self, i: &'a str) -> R<'a, (Nat, Span)> {
+    let i = self.ws(i)?;
+    let start = i;
+    let (radix, digits_input) = if let Some(r) = i.strip_prefix("0x") {
+      (16u32, r)
+    } else if let Some(r) = i.strip_prefix("0b") {
+      (2u32, r)
+    } else if let Some(r) = i.strip_prefix("0o") {
+      (8u32, r)
+    } else {
+      (10u32, i)
+    };
+    let end = digits_input
+      .find(|c: char| !c.is_digit(radix))
+      .unwrap_or(digits_input.len());
+    if end == 0 {
+      return self.fail(i, "number");
+    }
+    let run = &digits_input[..end];
+    let rest = &digits_input[end..];
+    let n = Nat(
+      BigUint::parse_bytes(run.as_bytes(), radix)
+        .expect("digit run parses in its radix"),
+    );
+    Ok((rest, (n, self.sp(start, rest))))
+  }
+
+  /// Nat literal bounded to `u64` (count annotations, indices, …).
+  fn nat_u64(&self, i: &'a str) -> R<'a, (u64, Span)> {
+    let (r, (n, span)) = self.natlit(i)?;
+    match n.to_u64() {
+      Some(v) => Ok((r, (v, span))),
+      None => self.fatal(ErrorKind::NatOutOfRange, span),
+    }
+  }
+
+  /// String literal with Lean escapes.
+  fn strlit(&self, i: &'a str) -> R<'a, (String, Span)> {
+    let i = self.ws(i)?;
+    let start = i;
+    let Some(mut r) = i.strip_prefix('"') else {
+      return self.fail(i, "string literal");
+    };
+    let mut out = String::new();
+    loop {
+      let Some(c) = r.chars().next() else {
+        return self.fatal(
+          ErrorKind::UnterminatedString,
+          Span::new(self.off(start), self.src.len()),
+        );
+      };
+      r = &r[c.len_utf8()..];
+      match c {
+        '"' => return Ok((r, (out, self.sp(start, r)))),
+        '\\' => {
+          let esc_start = self.off(r) - 1;
+          let Some(e) = r.chars().next() else {
+            return self.fatal(
+              ErrorKind::InvalidEscape,
+              Span::new(esc_start, self.src.len()),
+            );
+          };
+          r = &r[e.len_utf8()..];
+          match e {
+            'n' => out.push('\n'),
+            't' => out.push('\t'),
+            'r' => out.push('\r'),
+            '\\' => out.push('\\'),
+            '"' => out.push('"'),
+            '\'' => out.push('\''),
+            'x' => match self.hex_escape(r, 2, esc_start) {
+              Ok((r2, ch)) => {
+                out.push(ch);
+                r = r2;
+              },
+              Err(e) => return Err(e),
+            },
+            'u' => match self.hex_escape(r, 4, esc_start) {
+              Ok((r2, ch)) => {
+                out.push(ch);
+                r = r2;
+              },
+              Err(e) => return Err(e),
+            },
+            _ => {
+              return self.fatal(
+                ErrorKind::InvalidEscape,
+                Span::new(esc_start, self.off(r)),
+              );
+            },
+          }
+        },
+        c => out.push(c),
+      }
+    }
+  }
+
+  fn hex_escape(
+    &self,
+    r: &'a str,
+    n: usize,
+    esc_start: usize,
+  ) -> Result<(&'a str, char), NErr<PErr>> {
+    // `get` guards both length and char boundaries (a multibyte char
+    // right after `\x` must not panic the slicer).
+    let valid =
+      r.get(..n).is_some_and(|h| h.chars().all(|c| c.is_ascii_hexdigit()));
+    if !valid {
+      return Err(NErr::Failure(PErr {
+        rem: 0,
+        expected: vec![],
+        special: Some((
+          ErrorKind::InvalidEscape,
+          Span::new(esc_start, self.off(r)),
+        )),
+      }));
+    }
+    let v = u32::from_str_radix(&r[..n], 16).expect("checked hex");
+    match char::from_u32(v) {
+      Some(c) => Ok((&r[n..], c)),
+      None => Err(NErr::Failure(PErr {
+        rem: 0,
+        expected: vec![],
+        special: Some((
+          ErrorKind::InvalidEscape,
+          Span::new(esc_start, self.off(r) + n),
+        )),
+      })),
+    }
+  }
+
+  /// Universe expression: `uatom ("+" nat)?`.
+  fn univ(&self, i: &'a str) -> R<'a, UnivExpr> {
+    let (i, a) = self.uatom(i)?;
+    let j = self.ws(i)?;
+    if let Some(r) = j.strip_prefix('+') {
+      let (r2, (n, nsp)) = cut(self.nat_u64(r))?;
+      let span = a.span().to(nsp);
+      Ok((r2, UnivExpr::Add(Box::new(a), n, span)))
+    } else {
+      Ok((i, a))
+    }
+  }
+
+  /// Universe atom: literal, var, parens, `max`/`imax` (contextual
+  /// operators — a universe parameter literally named `max` needs
+  /// `«max»`).
+  fn uatom(&self, i: &'a str) -> R<'a, UnivExpr> {
+    let _g = self.enter(i)?;
+    let i = self.ws(i)?;
+    let start = i;
+    if i.starts_with(|c: char| c.is_ascii_digit()) {
+      let (r, (n, span)) = self.nat_u64(i)?;
+      return Ok((r, UnivExpr::Nat(n, span)));
+    }
+    if let Some(r) = i.strip_prefix('(') {
+      let (r, u) = cut(self.univ(r))?;
+      let (r, _) = cut(self.sym(r, ")"))?;
+      return Ok((r, u));
+    }
+    if i.starts_with('«') {
+      let (r, s) = self.quoted_component(i)?;
+      return Ok((r, UnivExpr::Var(NameComponent::Str(s), self.sp(start, r))));
+    }
+    match Self::ident_raw(i) {
+      Some(("max", r)) => {
+        let (r, a) = cut(self.uatom(r))?;
+        let (r, b) = cut(self.uatom(r))?;
+        let span = Span::new(self.off(start), b.span().end);
+        Ok((r, UnivExpr::Max(Box::new(a), Box::new(b), span)))
+      },
+      Some(("imax", r)) => {
+        let (r, a) = cut(self.uatom(r))?;
+        let (r, b) = cut(self.uatom(r))?;
+        let span = Span::new(self.off(start), b.span().end);
+        Ok((r, UnivExpr::IMax(Box::new(a), Box::new(b), span)))
+      },
+      Some((c, r)) if !is_reserved(c) => Ok((
+        r,
+        UnivExpr::Var(NameComponent::Str(c.to_string()), self.sp(start, r)),
+      )),
+      _ => self.fail(i, "universe"),
+    }
+  }
+
+  /// Adjacent `.{u, v}` level list (no whitespace before `.{`).
+  fn levels_adj(&self, i: &'a str) -> R<'a, Option<Vec<UnivExpr>>> {
+    if !i.starts_with(".{") {
+      return Ok((i, None));
+    }
+    let open = i;
+    let r = &i[2..];
+    // Empty `.{}` is a structured error.
+    let j = self.ws(r)?;
+    if let Some(after) = j.strip_prefix('}') {
+      return self.fatal(ErrorKind::EmptyLevels, self.sp(open, after));
+    }
+    let (mut rest, first) = cut(self.univ(r))?;
+    let mut levels = vec![first];
+    loop {
+      let j = self.ws(rest)?;
+      if let Some(r2) = j.strip_prefix(',') {
+        let (r3, u) = cut(self.univ(r2))?;
+        levels.push(u);
+        rest = r3;
+      } else if let Some(r2) = j.strip_prefix('}') {
+        return Ok((r2, Some(levels)));
+      } else {
+        return cut(self.fail(j, "`,` or `}`"));
+      }
+    }
+  }
+
+  /// Constant reference: `Name`, `#hash`, `Name#hash`, each with
+  /// optional adjacent `.{levels}`.
+  fn cref(&self, i: &'a str) -> R<'a, ConstRef> {
+    let i = self.ws(i)?;
+    let start = i;
+    if i.starts_with('#') {
+      let (r, h) = self.hash_raw(i)?;
+      let (r, levels) = self.levels_adj(r)?;
+      return Ok((
+        r,
+        ConstRef { name: None, hash: Some(h), levels, span: self.sp(start, r) },
+      ));
+    }
+    let (r, name) = self.name(i)?;
+    let (r, hash) = if r.starts_with('#') {
+      let (r2, h) = self.hash_raw(r)?;
+      (r2, Some(h))
+    } else {
+      (r, None)
+    };
+    let (r, levels) = self.levels_adj(r)?;
+    Ok((
+      r,
+      ConstRef { name: Some(name), hash, levels, span: self.sp(start, r) },
+    ))
+  }
+
+  /// Greedy optional universe argument for `Type`/`Sort`: a numeral, a
+  /// *simple* identifier or `«…»` component (not dotted/hashed — those
+  /// start the next application atom instead), or a parenthesized
+  /// universe.
+  fn uarg_opt(&self, i: &'a str) -> R<'a, Option<UnivExpr>> {
+    let j = self.ws(i)?;
+    if j.starts_with(|c: char| c.is_ascii_digit()) {
+      let (r, (n, span)) = self.nat_u64(j)?;
+      return Ok((r, Some(UnivExpr::Nat(n, span))));
+    }
+    if j.starts_with('«') {
+      // The printer's escape for universe variables spelled like
+      // operators (`Type «max»`) reparses here.
+      let (r, s) = self.quoted_component(j)?;
+      if r.starts_with('#') || r.starts_with('.') {
+        return Ok((i, None)); // a constant reference, not a uarg
+      }
+      let span = self.sp(j, r);
+      return Ok((r, Some(UnivExpr::Var(NameComponent::Str(s), span))));
+    }
+    if j.starts_with('(') {
+      // Committed attempt: a parse failure inside backtracks to "no
+      // argument" (the parens then read as an application argument).
+      match (|| -> R<'a, UnivExpr> {
+        let r = &j[1..];
+        let (r, u) = self.univ(r)?;
+        let (r, _) = self.sym(r, ")")?;
+        Ok((r, u))
+      })() {
+        Ok((r, u)) => return Ok((r, Some(u))),
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => return Ok((i, None)),
+      }
+    }
+    if let Some((c, r)) = Self::ident_raw(j) {
+      // A dotted or hash-pinned continuation means this identifier is
+      // a constant reference (the next application atom), not a
+      // universe variable — including `u.{…}` (levels).
+      let simple = !is_reserved(c)
+        && c != "max"
+        && c != "imax"
+        && c != "_"
+        && !r.starts_with('#')
+        && !r.starts_with('.');
+      if simple {
+        let span = self.sp(j, r);
+        return Ok((
+          r,
+          Some(UnivExpr::Var(NameComponent::Str(c.to_string()), span)),
+        ));
+      }
+    }
+    Ok((i, None))
+  }
+
+  /// Application atom.
+  fn atom(&self, i: &'a str) -> R<'a, Term> {
+    let _g = self.enter(i)?;
+    let i = self.ws(i)?;
+    let start = i;
+    let Some(c0) = i.chars().next() else {
+      return self.fail(i, "term");
+    };
+    match c0 {
+      '(' => {
+        let r = &i[1..];
+        let (r, t) = cut(self.term(r))?;
+        let (r, _) = cut(self.sym(r, ")"))?;
+        Ok((r, t))
+      },
+      '"' => {
+        let (r, (s, span)) = self.strlit(i)?;
+        Ok((r, Term::StrLit(s, span)))
+      },
+      '#' | '«' => {
+        let (r, c) = self.cref(i)?;
+        Ok((r, Term::Ref(c)))
+      },
+      c if c.is_ascii_digit() => {
+        let (r, (n, span)) = self.natlit(i)?;
+        Ok((r, Term::NatLit(n, span)))
+      },
+      c if is_id_first(c) => {
+        let (word, _) = Self::ident_raw(i).expect("id_first implies ident");
+        match word {
+          "_" => self.fatal(ErrorKind::Placeholder, self.sp(i, &i[1..])),
+          "Prop" => {
+            let (r, span) = self.kw(i, "Prop")?;
+            Ok((r, Term::Sort(SortKind::Prop, span)))
+          },
+          "Type" => {
+            let (r, ksp) = self.kw(i, "Type")?;
+            let (r, u) = self.uarg_opt(r)?;
+            let span = u.as_ref().map_or(ksp, |x| ksp.to(x.span()));
+            Ok((r, Term::Sort(SortKind::Type(u), span)))
+          },
+          "Sort" => {
+            let (r, ksp) = self.kw(i, "Sort")?;
+            let (r, u) = self.uarg_opt(r)?;
+            match u {
+              Some(u) => {
+                let span = ksp.to(u.span());
+                Ok((r, Term::Sort(SortKind::Sort(u), span)))
+              },
+              None => cut(self.fail(r, "universe")),
+            }
+          },
+          "proj" => {
+            let (r, ksp) = self.kw(i, "proj")?;
+            let (r, type_ref) = cut(self.cref(r))?;
+            let (r, (idx, _)) = cut(self.nat_u64(r))?;
+            let (r, val) = cut(self.atom(r))?;
+            let span = ksp.to(val.span());
+            Ok((r, Term::Proj { type_ref, idx, val: Box::new(val), span }))
+          },
+          w if is_reserved(w) => self.fail(i, "term"),
+          _ => {
+            let (r, c) = self.cref(i)?;
+            Ok((r, Term::Ref(c)))
+          },
+        }
+      },
+      _ => self.fail(start, "term"),
+    }
+  }
+
+  /// Application spine: `atom+`, left-associated, flat.
+  fn app(&self, i: &'a str) -> R<'a, Term> {
+    let (mut rest, head) = self.atom(i)?;
+    let mut args = Vec::new();
+    loop {
+      match self.atom(rest) {
+        Ok((r, t)) => {
+          args.push(t);
+          rest = r;
+        },
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => break,
+      }
+    }
+    if args.is_empty() {
+      Ok((rest, head))
+    } else {
+      let span = head.span().to(args.last().expect("nonempty").span());
+      Ok((rest, Term::App { head: Box::new(head), args, span }))
+    }
+  }
+
+  /// Binder name: identifier component or `_`.
+  fn binder_name(&self, i: &'a str) -> R<'a, BinderName> {
+    let i = self.ws(i)?;
+    if let Some((c, r)) = Self::ident_raw(i) {
+      let span = self.sp(i, r);
+      if c == "_" {
+        return Ok((r, BinderName::Anon(span)));
+      }
+      if is_reserved(c) {
+        return self.fail(i, "binder name");
+      }
+      return Ok((
+        r,
+        BinderName::Ident(NameComponent::Str(c.to_string()), span),
+      ));
+    }
+    if i.starts_with('«') {
+      let start = i;
+      let (r, s) = self.quoted_component(i)?;
+      return Ok((
+        r,
+        BinderName::Ident(NameComponent::Str(s), self.sp(start, r)),
+      ));
+    }
+    self.fail(i, "binder name")
+  }
+
+  /// One bracketed binder group. `(…)` is a *tentative* parse (a
+  /// backtrackable failure before the `:` lets callers re-read it as a
+  /// parenthesized term); `{…}`, `[…]`, `⦃…⦄` commit immediately —
+  /// no term starts with those brackets.
+  fn binder_group(&self, i: &'a str) -> R<'a, BinderGroup> {
+    let i = self.ws(i)?;
+    let start = i;
+    let (open, close, info): (char, &'static str, BinderInfo) =
+      if i.starts_with('(') {
+        ('(', ")", BinderInfo::Default)
+      } else if i.starts_with('{') {
+        ('{', "}", BinderInfo::Implicit)
+      } else if i.starts_with('[') {
+        ('[', "]", BinderInfo::InstImplicit)
+      } else if i.starts_with('⦃') {
+        ('⦃', "⦄", BinderInfo::StrictImplicit)
+      } else {
+        return self.fail(i, "binder");
+      };
+    let r = &i[open.len_utf8()..];
+    if open == '[' {
+      // `[inst : T]` or unnamed `[T]`.
+      if let Ok((r2, names)) = self.binder_names_colon(r) {
+        let (r3, ty) = cut(self.term(r2))?;
+        let (r4, _) = cut(self.sym(r3, close))?;
+        return Ok((
+          r4,
+          BinderGroup { info, names, ty, span: self.sp(start, r4) },
+        ));
+      }
+      let (r2, ty) = cut(self.term(r))?;
+      let (r3, _) = cut(self.sym(r2, close))?;
+      return Ok((
+        r3,
+        BinderGroup { info, names: vec![], ty, span: self.sp(start, r3) },
+      ));
+    }
+    let names_colon = self.binder_names_colon(r);
+    let (r2, names) = if open == '(' {
+      names_colon? // backtrackable: `(f a)` is a term
+    } else {
+      cut(names_colon)?
+    };
+    let (r3, ty) = cut(self.term(r2))?;
+    let (r4, _) = cut(self.sym(r3, close))?;
+    Ok((r4, BinderGroup { info, names, ty, span: self.sp(start, r4) }))
+  }
+
+  /// `ident+ :` — the committing prefix of a named binder group.
+  fn binder_names_colon(&self, i: &'a str) -> R<'a, Vec<BinderName>> {
+    let (mut rest, first) = self.binder_name(i)?;
+    let mut names = vec![first];
+    loop {
+      match self.binder_name(rest) {
+        Ok((r, n)) => {
+          names.push(n);
+          rest = r;
+        },
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => break,
+      }
+    }
+    let (rest, _) = self.sym(rest, ":")?;
+    Ok((rest, names))
+  }
+
+  /// `fun binder+ => term`.
+  fn fun_term(&self, i: &'a str) -> R<'a, Term> {
+    let (r, ksp) = self.kw(i, "fun")?;
+    let (r, groups) = cut(self.binder_groups1(r))?;
+    let (r, _) = cut(self.sym(r, "=>"))?;
+    let (r, body) = cut(self.term(r))?;
+    let span = ksp.to(body.span());
+    Ok((r, Term::Fun { binders: groups, body: Box::new(body), span }))
+  }
+
+  fn binder_groups1(&self, i: &'a str) -> R<'a, Vec<BinderGroup>> {
+    let (mut rest, first) = self.binder_group(i)?;
+    let mut groups = vec![first];
+    loop {
+      match self.binder_group(rest) {
+        Ok((r, g)) => {
+          groups.push(g);
+          rest = r;
+        },
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => break,
+      }
+    }
+    Ok((rest, groups))
+  }
+
+  /// `let x : T := v; b` / `have x : T := v; b`.
+  fn let_term(&self, i: &'a str, non_dep: bool) -> R<'a, Term> {
+    let word = if non_dep { "have" } else { "let" };
+    let (r, ksp) = self.kw(i, word)?;
+    let (r, name) = cut(self.binder_name(r))?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let (r, _) = cut(self.sym(r, ":="))?;
+    let (r, val) = cut(self.term(r))?;
+    let (r, _) = cut(self.sym(r, ";"))?;
+    let (r, body) = cut(self.term(r))?;
+    let span = ksp.to(body.span());
+    Ok((
+      r,
+      Term::Let {
+        non_dep,
+        name,
+        ty: Box::new(ty),
+        val: Box::new(val),
+        body: Box::new(body),
+        span,
+      },
+    ))
+  }
+
+  /// Dependent domain: `binder+ → term`. Succeeding at the first
+  /// binder group commits (a `(x : A)` group not followed by `→` is a
+  /// hard error — `(x : A)` alone is not a term).
+  fn pi_term(&self, i: &'a str) -> R<'a, Term> {
+    let start = self.ws(i)?;
+    let (r, first) = self.binder_group(i)?;
+    let mut groups = vec![first];
+    let mut rest = r;
+    loop {
+      match self.binder_group(rest) {
+        Ok((r, g)) => {
+          groups.push(g);
+          rest = r;
+        },
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => break,
+      }
+    }
+    let (r, _) = cut(self.arrow_tok(rest))?;
+    let (r, body) = cut(self.term(r))?;
+    let span = self.sp(start, start).to(body.span());
+    Ok((r, Term::Pi { binders: groups, body: Box::new(body), span }))
+  }
+
+  /// Arrow layer: dependent domain, or application with optional `→`.
+  fn pi_or_arrow(&self, i: &'a str) -> R<'a, Term> {
+    let j = self.ws(i)?;
+    if j.starts_with('(')
+      || j.starts_with('{')
+      || j.starts_with('[')
+      || j.starts_with('⦃')
+    {
+      match self.pi_term(j) {
+        Ok(v) => return Ok(v),
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => {},
+      }
+    }
+    let (r, lhs) = self.app(j)?;
+    match self.arrow_tok(r) {
+      Ok((r2, _)) => {
+        let (r3, cod) = cut(self.term(r2))?;
+        let span = lhs.span().to(cod.span());
+        Ok((r3, Term::Arrow { dom: Box::new(lhs), cod: Box::new(cod), span }))
+      },
+      Err(NErr::Failure(e)) => Err(NErr::Failure(e)),
+      Err(_) => Ok((r, lhs)),
+    }
+  }
+
+  /// Term entry point.
+  fn term(&self, i: &'a str) -> R<'a, Term> {
+    let _g = self.enter(i)?;
+    let (j, word) = self.peek_word(i)?;
+    match word {
+      Some("fun") => self.fun_term(j),
+      Some("let") => self.let_term(j, false),
+      Some("have") => self.let_term(j, true),
+      _ => self.pi_or_arrow(j),
+    }
+  }
+
+  /// `.{u, v}` universe-parameter binders on a declaration.
+  fn uparams(&self, i: &'a str) -> R<'a, Vec<UParam>> {
+    if !i.starts_with(".{") {
+      return Ok((i, vec![]));
+    }
+    let r = &i[2..];
+    let mut out = Vec::new();
+    let mut rest = r;
+    loop {
+      let j = self.ws(rest)?;
+      let start = j;
+      let (r2, comp) = if let Some((c, r2)) = Self::ident_raw(j) {
+        if is_reserved(c) || c == "_" {
+          return cut(self.fail(j, "universe parameter"));
+        }
+        (r2, NameComponent::Str(c.to_string()))
+      } else if j.starts_with('«') {
+        let (r2, s) = self.quoted_component(j)?;
+        (r2, NameComponent::Str(s))
+      } else {
+        return cut(self.fail(j, "universe parameter"));
+      };
+      out.push(UParam { name: comp, span: self.sp(start, r2) });
+      let j = self.ws(r2)?;
+      if let Some(r3) = j.strip_prefix(',') {
+        rest = r3;
+      } else if let Some(r3) = j.strip_prefix('}') {
+        return Ok((r3, out));
+      } else {
+        return cut(self.fail(j, "`,` or `}`"));
+      }
+    }
+  }
+
+  /// Optional declaration name + optional universe parameters. The
+  /// uparams attach adjacently to the name (`Foo.{u}`), or stand alone
+  /// after the keyword for anonymous declarations (`def .{u} : …`).
+  fn decl_name(&self, i: &'a str) -> R<'a, (Option<SName>, Vec<UParam>)> {
+    let j = self.ws(i)?;
+    if j.starts_with(".{") {
+      let (r, ups) = self.uparams(j)?;
+      return Ok((r, (None, ups)));
+    }
+    if j.starts_with('«')
+      || Self::ident_raw(j).is_some_and(|(c, _)| !is_reserved(c))
+    {
+      let (r, n) = self.name(j)?;
+      let (r, ups) = self.uparams(r)?;
+      return Ok((r, (Some(n), ups)));
+    }
+    Ok((j, (None, vec![])))
+  }
+
+  /// `(<key> := <nat>)` count annotation.
+  fn annot(
+    &self,
+    i: &'a str,
+    key: &'static str,
+    label: &'static str,
+  ) -> R<'a, u64> {
+    let i = self.ws(i)?;
+    let Some(r) = i.strip_prefix('(') else {
+      return self.fail(i, label);
+    };
+    let (r, _) = match self.kw(r, key) {
+      Ok(v) => v,
+      Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+      Err(_) => return self.fail(i, label),
+    };
+    let (r, _) = cut(self.sym(r, ":="))?;
+    let (r, (v, _)) = cut(self.nat_u64(r))?;
+    let (r, _) = cut(self.sym(r, ")"))?;
+    Ok((r, v))
+  }
+
+  /// Optional `(k := true|false)` on a recursor.
+  fn k_annot(&self, i: &'a str) -> R<'a, bool> {
+    let j = self.ws(i)?;
+    let Some(r) = j.strip_prefix('(') else {
+      return Ok((i, false));
+    };
+    match self.kw(r, "k") {
+      Ok((r, _)) => {
+        let (r, _) = cut(self.sym(r, ":="))?;
+        let (r, word) = self.peek_word(r)?;
+        let (r, v) = match word {
+          Some("true") => (self.kw(r, "true")?.0, true),
+          Some("false") => (self.kw(r, "false")?.0, false),
+          _ => return cut(self.fail(r, "true or false")),
+        };
+        let (r, _) = cut(self.sym(r, ")"))?;
+        Ok((r, v))
+      },
+      Err(NErr::Failure(e)) => Err(NErr::Failure(e)),
+      Err(_) => Ok((i, false)),
+    }
+  }
+
+  fn def_decl(
+    &self,
+    i: &'a str,
+    kw: DefKw,
+    kw_word: &'static str,
+    mods: Modifiers,
+    start: &'a str,
+  ) -> R<'a, Decl> {
+    let (r, _) = self.kw(i, kw_word)?;
+    if mods.partial_ && kw != DefKw::Def {
+      return cut(self.fail(start, "def after partial"));
+    }
+    let (r, (name, uparams)) = cut(self.decl_name(r))?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let (r, _) = cut(self.sym(r, ":="))?;
+    let (r, value) = cut(self.term(r))?;
+    let span = self.sp(start, r);
+    Ok((r, Decl::Def(DefDecl { kw, mods, name, uparams, ty, value, span })))
+  }
+
+  fn axiom_decl(
+    &self,
+    i: &'a str,
+    mods: Modifiers,
+    start: &'a str,
+  ) -> R<'a, Decl> {
+    let (r, _) = self.kw(i, "axiom")?;
+    if mods.partial_ {
+      return cut(self.fail(start, "def after partial"));
+    }
+    let (r, (name, uparams)) = cut(self.decl_name(r))?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let span = self.sp(start, r);
+    Ok((
+      r,
+      Decl::Axiom(AxiomDecl { unsafe_: mods.unsafe_, name, uparams, ty, span }),
+    ))
+  }
+
+  fn quot_decl(&self, i: &'a str, start: &'a str) -> R<'a, Decl> {
+    let (r, _) = self.kw(i, "quot")?;
+    let (r, word) = self.peek_word(r)?;
+    let (r, kind) = match word {
+      Some("type") => (self.kw(r, "type")?.0, QuotKindKw::Type),
+      Some("ctor") => (self.kw(r, "ctor")?.0, QuotKindKw::Ctor),
+      Some("lift") => (self.kw(r, "lift")?.0, QuotKindKw::Lift),
+      Some("ind") => (self.kw(r, "ind")?.0, QuotKindKw::Ind),
+      _ => return cut(self.fail(r, "quotient kind (type|ctor|lift|ind)")),
+    };
+    let (r, (name, uparams)) = cut(self.decl_name(r))?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let span = self.sp(start, r);
+    Ok((r, Decl::Quot(QuotDecl { kind, name, uparams, ty, span })))
+  }
+
+  fn ind_decl(
+    &self,
+    i: &'a str,
+    mods: Modifiers,
+    start: &'a str,
+  ) -> R<'a, Decl> {
+    let (r, _) = self.kw(i, "inductive")?;
+    if mods.partial_ {
+      return cut(self.fail(start, "def after partial"));
+    }
+    let (r, (name, uparams)) = cut(self.decl_name(r))?;
+    let (r, params) = cut(self.annot(r, "params", "(params := _)"))?;
+    let (r, indices) = cut(self.annot(r, "indices", "(indices := _)"))?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let (r, ctors) = self.ctor_block(r)?;
+    let span = self.sp(start, r);
+    Ok((
+      r,
+      Decl::Ind(IndDecl {
+        unsafe_: mods.unsafe_,
+        name,
+        uparams,
+        params,
+        indices,
+        ty,
+        ctors,
+        span,
+      }),
+    ))
+  }
+
+  fn ctor_block(&self, i: &'a str) -> R<'a, Vec<CtorDecl>> {
+    let (j, word) = self.peek_word(i)?;
+    if word != Some("where") {
+      return Ok((i, vec![]));
+    }
+    let (mut rest, _) = self.kw(j, "where")?;
+    let mut ctors = Vec::new();
+    loop {
+      match self.sym(rest, "|") {
+        Ok((r, bar_sp)) => {
+          let (r, (name, ups)) = cut(self.decl_name(r))?;
+          if let Some(up) = ups.first() {
+            return self.fatal(
+              ErrorKind::UnexpectedToken {
+                expected: "(params := _)".into(),
+                found: "universe parameters (constructors inherit the \
+                        inductive's)"
+                  .into(),
+              },
+              up.span,
+            );
+          }
+          let (r, params) = cut(self.annot(r, "params", "(params := _)"))?;
+          let (r, fields) = cut(self.annot(r, "fields", "(fields := _)"))?;
+          let (r, _) = cut(self.sym(r, ":"))?;
+          let (r, ty) = cut(self.term(r))?;
+          ctors.push(CtorDecl {
+            name,
+            params,
+            fields,
+            ty,
+            span: bar_sp.to(Span::new(self.off(r), self.off(r))),
+          });
+          rest = r;
+        },
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => break,
+      }
+    }
+    if ctors.is_empty() {
+      return cut(self.fail(rest, "|"));
+    }
+    Ok((rest, ctors))
+  }
+
+  fn recr_decl(
+    &self,
+    i: &'a str,
+    mods: Modifiers,
+    start: &'a str,
+  ) -> R<'a, Decl> {
+    let (r, _) = self.kw(i, "recursor")?;
+    if mods.partial_ {
+      return cut(self.fail(start, "def after partial"));
+    }
+    let (r, (name, uparams)) = cut(self.decl_name(r))?;
+    let (r, params) = cut(self.annot(r, "params", "(params := _)"))?;
+    let (r, indices) = cut(self.annot(r, "indices", "(indices := _)"))?;
+    let (r, motives) = cut(self.annot(r, "motives", "(motives := _)"))?;
+    let (r, minors) = cut(self.annot(r, "minors", "(minors := _)"))?;
+    let (r, k) = self.k_annot(r)?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let (r, rules) = self.rule_block(r)?;
+    let span = self.sp(start, r);
+    Ok((
+      r,
+      Decl::Recr(RecrDecl {
+        unsafe_: mods.unsafe_,
+        name,
+        uparams,
+        params,
+        indices,
+        motives,
+        minors,
+        k,
+        ty,
+        rules,
+        span,
+      }),
+    ))
+  }
+
+  fn rule_block(&self, i: &'a str) -> R<'a, Vec<RuleDecl>> {
+    let (j, word) = self.peek_word(i)?;
+    if word != Some("where") {
+      return Ok((i, vec![]));
+    }
+    let (mut rest, _) = self.kw(j, "where")?;
+    let mut rules = Vec::new();
+    loop {
+      match self.sym(rest, "|") {
+        Ok((r, bar_sp)) => {
+          let (r, _) = cut(self.kw(r, "rule"))?;
+          let (r, fields) = cut(self.annot(r, "fields", "(fields := _)"))?;
+          let (r, _) = cut(self.sym(r, ":="))?;
+          let (r, rhs) = cut(self.term(r))?;
+          rules.push(RuleDecl {
+            fields,
+            rhs,
+            span: bar_sp.to(Span::new(self.off(r), self.off(r))),
+          });
+          rest = r;
+        },
+        Err(NErr::Failure(e)) => return Err(NErr::Failure(e)),
+        Err(_) => break,
+      }
+    }
+    if rules.is_empty() {
+      return cut(self.fail(rest, "|"));
+    }
+    Ok((rest, rules))
+  }
+
+  fn prj_decl(
+    &self,
+    i: &'a str,
+    kind: PrjKind,
+    word: &'static str,
+    start: &'a str,
+  ) -> R<'a, Decl> {
+    let (r, _) = self.kw(i, word)?;
+    let (r, (name, uparams)) = cut(self.decl_name(r))?;
+    if let Some(up) = uparams.first() {
+      return self.fatal(
+        ErrorKind::UnexpectedToken {
+          expected: ":=".into(),
+          found: "universe parameters".into(),
+        },
+        up.span,
+      );
+    }
+    let (r, _) = cut(self.sym(r, ":="))?;
+    let r = self.ws(r)?;
+    let (r, block) = cut(self.hash_raw(r))?;
+    let (r, (idx, _)) = cut(self.nat_u64(r))?;
+    let (r, cidx) = if kind == PrjKind::CPrj {
+      let (r, (c, _)) = cut(self.nat_u64(r))?;
+      (r, Some(c))
+    } else {
+      (r, None)
+    };
+    let span = self.sp(start, r);
+    Ok((r, Decl::Prj(PrjDecl { kind, name, block, idx, cidx, span })))
+  }
+
+  fn mutual_decl(&self, i: &'a str, start: &'a str) -> R<'a, Decl> {
+    let (mut rest, _) = self.kw(i, "mutual")?;
+    let mut members = Vec::new();
+    loop {
+      let (j, word) = self.peek_word(rest)?;
+      if word == Some("end") {
+        let (r, _) = self.kw(j, "end")?;
+        if members.is_empty() {
+          return cut(self.fail(j, "declaration"));
+        }
+        return Ok((r, Decl::Mutual(members, self.sp(start, r))));
+      }
+      let (r, d) = cut(self.decl(rest))?;
+      match &d {
+        Decl::Def(_) | Decl::Ind(_) | Decl::Recr(_) => members.push(d),
+        other => {
+          return self.fatal(ErrorKind::BadMutualMember, other.span());
+        },
+      }
+      rest = r;
+    }
+  }
+
+  /// One declaration.
+  fn decl(&self, i: &'a str) -> R<'a, Decl> {
+    let start = self.ws(i)?;
+    let mut mods = Modifiers::default();
+    let mut rest = start;
+    loop {
+      let (j, word) = self.peek_word(rest)?;
+      match word {
+        Some("unsafe") if !mods.unsafe_ => {
+          mods.unsafe_ = true;
+          rest = self.kw(j, "unsafe")?.0;
+        },
+        Some("partial") if !mods.partial_ => {
+          mods.partial_ = true;
+          rest = self.kw(j, "partial")?.0;
+        },
+        _ => break,
+      }
+    }
+    if mods.unsafe_ && mods.partial_ {
+      return cut(self.fail(start, "either unsafe or partial (not both)"));
+    }
+    let (j, word) = self.peek_word(rest)?;
+    let has_mods = mods.unsafe_ || mods.partial_;
+    match word {
+      Some("def") => self.def_decl(j, DefKw::Def, "def", mods, start),
+      Some("theorem") => {
+        self.def_decl(j, DefKw::Theorem, "theorem", mods, start)
+      },
+      Some("opaque") => self.def_decl(j, DefKw::Opaque, "opaque", mods, start),
+      Some("axiom") => self.axiom_decl(j, mods, start),
+      Some("inductive") => self.ind_decl(j, mods, start),
+      Some("recursor") => self.recr_decl(j, mods, start),
+      Some("quot") if !has_mods => self.quot_decl(j, start),
+      Some("mutual") if !has_mods => self.mutual_decl(j, start),
+      Some("dprj") if !has_mods => {
+        self.prj_decl(j, PrjKind::DPrj, "dprj", start)
+      },
+      Some("iprj") if !has_mods => {
+        self.prj_decl(j, PrjKind::IPrj, "iprj", start)
+      },
+      Some("cprj") if !has_mods => {
+        self.prj_decl(j, PrjKind::CPrj, "cprj", start)
+      },
+      Some("rprj") if !has_mods => {
+        self.prj_decl(j, PrjKind::RPrj, "rprj", start)
+      },
+      _ => self.fail(j, "declaration"),
+    }
+  }
+
+  /// `import Foo.Bar#hash` / `import #hash`.
+  fn import_decl(&self, i: &'a str) -> R<'a, ImportDecl> {
+    let start = self.ws(i)?;
+    let (r, _) = self.kw(start, "import")?;
+    let j = self.ws(r)?;
+    let (r, prefix, hash) = if j.starts_with('#') {
+      let (r, h) = cut(self.hash_raw(j))?;
+      (r, None, h)
+    } else {
+      let (r, n) = cut(self.name(j))?;
+      if !r.starts_with('#') {
+        return cut(self.fail(r, "#hash"));
+      }
+      let (r, h) = cut(self.hash_raw(r))?;
+      (r, Some(n), h)
+    };
+    if hash.hex.len() != 64 {
+      return self.fatal(
+        ErrorKind::ImportHashLength { found: hash.hex.len() },
+        hash.span,
+      );
+    }
+    Ok((r, ImportDecl { prefix, hash, span: self.sp(start, r) }))
+  }
+
+  /// The trailing `⊢ value : type` main expression. The turnstile is
+  /// load-bearing: without it, a preceding declaration's final term
+  /// absorbs an atom-headed value as an application argument (found
+  /// by property testing); the marker is not an atom, so application
+  /// spines stop at it. Enforces EOF after the expression — at most
+  /// one main, and it must be last.
+  fn main_expr(&self, i: &'a str) -> R<'a, MainExpr> {
+    let start = self.ws(i)?;
+    let (r, _) = self.turnstile_tok(start)?;
+    self.main_expr_tail(start, r)
+  }
+
+  /// The `value : type` interior — deterministic on its own: no term
+  /// production consumes a bare `:`, so the value spine stops at the
+  /// annotation. Only the decl→main *boundary* needs the turnstile.
+  fn main_expr_tail(&self, start: &'a str, r: &'a str) -> R<'a, MainExpr> {
+    let (r, value) = cut(self.term(r))?;
+    let (r, _) = cut(self.sym(r, ":"))?;
+    let (r, ty) = cut(self.term(r))?;
+    let j = self.ws(r)?;
+    if !j.is_empty() {
+      let p = self.off(j);
+      return self.fatal(ErrorKind::MainExprNotLast, Span::new(p, p));
+    }
+    Ok((j, MainExpr { value, ty, span: self.sp(start, r) }))
+  }
+
+  /// Whole file: `ixon <version>` header, imports, declarations,
+  /// optional main expression, EOF.
+  fn file(&self, i: &'a str) -> R<'a, File> {
+    let start = self.ws(i)?;
+    // Optional version header: absent means version 1, forever
+    // (grammar versions ≥ 2 must declare themselves). A leading
+    // `ixon` followed by a numeral is always the header (a constant
+    // literally named `ixon` applied to a literal at file start needs
+    // parens); followed by anything else it is content.
+    let (r, version) = {
+      let (_, word) = self.peek_word(start)?;
+      if word == Some("ixon") {
+        let (after, _) = self.kw(start, "ixon")?;
+        let j = self.ws(after)?;
+        if j.starts_with(|c: char| c.is_ascii_digit()) {
+          let (r, (version, vsp)) = self.nat_u64(after)?;
+          if version != VERSION {
+            return self.fatal(
+              ErrorKind::UnknownVersion { found: version, supported: VERSION },
+              vsp,
+            );
+          }
+          (r, version)
+        } else {
+          (start, VERSION)
+        }
+      } else {
+        (start, VERSION)
+      }
+    };
+    let mut imports = Vec::new();
+    let mut rest = r;
+    loop {
+      let (_, word) = self.peek_word(rest)?;
+      if word != Some("import") {
+        break;
+      }
+      let (r, imp) = self.import_decl(rest)?;
+      imports.push(imp);
+      rest = r;
+    }
+    let mut decls = Vec::new();
+    let mut main = None;
+    loop {
+      let j = self.ws(rest)?;
+      if j.is_empty() {
+        rest = j;
+        break;
+      }
+      if j.starts_with('⊢') || j.starts_with("|-") {
+        let (r, m) = self.main_expr(j)?;
+        main = Some(m);
+        rest = r;
+        break;
+      }
+      // Bare `value : type` (no turnstile) is accepted only as the
+      // file's SOLE item: with no preceding declaration term there is
+      // no boundary to absorb into, and the interior is deterministic.
+      // After declarations the turnstile is required (bare form errors
+      // on the orphaned `:` — never a silent re-split).
+      let (_, word) = self.peek_word(j)?;
+      let keyword_item = matches!(
+        word,
+        Some(
+          "def"
+            | "theorem"
+            | "opaque"
+            | "axiom"
+            | "inductive"
+            | "recursor"
+            | "quot"
+            | "mutual"
+            | "unsafe"
+            | "partial"
+            | "dprj"
+            | "iprj"
+            | "cprj"
+            | "rprj"
+            | "import"
+        )
+      );
+      if !keyword_item && decls.is_empty() {
+        let (r, m) = self.main_expr_tail(j, j)?;
+        main = Some(m);
+        rest = r;
+        break;
+      }
+      let (r, d) = self.decl(j)?;
+      decls.push(d);
+      rest = r;
+    }
+    Ok((
+      rest,
+      File { version, imports, decls, main, span: self.sp(start, rest) },
+    ))
+  }
+}
+
+fn nat_from_decimal(digits: &str) -> Nat {
+  Nat(
+    BigUint::parse_bytes(digits.as_bytes(), 10)
+      .expect("decimal digit run parses"),
+  )
+}
+
+/// Short description of what sits at `pos`, for `UnexpectedToken`.
+fn found_snippet(src: &str, pos: usize) -> String {
+  let rest = &src[pos.min(src.len())..];
+  let Some(c0) = rest.chars().next() else {
+    return "end of input".to_string();
+  };
+  if is_id_first(c0) || c0.is_ascii_digit() {
+    let end = rest
+      .find(|c: char| !is_id_rest(c) && !c.is_ascii_digit())
+      .unwrap_or(rest.len());
+    // Truncate by chars, not bytes — a byte cap could split a
+    // multibyte character and panic.
+    let word: String = rest[..end].chars().take(24).collect();
+    format!("`{word}`")
+  } else {
+    format!("`{c0}`")
+  }
+}
+
+fn convert(src: &str, e: NErr<PErr>) -> SyntaxError {
+  let pe = match e {
+    NErr::Error(x) | NErr::Failure(x) => x,
+    NErr::Incomplete(_) => {
+      PErr { rem: 0, expected: vec!["more input"], special: None }
+    },
+  };
+  if let Some((kind, span)) = pe.special {
+    return SyntaxError::new(kind, span, src);
+  }
+  let pos = src.len().saturating_sub(pe.rem);
+  let expected = if pe.expected.is_empty() {
+    "valid syntax".to_string()
+  } else {
+    pe.expected.join(" or ")
+  };
+  SyntaxError::new(
+    ErrorKind::UnexpectedToken { expected, found: found_snippet(src, pos) },
+    Span::new(pos, pos),
+    src,
+  )
+}
+
+fn check_caps_pre(src: &str, limits: &Limits) -> Result<(), SyntaxError> {
+  if src.len() > limits.max_bytes {
+    return Err(SyntaxError::new(
+      ErrorKind::CapExceeded { which: Cap::Bytes, limit: limits.max_bytes },
+      Span::new(0, 0),
+      src,
+    ));
+  }
+  Ok(())
+}
+
+/// Parse a whole `.ixon` file.
+pub fn parse_file(src: &str, limits: &Limits) -> Result<File, SyntaxError> {
+  check_caps_pre(src, limits)?;
+  let p = P { src, limits, depth: Cell::new(0) };
+  match p.file(src) {
+    Ok((_, f)) => {
+      let nodes = count_file_nodes(&f);
+      if nodes > limits.max_nodes {
+        return Err(SyntaxError::new(
+          ErrorKind::CapExceeded { which: Cap::Nodes, limit: limits.max_nodes },
+          Span::new(0, 0),
+          src,
+        ));
+      }
+      Ok(f)
+    },
+    Err(e) => Err(convert(src, e)),
+  }
+}
+
+/// Parse a standalone term (whole input, for tools and tests).
+pub fn parse_term(src: &str, limits: &Limits) -> Result<Term, SyntaxError> {
+  check_caps_pre(src, limits)?;
+  let p = P { src, limits, depth: Cell::new(0) };
+  let r = p.term(src).and_then(|(rest, t)| {
+    let rest = p.ws(rest)?;
+    if rest.is_empty() { Ok((rest, t)) } else { p.fail(rest, "end of input") }
+  });
+  match r {
+    Ok((_, t)) => {
+      let nodes = count_term_nodes(&t);
+      if nodes > limits.max_nodes {
+        return Err(SyntaxError::new(
+          ErrorKind::CapExceeded { which: Cap::Nodes, limit: limits.max_nodes },
+          Span::new(0, 0),
+          src,
+        ));
+      }
+      Ok(t)
+    },
+    Err(e) => Err(convert(src, e)),
+  }
+}

--- a/crates/ixon/src/syntax/print.rs
+++ b/crates/ixon/src/syntax/print.rs
@@ -1,0 +1,565 @@
+//! Canonical pretty-printer for the Ixon text format.
+//!
+//! Deterministic by construction: same AST ⇒ same bytes (LF newlines,
+//! two-space indent, [`WIDTH`]-column layout, minimal parentheses).
+//! `parse ∘ print` is the identity on the printed text (the roundtrip
+//! fixpoint the tests enforce): every spelling choice here — when to
+//! parenthesize, when to `«…»`-escape, how `Type`/`Sort` arguments and
+//! pinned `Name#hash` references are laid out — exists to reparse to
+//! the same tree.
+
+use ix_common::env::{BinderInfo, NameComponent};
+
+use crate::syntax::ast::{
+  BinderGroup, BinderName, ConstRef, Decl, DefKw, File, HashRef, ImportDecl,
+  PrjKind, QuotKindKw, SName, SortKind, Term, UParam, UnivExpr,
+};
+use crate::syntax::parse::{is_id_first, is_id_rest, is_reserved};
+
+/// Canonical layout width, in columns. Part of the canonical form:
+/// both language implementations must agree on it.
+pub const WIDTH: usize = 100;
+
+/// Canonical indent step.
+const INDENT: usize = 2;
+
+// ---------------------------------------------------------------------------
+// Doc engine (Wadler-style, group-local fitting, iterative rendering)
+// ---------------------------------------------------------------------------
+
+/// A layout document. `width` caches the flattened width (`None` when
+/// the doc contains a hard newline), so grouping decisions are O(1)
+/// and whole-document rendering is O(n).
+struct Doc {
+  width: Option<usize>,
+  kind: DocKind,
+}
+
+enum DocKind {
+  Text(String),
+  Cat(Vec<Doc>),
+  /// Space when flat, newline when broken.
+  Line,
+  /// Always a newline.
+  Hard,
+  Group(Box<Doc>),
+  Nest(usize, Box<Doc>),
+}
+
+fn text(s: impl Into<String>) -> Doc {
+  let s = s.into();
+  Doc { width: Some(s.chars().count()), kind: DocKind::Text(s) }
+}
+
+fn cat(ds: Vec<Doc>) -> Doc {
+  let width = ds.iter().try_fold(0usize, |acc, d| d.width.map(|w| acc + w));
+  Doc { width, kind: DocKind::Cat(ds) }
+}
+
+fn line() -> Doc {
+  Doc { width: Some(1), kind: DocKind::Line }
+}
+
+fn hard() -> Doc {
+  Doc { width: None, kind: DocKind::Hard }
+}
+
+fn group(d: Doc) -> Doc {
+  Doc { width: d.width, kind: DocKind::Group(Box::new(d)) }
+}
+
+fn nest(d: Doc) -> Doc {
+  Doc { width: d.width, kind: DocKind::Nest(INDENT, Box::new(d)) }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Mode {
+  Flat,
+  Break,
+}
+
+fn render(doc: &Doc, width: usize) -> String {
+  let mut out = String::new();
+  let mut col = 0usize;
+  let mut stack: Vec<(usize, Mode, &Doc)> = vec![(0, Mode::Break, doc)];
+  while let Some((ind, mode, d)) = stack.pop() {
+    match &d.kind {
+      DocKind::Text(s) => {
+        out.push_str(s);
+        col += s.chars().count();
+      },
+      DocKind::Cat(ds) => {
+        for child in ds.iter().rev() {
+          stack.push((ind, mode, child));
+        }
+      },
+      DocKind::Line => match mode {
+        Mode::Flat => {
+          out.push(' ');
+          col += 1;
+        },
+        Mode::Break => {
+          out.push('\n');
+          out.extend(std::iter::repeat_n(' ', ind));
+          col = ind;
+        },
+      },
+      DocKind::Hard => {
+        out.push('\n');
+        out.extend(std::iter::repeat_n(' ', ind));
+        col = ind;
+      },
+      DocKind::Nest(n, child) => stack.push((ind + n, mode, child)),
+      DocKind::Group(child) => {
+        let flat = match child.width {
+          Some(w) => col + w <= width,
+          None => false,
+        };
+        stack.push((ind, if flat { Mode::Flat } else { Mode::Break }, child));
+      },
+    }
+  }
+  out
+}
+
+// ---------------------------------------------------------------------------
+// Lexical spelling
+// ---------------------------------------------------------------------------
+
+/// Can `s` print as a bare identifier component?
+fn is_bare_component(s: &str) -> bool {
+  let mut chars = s.chars();
+  let Some(c0) = chars.next() else { return false };
+  is_id_first(c0) && chars.all(is_id_rest) && !is_reserved(s)
+}
+
+/// Print one name component: bare when possible, `«…»` otherwise.
+/// `Num` components print as bare digits (the parser reads bare digit
+/// runs in non-leading position as `Num`; `«123»` stays `Str`).
+fn component_str(c: &NameComponent) -> String {
+  match c {
+    NameComponent::Str(s) => {
+      if is_bare_component(s) {
+        s.clone()
+      } else {
+        format!("«{s}»")
+      }
+    },
+    NameComponent::Num(n) => n.0.to_string(),
+  }
+}
+
+fn sname_str(n: &SName) -> String {
+  n.parts.iter().map(component_str).collect::<Vec<_>>().join(".")
+}
+
+fn hash_str(h: &HashRef) -> String {
+  format!("#{}", h.hex)
+}
+
+/// Lean-style string escaping.
+fn escape_string(s: &str) -> String {
+  let mut out = String::with_capacity(s.len() + 2);
+  out.push('"');
+  for c in s.chars() {
+    match c {
+      '"' => out.push_str("\\\""),
+      '\\' => out.push_str("\\\\"),
+      '\n' => out.push_str("\\n"),
+      '\t' => out.push_str("\\t"),
+      '\r' => out.push_str("\\r"),
+      c if (c as u32) < 0x20 || c as u32 == 0x7f => {
+        out.push_str(&format!("\\x{:02x}", c as u32));
+      },
+      c => out.push(c),
+    }
+  }
+  out.push('"');
+  out
+}
+
+// ---------------------------------------------------------------------------
+// Universes
+// ---------------------------------------------------------------------------
+
+/// Print a universe variable component; `max`/`imax` are operators in
+/// universe positions, so a parameter spelled that way must escape.
+fn uvar_str(c: &NameComponent) -> String {
+  match c {
+    NameComponent::Str(s) if s == "max" || s == "imax" => format!("«{s}»"),
+    other => component_str(other),
+  }
+}
+
+/// `atom_ctx`: the position only admits a universe *atom* (arguments
+/// of `max`/`imax`, `Type`/`Sort` arguments) — compounds parenthesize.
+fn univ_str(u: &UnivExpr, atom_ctx: bool) -> String {
+  match u {
+    UnivExpr::Nat(n, _) => n.to_string(),
+    UnivExpr::Var(c, _) => uvar_str(c),
+    UnivExpr::Add(a, n, _) => {
+      // Fold nested `Add`s: the grammar admits a single `+ n`.
+      let (base, total) = fold_add(a, *n);
+      let s = format!("{} + {}", univ_str(base, false), total);
+      if atom_ctx { format!("({s})") } else { s }
+    },
+    UnivExpr::Max(a, b, _) => {
+      let s = format!("max {} {}", univ_str(a, true), univ_str(b, true));
+      if atom_ctx { format!("({s})") } else { s }
+    },
+    UnivExpr::IMax(a, b, _) => {
+      let s = format!("imax {} {}", univ_str(a, true), univ_str(b, true));
+      if atom_ctx { format!("({s})") } else { s }
+    },
+  }
+}
+
+fn fold_add(u: &UnivExpr, acc: u64) -> (&UnivExpr, u64) {
+  match u {
+    UnivExpr::Add(inner, n, _) => fold_add(inner, acc + n),
+    other => (other, acc),
+  }
+}
+
+fn cref_str(c: &ConstRef) -> String {
+  let mut s = String::new();
+  if let Some(n) = &c.name {
+    s.push_str(&sname_str(n));
+  }
+  if let Some(h) = &c.hash {
+    s.push_str(&hash_str(h));
+  }
+  if let Some(ls) = &c.levels {
+    s.push_str(".{");
+    let parts: Vec<String> = ls.iter().map(|u| univ_str(u, false)).collect();
+    s.push_str(&parts.join(", "));
+    s.push('}');
+  }
+  s
+}
+
+// ---------------------------------------------------------------------------
+// Terms
+// ---------------------------------------------------------------------------
+
+/// Precedence: 0 = `fun`/`let` layer, 1 = arrow layer, 2 = "loose
+/// atoms" (application spines, `Type u`/`Sort u`, `proj`), 3 = closed
+/// atoms. A node prints bare iff its precedence ≥ the context's
+/// minimum; `Type`/`Sort` sit at 2 even when argument-less so a spine
+/// argument can never be captured as their universe argument.
+fn term_prec(t: &Term) -> u8 {
+  match t {
+    Term::Fun { .. } | Term::Let { .. } => 0,
+    Term::Pi { .. } | Term::Arrow { .. } => 1,
+    Term::Sort(SortKind::Prop, _)
+    | Term::Ref(_)
+    | Term::NatLit(..)
+    | Term::StrLit(..) => 3,
+    Term::App { .. } | Term::Proj { .. } | Term::Sort(..) => 2,
+  }
+}
+
+fn term_doc(t: &Term, min_prec: u8) -> Doc {
+  let d = term_doc_bare(t);
+  if term_prec(t) < min_prec { cat(vec![text("("), d, text(")")]) } else { d }
+}
+
+fn term_doc_bare(t: &Term) -> Doc {
+  match t {
+    Term::Ref(c) => text(cref_str(c)),
+    Term::Sort(k, _) => match k {
+      SortKind::Prop => text("Prop"),
+      SortKind::Type(None) => text("Type"),
+      SortKind::Type(Some(u)) => text(format!("Type {}", univ_str(u, true))),
+      SortKind::Sort(u) => text(format!("Sort {}", univ_str(u, true))),
+    },
+    Term::NatLit(n, _) => text(n.0.to_string()),
+    Term::StrLit(s, _) => text(escape_string(s)),
+    Term::App { head, args, .. } => {
+      // Flatten nested spines: `(f a) b` prints `f a b`.
+      let mut h: &Term = head;
+      let mut all: Vec<&Term> = args.iter().collect();
+      while let Term::App { head: h2, args: a2, .. } = h {
+        let mut front: Vec<&Term> = a2.iter().collect();
+        front.extend(all);
+        all = front;
+        h = h2;
+      }
+      let mut ds = vec![term_doc(h, 3)];
+      for a in all {
+        ds.push(line());
+        ds.push(term_doc(a, 3));
+      }
+      group(nest(cat(ds)))
+    },
+    Term::Fun { binders, body, .. } => {
+      let mut ds = vec![text("fun")];
+      for b in binders {
+        ds.push(text(" "));
+        ds.push(binder_doc(b));
+      }
+      ds.push(text(" =>"));
+      ds.push(group(nest(cat(vec![line(), term_doc(body, 0)]))));
+      cat(ds)
+    },
+    Term::Pi { binders, body, .. } => {
+      let mut ds = Vec::new();
+      for b in binders {
+        ds.push(binder_doc(b));
+        ds.push(text(" "));
+      }
+      ds.push(text("→"));
+      ds.push(group(nest(cat(vec![line(), term_doc(body, 1)]))));
+      cat(ds)
+    },
+    Term::Arrow { dom, cod, .. } => cat(vec![
+      term_doc(dom, 2),
+      text(" →"),
+      group(nest(cat(vec![line(), term_doc(cod, 1)]))),
+    ]),
+    Term::Let { non_dep, name, ty, val, body, .. } => {
+      let kw = if *non_dep { "have" } else { "let" };
+      cat(vec![
+        text(format!("{kw} {} : ", binder_name_str(name))),
+        term_doc(ty, 0),
+        text(" :="),
+        group(nest(cat(vec![line(), term_doc(val, 0)]))),
+        text(";"),
+        hard(),
+        term_doc(body, 0),
+      ])
+    },
+    Term::Proj { type_ref, idx, val, .. } => cat(vec![
+      text(format!("proj {} {idx} ", cref_str(type_ref))),
+      term_doc(val, 3),
+    ]),
+  }
+}
+
+fn binder_name_str(b: &BinderName) -> String {
+  match b {
+    BinderName::Ident(c, _) => component_str(c),
+    BinderName::Anon(_) => "_".to_string(),
+  }
+}
+
+fn binder_doc(b: &BinderGroup) -> Doc {
+  let (open, close) = match b.info {
+    BinderInfo::Default => ("(", ")"),
+    BinderInfo::Implicit => ("{", "}"),
+    BinderInfo::StrictImplicit => ("⦃", "⦄"),
+    BinderInfo::InstImplicit => ("[", "]"),
+  };
+  let mut ds = vec![text(open)];
+  if b.names.is_empty() {
+    // Unnamed instance binder `[T]`.
+    ds.push(term_doc(&b.ty, 0));
+  } else {
+    let names: Vec<String> = b.names.iter().map(binder_name_str).collect();
+    ds.push(text(format!("{} : ", names.join(" "))));
+    ds.push(term_doc(&b.ty, 0));
+  }
+  ds.push(text(close));
+  group(cat(ds))
+}
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+fn uparams_str(ups: &[UParam]) -> String {
+  if ups.is_empty() {
+    return String::new();
+  }
+  let parts: Vec<String> = ups.iter().map(|u| uvar_str(&u.name)).collect();
+  format!(".{{{}}}", parts.join(", "))
+}
+
+/// `def Foo.{u}` header prefix: keyword, optional name, uparams.
+fn head_str(kw: &str, name: &Option<SName>, ups: &[UParam]) -> String {
+  let mut s = String::from(kw);
+  if let Some(n) = name {
+    s.push(' ');
+    s.push_str(&sname_str(n));
+    s.push_str(&uparams_str(ups));
+  } else if !ups.is_empty() {
+    s.push(' ');
+    s.push_str(&uparams_str(ups));
+  }
+  s
+}
+
+fn sig_doc(head: String, ty: &Term) -> Doc {
+  cat(vec![
+    text(head),
+    text(" :"),
+    group(nest(cat(vec![line(), term_doc(ty, 0)]))),
+  ])
+}
+
+fn decl_doc(d: &Decl) -> Doc {
+  match d {
+    Decl::Def(x) => {
+      let mut kw = String::new();
+      if x.mods.unsafe_ {
+        kw.push_str("unsafe ");
+      }
+      if x.mods.partial_ {
+        kw.push_str("partial ");
+      }
+      kw.push_str(match x.kw {
+        DefKw::Def => "def",
+        DefKw::Theorem => "theorem",
+        DefKw::Opaque => "opaque",
+      });
+      cat(vec![
+        sig_doc(head_str(&kw, &x.name, &x.uparams), &x.ty),
+        text(" :="),
+        group(nest(cat(vec![line(), term_doc(&x.value, 0)]))),
+      ])
+    },
+    Decl::Axiom(x) => {
+      let kw = if x.unsafe_ { "unsafe axiom" } else { "axiom" };
+      sig_doc(head_str(kw, &x.name, &x.uparams), &x.ty)
+    },
+    Decl::Quot(x) => {
+      let kind = match x.kind {
+        QuotKindKw::Type => "type",
+        QuotKindKw::Ctor => "ctor",
+        QuotKindKw::Lift => "lift",
+        QuotKindKw::Ind => "ind",
+      };
+      sig_doc(head_str(&format!("quot {kind}"), &x.name, &x.uparams), &x.ty)
+    },
+    Decl::Ind(x) => {
+      let kw = if x.unsafe_ { "unsafe inductive" } else { "inductive" };
+      let head = format!(
+        "{} (params := {}) (indices := {})",
+        head_str(kw, &x.name, &x.uparams),
+        x.params,
+        x.indices
+      );
+      let mut ds = vec![sig_doc(head, &x.ty)];
+      if !x.ctors.is_empty() {
+        ds.push(text(" where"));
+        let mut items = Vec::new();
+        for c in &x.ctors {
+          items.push(hard());
+          let chead = format!(
+            "{} (params := {}) (fields := {})",
+            head_str("|", &c.name, &[]),
+            c.params,
+            c.fields
+          );
+          items.push(sig_doc(chead, &c.ty));
+        }
+        ds.push(nest(cat(items)));
+      }
+      cat(ds)
+    },
+    Decl::Recr(x) => {
+      let kw = if x.unsafe_ { "unsafe recursor" } else { "recursor" };
+      let mut head = format!(
+        "{} (params := {}) (indices := {}) (motives := {}) (minors := {})",
+        head_str(kw, &x.name, &x.uparams),
+        x.params,
+        x.indices,
+        x.motives,
+        x.minors
+      );
+      if x.k {
+        head.push_str(" (k := true)");
+      }
+      let mut ds = vec![sig_doc(head, &x.ty)];
+      if !x.rules.is_empty() {
+        ds.push(text(" where"));
+        let mut items = Vec::new();
+        for r in &x.rules {
+          items.push(hard());
+          items.push(cat(vec![
+            text(format!("| rule (fields := {}) :=", r.fields)),
+            group(nest(cat(vec![line(), term_doc(&r.rhs, 0)]))),
+          ]));
+        }
+        ds.push(nest(cat(items)));
+      }
+      cat(ds)
+    },
+    Decl::Mutual(members, _) => {
+      let mut items = Vec::new();
+      for m in members {
+        items.push(hard());
+        items.push(decl_doc(m));
+      }
+      cat(vec![text("mutual"), nest(cat(items)), hard(), text("end")])
+    },
+    Decl::Prj(x) => {
+      let kw = match x.kind {
+        PrjKind::DPrj => "dprj",
+        PrjKind::IPrj => "iprj",
+        PrjKind::CPrj => "cprj",
+        PrjKind::RPrj => "rprj",
+      };
+      let mut s = head_str(kw, &x.name, &[]);
+      s.push_str(&format!(" := {} {}", hash_str(&x.block), x.idx));
+      if let Some(c) = x.cidx {
+        s.push_str(&format!(" {c}"));
+      }
+      text(s)
+    },
+  }
+}
+
+fn import_str(i: &ImportDecl) -> String {
+  match &i.prefix {
+    Some(p) => format!("import {}{}", sname_str(p), hash_str(&i.hash)),
+    None => format!("import {}", hash_str(&i.hash)),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Print a term (canonical form, no trailing newline).
+pub fn print_term(t: &Term) -> String {
+  render(&group(term_doc(t, 0)), WIDTH)
+}
+
+/// Print one declaration (canonical form, no trailing newline).
+pub fn print_decl(d: &Decl) -> String {
+  render(&decl_doc(d), WIDTH)
+}
+
+/// Print a whole file in canonical form: sections (imports block,
+/// declarations, optional trailing main expression) separated by
+/// blank lines, trailing newline. The version header is emitted only
+/// for versions ≥ 2 — absent means version 1, forever. The main
+/// expression's value prints at precedence 2 — `fun`/`let`/arrows
+/// parenthesize, so `⊢ (fun (x : A) => x) : A → A` rather than the
+/// visually ambiguous bare form (both reparse identically).
+pub fn print_file(f: &File) -> String {
+  let mut sections: Vec<String> = Vec::new();
+  if f.version != 1 {
+    sections.push(format!("ixon {}", f.version));
+  }
+  if !f.imports.is_empty() {
+    sections
+      .push(f.imports.iter().map(import_str).collect::<Vec<_>>().join("\n"));
+  }
+  for d in &f.decls {
+    sections.push(print_decl(d));
+  }
+  if let Some(m) = &f.main {
+    let doc = cat(vec![
+      text("⊢ "),
+      term_doc(&m.value, 2),
+      text(" :"),
+      group(nest(cat(vec![line(), term_doc(&m.ty, 0)]))),
+    ]);
+    sections.push(render(&doc, WIDTH));
+  }
+  let mut out = sections.join("\n\n");
+  out.push('\n');
+  out
+}

--- a/crates/ixon/src/syntax/props.rs
+++ b/crates/ixon/src/syntax/props.rs
@@ -1,0 +1,675 @@
+//! quickcheck property tests for the Ixon text syntax.
+//!
+//! Generators produce arbitrary *valid* ASTs (the invariants the parser
+//! guarantees: nonempty spines, name-or-hash references, leading `Str`
+//! name components, …) and the properties enforce, over the whole AST
+//! space:
+//!
+//! - the canonical-printer fixpoint `print ∘ parse ∘ print = print`
+//!   (spans differ across a roundtrip, so equality lives at the text
+//!   level);
+//! - totality and determinism of parsing on arbitrary and mutated
+//!   input (R2: never a panic, always a value or a structured error);
+//! - the metering claim documented on [`Limits`]: the grammar has no
+//!   ε-productions, so node count is bounded by printed byte length.
+//!
+//! Shrinking is implemented for real: term shrinkers walk to subterms
+//! and minimal replacements (`Prop`), so failures arrive minimized.
+
+// `#[quickcheck]` requires owned arguments (crate convention, cf.
+// expr.rs / constant.rs).
+#![allow(clippy::needless_pass_by_value)]
+
+use bignat::Nat;
+use ix_common::env::{BinderInfo, NameComponent};
+use num_bigint::BigUint;
+use quickcheck::{Arbitrary, Gen};
+use quickcheck_macros::quickcheck;
+
+use crate::syntax::ast::{
+  AxiomDecl, BinderGroup, BinderName, ConstRef, CtorDecl, Decl, DefDecl, DefKw,
+  File, HashRef, ImportDecl, IndDecl, MainExpr, Modifiers, PrjDecl, PrjKind,
+  QuotDecl, QuotKindKw, RecrDecl, RuleDecl, SName, SortKind, Span, Term,
+  UParam, UnivExpr, count_term_nodes,
+};
+use crate::syntax::{Limits, parse_file, parse_term, print_file, print_term};
+
+// ---------------------------------------------------------------------------
+// Generators
+// ---------------------------------------------------------------------------
+
+fn pick(g: &mut Gen, n: usize) -> usize {
+  usize::arbitrary(g) % n
+}
+
+fn small_u64(g: &mut Gen, n: u64) -> u64 {
+  u64::arbitrary(g) % n
+}
+
+/// Component pool: bare identifiers, unicode, primes/`!?`, reserved
+/// words and digit-strings (which must print `«…»`-escaped), and a
+/// spaced string (ditto).
+const STR_POOL: &[&str] = &[
+  "x",
+  "y",
+  "foo",
+  "bar'",
+  "h!?",
+  "α",
+  "ℕ",
+  "add_comm",
+  "Nat",
+  "Except",
+  "def",
+  "weird name",
+  "123",
+  "max",
+];
+
+/// Leading components must be `Str` and are drawn from the same pool
+/// (escaping makes even `"123"` legal in leading position).
+fn arb_str_component(g: &mut Gen) -> NameComponent {
+  NameComponent::Str(STR_POOL[pick(g, STR_POOL.len())].to_string())
+}
+
+fn arb_component(g: &mut Gen) -> NameComponent {
+  if pick(g, 5) == 0 {
+    NameComponent::Num(Nat(BigUint::from(small_u64(g, 1000))))
+  } else {
+    arb_str_component(g)
+  }
+}
+
+fn arb_sname(g: &mut Gen) -> SName {
+  let mut parts = vec![arb_str_component(g)];
+  for _ in 0..pick(g, 3) {
+    parts.push(arb_component(g));
+  }
+  SName { parts, span: Span::default() }
+}
+
+const HEX: &[u8] = b"0123456789abcdef";
+
+fn arb_hex(g: &mut Gen, len: usize) -> String {
+  (0..len).map(|_| HEX[pick(g, 16)] as char).collect()
+}
+
+fn arb_hash(g: &mut Gen) -> HashRef {
+  let len = 4 + pick(g, 61);
+  HashRef { hex: arb_hex(g, len), span: Span::default() }
+}
+
+/// Universe variables: `Str` components only (a `Num` universe
+/// variable prints as a numeral and reparses as a literal). The pool
+/// includes `"max"`, which must print escaped in universe positions.
+fn arb_uvar(g: &mut Gen) -> NameComponent {
+  NameComponent::Str(
+    ["u", "v", "w", "max", "weird name"][pick(g, 5)].to_string(),
+  )
+}
+
+fn arb_univ(g: &mut Gen, depth: usize) -> UnivExpr {
+  let sp = Span::default();
+  if depth == 0 {
+    return match pick(g, 2) {
+      0 => UnivExpr::Nat(small_u64(g, 4), sp),
+      _ => UnivExpr::Var(arb_uvar(g), sp),
+    };
+  }
+  match pick(g, 5) {
+    0 => UnivExpr::Nat(small_u64(g, 4), sp),
+    1 => UnivExpr::Var(arb_uvar(g), sp),
+    2 => {
+      UnivExpr::Add(Box::new(arb_univ(g, depth - 1)), 1 + small_u64(g, 3), sp)
+    },
+    3 => UnivExpr::Max(
+      Box::new(arb_univ(g, depth - 1)),
+      Box::new(arb_univ(g, depth - 1)),
+      sp,
+    ),
+    _ => UnivExpr::IMax(
+      Box::new(arb_univ(g, depth - 1)),
+      Box::new(arb_univ(g, depth - 1)),
+      sp,
+    ),
+  }
+}
+
+fn arb_cref(g: &mut Gen) -> ConstRef {
+  let name = if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None };
+  let hash =
+    if name.is_none() || pick(g, 4) == 0 { Some(arb_hash(g)) } else { None };
+  let levels = if pick(g, 4) == 0 {
+    Some((0..1 + pick(g, 2)).map(|_| arb_univ(g, 1)).collect())
+  } else {
+    None
+  };
+  ConstRef { name, hash, levels, span: Span::default() }
+}
+
+fn arb_binder_name(g: &mut Gen) -> BinderName {
+  if pick(g, 6) == 0 {
+    BinderName::Anon(Span::default())
+  } else {
+    BinderName::Ident(arb_str_component(g), Span::default())
+  }
+}
+
+fn arb_binder(g: &mut Gen, depth: usize) -> BinderGroup {
+  let info = BinderInfo::arbitrary(g);
+  let names = if info == BinderInfo::InstImplicit && pick(g, 2) == 0 {
+    vec![] // unnamed instance binder `[T]`
+  } else {
+    (0..1 + pick(g, 2)).map(|_| arb_binder_name(g)).collect()
+  };
+  BinderGroup { info, names, ty: arb_term(g, depth), span: Span::default() }
+}
+
+fn arb_sort(g: &mut Gen) -> SortKind {
+  match pick(g, 4) {
+    0 => SortKind::Prop,
+    1 => SortKind::Type(None),
+    2 => SortKind::Type(Some(arb_univ(g, 1))),
+    _ => SortKind::Sort(arb_univ(g, 1)),
+  }
+}
+
+fn arb_term(g: &mut Gen, depth: usize) -> Term {
+  let sp = Span::default();
+  if depth == 0 {
+    return match pick(g, 6) {
+      0 => Term::NatLit(Nat(BigUint::from(u64::arbitrary(g))), sp),
+      1 => Term::StrLit(String::arbitrary(g), sp),
+      2 => Term::Sort(arb_sort(g), sp),
+      _ => Term::Ref(arb_cref(g)),
+    };
+  }
+  let d = depth - 1;
+  match pick(g, 10) {
+    0 => Term::Sort(arb_sort(g), sp),
+    1 | 2 => Term::App {
+      head: Box::new(arb_term(g, d)),
+      args: (0..1 + pick(g, 3)).map(|_| arb_term(g, d)).collect(),
+      span: sp,
+    },
+    3 | 4 => Term::Fun {
+      binders: (0..1 + pick(g, 2)).map(|_| arb_binder(g, d)).collect(),
+      body: Box::new(arb_term(g, d)),
+      span: sp,
+    },
+    5 => Term::Pi {
+      binders: (0..1 + pick(g, 2)).map(|_| arb_binder(g, d)).collect(),
+      body: Box::new(arb_term(g, d)),
+      span: sp,
+    },
+    6 => Term::Arrow {
+      dom: Box::new(arb_term(g, d)),
+      cod: Box::new(arb_term(g, d)),
+      span: sp,
+    },
+    7 => Term::Let {
+      non_dep: bool::arbitrary(g),
+      name: arb_binder_name(g),
+      ty: Box::new(arb_term(g, d)),
+      val: Box::new(arb_term(g, d)),
+      body: Box::new(arb_term(g, d)),
+      span: sp,
+    },
+    8 => Term::Proj {
+      type_ref: arb_cref(g),
+      idx: small_u64(g, 8),
+      val: Box::new(arb_term(g, d)),
+      span: sp,
+    },
+    _ => Term::Ref(arb_cref(g)),
+  }
+}
+
+fn arb_uparams(g: &mut Gen) -> Vec<UParam> {
+  (0..pick(g, 3))
+    .map(|_| UParam { name: arb_uvar(g), span: Span::default() })
+    .collect()
+}
+
+fn arb_modifiers(g: &mut Gen, kw: DefKw) -> Modifiers {
+  // The parser rejects `partial` on non-`def` and the unsafe+partial
+  // combination.
+  match pick(g, 4) {
+    0 => Modifiers { unsafe_: true, partial_: false },
+    1 if kw == DefKw::Def => Modifiers { unsafe_: false, partial_: true },
+    _ => Modifiers::default(),
+  }
+}
+
+fn arb_def(g: &mut Gen, depth: usize) -> DefDecl {
+  let kw = *g.choose(&[DefKw::Def, DefKw::Theorem, DefKw::Opaque]).unwrap();
+  DefDecl {
+    kw,
+    mods: arb_modifiers(g, kw),
+    name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+    uparams: arb_uparams(g),
+    ty: arb_term(g, depth),
+    value: arb_term(g, depth),
+    span: Span::default(),
+  }
+}
+
+fn arb_ind(g: &mut Gen, depth: usize) -> IndDecl {
+  IndDecl {
+    unsafe_: bool::arbitrary(g),
+    name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+    uparams: arb_uparams(g),
+    params: small_u64(g, 4),
+    indices: small_u64(g, 4),
+    ty: arb_term(g, depth),
+    ctors: (0..pick(g, 3))
+      .map(|_| CtorDecl {
+        name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+        params: small_u64(g, 4),
+        fields: small_u64(g, 4),
+        ty: arb_term(g, depth),
+        span: Span::default(),
+      })
+      .collect(),
+    span: Span::default(),
+  }
+}
+
+fn arb_recr(g: &mut Gen, depth: usize) -> RecrDecl {
+  RecrDecl {
+    unsafe_: bool::arbitrary(g),
+    name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+    uparams: arb_uparams(g),
+    params: small_u64(g, 4),
+    indices: small_u64(g, 4),
+    motives: 1 + small_u64(g, 2),
+    minors: small_u64(g, 4),
+    k: bool::arbitrary(g),
+    ty: arb_term(g, depth),
+    rules: (0..pick(g, 3))
+      .map(|_| RuleDecl {
+        fields: small_u64(g, 4),
+        rhs: arb_term(g, depth),
+        span: Span::default(),
+      })
+      .collect(),
+    span: Span::default(),
+  }
+}
+
+fn arb_decl(g: &mut Gen, depth: usize) -> Decl {
+  match pick(g, 8) {
+    0 | 1 => Decl::Def(arb_def(g, depth)),
+    2 => Decl::Axiom(AxiomDecl {
+      unsafe_: bool::arbitrary(g),
+      name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+      uparams: arb_uparams(g),
+      ty: arb_term(g, depth),
+      span: Span::default(),
+    }),
+    3 => Decl::Quot(QuotDecl {
+      kind: *g
+        .choose(&[
+          QuotKindKw::Type,
+          QuotKindKw::Ctor,
+          QuotKindKw::Lift,
+          QuotKindKw::Ind,
+        ])
+        .unwrap(),
+      name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+      uparams: arb_uparams(g),
+      ty: arb_term(g, depth),
+      span: Span::default(),
+    }),
+    4 => Decl::Ind(arb_ind(g, depth)),
+    5 => Decl::Recr(arb_recr(g, depth)),
+    6 => {
+      let members = (0..1 + pick(g, 2))
+        .map(|_| match pick(g, 3) {
+          0 => Decl::Ind(arb_ind(g, depth)),
+          1 => Decl::Recr(arb_recr(g, depth)),
+          _ => Decl::Def(arb_def(g, depth)),
+        })
+        .collect();
+      Decl::Mutual(members, Span::default())
+    },
+    _ => {
+      let kind = *g
+        .choose(&[PrjKind::DPrj, PrjKind::IPrj, PrjKind::CPrj, PrjKind::RPrj])
+        .unwrap();
+      Decl::Prj(PrjDecl {
+        kind,
+        name: if pick(g, 4) > 0 { Some(arb_sname(g)) } else { None },
+        block: arb_hash(g),
+        idx: small_u64(g, 8),
+        cidx: (kind == PrjKind::CPrj).then(|| small_u64(g, 8)),
+        span: Span::default(),
+      })
+    },
+  }
+}
+
+fn arb_import(g: &mut Gen) -> ImportDecl {
+  ImportDecl {
+    prefix: if pick(g, 2) == 0 { Some(arb_sname(g)) } else { None },
+    hash: HashRef { hex: arb_hex(g, 64), span: Span::default() },
+    span: Span::default(),
+  }
+}
+
+fn arb_file(g: &mut Gen) -> File {
+  File {
+    version: crate::syntax::VERSION,
+    imports: (0..pick(g, 3)).map(|_| arb_import(g)).collect(),
+    decls: (0..pick(g, 4)).map(|_| arb_decl(g, 2)).collect(),
+    main: (pick(g, 3) == 0).then(|| MainExpr {
+      value: arb_term(g, 2),
+      ty: arb_term(g, 2),
+      span: Span::default(),
+    }),
+    span: Span::default(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shrinking
+// ---------------------------------------------------------------------------
+
+fn prop_leaf() -> Term {
+  Term::Sort(SortKind::Prop, Span::default())
+}
+
+fn is_prop_leaf(t: &Term) -> bool {
+  matches!(t, Term::Sort(SortKind::Prop, _))
+}
+
+/// Immediate subterms plus minimal replacements — every candidate is
+/// strictly smaller by node count or is the `Prop` leaf (which shrinks
+/// to nothing), so shrinking terminates.
+fn shrink_term(t: &Term) -> Vec<Term> {
+  let mut out = Vec::new();
+  if !is_prop_leaf(t) {
+    out.push(prop_leaf());
+  }
+  match t {
+    Term::App { head, args, .. } => {
+      out.push((**head).clone());
+      out.extend(args.iter().cloned());
+      if args.len() > 1 {
+        for i in 0..args.len() {
+          let mut a = args.clone();
+          a.remove(i);
+          out.push(Term::App {
+            head: head.clone(),
+            args: a,
+            span: Span::default(),
+          });
+        }
+      }
+    },
+    Term::Fun { binders, body, .. } | Term::Pi { binders, body, .. } => {
+      out.push((**body).clone());
+      out.extend(binders.iter().map(|b| b.ty.clone()));
+    },
+    Term::Arrow { dom, cod, .. } => {
+      out.push((**dom).clone());
+      out.push((**cod).clone());
+    },
+    Term::Let { ty, val, body, .. } => {
+      out.push((**ty).clone());
+      out.push((**val).clone());
+      out.push((**body).clone());
+    },
+    Term::Proj { val, .. } => out.push((**val).clone()),
+    Term::Ref(r) => {
+      if r.levels.is_some() {
+        out.push(Term::Ref(ConstRef { levels: None, ..r.clone() }));
+      }
+      if r.name.is_some() && r.hash.is_some() {
+        out.push(Term::Ref(ConstRef { hash: None, ..r.clone() }));
+      }
+    },
+    Term::StrLit(s, _) if !s.is_empty() => {
+      out.push(Term::StrLit(String::new(), Span::default()));
+    },
+    _ => {},
+  }
+  out
+}
+
+fn shrink_decl(d: &Decl) -> Vec<Decl> {
+  let mut out = Vec::new();
+  match d {
+    Decl::Def(x) => {
+      for ty in shrink_term(&x.ty) {
+        out.push(Decl::Def(DefDecl { ty, ..x.clone() }));
+      }
+      for value in shrink_term(&x.value) {
+        out.push(Decl::Def(DefDecl { value, ..x.clone() }));
+      }
+    },
+    Decl::Axiom(x) => {
+      for ty in shrink_term(&x.ty) {
+        out.push(Decl::Axiom(AxiomDecl { ty, ..x.clone() }));
+      }
+    },
+    Decl::Quot(x) => {
+      for ty in shrink_term(&x.ty) {
+        out.push(Decl::Quot(QuotDecl { ty, ..x.clone() }));
+      }
+    },
+    Decl::Ind(x) => {
+      for i in 0..x.ctors.len() {
+        let mut c = x.ctors.clone();
+        c.remove(i);
+        out.push(Decl::Ind(IndDecl { ctors: c, ..x.clone() }));
+      }
+      for ty in shrink_term(&x.ty) {
+        out.push(Decl::Ind(IndDecl { ty, ..x.clone() }));
+      }
+    },
+    Decl::Recr(x) => {
+      for i in 0..x.rules.len() {
+        let mut r = x.rules.clone();
+        r.remove(i);
+        out.push(Decl::Recr(RecrDecl { rules: r, ..x.clone() }));
+      }
+      for ty in shrink_term(&x.ty) {
+        out.push(Decl::Recr(RecrDecl { ty, ..x.clone() }));
+      }
+    },
+    Decl::Mutual(members, _) => {
+      out.extend(members.iter().cloned());
+      if members.len() > 1 {
+        for i in 0..members.len() {
+          let mut m = members.clone();
+          m.remove(i);
+          out.push(Decl::Mutual(m, Span::default()));
+        }
+      }
+      for (i, member) in members.iter().enumerate() {
+        for s in shrink_decl(member) {
+          if matches!(s, Decl::Def(_) | Decl::Ind(_) | Decl::Recr(_)) {
+            let mut m = members.clone();
+            m[i] = s;
+            out.push(Decl::Mutual(m, Span::default()));
+          }
+        }
+      }
+    },
+    Decl::Prj(_) => {},
+  }
+  out
+}
+
+#[derive(Debug, Clone)]
+struct ArbTerm(Term);
+
+impl Arbitrary for ArbTerm {
+  fn arbitrary(g: &mut Gen) -> Self {
+    ArbTerm(arb_term(g, 4))
+  }
+
+  fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+    Box::new(shrink_term(&self.0).into_iter().map(ArbTerm))
+  }
+}
+
+#[derive(Debug, Clone)]
+struct ArbFile(File);
+
+impl Arbitrary for ArbFile {
+  fn arbitrary(g: &mut Gen) -> Self {
+    ArbFile(arb_file(g))
+  }
+
+  fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
+    let f = &self.0;
+    let mut out = Vec::new();
+    for i in 0..f.imports.len() {
+      let mut imports = f.imports.clone();
+      imports.remove(i);
+      out.push(File { imports, ..f.clone() });
+    }
+    for i in 0..f.decls.len() {
+      let mut decls = f.decls.clone();
+      decls.remove(i);
+      out.push(File { decls, ..f.clone() });
+    }
+    if f.main.is_some() {
+      out.push(File { main: None, ..f.clone() });
+    }
+    if let Some(m) = &f.main {
+      for v in shrink_term(&m.value) {
+        out.push(File {
+          main: Some(MainExpr { value: v, ..m.clone() }),
+          ..f.clone()
+        });
+      }
+      for t in shrink_term(&m.ty) {
+        out.push(File {
+          main: Some(MainExpr { ty: t, ..m.clone() }),
+          ..f.clone()
+        });
+      }
+    }
+    for (i, d) in f.decls.iter().enumerate() {
+      for s in shrink_decl(d) {
+        let mut decls = f.decls.clone();
+        decls[i] = s;
+        out.push(File { decls, ..f.clone() });
+      }
+    }
+    Box::new(out.into_iter().map(ArbFile))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+fn lims() -> Limits {
+  Limits::default()
+}
+
+/// `print ∘ parse ∘ print = print` at the term level.
+#[quickcheck]
+fn prop_term_print_parse_print_fixpoint(t: ArbTerm) -> bool {
+  let p1 = print_term(&t.0);
+  match parse_term(&p1, &lims()) {
+    Ok(t2) => {
+      let p2 = print_term(&t2);
+      if p1 == p2 {
+        true
+      } else {
+        eprintln!("not a fixpoint:\n--- p1\n{p1}\n--- p2\n{p2}");
+        false
+      }
+    },
+    Err(e) => {
+      eprintln!("reparse failed: {e}\n---\n{p1}");
+      false
+    },
+  }
+}
+
+/// `print ∘ parse ∘ print = print` at the file level (all decl forms,
+/// imports included).
+#[quickcheck]
+fn prop_file_print_parse_print_fixpoint(f: ArbFile) -> bool {
+  let p1 = print_file(&f.0);
+  match parse_file(&p1, &lims()) {
+    Ok(f2) => {
+      let p2 = print_file(&f2);
+      if p1 == p2 {
+        true
+      } else {
+        eprintln!("not a fixpoint:\n--- p1\n{p1}\n--- p2\n{p2}");
+        false
+      }
+    },
+    Err(e) => {
+      eprintln!("reparse failed: {e}\n---\n{p1}");
+      false
+    },
+  }
+}
+
+/// The metering claim on [`Limits`]: no ε-productions, so the parsed
+/// node count is bounded by the printed byte length.
+#[quickcheck]
+fn prop_node_count_bounded_by_bytes(t: ArbTerm) -> bool {
+  let p = print_term(&t.0);
+  match parse_term(&p, &lims()) {
+    Ok(t2) => count_term_nodes(&t2) <= p.len(),
+    Err(_) => false,
+  }
+}
+
+/// Totality on arbitrary input: a value or a structured error, never a
+/// panic (R2). Exercises both entry points.
+#[quickcheck]
+fn prop_parse_total_on_arbitrary_strings(s: String) -> bool {
+  let _ = parse_term(&s, &lims());
+  let _ = parse_file(&s, &lims());
+  true
+}
+
+/// Determinism: parsing the same bytes twice yields identical results
+/// (values and errors are `PartialEq`).
+#[quickcheck]
+fn prop_parse_deterministic(s: String) -> bool {
+  parse_file(&s, &lims()) == parse_file(&s, &lims())
+    && parse_term(&s, &lims()) == parse_term(&s, &lims())
+}
+
+/// Caps are respected and never panic, even when tiny.
+#[quickcheck]
+fn prop_tiny_limits_total(s: String) -> bool {
+  let tiny = Limits { max_bytes: 64, max_nodes: 16, max_depth: 4 };
+  let _ = parse_term(&s, &tiny);
+  let _ = parse_file(&s, &tiny);
+  true
+}
+
+/// Near-valid fuzz: mutate bytes of canonical output, reparse
+/// (lossy-decoded), and require totality. This walks the interesting
+/// boundary between valid and invalid text.
+#[quickcheck]
+fn prop_mutated_canonical_text_total(
+  t: ArbTerm,
+  muts: Vec<(usize, u8)>,
+) -> bool {
+  let mut bytes = print_term(&t.0).into_bytes();
+  if bytes.is_empty() {
+    return true;
+  }
+  for (pos, b) in muts {
+    let n = bytes.len();
+    bytes[pos % n] = b;
+  }
+  let s = String::from_utf8_lossy(&bytes);
+  let _ = parse_term(&s, &lims());
+  let _ = parse_file(&s, &lims());
+  true
+}


### PR DESCRIPTION
…t and Lean

A Lean-resembling closed grammar denoting the named Ix level (never the pack tables): all decl forms (def/theorem/opaque, axiom, quot, inductive, recursor, mutual, projections), imports as namespace mounts with Name#hash pinned references, and a trailing main expression `|- value : type` (an anonymous definition, marked as the bundle main).

- crates/ixon/src/syntax/: nom parser, Wadler-style canonical printer (cached-width doc engine), structured positioned errors, byte/node/depth metering; quickcheck properties (printer fixpoint, totality on arbitrary and mutated input, node count <= printed bytes).
- Ix/IxonSyntax/: behavioral Lean mirror (char-array scanner with byte spans, same doc engine); LSpec suite `ixon-syntax` with SlimCheck properties; unit corpora share golden strings with the Rust suite, and both printers emit byte-identical canonical output (verified by direct diff; FFI parity externs come with the resolve stage).

Grammar decisions locked by property testing: declaration-starting words are reserved; the main-expression turnstile is required after declarations and optional for sole-item files; the version header is optional (absent means version 1, forever); whitespace is the explicit space/tab/CR/LF set; Name#hash lexing is
adjacency-sensitive.