### PR TITLE
zisk/sp1: make guest crates standalone workspace roots

### DIFF
--- a/sp1/guest/Cargo.toml
+++ b/sp1/guest/Cargo.toml
@@ -1,3 +1,13 @@
+# Standalone workspace root. This guest crate is compiled out-of-tree for
+# the zkVM target and never joins the host Cargo workspace; its own (empty)
+# `[workspace]` pins cargo's upward workspace search to this directory.
+# Without it, a NESTED checkout — e.g. the benchmark base-run, which checks
+# the base repo out under `base/` inside the PR checkout — lets cargo walk
+# past the relative `exclude` paths in the outer manifests and resolve this
+# crate to the outer workspace, failing the build script with "current
+# package believes it's in a workspace when it's not".
+[workspace]
+
 [package]
 name = "sp1-guest"
 version = "0.1.0"

--- a/zisk/agg-guest/Cargo.toml
+++ b/zisk/agg-guest/Cargo.toml
@@ -1,3 +1,13 @@
+# Standalone workspace root. This guest crate is compiled out-of-tree for
+# the zkVM target and never joins the host Cargo workspace; its own (empty)
+# `[workspace]` pins cargo's upward workspace search to this directory.
+# Without it, a NESTED checkout — e.g. the benchmark base-run, which checks
+# the base repo out under `base/` inside the PR checkout — lets cargo walk
+# past the relative `exclude` paths in the outer manifests and resolve this
+# crate to the outer workspace, failing the build script with "current
+# package believes it's in a workspace when it's not".
+[workspace]
+
 [package]
 name = "zisk-agg-guest"
 version = "0.1.0"

--- a/zisk/guest/Cargo.toml
+++ b/zisk/guest/Cargo.toml
@@ -1,3 +1,13 @@
+# Standalone workspace root. This guest crate is compiled out-of-tree for
+# the zkVM target and never joins the host Cargo workspace; its own (empty)
+# `[workspace]` pins cargo's upward workspace search to this directory.
+# Without it, a NESTED checkout — e.g. the benchmark base-run, which checks
+# the base repo out under `base/` inside the PR checkout — lets cargo walk
+# past the relative `exclude` paths in the outer manifests and resolve this
+# crate to the outer workspace, failing the build script with "current
+# package believes it's in a workspace when it's not".
+[workspace]
+
 [package]
 name = "zisk-guest"
 version = "0.1.0"


### PR DESCRIPTION
The zkVM guest crates (zisk/guest, zisk/agg-guest, sp1/guest) are compiled out-of-tree for the riscv target by the zkVM build scripts, never as part of the host workspace. They carried no `[workspace]` of their own and relied purely on the ancestor manifests' `exclude` lists to be treated as standalone.

That breaks under a NESTED checkout. The benchmark base-run (bench-pr.yml) checks the base repo out under `base/` INSIDE the PR checkout, so the base guest lives at `base/zisk/guest`. The root manifest's `exclude = ["zisk", "sp1"]` is relative, so it covers `./zisk` but not `./base/zisk`; cargo's workspace search for the base guest walks up past `base/zisk` (which excludes it) to the outer PR-checkout root, which neither lists nor excludes it, and `ziskbuild`'s `cargo metadata` call panics with "current package believes it's in a workspace when it's not". The base-side `zisk-host` build then fails and the main column of the bench comparison comes up empty (seen on the zisk-InitStd-execute base run).

Give each guest its own empty `[workspace]` table so cargo pins its workspace to the crate itself and never walks up to an ancestor, regardless of nesting — exactly what the cargo error recommends. Verified by reproducing the nested layout: without the table cargo emits the exact error; with it, resolution no longer reaches the outer workspace. The guests use no `workspace = true` inheritance, so a standalone root changes nothing else.

Fixes the `n/a` errors for the base branch in the `!benchmark` output, e.g. https://github.com/argumentcomputer/ix/pull/442#issuecomment-5072550991 ([workflow logs](https://github.com/argumentcomputer/ix/actions/runs/30112253032/job/89545278818#step:20:68))