### PR TITLE
multi-stark bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=c4355cb9140ece62fbbb41610203b52f641b9a92#c4355cb9140ece62fbbb41610203b52f641b9a92"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=2501b4fafd0cdc3ec2dd013011f497c779b87297#2501b4fafd0cdc3ec2dd013011f497c779b87297"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=40092c160f51fdc2330b9e388873ece3fa4c12c2#40092c160f51fdc2330b9e388873ece3fa4c12c2"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=1c6ef62076b303d31ad99c0750e00abd6560882b#1c6ef62076b303d31ad99c0750e00abd6560882b"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=1c6ef62076b303d31ad99c0750e00abd6560882b#1c6ef62076b303d31ad99c0750e00abd6560882b"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=b76e43b388c4a0a60553d3b4d5d8ac2cbf772959#b76e43b388c4a0a60553d3b4d5d8ac2cbf772959"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=b76e43b388c4a0a60553d3b4d5d8ac2cbf772959#b76e43b388c4a0a60553d3b4d5d8ac2cbf772959"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=c4355cb9140ece62fbbb41610203b52f641b9a92#c4355cb9140ece62fbbb41610203b52f641b9a92"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 # `zisk/` and `sp1/` are their own Cargo workspaces (guest + host) built via
 # the respective zkVM toolchains; excluded so host workspace ops don't pick
 # them up.
-exclude = ["zisk", "sp1"]
+exclude = ["zisk", "sp1", "multi-stark"]
 resolver = "2"
 
 [profile.dev]
@@ -51,7 +51,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "1c6ef62076b303d31ad99c0750e00abd6560882b" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "b76e43b388c4a0a60553d3b4d5d8ac2cbf772959" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "b76e43b388c4a0a60553d3b4d5d8ac2cbf772959" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "c4355cb9140ece62fbbb41610203b52f641b9a92" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "40092c160f51fdc2330b9e388873ece3fa4c12c2" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "1c6ef62076b303d31ad99c0750e00abd6560882b" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "c4355cb9140ece62fbbb41610203b52f641b9a92" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "2501b4fafd0cdc3ec2dd013011f497c779b87297" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Ix/MultiStark/SystemDeserialize.lean
+++ b/Ix/MultiStark/SystemDeserialize.lean
@@ -19,17 +19,18 @@ flat base-field node graph, so this reader parses that compiled form:
 * PER-CIRCUIT RECORD: a `u32 LE len` prefix followed by exactly `len`
   contiguous bytes —
     - 8 × u32: main_width, preprocessed_width, preprocessed_height,
-      num_publics, stage_2_width, max_constraint_degree, lookup_prefix_len,
-      node_count
+      constraint_count (user roots + (L+3)·D — the `observe_shape` value),
+      stage_2_width, max_constraint_degree (combined user + logUp),
+      lookup_prefix_len, node_count
     - `node_count` tagged nodes (children are u32 NodeIds, never sub-trees):
       0 Const(u64) · 1 Var(u8 source, u8 offset, u32 index) · 2 Public(u32) ·
       3 IsFirstRow · 4 IsLastRow · 5 IsTransition ·
       6 Add(u32,u32) · 7 Sub(u32,u32) · 8 Mul(u32,u32) · 9 Neg(u32)
-    - u32 zero_count, then that many u32 constraint-root NodeIds
-    - u32 lookup_count, then the compiled lookups (multiplicity + args as
-      NodeIds) — the verifier does NOT need these (the lookup argument's
-      constraints are compiled into `zeros`), so the reader SKIPS them via
-      the record length prefix.
+    - u32 zero_count, then that many u32 constraint-root NodeIds (USER
+      constraints only — the logUp constraints are never compiled)
+    - u32 lookup_count, then the compiled lookups (u32 multiplicity NodeId,
+      u32 arg count, arg NodeIds) — these drive the verifier's direct
+      logUp constraint evaluation (`Verifier.lean`).
 * TRAILER: preprocessed commit (`0` = None / `1` + MerkleCap) then one u16
   per circuit for the preprocessed index (`0xFFFF` = None).
 
@@ -76,7 +77,10 @@ def systemDeserialize := ⟦
   -- NodeIds (`zeros`), and the maximum constraint degree (for the quotient
   -- degree). The lookups are omitted — their constraints are compiled into
   -- `zeros`, so the verifier never needs them.
-  enum SysCircuit { Mk(List‹SysNode›, G, List‹G›, G) }   -- nodes, node_count, zeros, max_constraint_degree
+  -- A compiled lookup: multiplicity node id + argument node ids (all into
+  -- the graph's lookup prefix). Drives the direct logUp evaluation.
+  enum SysLookup { Mk(G, List‹G›) }
+  enum SysCircuit { Mk(List‹SysNode›, G, List‹G›, G, List‹SysLookup›) }   -- nodes, node_count, zeros, max_constraint_degree, lookups
 
   -- log_blowup, cap_height, log_final_poly_len, max_log_arity, num_queries,
   -- commit_proof_of_work_bits, query_proof_of_work_bits — the commitment + FRI
@@ -229,30 +233,49 @@ def systemDeserialize := ⟦
     }
   }
 
+  fn read_sys_lookup(i: G) -> (SysLookup, G) {
+    let (m, i1) = #read_vk_u32(i);
+    let (ac, i2) = #read_vk_u32(i1);
+    let (args, i3) = read_node_ids_n(i2, ac);
+    (SysLookup.Mk(m, args), i3)
+  }
+  fn read_sys_lookups_n(i: G, n: G) -> (List‹SysLookup›, G) {
+    match n {
+      0 => (store(ListNode.Nil), i),
+      _ =>
+        let (x, j) = read_sys_lookup(i);
+        let (rest, j2) = read_sys_lookups_n(j, n - 1);
+        (store(ListNode.Cons(x, rest)), j2),
+    }
+  }
+
   -- One circuit record: a u32 length prefix then the contiguous record. The
-  -- 8-word header, the node stream, and the zeros are parsed; the compiled
-  -- lookups (which the verifier does not use) are skipped by jumping to the
-  -- record end via the length prefix. Besides the parsed circuit, returns its
-  -- 6 shape words as u64 limbs, in `observe_shape` order: constraint_count
-  -- (= zero_count), max_constraint_degree, preprocessed_height,
-  -- preprocessed_width, main_width, stage_2_width.
+  -- 8-word header, the node stream, the zeros, and the compiled lookups
+  -- (which drive the direct logUp evaluation) are all parsed. Besides the
+  -- parsed circuit, returns its 6 shape words as u64 limbs, in
+  -- `observe_shape` order: constraint_count (user roots + (L+3)·D, read
+  -- from the header), max_constraint_degree (combined),
+  -- preprocessed_height, preprocessed_width, main_width, stage_2_width.
   fn read_sys_circuit(base: G) -> (SysCircuit, [U64; 6], G) {
     let (rec_len, r0) = #read_vk_u32(base);
     let (mw, mwl, c1) = #read_vk_u32_limb(r0);
     let (pw, pwl, c2) = #read_vk_u32_limb(c1);
     let (ph, phl, c3) = #read_vk_u32_limb(c2);
-    let (np, c4) = #read_vk_u32(c3);
+    let (cc, ccl, c4) = #read_vk_u32_limb(c3);
     let (s2w, s2wl, c5) = #read_vk_u32_limb(c4);
     let (md, mdl, c6) = #read_vk_u32_limb(c5);
     let (lpl, c7) = #read_vk_u32(c6);
     let (ncount, c8) = #read_vk_u32(c7);
     let (nodes, c9) = read_nodes_n(c8, ncount);
-    let (zcount, zcl, c10) = #read_vk_u32_limb(c9);
+    let (zcount, c10) = #read_vk_u32(c9);
     let (zeros, c11) = read_node_ids_n(c10, zcount);
-    -- The remaining bytes of the record are the compiled lookups; skip them.
+    let (lcount, c12) = #read_vk_u32(c11);
+    let (lks, c13) = read_sys_lookups_n(c12, lcount);
+    -- The record length prefix must frame exactly the parsed content.
     let rend = r0 + rec_len;
-    (SysCircuit.Mk(nodes, ncount, zeros, md),
-     [zcl, mdl, phl, pwl, mwl, s2wl], rend)
+    assert_eq!(rend - c13, 0);
+    (SysCircuit.Mk(nodes, ncount, zeros, md, lks),
+     [ccl, mdl, phl, pwl, mwl, s2wl], rend)
   }
   fn cons_shape6(l: [U64; 6], tail: List‹U64›) -> List‹U64› {
     store(ListNode.Cons(l[0], store(ListNode.Cons(l[1], store(ListNode.Cons(l[2],

--- a/Ix/MultiStark/SystemDeserialize.lean
+++ b/Ix/MultiStark/SystemDeserialize.lean
@@ -22,14 +22,16 @@ flat base-field node graph, so this reader parses that compiled form:
       constraint_count (user roots + (L+3)·D — the `observe_shape` value),
       stage_2_width, max_constraint_degree (combined user + logUp),
       lookup_prefix_len, node_count
-    - `node_count` tagged nodes (children are u32 NodeIds, never sub-trees):
-      0 Const(u64) · 1 Var(u8 source, u8 offset, u32 index) · 2 Public(u32) ·
+    - `node_count` tagged nodes (dense v5: u16 children, never sub-trees):
+      0 ConstSmall(u16) · 1 ConstBig(u64) · 2 Public(u8) ·
       3 IsFirstRow · 4 IsLastRow · 5 IsTransition ·
-      6 Add(u32,u32) · 7 Sub(u32,u32) · 8 Mul(u32,u32) · 9 Neg(u32)
-    - u32 zero_count, then that many u32 constraint-root NodeIds (USER
+      6 Add(u16,u16) · 7 Sub(u16,u16) · 8 Mul(u16,u16) · 9 Neg(u16) ·
+      10..15 Var(u16 index) with (source, offset) packed in the tag
+      (tag = 10 + 2·source + offset)
+    - u32 zero_count, then that many u16 constraint-root NodeIds (USER
       constraints only — the logUp constraints are never compiled)
-    - u32 lookup_count, then the compiled lookups (u32 multiplicity NodeId,
-      u32 arg count, arg NodeIds) — these drive the verifier's direct
+    - u32 lookup_count, then the compiled lookups (u16 multiplicity NodeId,
+      u16 arg count, u16 arg NodeIds) — these drive the verifier's direct
       logUp constraint evaluation (`Verifier.lean`).
 * TRAILER: preprocessed commit (`0` = None / `1` + MerkleCap) then one u16
   per circuit for the preprocessed index (`0xFFFF` = None).
@@ -181,34 +183,39 @@ def systemDeserialize := ⟦
   -- are u32 NodeIds — there is no recursion over sub-expressions.
   -- ==========================================================================
 
+  -- Dense (v5) node encoding: u16 child ids and column indices; the Var
+  -- (source, offset) pair packed into the tag (10 + 2·source + offset);
+  -- small (u16) / big (u64) constant split; u8 public index.
   fn read_node(i: G) -> (SysNode, G) {
     let (tag, i1) = #read_vk_tag(i);
     match tag {
-      0 => let (c, i2) = #read_field(i1); (SysNode.Const(c), i2),
-      1 =>
-        let (s, i2) = #read_vk_tag(i1);
-        let (o, i3) = #read_vk_tag(i2);
-        let (idx, i4) = #read_vk_u32(i3);
-        (SysNode.Var(s, o, idx), i4),
-      2 => let (idx, i2) = #read_vk_u32(i1); (SysNode.Public(idx), i2),
+      0 => let (c, i2) = #read_vk_u16(i1); (SysNode.Const(c), i2),
+      1 => let (c, i2) = #read_field(i1); (SysNode.Const(c), i2),
+      2 => let (idx, i2) = #read_vk_tag(i1); (SysNode.Public(idx), i2),
       3 => (SysNode.IsFirstRow, i1),
       4 => (SysNode.IsLastRow, i1),
       5 => (SysNode.IsTransition, i1),
       6 =>
-        let (a, i2) = #read_vk_u32(i1);
-        let (b, i3) = #read_vk_u32(i2);
+        let (a, i2) = #read_vk_u16(i1);
+        let (b, i3) = #read_vk_u16(i2);
         (SysNode.Add(a, b), i3),
       7 =>
-        let (a, i2) = #read_vk_u32(i1);
-        let (b, i3) = #read_vk_u32(i2);
+        let (a, i2) = #read_vk_u16(i1);
+        let (b, i3) = #read_vk_u16(i2);
         (SysNode.Sub(a, b), i3),
       8 =>
-        let (a, i2) = #read_vk_u32(i1);
-        let (b, i3) = #read_vk_u32(i2);
+        let (a, i2) = #read_vk_u16(i1);
+        let (b, i3) = #read_vk_u16(i2);
         (SysNode.Mul(a, b), i3),
-      _ =>
-        let (a, i2) = #read_vk_u32(i1);
+      9 =>
+        let (a, i2) = #read_vk_u16(i1);
         (SysNode.Neg(a), i2),
+      10 => let (idx, i2) = #read_vk_u16(i1); (SysNode.Var(0, 0, idx), i2),
+      11 => let (idx, i2) = #read_vk_u16(i1); (SysNode.Var(0, 1, idx), i2),
+      12 => let (idx, i2) = #read_vk_u16(i1); (SysNode.Var(1, 0, idx), i2),
+      13 => let (idx, i2) = #read_vk_u16(i1); (SysNode.Var(1, 1, idx), i2),
+      14 => let (idx, i2) = #read_vk_u16(i1); (SysNode.Var(2, 0, idx), i2),
+      _ => let (idx, i2) = #read_vk_u16(i1); (SysNode.Var(2, 1, idx), i2),
     }
   }
 
@@ -222,20 +229,20 @@ def systemDeserialize := ⟦
     }
   }
 
-  -- A run of u32 NodeIds (the `zeros` constraint roots).
+  -- A run of u16 NodeIds (constraint roots / lookup argument ids).
   fn read_node_ids_n(i: G, n: G) -> (List‹G›, G) {
     match n {
       0 => (store(ListNode.Nil), i),
       _ =>
-        let (id, i1) = #read_vk_u32(i);
+        let (id, i1) = #read_vk_u16(i);
         let (rest, i2) = read_node_ids_n(i1, n - 1);
         (store(ListNode.Cons(id, rest)), i2),
     }
   }
 
   fn read_sys_lookup(i: G) -> (SysLookup, G) {
-    let (m, i1) = #read_vk_u32(i);
-    let (ac, i2) = #read_vk_u32(i1);
+    let (m, i1) = #read_vk_u16(i);
+    let (ac, i2) = #read_vk_u16(i1);
     let (args, i3) = read_node_ids_n(i2, ac);
     (SysLookup.Mk(m, args), i3)
   }

--- a/Ix/MultiStark/SystemDeserialize.lean
+++ b/Ix/MultiStark/SystemDeserialize.lean
@@ -8,29 +8,42 @@ public import Ix.MultiStark.Deserialize
 # Verifying-key deserializer (Aiur)
 
 Aiur port of `crates/aiur/src/vk_codec.rs` — reconstructs the verifier's
-`System<AiurCircuit>` from the bytes the prover places on the IO channel.
+`System<AiurConfig>` from the bytes the prover places on the IO channel.
 
-Split-streams wire format (v2, mirrors `vk_codec.rs` — see its module docs
-for the full layout): a global header (7 × u16 parameters + u16 circuit
-count), then one contiguous record per circuit — 5 × u32 segment lengths
-followed by the TAGS / IDX / C2 / C8 / META segments — then the trailer
-(preprocessed commit + u16 preprocessed indices, `0xFFFF` = None). Every
-field class has a single fixed width, so all reads are static-size
-`io_read` chunks:
+Wire format (v3, mirrors `vk_codec.rs` — see its module docs for the full
+layout). The multi-stark constraint-IR migration replaced the per-circuit
+*symbolic* AIR (`SymbolicExpression` trees + `LookupAir`) with a *compiled*
+flat base-field node graph, so this reader parses that compiled form:
 
-* TAGS : 1 byte per node — low nibble = kind, high nibble = aux
-         (Variable: entry kind + 8·rotation; Constant: size class)
-* IDX  : u16 per Variable (column index)
-* C2   : u16 per small constant; C8 : u64 per large constant
-* META : u32 per count / metadata field
+* GLOBAL HEADER: 7 × u16 parameters + u16 circuit count.
+* PER-CIRCUIT RECORD: a `u32 LE len` prefix followed by exactly `len`
+  contiguous bytes —
+    - 8 × u32: main_width, preprocessed_width, preprocessed_height,
+      num_publics, stage_2_width, max_constraint_degree, lookup_prefix_len,
+      node_count
+    - `node_count` tagged nodes (children are u32 NodeIds, never sub-trees):
+      0 Const(u64) · 1 Var(u8 source, u8 offset, u32 index) · 2 Public(u32) ·
+      3 IsFirstRow · 4 IsLastRow · 5 IsTransition ·
+      6 Add(u32,u32) · 7 Sub(u32,u32) · 8 Mul(u32,u32) · 9 Neg(u32)
+    - u32 zero_count, then that many u32 constraint-root NodeIds
+    - u32 lookup_count, then the compiled lookups (multiplicity + args as
+      NodeIds) — the verifier does NOT need these (the lookup argument's
+      constraints are compiled into `zeros`), so the reader SKIPS them via
+      the record length prefix.
+* TRAILER: preprocessed commit (`0` = None / `1` + MerkleCap) then one u16
+  per circuit for the preprocessed index (`0xFFFF` = None).
 
-`degree_multiple` is not on the wire (and unused by the verifier — the
-constraint folder just evaluates the tree), so `SymExpr` no longer carries
-it. The vk stream (IO channel 1) is read by byte offset — the readers
-thread one cursor per segment; the record header binds the cursors and the
-per-record end asserts pin each segment's exact consumption. The leaf
-fetches are unconstrained — the digest binding (`b3_io` over the whole
-arena) is what makes the bytes meaningful.
+The vk stream (IO channel 1) is read by byte offset with a single cursor —
+a v3 record is a contiguous byte range, so there are no separate segment
+cursors. The leaf fetches are unconstrained; the digest binding (`b3_io`
+over the whole arena, bound to the public `system_digest`) is what makes
+the bytes meaningful. Per-node degrees are neither serialized nor needed
+(the node sweep just evaluates the graph).
+
+The Fiat-Shamir shape limbs are unchanged from v2: `observe_shape` still
+feeds the challenger the circuit count then, per circuit, the six words
+constraint_count, max_constraint_degree, preprocessed_height,
+preprocessed_width, main_width, stage_2_width (as 8-byte LE limbs).
 -/
 
 public section
@@ -39,53 +52,31 @@ namespace MultiStark
 
 def systemDeserialize := ⟦
   -- ==========================================================================
-  -- Reconstructed `System<AiurCircuit>` as Aiur data.
+  -- Reconstructed `System<AiurConfig>` as Aiur data (compiled form).
   -- ==========================================================================
 
-  -- `SymbolicVariable.entry` (a column reference within the window). The
-  -- payload of Preprocessed/Main/Stage2 is the rotation offset (0 or 1).
-  enum SysEntry {
-    Preprocessed(G),
-    Main(G),
-    Stage2(G),
-    Public,
-    Stage2Public,
-    Challenge
-  }
-
-  -- `SymbolicExpression<G>` — the AIR constraint tree. Children are pointers.
-  -- (`degree_multiple` is not materialized: the wire drops it and the
-  -- constraint folder never reads it.)
-  enum SymExpr {
-    Var(SysEntry, G),            -- entry, index
+  -- A compiled constraint node (`multi_stark::circuit::Node`). Children of
+  -- Add/Sub/Mul/Neg are NodeIds (indices into the circuit's node vector),
+  -- not sub-trees: the graph is flat and topologically ordered (a node's
+  -- children always have smaller indices).
+  enum SysNode {
+    Const(G),            -- native Goldilocks constant (reduced on read)
+    Var(G, G, G),        -- source (0 Preprocessed, 1 Main, 2 Stage2), offset (0 current, 1 next), column index
+    Public(G),           -- public-input coordinate index
     IsFirstRow,
     IsLastRow,
     IsTransition,
-    Const(G),                   -- a native Goldilocks constant (reduced on read)
-    Add(&SymExpr, &SymExpr),
-    Sub(&SymExpr, &SymExpr),
-    Neg(&SymExpr),
-    Mul(&SymExpr, &SymExpr)
+    Add(G, G),           -- child NodeIds
+    Sub(G, G),
+    Mul(G, G),
+    Neg(G)
   }
 
-  enum SysLookup { Mk(SymExpr, List‹SymExpr›) }          -- multiplicity, args
-
-  enum SysConstraints { Mk(List‹SymExpr›, G, G, G) }     -- zeros, sel_start, sel_end, width
-
-  enum SysMemory { Mk(G) }                               -- width
-
-  enum SysAir {
-    Function(SysConstraints),
-    Memory(SysMemory),
-    Bytes1,
-    Bytes2
-  }
-
-  enum SysLookupAir { Mk(SysAir, List‹SysLookup›) }      -- inner_air, lookups
-
-  -- air, constraint_count, max_constraint_degree, preprocessed_height,
-  -- preprocessed_width, stage_1_width, stage_2_width.
-  enum SysCircuit { Mk(SysLookupAir, G, G, G, G, G, G) }
+  -- A compiled circuit: the flat node vector, its length, the constraint-root
+  -- NodeIds (`zeros`), and the maximum constraint degree (for the quotient
+  -- degree). The lookups are omitted — their constraints are compiled into
+  -- `zeros`, so the verifier never needs them.
+  enum SysCircuit { Mk(List‹SysNode›, G, List‹G›, G) }   -- nodes, node_count, zeros, max_constraint_degree
 
   -- log_blowup, cap_height, log_final_poly_len, max_log_arity, num_queries,
   -- commit_proof_of_work_bits, query_proof_of_work_bits — the commitment + FRI
@@ -101,9 +92,7 @@ def systemDeserialize := ⟦
   -- challenger observes before any commitment — the 7 parameters (bound via
   -- the challenger seed) followed by the system shape (`observe_shape`: the
   -- circuit count, then 6 metadata words per circuit) — kept as limbs because
-  -- the Fiat-Shamir replay needs their little-endian bytes. The OBSERVED
-  -- values are width-independent, so the narrow wire fields pad to the same
-  -- 8-byte limbs v1 produced.
+  -- the Fiat-Shamir replay needs their little-endian bytes.
   enum Sys { Mk(SysParams, List‹U64›, List‹SysCircuit›, OptCommit, List‹OptIdx›) }
 
   -- ==========================================================================
@@ -117,7 +106,8 @@ def systemDeserialize := ⟦
     (u8_from_field_unsafe(b), i + 1)
   }
 
-  -- A TAGS byte, kept as a raw field value for match dispatch.
+  -- A single byte kept as a raw field value for match dispatch (tags, source,
+  -- offset).
   fn read_vk_tag(i: G) -> (G, G) {
     let [b] = io_read(1, i, 1);
     (b, i + 1)
@@ -158,7 +148,7 @@ def systemDeserialize := ⟦
       u8_from_field_unsafe(b6), u8_from_field_unsafe(b7)], i + 8)
   }
 
-  -- A large (C8) Goldilocks constant, reduced into a native field value so it
+  -- A full (u64) Goldilocks constant, reduced into a native field value so it
   -- can feed the composition arithmetic directly.
   fn read_field(i: G) -> (G, G) {
     let (u, j) = #read_vk_u64(i);
@@ -183,127 +173,86 @@ def systemDeserialize := ⟦
   }
 
   -- ==========================================================================
-  -- Expression reader. Cursors: t = TAGS, x = IDX, a = C2, b = C8. The tag
-  -- byte packs kind (low nibble) + aux (high nibble); the match keys are the
-  -- whole byte values (kind + 16·aux).
+  -- Node reader. A node is a single tagged record whose children (when any)
+  -- are u32 NodeIds — there is no recursion over sub-expressions.
   -- ==========================================================================
 
-  fn read_sym_expr(t: G, x: G, a: G, b: G) -> (SymExpr, G, G, G, G) {
-    let (tag, t1) = #read_vk_tag(t);
+  fn read_node(i: G) -> (SysNode, G) {
+    let (tag, i1) = #read_vk_tag(i);
     match tag {
-      -- Var: aux = entry kind + 8·rotation
-      0 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Preprocessed(0), i), t1, x1, a, b),
-      16 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Main(0), i), t1, x1, a, b),
-      32 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Stage2(0), i), t1, x1, a, b),
-      48 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Public, i), t1, x1, a, b),
-      64 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Stage2Public, i), t1, x1, a, b),
-      80 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Challenge, i), t1, x1, a, b),
-      128 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Preprocessed(1), i), t1, x1, a, b),
-      144 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Main(1), i), t1, x1, a, b),
-      160 => let (i, x1) = #read_vk_u16(x); (SymExpr.Var(SysEntry.Stage2(1), i), t1, x1, a, b),
-      1 => (SymExpr.IsFirstRow, t1, x, a, b),
-      2 => (SymExpr.IsLastRow, t1, x, a, b),
-      3 => (SymExpr.IsTransition, t1, x, a, b),
-      -- Const: aux = size class (0 -> C2, 1 -> C8)
-      4 => let (c, a1) = #read_vk_u16(a); (SymExpr.Const(c), t1, x, a1, b),
-      20 => let (c, b1) = #read_field(b); (SymExpr.Const(c), t1, x, a, b1),
-      5 =>
-        let (l, t2, x2, a2, b2) = read_sym_expr(t1, x, a, b);
-        let (r, t3, x3, a3, b3) = read_sym_expr(t2, x2, a2, b2);
-        (SymExpr.Add(store(l), store(r)), t3, x3, a3, b3),
+      0 => let (c, i2) = #read_field(i1); (SysNode.Const(c), i2),
+      1 =>
+        let (s, i2) = #read_vk_tag(i1);
+        let (o, i3) = #read_vk_tag(i2);
+        let (idx, i4) = #read_vk_u32(i3);
+        (SysNode.Var(s, o, idx), i4),
+      2 => let (idx, i2) = #read_vk_u32(i1); (SysNode.Public(idx), i2),
+      3 => (SysNode.IsFirstRow, i1),
+      4 => (SysNode.IsLastRow, i1),
+      5 => (SysNode.IsTransition, i1),
       6 =>
-        let (l, t2, x2, a2, b2) = read_sym_expr(t1, x, a, b);
-        let (r, t3, x3, a3, b3) = read_sym_expr(t2, x2, a2, b2);
-        (SymExpr.Sub(store(l), store(r)), t3, x3, a3, b3),
+        let (a, i2) = #read_vk_u32(i1);
+        let (b, i3) = #read_vk_u32(i2);
+        (SysNode.Add(a, b), i3),
       7 =>
-        let (l, t2, x2, a2, b2) = read_sym_expr(t1, x, a, b);
-        (SymExpr.Neg(store(l)), t2, x2, a2, b2),
+        let (a, i2) = #read_vk_u32(i1);
+        let (b, i3) = #read_vk_u32(i2);
+        (SysNode.Sub(a, b), i3),
+      8 =>
+        let (a, i2) = #read_vk_u32(i1);
+        let (b, i3) = #read_vk_u32(i2);
+        (SysNode.Mul(a, b), i3),
       _ =>
-        let (l, t2, x2, a2, b2) = read_sym_expr(t1, x, a, b);
-        let (r, t3, x3, a3, b3) = read_sym_expr(t2, x2, a2, b2);
-        (SymExpr.Mul(store(l), store(r)), t3, x3, a3, b3),
+        let (a, i2) = #read_vk_u32(i1);
+        (SysNode.Neg(a), i2),
     }
   }
 
-  fn read_sym_exprs_n(t: G, x: G, a: G, b: G, n: G) -> (List‹SymExpr›, G, G, G, G) {
+  fn read_nodes_n(i: G, n: G) -> (List‹SysNode›, G) {
     match n {
-      0 => (store(ListNode.Nil), t, x, a, b),
+      0 => (store(ListNode.Nil), i),
       _ =>
-        let (e, t1, x1, a1, b1) = read_sym_expr(t, x, a, b);
-        let (rest, t2, x2, a2, b2) = read_sym_exprs_n(t1, x1, a1, b1, n - 1);
-        (store(ListNode.Cons(e, rest)), t2, x2, a2, b2),
+        let (nd, i1) = read_node(i);
+        let (rest, i2) = read_nodes_n(i1, n - 1);
+        (store(ListNode.Cons(nd, rest)), i2),
     }
   }
 
-  -- ==========================================================================
-  -- Circuit readers. Cursor m = META joins for the count/metadata fields.
-  -- ==========================================================================
-
-  fn read_sys_lookup(t: G, x: G, a: G, b: G, m: G) -> (SysLookup, G, G, G, G, G) {
-    let (mul, t1, x1, a1, b1) = read_sym_expr(t, x, a, b);
-    let (na, m1) = #read_vk_u32(m);
-    let (args, t2, x2, a2, b2) = read_sym_exprs_n(t1, x1, a1, b1, na);
-    (SysLookup.Mk(mul, args), t2, x2, a2, b2, m1)
-  }
-  fn read_sys_lookups_n(t: G, x: G, a: G, b: G, m: G, n: G) -> (List‹SysLookup›, G, G, G, G, G) {
+  -- A run of u32 NodeIds (the `zeros` constraint roots).
+  fn read_node_ids_n(i: G, n: G) -> (List‹G›, G) {
     match n {
-      0 => (store(ListNode.Nil), t, x, a, b, m),
+      0 => (store(ListNode.Nil), i),
       _ =>
-        let (l, t1, x1, a1, b1, m1) = read_sys_lookup(t, x, a, b, m);
-        let (rest, t2, x2, a2, b2, m2) = read_sys_lookups_n(t1, x1, a1, b1, m1, n - 1);
-        (store(ListNode.Cons(l, rest)), t2, x2, a2, b2, m2),
+        let (id, i1) = #read_vk_u32(i);
+        let (rest, i2) = read_node_ids_n(i1, n - 1);
+        (store(ListNode.Cons(id, rest)), i2),
     }
   }
 
-  fn read_sys_air(t: G, x: G, a: G, b: G, m: G) -> (SysAir, G, G, G, G, G) {
-    let (tag, t1) = #read_vk_tag(t);
-    match tag {
-      0 =>
-        let (nz, m1) = #read_vk_u32(m);
-        let (zeros, t2, x2, a2, b2) = read_sym_exprs_n(t1, x, a, b, nz);
-        let (ss, m2) = #read_vk_u32(m1);
-        let (se, m3) = #read_vk_u32(m2);
-        let (w, m4) = #read_vk_u32(m3);
-        (SysAir.Function(SysConstraints.Mk(zeros, ss, se, w)), t2, x2, a2, b2, m4),
-      1 => let (w, m1) = #read_vk_u32(m); (SysAir.Memory(SysMemory.Mk(w)), t1, x, a, b, m1),
-      2 => (SysAir.Bytes1, t1, x, a, b, m),
-      _ => (SysAir.Bytes2, t1, x, a, b, m),
-    }
-  }
-
-  -- One circuit record: 5 × u32 segment lengths, then the segments. Besides
-  -- the parsed circuit, also returns its 6 metadata words as u64 limbs —
-  -- `observe_shape` feeds exactly these bytes into the challenger. The end
-  -- asserts pin every segment to exact consumption, binding the header
-  -- lengths to the parsed structure.
+  -- One circuit record: a u32 length prefix then the contiguous record. The
+  -- 8-word header, the node stream, and the zeros are parsed; the compiled
+  -- lookups (which the verifier does not use) are skipped by jumping to the
+  -- record end via the length prefix. Besides the parsed circuit, returns its
+  -- 6 shape words as u64 limbs, in `observe_shape` order: constraint_count
+  -- (= zero_count), max_constraint_degree, preprocessed_height,
+  -- preprocessed_width, main_width, stage_2_width.
   fn read_sys_circuit(base: G) -> (SysCircuit, [U64; 6], G) {
-    let (lt, h1) = #read_vk_u32(base);
-    let (lx, h2) = #read_vk_u32(h1);
-    let (la, h3) = #read_vk_u32(h2);
-    let (lb, h4) = #read_vk_u32(h3);
-    let (lm, h5) = #read_vk_u32(h4);
-    let t0 = h5;
-    let x0 = t0 + lt;
-    let a0 = x0 + lx;
-    let b0 = a0 + la;
-    let m0 = b0 + lb;
-    let rend = m0 + lm;
-    let (air, t1, x1, a1, b1, m1) = read_sys_air(t0, x0, a0, b0, m0);
-    let (nl, m2) = #read_vk_u32(m1);
-    let (lookups, t2, x2, a2, b2, m3) = read_sys_lookups_n(t1, x1, a1, b1, m2, nl);
-    let (cc, ccl, m4) = #read_vk_u32_limb(m3);
-    let (md, mdl, m5) = #read_vk_u32_limb(m4);
-    let (ph, phl, m6) = #read_vk_u32_limb(m5);
-    let (pw, pwl, m7) = #read_vk_u32_limb(m6);
-    let (w1, w1l, m8) = #read_vk_u32_limb(m7);
-    let (w2, w2l, m9) = #read_vk_u32_limb(m8);
-    assert_eq!(t2, x0);
-    assert_eq!(x2, a0);
-    assert_eq!(a2, b0);
-    assert_eq!(b2, m0);
-    assert_eq!(m9, rend);
-    (SysCircuit.Mk(SysLookupAir.Mk(air, lookups), cc, md, ph, pw, w1, w2),
-     [ccl, mdl, phl, pwl, w1l, w2l], rend)
+    let (rec_len, r0) = #read_vk_u32(base);
+    let (mw, mwl, c1) = #read_vk_u32_limb(r0);
+    let (pw, pwl, c2) = #read_vk_u32_limb(c1);
+    let (ph, phl, c3) = #read_vk_u32_limb(c2);
+    let (np, c4) = #read_vk_u32(c3);
+    let (s2w, s2wl, c5) = #read_vk_u32_limb(c4);
+    let (md, mdl, c6) = #read_vk_u32_limb(c5);
+    let (lpl, c7) = #read_vk_u32(c6);
+    let (ncount, c8) = #read_vk_u32(c7);
+    let (nodes, c9) = read_nodes_n(c8, ncount);
+    let (zcount, zcl, c10) = #read_vk_u32_limb(c9);
+    let (zeros, c11) = read_node_ids_n(c10, zcount);
+    -- The remaining bytes of the record are the compiled lookups; skip them.
+    let rend = r0 + rec_len;
+    (SysCircuit.Mk(nodes, ncount, zeros, md),
+     [zcl, mdl, phl, pwl, mwl, s2wl], rend)
   }
   fn cons_shape6(l: [U64; 6], tail: List‹U64›) -> List‹U64› {
     store(ListNode.Cons(l[0], store(ListNode.Cons(l[1], store(ListNode.Cons(l[2],
@@ -367,7 +316,7 @@ def systemDeserialize := ⟦
      j6)
   }
 
-  -- Full `System<AiurCircuit>`, read from the channel-1 IO arena starting at
+  -- Full `System<AiurConfig>`, read from the channel-1 IO arena starting at
   -- byte offset `i`. Returns the end offset; the entrypoint asserts full
   -- consumption.
   fn read_system(i: G) -> (Sys, G) {

--- a/Ix/MultiStark/SystemDeserialize.lean
+++ b/Ix/MultiStark/SystemDeserialize.lean
@@ -16,21 +16,20 @@ layout). The multi-stark constraint-IR migration replaced the per-circuit
 flat base-field node graph, so this reader parses that compiled form:
 
 * GLOBAL HEADER: 7 × u16 parameters + u16 circuit count.
-* PER-CIRCUIT RECORD: a `u32 LE len` prefix followed by exactly `len`
-  contiguous bytes —
-    - 8 × u32: main_width, preprocessed_width, preprocessed_height,
-      constraint_count (user roots + (L+3)·D — the `observe_shape` value),
-      stage_2_width, max_constraint_degree (combined user + logUp),
-      lookup_prefix_len, node_count
+* PER-CIRCUIT RECORD (no framing prefix; nothing derivable is serialized —
+  constraint_count, stage_2_width, num_publics, and lookup_prefix_len are
+  all recomputed from the counts below):
+    - u16 main_width, u16 preprocessed_width, u32 preprocessed_height,
+      u16 max_constraint_degree (combined user + logUp), u16 node_count
     - `node_count` tagged nodes (dense v5: u16 children, never sub-trees):
       0 ConstSmall(u16) · 1 ConstBig(u64) · 2 Public(u8) ·
       3 IsFirstRow · 4 IsLastRow · 5 IsTransition ·
       6 Add(u16,u16) · 7 Sub(u16,u16) · 8 Mul(u16,u16) · 9 Neg(u16) ·
       10..15 Var(u16 index) with (source, offset) packed in the tag
       (tag = 10 + 2·source + offset)
-    - u32 zero_count, then that many u16 constraint-root NodeIds (USER
+    - u16 zero_count, then that many u16 constraint-root NodeIds (USER
       constraints only — the logUp constraints are never compiled)
-    - u32 lookup_count, then the compiled lookups (u16 multiplicity NodeId,
+    - u16 lookup_count, then the compiled lookups (u16 multiplicity NodeId,
       u16 arg count, u16 arg NodeIds) — these drive the verifier's direct
       logUp constraint evaluation (`Verifier.lean`).
 * TRAILER: preprocessed commit (`0` = None / `1` + MerkleCap) then one u16
@@ -264,25 +263,24 @@ def systemDeserialize := ⟦
   -- from the header), max_constraint_degree (combined),
   -- preprocessed_height, preprocessed_width, main_width, stage_2_width.
   fn read_sys_circuit(base: G) -> (SysCircuit, [U64; 6], G) {
-    let (rec_len, r0) = #read_vk_u32(base);
-    let (mw, mwl, c1) = #read_vk_u32_limb(r0);
-    let (pw, pwl, c2) = #read_vk_u32_limb(c1);
+    let (mw, mwl, c1) = #read_vk_u16_limb(base);
+    let (pw, pwl, c2) = #read_vk_u16_limb(c1);
     let (ph, phl, c3) = #read_vk_u32_limb(c2);
-    let (cc, ccl, c4) = #read_vk_u32_limb(c3);
-    let (s2w, s2wl, c5) = #read_vk_u32_limb(c4);
-    let (md, mdl, c6) = #read_vk_u32_limb(c5);
-    let (lpl, c7) = #read_vk_u32(c6);
-    let (ncount, c8) = #read_vk_u32(c7);
-    let (nodes, c9) = read_nodes_n(c8, ncount);
-    let (zcount, c10) = #read_vk_u32(c9);
-    let (zeros, c11) = read_node_ids_n(c10, zcount);
-    let (lcount, c12) = #read_vk_u32(c11);
-    let (lks, c13) = read_sys_lookups_n(c12, lcount);
-    -- The record length prefix must frame exactly the parsed content.
-    let rend = r0 + rec_len;
-    assert_eq!(rend - c13, 0);
+    let (md, mdl, c4) = #read_vk_u16_limb(c3);
+    let (ncount, c5) = #read_vk_u16(c4);
+    let (nodes, c6) = read_nodes_n(c5, ncount);
+    let (zcount, c7) = #read_vk_u16(c6);
+    let (zeros, c8) = read_node_ids_n(c7, zcount);
+    let (lcount, c9) = #read_vk_u16(c8);
+    let (lks, c10) = read_sys_lookups_n(c9, lcount);
+    -- Derived shape values (not serialized): constraint_count = user roots
+    -- + (L+3)·D and stage_2_width = (1+L)·D, their observation limbs built
+    -- by byte decomposition (both values are far below 2^32, so the
+    -- canonical decomposition IS the little-endian u64 limb).
+    let ccl = gl_to_bytes(zcount + 2 * (lcount + 3));
+    let s2wl = gl_to_bytes(2 * (1 + lcount));
     (SysCircuit.Mk(nodes, ncount, zeros, md, lks),
-     [ccl, mdl, phl, pwl, mwl, s2wl], rend)
+     [ccl, mdl, phl, pwl, mwl, s2wl], c10)
   }
   fn cons_shape6(l: [U64; 6], tail: List‹U64›) -> List‹U64› {
     store(ListNode.Cons(l[0], store(ListNode.Cons(l[1], store(ListNode.Cons(l[2],

--- a/Ix/MultiStark/Verifier.lean
+++ b/Ix/MultiStark/Verifier.lean
@@ -535,143 +535,109 @@ def verifier := ⟦
     }
   }
 
-  -- Evaluate a symbolic AIR expression at the opened point (Rust:
-  -- `SymbolicExpression::interpret`). Function-circuit `zeros` and lookup
-  -- args/multiplicities only ever reference `Main`/`Preprocessed` entries
-  -- (offset 0) and constants; the other entries never appear here.
-  fn eval_sym(e: SymExpr, main: List‹Ext›, prep: List‹Ext›) -> Ext {
-    match e {
-      SymExpr.Var(entry, idx) =>
-        match entry {
-          SysEntry.Main(_o) => list_lookup(main, idx),
-          SysEntry.Preprocessed(_o) => list_lookup(prep, idx),
-          SysEntry.Stage2(_o) => [0, 0],
-          SysEntry.Public => [0, 0],
-          SysEntry.Stage2Public => [0, 0],
-          SysEntry.Challenge => [0, 0],
+  -- ==========================================================================
+  -- Compiled node-graph evaluation (replaces the symbolic AIR folder).
+  --
+  -- The composition polynomial at ζ is `Σᵢ α^(k-1-i)·zeroᵢ`, where each `zeroᵢ`
+  -- is the value of a constraint-root node. The nodes form a flat,
+  -- topologically ordered graph (children precede parents), so one forward
+  -- sweep computes an ExtVal per node (Rust: `multi_stark::eval`'s dense
+  -- sweep). The buffer is built in REVERSE (prepend; head = most recent):
+  -- when the k-th node (0-based) is processed the buffer holds k values
+  -- `[v_{k-1}, …, v_0]`, so child NodeId `c` sits at buffer index `k-1-c`. The
+  -- lookup-argument constraints are already compiled into `zeros`, so nothing
+  -- special is done for them (Rust `verifier.rs` evaluates one node graph and
+  -- Horner-folds the roots).
+  -- ==========================================================================
+
+  -- A node child's value from the FORWARD buffer: node `c`'s value sits at
+  -- buffer index `c` (children always have smaller NodeIds than their parent,
+  -- so they are already present).
+  fn buf_child(buf: List‹Ext›, c: G) -> Ext {
+    list_lookup(buf, c)
+  }
+
+  -- Evaluate one node into an ExtVal, given the forward buffer and the leaf
+  -- context. Stage-2 columns are the OPENED BASE columns used directly (no
+  -- `from_ext_basis` reassembly).
+  fn eval_node(nd: SysNode, buf: List‹Ext›,
+      main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
+      s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
+      isf: Ext, isl: Ext, ist: Ext) -> Ext {
+    match nd {
+      SysNode.Const(c) => [c, 0],
+      SysNode.Var(src, off, idx) =>
+        -- flatten (source, offset) into one selector: 2·source + offset,
+        -- with source 0 Preprocessed / 1 Main / 2 Stage2, offset 0 cur / 1 next.
+        let sel = src + src + off;
+        match sel {
+          0 => list_lookup(prep, idx),
+          1 => list_lookup(prep_next, idx),
+          2 => list_lookup(main, idx),
+          3 => list_lookup(main_next, idx),
+          4 => list_lookup(s2, idx),
+          _ => list_lookup(s2next, idx),
         },
-      SymExpr.IsFirstRow => [0, 0],
-      SymExpr.IsLastRow => [0, 0],
-      SymExpr.IsTransition => [0, 0],
-      SymExpr.Const(c) => [c, 0],
-      SymExpr.Add(x, y) => eg_add(eval_sym(load(x), main, prep), eval_sym(load(y), main, prep)),
-      SymExpr.Sub(x, y) => eg_sub(eval_sym(load(x), main, prep), eval_sym(load(y), main, prep)),
-      SymExpr.Neg(x) => eg_neg(eval_sym(load(x), main, prep)),
-      SymExpr.Mul(x, y) => eg_mul(eval_sym(load(x), main, prep), eval_sym(load(y), main, prep)),
+      SysNode.Public(idx) => list_lookup(publics, idx),
+      SysNode.IsFirstRow => isf,
+      SysNode.IsLastRow => isl,
+      SysNode.IsTransition => ist,
+      SysNode.Add(a, b) => eg_add(buf_child(buf, a), buf_child(buf, b)),
+      SysNode.Sub(a, b) => eg_sub(buf_child(buf, a), buf_child(buf, b)),
+      SysNode.Mul(a, b) => eg_mul(buf_child(buf, a), buf_child(buf, b)),
+      SysNode.Neg(a) => eg_neg(buf_child(buf, a)),
     }
   }
 
-  -- `fingerprint(r, args) = Σ argᵢ·rⁱ` (Horner over the reversed argument list,
-  -- `lookup.rs::fingerprint`).
-  fn fingerprint_ext(r: Ext, args: List‹SymExpr›, main: List‹Ext›, prep: List‹Ext›) -> Ext {
-    match load(args) {
-      ListNode.Nil => [0, 0],
-      ListNode.Cons(a, rest) =>
-        eg_add(eval_sym(a, main, prep), eg_mul(r, fingerprint_ext(r, rest, main, prep))),
+  -- Forward sweep: append each node's value so that `buf[i]` is node `i`'s
+  -- value. `buf` starts `Nil`.
+  fn sweep_nodes(nodes: List‹SysNode›, buf: List‹Ext›,
+      main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
+      s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
+      isf: Ext, isl: Ext, ist: Ext) -> List‹Ext› {
+    match load(nodes) {
+      ListNode.Nil => buf,
+      ListNode.Cons(nd, rest) =>
+        let v = eval_node(nd, buf, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+        sweep_nodes(rest, list_concat(buf, store(ListNode.Cons(v, store(ListNode.Nil)))),
+                    main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
     }
   }
 
-  -- Fold the inner-AIR `zeros` constraints (Function circuit): each is asserted
-  -- zero on the main (stage-1) row, with no preprocessed row.
-  fn fold_zeros(acc: Ext, alpha: Ext, zeros: List‹SymExpr›, main: List‹Ext›) -> Ext {
+  -- Horner-fold the constraint roots with α: `acc := acc·α + buf[z]` for each
+  -- root NodeId `z`, in `zeros` order (the canonical compiled order the prover
+  -- folded in).
+  fn fold_roots(acc: Ext, alpha: Ext, zeros: List‹G›, buf: List‹Ext›) -> Ext {
     match load(zeros) {
       ListNode.Nil => acc,
       ListNode.Cons(z, rest) =>
-        fold_zeros(ood_fold(acc, alpha, eval_sym(z, main, store(ListNode.Nil))), alpha, rest, main),
+        let v = list_lookup(buf, z);
+        fold_roots(ood_fold(acc, alpha, v), alpha, rest, buf),
     }
   }
 
-  -- Fold the selector boolean checks (Function circuit): `assert_bool(row[s])`
-  -- = `assert_zero(s·(s-1))` for `s` in the selector range `[idx, idx+count)`.
-  fn fold_sel_bools(acc: Ext, alpha: Ext, main: List‹Ext›, idx: G, count: G) -> Ext {
-    match count {
-      0 => acc,
-      _ =>
-        let x = list_lookup(main, idx);
-        let bc = eg_mul(x, eg_sub(x, [1, 0]));
-        fold_sel_bools(ood_fold(acc, alpha, bc), alpha, main, idx + 1, count - 1),
-    }
+  -- The composition polynomial `composition(ζ)` for one circuit: sweep the
+  -- compiled node graph over the opened rows / publics / selectors, then
+  -- Horner-fold the constraint roots with α.
+  fn ood_composition(nodes: List‹SysNode›, zeros: List‹G›,
+      main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
+      s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
+      isf: Ext, isl: Ext, ist: Ext, alpha: Ext) -> Ext {
+    let buf = sweep_nodes(nodes, store(ListNode.Nil),
+                          main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+    fold_roots([0, 0], alpha, zeros, buf)
   }
 
-  -- Fold the per-lookup constraints (`LookupAir::eval`): for lookup `k`,
-  -- `assert_one_ext(messageₖ · minvₖ)` = `assert_zero_ext(messageₖ·minvₖ - 1)`,
-  -- where `minvₖ = stage_2_row[1+k]` and
-  -- `messageₖ = lookup_challenge + fingerprint(fingerprint_challenge, argsₖ)`.
-  -- Simultaneously builds `acc_expr = stage_2_row[0] + Σ multiplicityₖ·minvₖ`.
-  -- Returns `(folder_acc, acc_expr)`.
-  fn fold_lookups(acc: Ext, alpha: Ext, lookups: List‹SysLookup›, k: G,
-      main: List‹Ext›, prep: List‹Ext›, s2row: List‹Ext›,
-      lch: Ext, fch: Ext, acc_expr: Ext) -> (Ext, Ext) {
-    match load(lookups) {
-      ListNode.Nil => (acc, acc_expr),
-      ListNode.Cons(lk, rest) =>
-        let SysLookup.Mk(mult_e, args) = lk;
-        let minv = list_lookup(s2row, k + 1);
-        let mult = eval_sym(mult_e, main, prep);
-        let fp = fingerprint_ext(fch, args, main, prep);
-        let message = eg_add(lch, fp);
-        let c = eg_sub(eg_mul(message, minv), [1, 0]);
-        let acc = ood_fold(acc, alpha, c);
-        let acc_expr = eg_add(acc_expr, eg_mul(mult, minv));
-        fold_lookups(acc, alpha, rest, k + 1, main, prep, s2row, lch, fch, acc_expr),
-    }
-  }
-
-  -- The composition polynomial `composition(ζ)` for one circuit: replays the
-  -- inner-AIR constraints (per air kind) followed by the lookup-argument
-  -- constraints, folding each with `α` exactly as `LookupAir::eval` drives the
-  -- verifier folder. `accp`/`naccp` are the current/next lookup accumulators.
-  fn ood_composition(air: SysAir, lookups: List‹SysLookup›,
-      main: List‹Ext›, main_next: List‹Ext›, s2row: List‹Ext›, s2next: List‹Ext›,
-      prep: List‹Ext›, isf: Ext, isl: Ext, ist: Ext,
-      lch: Ext, fch: Ext, accp: Ext, naccp: Ext, alpha: Ext) -> Ext {
-    -- inner-AIR constraints first, then hand the accumulator to the lookup tail
-    -- (split so each `match air` arm ends in a tail call — Aiur forbids
-    -- non-tail matches).
-    match air {
-      SysAir.Function(c) =>
-        let SysConstraints.Mk(zeros, ss, se, _w) = c;
-        let acc = fold_zeros([0, 0], alpha, zeros, main);
-        let acc = fold_sel_bools(acc, alpha, main, ss, se - ss);
-        ood_comp_tail(acc, lookups, main, prep, s2row, s2next, isf, isl, ist, lch, fch, accp, naccp, alpha),
-      SysAir.Memory(m) =>
-        let SysMemory.Mk(_w) = m;
-        -- `Memory::eval`: is_real = col 1, ptr = col 2 (current and next row).
-        let is_real = list_lookup(main, 1);
-        let ptr = list_lookup(main, 2);
-        let is_real_next = list_lookup(main_next, 1);
-        let ptr_next = list_lookup(main_next, 2);
-        -- assert_bool(is_real)
-        let acc = ood_fold([0, 0], alpha, eg_mul(is_real, eg_sub(is_real, [1, 0])));
-        -- is_real_transition = is_real_next · is_transition
-        let irt = eg_mul(is_real_next, ist);
-        -- when(irt).assert_one(is_real) = irt·(is_real - 1)
-        let acc = ood_fold(acc, alpha, eg_mul(irt, eg_sub(is_real, [1, 0])));
-        -- when(irt).assert_eq(ptr+1, ptr_next) = irt·(ptr + 1 - ptr_next)
-        let acc = ood_fold(acc, alpha, eg_mul(irt, eg_sub(eg_add(ptr, [1, 0]), ptr_next)));
-        ood_comp_tail(acc, lookups, main, prep, s2row, s2next, isf, isl, ist, lch, fch, accp, naccp, alpha),
-      SysAir.Bytes1 =>
-        ood_comp_tail([0, 0], lookups, main, prep, s2row, s2next, isf, isl, ist, lch, fch, accp, naccp, alpha),
-      SysAir.Bytes2 =>
-        ood_comp_tail([0, 0], lookups, main, prep, s2row, s2next, isf, isl, ist, lch, fch, accp, naccp, alpha),
-    }
-  }
-
-  -- Tail of `ood_composition`: fold the lookup-argument constraints onto the
-  -- inner-AIR accumulator, then the three accumulator boundary constraints.
-  fn ood_comp_tail(acc: Ext, lookups: List‹SysLookup›, main: List‹Ext›, prep: List‹Ext›,
-      s2row: List‹Ext›, s2next: List‹Ext›, isf: Ext, isl: Ext, ist: Ext,
-      lch: Ext, fch: Ext, accp: Ext, naccp: Ext, alpha: Ext) -> Ext {
-    let (acc, acc_expr) =
-      fold_lookups(acc, alpha, lookups, 0, main, prep, s2row, lch, fch, list_lookup(s2row, 0));
-    let acc_col = list_lookup(s2row, 0);
-    let next_acc_col = list_lookup(s2next, 0);
-    -- when_first_row: acc_col = accp
-    let acc = ood_fold(acc, alpha, eg_mul(isf, eg_sub(acc_col, accp)));
-    -- when_transition: acc_expr = next_acc_col
-    let acc = ood_fold(acc, alpha, eg_mul(ist, eg_sub(acc_expr, next_acc_col)));
-    -- when_last_row: acc_expr = naccp
-    ood_fold(acc, alpha, eg_mul(isl, eg_sub(acc_expr, naccp)))
+  -- The public-input coordinates for one circuit's lookup argument: the base
+  -- coordinates of (β, γ, current acc, next acc), each lifted into ExtVal
+  -- (`EF::from(coord)`). Indexed by the compiled `Public` node index
+  -- (`num_publics = 4·D`, `D = 2`).
+  fn build_publics(lch: Ext, fch: Ext, accp: Ext, naccp: Ext) -> List‹Ext› {
+    store(ListNode.Cons([lch[0], 0], store(ListNode.Cons([lch[1], 0],
+    store(ListNode.Cons([fch[0], 0], store(ListNode.Cons([fch[1], 0],
+    store(ListNode.Cons([accp[0], 0], store(ListNode.Cons([accp[1], 0],
+    store(ListNode.Cons([naccp[0], 0], store(ListNode.Cons([naccp[1], 0],
+    store(ListNode.Nil)))))))))))))))))
   }
 
   -- ==========================================================================
@@ -710,17 +676,17 @@ def verifier := ⟦
     }
   }
 
-  -- The preprocessed opened row at ζ for circuit `i`, or `Nil` if the circuit
-  -- has no preprocessed trace (`preprocessed_indices[i] = None`).
-  fn ood_prep_row(prep_opt: PreprocessedOpt, oi: OptIdx) -> List‹Ext› {
+  -- The preprocessed opened rows (current, next) at ζ for circuit `i`, or
+  -- `(Nil, Nil)` if the circuit has no preprocessed trace.
+  fn ood_prep_rows(prep_opt: PreprocessedOpt, oi: OptIdx) -> (List‹Ext›, List‹Ext›) {
     match oi {
-      OptIdx.NoIdx => store(ListNode.Nil),
+      OptIdx.NoIdx => (store(ListNode.Nil), store(ListNode.Nil)),
       OptIdx.SomeIdx(j) =>
         match prep_opt {
-          PreprocessedOpt.NoPreprocessed => store(ListNode.Nil),
+          PreprocessedOpt.NoPreprocessed => (store(ListNode.Nil), store(ListNode.Nil)),
           PreprocessedOpt.SomePreprocessed(round) =>
             let pr = list_lookup(round, j);
-            list_lookup(pr, 0),
+            (list_lookup(pr, 0), list_lookup(pr, 1)),
         },
     }
   }
@@ -736,8 +702,7 @@ def verifier := ⟦
     match load(circuits) {
       ListNode.Nil => 1,
       ListNode.Cons(circ, rest) =>
-        let SysCircuit.Mk(lair, _cc, md, _ph, _pw, _w1, _w2) = circ;
-        let SysLookupAir.Mk(air, lookups) = lair;
+        let SysCircuit.Mk(nodes, _node_count, zeros, md) = circ;
         let l = to_field(list_lookup(log_degrees, i));
         let qd = quotient_degree_of(md);
         let naccp = list_lookup(accs, i);
@@ -745,17 +710,18 @@ def verifier := ⟦
         let main = list_lookup(s1, 0);
         let main_next = list_lookup(s1, 1);
         let s2 = list_lookup(stage2, i);
-        let s2row = reconstruct_ext_row(list_lookup(s2, 0));
-        let s2next = reconstruct_ext_row(list_lookup(s2, 1));
-        let prep = ood_prep_row(prep_opt, list_lookup(prep_indices, i));
+        -- Stage-2 opened rows are base columns; used directly (no pairing).
+        let s2row = list_lookup(s2, 0);
+        let s2next = list_lookup(s2, 1);
+        let (prep, prep_next) = ood_prep_rows(prep_opt, list_lookup(prep_indices, i));
         let (isf, isl, ist, invv) = trace_selectors(zeta, l);
-        let comp = ood_composition(air, lookups, main, main_next, s2row, s2next,
-                                   prep, isf, isl, ist, lch, fch, accp, naccp, alpha);
+        let publics = build_publics(lch, fch, accp, naccp);
+        let comp = ood_composition(nodes, zeros,
+                                   main, main_next, prep, prep_next, s2row, s2next,
+                                   publics, isf, isl, ist, alpha);
         -- circuit i's wide quotient row, its base-coordinate pairs folded back
         -- into the `qd` slice values (Rust: `quotient_row.chunks_exact(D)`)
         let slices = reconstruct_ext_row(list_lookup(list_lookup(q_opened, i), 0));
-        -- shape: `quotient_opened_values[pos][0].len() == quotient_degree · D`
-        -- (Rust `check_shapes`)
         assert_eq!(eq_zero(list_length(slices) - qd), 1);
         let quot = quotient_eval(slices, ext_exp_pow2(zeta, l), [1, 0]);
         assert_eq!(eg_eq(eg_mul(comp, invv), quot), 1);

--- a/Ix/MultiStark/Verifier.lean
+++ b/Ix/MultiStark/Verifier.lean
@@ -540,30 +540,26 @@ def verifier := ⟦
   --
   -- The composition polynomial at ζ is `Σᵢ α^(k-1-i)·zeroᵢ`, where each `zeroᵢ`
   -- is the value of a constraint-root node. The nodes form a flat,
-  -- topologically ordered graph (children precede parents), so one forward
-  -- sweep computes an ExtVal per node (Rust: `multi_stark::eval`'s dense
-  -- sweep). The buffer is built in REVERSE (prepend; head = most recent):
-  -- when the k-th node (0-based) is processed the buffer holds k values
-  -- `[v_{k-1}, …, v_0]`, so child NodeId `c` sits at buffer index `k-1-c`. The
-  -- lookup-argument constraints are already compiled into `zeros`, so nothing
-  -- special is done for them (Rust `verifier.rs` evaluates one node graph and
-  -- Horner-folds the roots).
+  -- topologically ordered DAG (children by NodeId, children precede parents).
+  -- Instead of the Rust prover's dense forward sweep (which would build an
+  -- O(n²) temporary value-buffer list here), `eval_at` interprets the graph
+  -- directly by recursing into children. Aiur memoizes calls by argument
+  -- pointers, so each node is evaluated at most once per opening context and
+  -- every further reference — DAG sharing, later constraint roots — is a
+  -- cache hit; node fetches share `list_drop`'s cached drop-chain over the
+  -- one `nodes` list. The lookup-argument constraints are already compiled
+  -- into `zeros`, so nothing special is done for them (Rust `verifier.rs`
+  -- evaluates one node graph and Horner-folds the roots).
   -- ==========================================================================
 
-  -- A node child's value from the FORWARD buffer: node `c`'s value sits at
-  -- buffer index `c` (children always have smaller NodeIds than their parent,
-  -- so they are already present).
-  fn buf_child(buf: List‹Ext›, c: G) -> Ext {
-    list_lookup(buf, c)
-  }
-
-  -- Evaluate one node into an ExtVal, given the forward buffer and the leaf
-  -- context. Stage-2 columns are the OPENED BASE columns used directly (no
+  -- Evaluate node `i` of the graph into an ExtVal, given the leaf context.
+  -- Stage-2 columns are the OPENED BASE columns used directly (no
   -- `from_ext_basis` reassembly).
-  fn eval_node(nd: SysNode, buf: List‹Ext›,
+  fn eval_at(nodes: List‹SysNode›, i: G,
       main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
       s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
       isf: Ext, isl: Ext, ist: Ext) -> Ext {
+    let nd = list_lookup(nodes, i);
     match nd {
       SysNode.Const(c) => [c, 0],
       SysNode.Var(src, off, idx) =>
@@ -582,50 +578,46 @@ def verifier := ⟦
       SysNode.IsFirstRow => isf,
       SysNode.IsLastRow => isl,
       SysNode.IsTransition => ist,
-      SysNode.Add(a, b) => eg_add(buf_child(buf, a), buf_child(buf, b)),
-      SysNode.Sub(a, b) => eg_sub(buf_child(buf, a), buf_child(buf, b)),
-      SysNode.Mul(a, b) => eg_mul(buf_child(buf, a), buf_child(buf, b)),
-      SysNode.Neg(a) => eg_neg(buf_child(buf, a)),
+      SysNode.Add(a, b) =>
+        eg_add(eval_at(nodes, a, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
+               eval_at(nodes, b, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist)),
+      SysNode.Sub(a, b) =>
+        eg_sub(eval_at(nodes, a, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
+               eval_at(nodes, b, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist)),
+      SysNode.Mul(a, b) =>
+        eg_mul(eval_at(nodes, a, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
+               eval_at(nodes, b, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist)),
+      SysNode.Neg(a) =>
+        eg_neg(eval_at(nodes, a, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist)),
     }
   }
 
-  -- Forward sweep: append each node's value so that `buf[i]` is node `i`'s
-  -- value. `buf` starts `Nil`.
-  fn sweep_nodes(nodes: List‹SysNode›, buf: List‹Ext›,
+  -- Horner-fold the constraint roots with α: `acc := acc·α + eval_at(z)` for
+  -- each root NodeId `z`, in `zeros` order (the canonical compiled order the
+  -- prover folded in). Roots share subgraphs, so their evaluations hit the
+  -- `eval_at` cache.
+  fn fold_roots(acc: Ext, alpha: Ext, zeros: List‹G›, nodes: List‹SysNode›,
       main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
       s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
-      isf: Ext, isl: Ext, ist: Ext) -> List‹Ext› {
-    match load(nodes) {
-      ListNode.Nil => buf,
-      ListNode.Cons(nd, rest) =>
-        let v = eval_node(nd, buf, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
-        sweep_nodes(rest, list_concat(buf, store(ListNode.Cons(v, store(ListNode.Nil)))),
-                    main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
-    }
-  }
-
-  -- Horner-fold the constraint roots with α: `acc := acc·α + buf[z]` for each
-  -- root NodeId `z`, in `zeros` order (the canonical compiled order the prover
-  -- folded in).
-  fn fold_roots(acc: Ext, alpha: Ext, zeros: List‹G›, buf: List‹Ext›) -> Ext {
+      isf: Ext, isl: Ext, ist: Ext) -> Ext {
     match load(zeros) {
       ListNode.Nil => acc,
       ListNode.Cons(z, rest) =>
-        let v = list_lookup(buf, z);
-        fold_roots(ood_fold(acc, alpha, v), alpha, rest, buf),
+        let v = eval_at(nodes, z, main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+        fold_roots(ood_fold(acc, alpha, v), alpha, rest, nodes,
+                   main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
     }
   }
 
-  -- The composition polynomial `composition(ζ)` for one circuit: sweep the
-  -- compiled node graph over the opened rows / publics / selectors, then
-  -- Horner-fold the constraint roots with α.
+  -- The composition polynomial `composition(ζ)` for one circuit: interpret
+  -- the compiled node graph at each constraint root over the opened rows /
+  -- publics / selectors, Horner-folding with α.
   fn ood_composition(nodes: List‹SysNode›, zeros: List‹G›,
       main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
       s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
       isf: Ext, isl: Ext, ist: Ext, alpha: Ext) -> Ext {
-    let buf = sweep_nodes(nodes, store(ListNode.Nil),
-                          main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
-    fold_roots([0, 0], alpha, zeros, buf)
+    fold_roots([0, 0], alpha, zeros, nodes,
+               main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist)
   }
 
   -- The public-input coordinates for one circuit's lookup argument: the base

--- a/Ix/MultiStark/Verifier.lean
+++ b/Ix/MultiStark/Verifier.lean
@@ -609,15 +609,103 @@ def verifier := ⟦
     }
   }
 
+  -- ==========================================================================
+  -- Direct logUp constraint evaluation (mirrors Rust
+  -- `lookup::logup_constraint_values`). The logUp constraints are protocol
+  -- machinery, never compiled into the vk's node graph: their values at ζ
+  -- are computed here from the lookup ids (evaluated through the memoized
+  -- `eval_at`), the stage-2 openings, and the lookup publics, and folded
+  -- with α after the user roots — per lookup the 2 coordinates of
+  -- `(β + fingerprint(γ, args))·inv − 1`, then the first-row, transition,
+  -- and last-row accumulator constraints (2 coordinates each).
+  --
+  -- Coordinates: a coordinate-expanded logUp constraint is a PAIR of
+  -- base-field polynomials; at ζ each coordinate is an Ext value. Pair
+  -- products are in X² = 7 with Ext coefficients:
+  -- (a0·b0 + 7·a1·b1, a0·b1 + a1·b0).
+  -- ==========================================================================
+  fn pair_mul(a0: Ext, a1: Ext, b0: Ext, b1: Ext) -> (Ext, Ext) {
+    (eg_add(eg_mul(a0, b0), eg_mul([7, 0], eg_mul(a1, b1))),
+     eg_add(eg_mul(a0, b1), eg_mul(a1, b0)))
+  }
+
+  -- fingerprint(γ, args) = Σᵢ argsᵢ·γ^i as a coordinate pair:
+  -- fp(Cons(a, rest)) = (eval a, 0) + γ ⊗ fp(rest); args embed in coord 0.
+  fn logup_fingerprint(args: List‹G›, g0: Ext, g1: Ext, nodes: List‹SysNode›,
+      main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
+      s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
+      isf: Ext, isl: Ext, ist: Ext) -> (Ext, Ext) {
+    match load(args) {
+      ListNode.Nil => ([0, 0], [0, 0]),
+      ListNode.Cons(a, rest) =>
+        let (f0, f1) = logup_fingerprint(rest, g0, g1, nodes,
+          main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+        let (m0, m1) = pair_mul(f0, f1, g0, g1);
+        let av = eval_at(nodes, a, main, main_next, prep, prep_next, s2, s2next,
+                         publics, isf, isl, ist);
+        (eg_add(m0, av), m1),
+    }
+  }
+
+  -- Per-lookup message constraints, folding into the α accumulator as we
+  -- go and accumulating `acc_expr = acc_col + Σⱼ multⱼ·invⱼ` (as a
+  -- coordinate pair) for the accumulator constraints. `j` is the lookup
+  -- slot (inverse columns at stage-2 slots 1+j).
+  fn logup_lookups_fold(acc: Ext, alpha: Ext, lks: List‹SysLookup›, j: G,
+      ae0: Ext, ae1: Ext, b0: Ext, b1: Ext, g0: Ext, g1: Ext,
+      nodes: List‹SysNode›,
+      main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
+      s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
+      isf: Ext, isl: Ext, ist: Ext) -> (Ext, Ext, Ext) {
+    match load(lks) {
+      ListNode.Nil => (acc, ae0, ae1),
+      ListNode.Cons(lk, rest) =>
+        let SysLookup.Mk(mid, args) = lk;
+        let inv0 = list_lookup(s2, 2 + j + j);
+        let inv1 = list_lookup(s2, 3 + j + j);
+        let (f0, f1) = logup_fingerprint(args, g0, g1, nodes,
+          main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+        let (c0, c1) = pair_mul(eg_add(f0, b0), eg_add(f1, b1), inv0, inv1);
+        let acc1 = ood_fold(ood_fold(acc, alpha, eg_sub(c0, [1, 0])), alpha, c1);
+        let m = eval_at(nodes, mid, main, main_next, prep, prep_next, s2, s2next,
+                        publics, isf, isl, ist);
+        logup_lookups_fold(acc1, alpha, rest, j + 1,
+          eg_add(ae0, eg_mul(m, inv0)), eg_add(ae1, eg_mul(m, inv1)),
+          b0, b1, g0, g1, nodes,
+          main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist),
+    }
+  }
+
   -- The composition polynomial `composition(ζ)` for one circuit: interpret
-  -- the compiled node graph at each constraint root over the opened rows /
-  -- publics / selectors, Horner-folding with α.
-  fn ood_composition(nodes: List‹SysNode›, zeros: List‹G›,
+  -- the compiled node graph at each USER constraint root, then fold the
+  -- directly-evaluated logUp constraint values, all Horner-folded with α
+  -- in the canonical protocol order.
+  fn ood_composition(nodes: List‹SysNode›, zeros: List‹G›, lks: List‹SysLookup›,
       main: List‹Ext›, main_next: List‹Ext›, prep: List‹Ext›, prep_next: List‹Ext›,
       s2: List‹Ext›, s2next: List‹Ext›, publics: List‹Ext›,
       isf: Ext, isl: Ext, ist: Ext, alpha: Ext) -> Ext {
-    fold_roots([0, 0], alpha, zeros, nodes,
-               main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist)
+    let base = fold_roots([0, 0], alpha, zeros, nodes,
+               main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+    -- publics layout: β=(0,1), γ=(2,3), acc=(4,5), next_acc=(6,7).
+    let b0 = list_lookup(publics, 0); let b1 = list_lookup(publics, 1);
+    let g0 = list_lookup(publics, 2); let g1 = list_lookup(publics, 3);
+    let a0 = list_lookup(publics, 4); let a1 = list_lookup(publics, 5);
+    let na0 = list_lookup(publics, 6); let na1 = list_lookup(publics, 7);
+    -- stage-2 slot 0 = the running accumulator column.
+    let ac0 = list_lookup(s2, 0); let ac1 = list_lookup(s2, 1);
+    let nc0 = list_lookup(s2next, 0); let nc1 = list_lookup(s2next, 1);
+    let (acc, ae0, ae1) = logup_lookups_fold(base, alpha, lks, 0, ac0, ac1,
+      b0, b1, g0, g1, nodes,
+      main, main_next, prep, prep_next, s2, s2next, publics, isf, isl, ist);
+    -- First row: acc_col = acc.
+    let acc = ood_fold(acc, alpha, eg_mul(isf, eg_sub(ac0, a0)));
+    let acc = ood_fold(acc, alpha, eg_mul(isf, eg_sub(ac1, a1)));
+    -- Transition: acc_expr = next row's accumulator column.
+    let acc = ood_fold(acc, alpha, eg_mul(ist, eg_sub(ae0, nc0)));
+    let acc = ood_fold(acc, alpha, eg_mul(ist, eg_sub(ae1, nc1)));
+    -- Last row: acc_expr = next_acc.
+    let acc = ood_fold(acc, alpha, eg_mul(isl, eg_sub(ae0, na0)));
+    ood_fold(acc, alpha, eg_mul(isl, eg_sub(ae1, na1)))
   }
 
   -- The public-input coordinates for one circuit's lookup argument: the base
@@ -694,7 +782,7 @@ def verifier := ⟦
     match load(circuits) {
       ListNode.Nil => 1,
       ListNode.Cons(circ, rest) =>
-        let SysCircuit.Mk(nodes, _node_count, zeros, md) = circ;
+        let SysCircuit.Mk(nodes, _node_count, zeros, md, lks) = circ;
         let l = to_field(list_lookup(log_degrees, i));
         let qd = quotient_degree_of(md);
         let naccp = list_lookup(accs, i);
@@ -708,7 +796,7 @@ def verifier := ⟦
         let (prep, prep_next) = ood_prep_rows(prep_opt, list_lookup(prep_indices, i));
         let (isf, isl, ist, invv) = trace_selectors(zeta, l);
         let publics = build_publics(lch, fch, accp, naccp);
-        let comp = ood_composition(nodes, zeros,
+        let comp = ood_composition(nodes, zeros, lks,
                                    main, main_next, prep, prep_next, s2row, s2next,
                                    publics, isf, isl, ist, alpha);
         -- circuit i's wide quotient row, its base-coordinate pairs folded back

--- a/crates/aiur/src/constraints.rs
+++ b/crates/aiur/src/constraints.rs
@@ -1,7 +1,5 @@
 use multi_stark::{
-  builder::symbolic::{SymbolicExpression, var},
   lookup::Lookup,
-  p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
   p3_field::{Field, PrimeCharacteristicRing},
 };
 use std::{array, ops::Range, sync::LazyLock};
@@ -21,8 +19,20 @@ use crate::{
   u8_shift_right_channel, u8_sub_channel, u8_xor_channel,
 };
 
-type Expr = SymbolicExpression<G>;
+type Expr = multi_stark::expr::Expr<G>;
 type Degree = u8;
+
+/// Main-trace column variable at index `i`.
+#[inline]
+fn var(i: usize) -> Expr {
+  Expr::main(u32::try_from(i).expect("column index exceeds u32"))
+}
+
+/// Base-field constant expression.
+#[inline]
+fn konst(value: G) -> Expr {
+  Expr::constant(value)
+}
 
 /// `256⁻¹` in the Goldilocks field. The field inversion is expensive, so it is
 /// computed once and reused by the byte carry-chain constraints.
@@ -33,28 +43,6 @@ pub struct Constraints {
   pub zeros: Vec<Expr>,
   pub selectors: Range<usize>,
   pub width: usize,
-}
-
-impl BaseAir<G> for Constraints {
-  fn width(&self) -> usize {
-    self.width
-  }
-}
-
-impl<AB> Air<AB> for Constraints
-where
-  AB: AirBuilder<F = G>,
-{
-  fn eval(&self, builder: &mut AB) {
-    let main = builder.main();
-    let row = main.current_slice();
-    for zero in &self.zeros {
-      builder.assert_zero(zero.interpret(row, None));
-    }
-    for sel in self.selectors.clone() {
-      builder.assert_bool(row[sel]);
-    }
-  }
 }
 
 struct ConstraintState {
@@ -124,13 +112,23 @@ impl Toplevel {
       column: 0,
       lookup: 0,
       map: vec![],
-      lookups: vec![Lookup::empty(); function.layout.lookups],
+      lookups: vec![empty_lookup(); function.layout.lookups],
       constraints,
       yield_info: vec![],
     };
     function.build_constraints(&mut state);
+    // The old `Air::eval` asserted each selector column boolean; the new
+    // system compiles a constraint vector, so materialize those explicitly.
+    for sel in state.constraints.selectors.clone() {
+      let s = var(sel);
+      state.constraints.zeros.push(s.clone() * (s - konst(G::ONE)));
+    }
     (state.constraints, state.lookups)
   }
+}
+
+fn empty_lookup() -> Lookup<Expr> {
+  Lookup { multiplicity: konst(G::ZERO), args: vec![] }
 }
 
 impl Function {
@@ -160,7 +158,7 @@ impl Block {
     state
       .constraints
       .zeros
-      .push(block_sel.clone() * (Expr::from(G::ONE) - block_sel));
+      .push(block_sel.clone() * (konst(G::ONE) - block_sel));
     self.ops.iter().for_each(|op| op.collect_constraints(&sel, state));
     self.ctrl.collect_constraints(sel, state);
   }
@@ -177,12 +175,12 @@ impl Block {
         var(state.selector_index(*sel))
       },
       Ctrl::Match(_, cases, def) | Ctrl::MatchContinue(_, cases, def, ..) => {
-        let mut sel = Expr::from(G::ZERO);
+        let mut sel = konst(G::ZERO);
         for branch in cases.values() {
-          sel += branch.get_block_selector(state);
+          sel = sel + branch.get_block_selector(state);
         }
         if let Some(branch) = def {
-          sel += branch.get_block_selector(state);
+          sel = sel + branch.get_block_selector(state);
         }
         sel
       },
@@ -194,12 +192,12 @@ impl Block {
 /// constraints. Each branch is processed with save/restore so branches share
 /// auxiliary columns. Returns (max_column, max_lookup) across all branches.
 fn collect_branch_constraints(
-  var: ValIdx,
+  var_idx: ValIdx,
   cases: &FxIndexMap<G, Block>,
   def: &Option<Box<Block>>,
   state: &mut ConstraintState,
 ) -> (usize, usize) {
-  let (var, _) = state.map[var].clone();
+  let (matched, _) = state.map[var_idx].clone();
   let init = state.save();
   let mut max_column = init.column;
   let mut max_lookup = init.lookup;
@@ -208,7 +206,7 @@ fn collect_branch_constraints(
     state
       .constraints
       .zeros
-      .push(branch_sel.clone() * (var.clone() - Expr::from(value)));
+      .push(branch_sel.clone() * (matched.clone() - konst(value)));
     branch.collect_constraints(branch_sel, state);
     max_column = max_column.max(state.column);
     max_lookup = max_lookup.max(state.lookup);
@@ -220,7 +218,7 @@ fn collect_branch_constraints(
       let inverse = state.next_auxiliary();
       state.constraints.zeros.push(
         branch_sel.clone()
-          * ((var.clone() - Expr::from(value)) * inverse - Expr::from(G::ONE)),
+          * ((matched.clone() - konst(value)) * inverse - konst(G::ONE)),
       );
     }
     branch.collect_constraints(branch_sel, state);
@@ -238,8 +236,8 @@ impl Ctrl {
       Ctrl::Return(_, values) => {
         // channel and function index
         let mut args = vec![
-          sel.clone() * function_channel(),
-          sel.clone() * state.function_index,
+          sel.clone() * konst(function_channel()),
+          sel.clone() * konst(state.function_index),
         ];
         // input
         args.extend(
@@ -260,14 +258,14 @@ impl Ctrl {
           values.iter().map(|&v| state.map[v].clone()).collect();
         state.yield_info.push((yield_sel, yield_vals));
       },
-      Ctrl::Match(var, cases, def) => {
+      Ctrl::Match(var_idx, cases, def) => {
         let (max_column, max_lookup) =
-          collect_branch_constraints(*var, cases, def, state);
+          collect_branch_constraints(*var_idx, cases, def, state);
         state.column = max_column;
         state.lookup = max_lookup;
       },
       Ctrl::MatchContinue(
-        var,
+        var_idx,
         cases,
         def,
         output_size,
@@ -277,7 +275,7 @@ impl Ctrl {
       ) => {
         let yield_info_base = state.yield_info.len();
         let (max_column, max_lookup) =
-          collect_branch_constraints(*var, cases, def, state);
+          collect_branch_constraints(*var_idx, cases, def, state);
 
         // Advance past the shared branch region so merge + continuation
         // auxiliaries don't collide with branch auxiliaries.
@@ -292,7 +290,7 @@ impl Ctrl {
         let cont_sel = yields
           .iter()
           .map(|(sel, _)| sel.clone())
-          .fold(Expr::from(G::ZERO), |a, b| a + b);
+          .fold(konst(G::ZERO), |a, b| a + b);
 
         // Merge constraints, gated by the parent selector `sel`. Gating is
         // required because a matchContinue inside a tail match branch may be
@@ -303,7 +301,7 @@ impl Ctrl {
           let sum = yields
             .iter()
             .map(|(sel_j, vals)| sel_j.clone() * vals[i].0.clone())
-            .fold(Expr::from(G::ZERO), |a, b| a + b);
+            .fold(konst(G::ZERO), |a, b| a + b);
           state.constraints.zeros.push(sel.clone() * (merged.clone() - sum));
           state.map.push((merged, 1));
         }
@@ -350,9 +348,9 @@ impl Op {
       },
       Op::EqZero(a) => {
         let (a, deg) = state.map[*a].clone();
-        if let Expr::Constant(a) = a {
+        if let Expr::Const(a) = a {
           assert_eq!(deg, 0);
-          state.map.push((Expr::from_bool(a == G::ZERO), 0));
+          state.map.push((konst(G::from_bool(a == G::ZERO)), 0));
         } else {
           // We have two constraints:
           // 1. ax = 0
@@ -368,7 +366,7 @@ impl Op {
           state
             .constraints
             .zeros
-            .push(sel.clone() * (a * d + x.clone() - Expr::ONE));
+            .push(sel.clone() * (a * d + x.clone() - konst(G::ONE)));
           state.map.push((x, 1));
         }
       },
@@ -382,8 +380,8 @@ impl Op {
         } else {
           // channel and function index
           let mut lookup_args = vec![
-            sel.clone() * function_channel(),
-            sel.clone() * G::from_usize(*function_index),
+            sel.clone() * konst(function_channel()),
+            sel.clone() * konst(G::from_usize(*function_index)),
           ];
           // input
           lookup_args.extend(
@@ -399,7 +397,7 @@ impl Op {
 
           let lookup = state.next_lookup();
           combine_lookup_args(lookup, lookup_args);
-          lookup.multiplicity += sel.clone();
+          lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
         }
       },
       Op::Store(values) => {
@@ -408,8 +406,8 @@ impl Op {
         let ptr = state.next_auxiliary();
         state.map.push((ptr.clone(), 1));
         let mut lookup_args = vec![
-          sel.clone() * memory_channel(),
-          sel.clone() * G::from_usize(size),
+          sel.clone() * konst(memory_channel()),
+          sel.clone() * konst(G::from_usize(size)),
           sel.clone() * ptr,
         ];
         // stored values
@@ -419,13 +417,13 @@ impl Op {
 
         let lookup = state.next_lookup();
         combine_lookup_args(lookup, lookup_args);
-        lookup.multiplicity += sel.clone();
+        lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
       },
       Op::Load(size, ptr) => {
         // channel, size and pointer
         let mut lookup_args = vec![
-          sel.clone() * memory_channel(),
-          sel.clone() * G::from_usize(*size),
+          sel.clone() * konst(memory_channel()),
+          sel.clone() * konst(G::from_usize(*size)),
           sel.clone() * state.map[*ptr].0.clone(),
         ];
         // loaded values
@@ -438,7 +436,7 @@ impl Op {
 
         let lookup = state.next_lookup();
         combine_lookup_args(lookup, lookup_args);
-        lookup.multiplicity += sel.clone();
+        lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
       },
       Op::AssertEq(xs, ys) => {
         assert_eq!(xs.len(), ys.len());
@@ -496,14 +494,14 @@ impl Op {
         combine_lookup_args(
           lookup,
           vec![
-            sel.clone() * u8_add_channel(),
+            sel.clone() * konst(u8_add_channel()),
             sel.clone() * x.clone(),
             sel.clone() * y.clone(),
             sel.clone() * z.clone(),
           ],
         );
-        lookup.multiplicity += sel.clone();
-        let carry = (x + y - z.clone()) * *INV_256;
+        lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
+        let carry = (x + y - z.clone()) * konst(*INV_256);
         state.map.push((z, 1));
         state.map.push((carry, x_deg.max(y_deg).max(1)));
       },
@@ -526,14 +524,14 @@ impl Op {
         combine_lookup_args(
           lookup,
           vec![
-            sel.clone() * u8_sub_channel(),
+            sel.clone() * konst(u8_sub_channel()),
             sel.clone() * x.clone(),
             sel.clone() * y.clone(),
             sel.clone() * z.clone(),
           ],
         );
-        lookup.multiplicity += sel.clone();
-        let borrow = (z.clone() + y - x) * *INV_256;
+        lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
+        let borrow = (z.clone() + y - x) * konst(*INV_256);
         state.map.push((z, 1));
         state.map.push((borrow, x_deg.max(y_deg).max(1)));
       },
@@ -586,12 +584,12 @@ impl Op {
         combine_lookup_args(
           lookup,
           vec![
-            sel.clone() * u8_range_check_channel(),
+            sel.clone() * konst(u8_range_check_channel()),
             sel.clone() * x,
             sel.clone() * y,
           ],
         );
-        lookup.multiplicity += sel.clone();
+        lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
       },
       Op::U32LessThan(x_idx, y_idx) => {
         // u32 less-than via addition carry chain.
@@ -626,25 +624,21 @@ impl Op {
         let base =
           |k: usize| G::from_u64(256u64.pow(u32::try_from(k).unwrap()));
         let recompose = |bytes: &[Expr; 4]| {
-          bytes
-            .iter()
-            .enumerate()
-            .fold(Expr::Constant(G::ZERO), |acc, (k, b)| {
-              acc + b.clone() * base(k)
-            })
+          bytes.iter().enumerate().fold(konst(G::ZERO), |acc, (k, b)| {
+            acc + b.clone() * konst(base(k))
+          })
         };
         state.constraints.zeros.push(sel.clone() * (a - recompose(&x_bytes)));
         state.constraints.zeros.push(sel.clone() * (b - recompose(&z_bytes)));
 
         // Carry chain: a + c + 1 = b + carry * 2^32
-        let mut carry = Expr::ONE; // initial carry = 1 for strict less-than
+        let mut carry = konst(G::ONE); // initial carry = 1 for strict less-than
         for k in 0..4 {
           let sum = x_bytes[k].clone() + y_bytes[k].clone() + carry;
-          carry = (sum - z_bytes[k].clone()) * *INV_256;
-          state
-            .constraints
-            .zeros
-            .push(sel.clone() * (carry.clone() * (carry.clone() - Expr::ONE)));
+          carry = (sum - z_bytes[k].clone()) * konst(*INV_256);
+          state.constraints.zeros.push(
+            sel.clone() * (carry.clone() * (carry.clone() - konst(G::ONE))),
+          );
         }
 
         // Range-check byte pairs via Bytes2 lookups
@@ -661,16 +655,16 @@ impl Op {
           combine_lookup_args(
             lookup,
             vec![
-              sel.clone() * rc_channel,
+              sel.clone() * konst(rc_channel),
               sel.clone() * pair.0.clone(),
               sel.clone() * pair.1.clone(),
             ],
           );
-          lookup.multiplicity += sel.clone();
+          lookup.multiplicity = lookup.multiplicity.clone() + sel.clone();
         }
 
         // Output: 1 - carry
-        let output = Expr::ONE - carry;
+        let output = konst(G::ONE) - carry;
         state.map.push((output, 1));
       },
       Op::IOSetInfo(..) | Op::IOWrite(..) | Op::Debug(..) => (),
@@ -708,13 +702,13 @@ fn bytes1_constraints(
   byte: usize,
   op: &Bytes1Op,
   channel: G,
-  sel: SymbolicExpression<G>,
+  sel: Expr,
   state: &mut ConstraintState,
 ) {
   let size = Bytes1.output_size(op);
 
   let mut lookup_args =
-    vec![sel.clone() * channel, sel.clone() * state.map[byte].0.clone()];
+    vec![sel.clone() * konst(channel), sel.clone() * state.map[byte].0.clone()];
 
   let output = (0..size).map(|_| {
     let col = state.next_auxiliary();
@@ -725,7 +719,7 @@ fn bytes1_constraints(
 
   let lookup = state.next_lookup();
   combine_lookup_args(lookup, lookup_args);
-  lookup.multiplicity += sel;
+  lookup.multiplicity = lookup.multiplicity.clone() + sel;
 }
 
 fn bytes2_constraints(
@@ -733,13 +727,13 @@ fn bytes2_constraints(
   j: usize,
   op: &Bytes2Op,
   channel: G,
-  sel: SymbolicExpression<G>,
+  sel: Expr,
   state: &mut ConstraintState,
 ) {
   let size = Bytes2.output_size(op);
 
   let mut lookup_args = vec![
-    sel.clone() * channel,
+    sel.clone() * konst(channel),
     sel.clone() * state.map[i].0.clone(),
     sel.clone() * state.map[j].0.clone(),
   ];
@@ -753,17 +747,17 @@ fn bytes2_constraints(
 
   let lookup = state.next_lookup();
   combine_lookup_args(lookup, lookup_args);
-  lookup.multiplicity += sel;
+  lookup.multiplicity = lookup.multiplicity.clone() + sel;
 }
 
 fn combine_lookup_args(
-  lookup: &mut Lookup<SymbolicExpression<G>>,
-  args: impl IntoIterator<Item = SymbolicExpression<G>>,
+  lookup: &mut Lookup<Expr>,
+  args: impl IntoIterator<Item = Expr>,
 ) {
   let mut args_iterator = args.into_iter();
   lookup.args.iter_mut().zip(args_iterator.by_ref()).for_each(
     |(arg, value)| {
-      *arg += value;
+      *arg = arg.clone() + value;
     },
   );
   lookup.args.extend(args_iterator);

--- a/crates/aiur/src/gadgets.rs
+++ b/crates/aiur/src/gadgets.rs
@@ -2,7 +2,7 @@ pub(crate) mod bytes1;
 pub(crate) mod bytes2;
 
 use multi_stark::{
-  builder::symbolic::SymbolicExpression,
+  expr::Expr,
   lookup::{Lookup, LookupValues},
   p3_matrix::dense::RowMajorMatrix,
 };
@@ -25,6 +25,12 @@ pub(crate) trait AiurGadget {
   /// Returns the number of output values this gadget produces for the given operation.
   fn output_size(&self, op: &Self::Op) -> usize;
 
+  /// Main-trace width of the gadget circuit.
+  fn main_width(&self) -> usize;
+
+  /// The gadget's preprocessed trace, if any.
+  fn preprocessed(&self) -> Option<RowMajorMatrix<G>>;
+
   /// Executes the gadget on concrete inputs, returning the resulting output values.
   fn execute(
     &self,
@@ -33,8 +39,8 @@ pub(crate) trait AiurGadget {
     record: &mut QueryRecord,
   ) -> Vec<G>;
 
-  /// Returns the symbolic lookups associated with this gadget.
-  fn lookups(&self) -> Vec<Lookup<SymbolicExpression<G>>>;
+  /// Returns the lookups associated with this gadget.
+  fn lookups(&self) -> Vec<Lookup<Expr<G>>>;
 
   /// Returns the witness data for the prover, including a row-major trace matrix and
   /// the flat lookup values.

--- a/crates/aiur/src/gadgets/bytes1.rs
+++ b/crates/aiur/src/gadgets/bytes1.rs
@@ -1,7 +1,6 @@
 use multi_stark::{
-  builder::symbolic::{SymbolicExpression, preprocessed_var, var},
+  expr::Expr,
   lookup::{Lookup, LookupValues},
-  p3_air::{Air, AirBuilder, BaseAir},
   p3_field::{PrimeCharacteristicRing, PrimeField64},
   p3_matrix::dense::RowMajorMatrix,
 };
@@ -33,13 +32,22 @@ pub enum Bytes1Op {
   ShiftRight,
 }
 
-impl BaseAir<G> for Bytes1 {
-  fn width(&self) -> usize {
+impl AiurGadget for Bytes1 {
+  type Op = Bytes1Op;
+
+  fn output_size(&self, op: &Bytes1Op) -> usize {
+    match op {
+      Bytes1Op::BitDecomposition => 8,
+      Bytes1Op::ShiftLeft | Bytes1Op::ShiftRight => 1,
+    }
+  }
+
+  fn main_width(&self) -> usize {
     TRACE_WIDTH
   }
 
   /// Builds the preprocessed trace over all 256 byte values.
-  fn preprocessed_trace(&self) -> Option<RowMajorMatrix<G>> {
+  fn preprocessed(&self) -> Option<RowMajorMatrix<G>> {
     let mut values = vec![G::ZERO; 256 * PREPROCESSED_TRACE_WIDTH];
     values.chunks_exact_mut(PREPROCESSED_TRACE_WIDTH).enumerate().for_each(
       |(i, row)| {
@@ -63,22 +71,6 @@ impl BaseAir<G> for Bytes1 {
       },
     );
     Some(RowMajorMatrix::new(values, PREPROCESSED_TRACE_WIDTH))
-  }
-}
-
-impl<AB: AirBuilder<F = G>> Air<AB> for Bytes1 {
-  /// A no-op, since all constraints are enforced through lookups.
-  fn eval(&self, _builder: &mut AB) {}
-}
-
-impl AiurGadget for Bytes1 {
-  type Op = Bytes1Op;
-
-  fn output_size(&self, op: &Bytes1Op) -> usize {
-    match op {
-      Bytes1Op::BitDecomposition => 8,
-      Bytes1Op::ShiftLeft | Bytes1Op::ShiftRight => 1,
-    }
   }
 
   fn execute(
@@ -104,33 +96,35 @@ impl AiurGadget for Bytes1 {
     }
   }
 
-  fn lookups(&self) -> Vec<Lookup<SymbolicExpression<G>>> {
+  fn lookups(&self) -> Vec<Lookup<Expr<G>>> {
     // Channels
-    let bit_decomposition_channel = u8_bit_decomposition_channel().into();
-    let shift_left_channel = u8_shift_left_channel().into();
-    let shift_right_channel = u8_shift_right_channel().into();
+    let bit_decomposition_channel =
+      Expr::constant(u8_bit_decomposition_channel());
+    let shift_left_channel = Expr::constant(u8_shift_left_channel());
+    let shift_right_channel = Expr::constant(u8_shift_right_channel());
 
     // Multiplicity columns
-    let bit_decomposition_multiplicity = var(0);
-    let shift_left_multiplicity = var(1);
-    let shift_right_multiplicity = var(2);
+    let bit_decomposition_multiplicity = Expr::main(0);
+    let shift_left_multiplicity = Expr::main(1);
+    let shift_right_multiplicity = Expr::main(2);
 
     // Preprocessed columns
-    let byte = preprocessed_var(0);
-    let byte_bit0 = preprocessed_var(1);
-    let byte_bit1 = preprocessed_var(2);
-    let byte_bit2 = preprocessed_var(3);
-    let byte_bit3 = preprocessed_var(4);
-    let byte_bit4 = preprocessed_var(5);
-    let byte_bit5 = preprocessed_var(6);
-    let byte_bit6 = preprocessed_var(7);
-    let byte_bit7 = preprocessed_var(8);
-    let byte_left_shifted = preprocessed_var(9);
-    let byte_right_shifted = preprocessed_var(10);
+    let byte = Expr::preprocessed(0);
+    let byte_bit0 = Expr::preprocessed(1);
+    let byte_bit1 = Expr::preprocessed(2);
+    let byte_bit2 = Expr::preprocessed(3);
+    let byte_bit3 = Expr::preprocessed(4);
+    let byte_bit4 = Expr::preprocessed(5);
+    let byte_bit5 = Expr::preprocessed(6);
+    let byte_bit6 = Expr::preprocessed(7);
+    let byte_bit7 = Expr::preprocessed(8);
+    let byte_left_shifted = Expr::preprocessed(9);
+    let byte_right_shifted = Expr::preprocessed(10);
 
-    let pull_bit_decomposition = Lookup::pull(
-      bit_decomposition_multiplicity,
-      vec![
+    // pull = negated multiplicity.
+    let pull_bit_decomposition = Lookup {
+      multiplicity: -bit_decomposition_multiplicity,
+      args: vec![
         bit_decomposition_channel,
         byte.clone(),
         byte_bit0,
@@ -142,17 +136,17 @@ impl AiurGadget for Bytes1 {
         byte_bit6,
         byte_bit7,
       ],
-    );
+    };
 
-    let pull_shift_left = Lookup::pull(
-      shift_left_multiplicity,
-      vec![shift_left_channel, byte.clone(), byte_left_shifted],
-    );
+    let pull_shift_left = Lookup {
+      multiplicity: -shift_left_multiplicity,
+      args: vec![shift_left_channel, byte.clone(), byte_left_shifted],
+    };
 
-    let pull_shift_right = Lookup::pull(
-      shift_right_multiplicity,
-      vec![shift_right_channel, byte, byte_right_shifted],
-    );
+    let pull_shift_right = Lookup {
+      multiplicity: -shift_right_multiplicity,
+      args: vec![shift_right_channel, byte, byte_right_shifted],
+    };
 
     vec![pull_bit_decomposition, pull_shift_left, pull_shift_right]
   }

--- a/crates/aiur/src/gadgets/bytes2.rs
+++ b/crates/aiur/src/gadgets/bytes2.rs
@@ -1,7 +1,6 @@
 use multi_stark::{
-  builder::symbolic::{SymbolicExpression, preprocessed_var, var},
+  expr::Expr,
   lookup::{Lookup, LookupValues},
-  p3_air::{Air, AirBuilder, BaseAir},
   p3_field::{PrimeCharacteristicRing, PrimeField64},
   p3_matrix::dense::RowMajorMatrix,
 };
@@ -62,13 +61,28 @@ pub enum Bytes2Op {
   ChainRotr4,
 }
 
-impl BaseAir<G> for Bytes2 {
-  fn width(&self) -> usize {
+impl AiurGadget for Bytes2 {
+  type Op = Bytes2Op;
+
+  fn output_size(&self, op: &Bytes2Op) -> usize {
+    match op {
+      Bytes2Op::Xor
+      | Bytes2Op::And
+      | Bytes2Op::Or
+      | Bytes2Op::LessThan
+      | Bytes2Op::Add
+      | Bytes2Op::Sub => 1,
+      Bytes2Op::Mul => 2,
+      Bytes2Op::ChainRotr7 | Bytes2Op::ChainRotr4 => 3,
+    }
+  }
+
+  fn main_width(&self) -> usize {
     TRACE_WIDTH
   }
 
   /// Builds the preprocessed trace over all 256 byte values.
-  fn preprocessed_trace(&self) -> Option<RowMajorMatrix<G>> {
+  fn preprocessed(&self) -> Option<RowMajorMatrix<G>> {
     let mut trace_values =
       Vec::with_capacity(256 * 256 * PREPROCESSED_TRACE_WIDTH);
     for i in 0..=u8::MAX {
@@ -114,28 +128,6 @@ impl BaseAir<G> for Bytes2 {
       }
     }
     Some(RowMajorMatrix::new(trace_values, PREPROCESSED_TRACE_WIDTH))
-  }
-}
-
-impl<AB: AirBuilder<F = G>> Air<AB> for Bytes2 {
-  /// A no-op, since all constraints are enforced through lookups.
-  fn eval(&self, _builder: &mut AB) {}
-}
-
-impl AiurGadget for Bytes2 {
-  type Op = Bytes2Op;
-
-  fn output_size(&self, op: &Bytes2Op) -> usize {
-    match op {
-      Bytes2Op::Xor
-      | Bytes2Op::And
-      | Bytes2Op::Or
-      | Bytes2Op::LessThan
-      | Bytes2Op::Add
-      | Bytes2Op::Sub => 1,
-      Bytes2Op::Mul => 2,
-      Bytes2Op::ChainRotr7 | Bytes2Op::ChainRotr4 => 3,
-    }
   }
 
   fn execute(
@@ -191,90 +183,93 @@ impl AiurGadget for Bytes2 {
     }
   }
 
-  fn lookups(&self) -> Vec<Lookup<SymbolicExpression<G>>> {
+  fn lookups(&self) -> Vec<Lookup<Expr<G>>> {
     // Channels
-    let xor_channel = u8_xor_channel().into();
-    let add_channel = u8_add_channel().into();
-    let sub_channel = u8_sub_channel().into();
-    let and_channel = u8_and_channel().into();
-    let or_channel = u8_or_channel().into();
-    let less_than_channel = u8_less_than_channel().into();
-    let range_check_channel = u8_range_check_channel().into();
-    let mul_channel = u8_mul_channel().into();
-    let chain_rotr7_channel = u8_chain_rotr7_channel().into();
-    let chain_rotr4_channel = u8_chain_rotr4_channel().into();
+    let xor_channel = Expr::constant(u8_xor_channel());
+    let add_channel = Expr::constant(u8_add_channel());
+    let sub_channel = Expr::constant(u8_sub_channel());
+    let and_channel = Expr::constant(u8_and_channel());
+    let or_channel = Expr::constant(u8_or_channel());
+    let less_than_channel = Expr::constant(u8_less_than_channel());
+    let range_check_channel = Expr::constant(u8_range_check_channel());
+    let mul_channel = Expr::constant(u8_mul_channel());
+    let chain_rotr7_channel = Expr::constant(u8_chain_rotr7_channel());
+    let chain_rotr4_channel = Expr::constant(u8_chain_rotr4_channel());
 
     // Multiplicity columns
-    let xor_multiplicity = var(0);
-    let add_multiplicity = var(1);
-    let sub_multiplicity = var(2);
-    let and_multiplicity = var(3);
-    let or_multiplicity = var(4);
-    let less_than_multiplicity = var(5);
-    let range_check_multiplicity = var(6);
-    let mul_multiplicity = var(7);
-    let chain_rotr7_multiplicity = var(8);
-    let chain_rotr4_multiplicity = var(9);
+    let xor_multiplicity = Expr::main(0);
+    let add_multiplicity = Expr::main(1);
+    let sub_multiplicity = Expr::main(2);
+    let and_multiplicity = Expr::main(3);
+    let or_multiplicity = Expr::main(4);
+    let less_than_multiplicity = Expr::main(5);
+    let range_check_multiplicity = Expr::main(6);
+    let mul_multiplicity = Expr::main(7);
+    let chain_rotr7_multiplicity = Expr::main(8);
+    let chain_rotr4_multiplicity = Expr::main(9);
 
     // Preprocessed columns
-    let i = preprocessed_var(0);
-    let j = preprocessed_var(1);
-    let xor = preprocessed_var(2);
-    let add_r = preprocessed_var(3);
-    let sub_r = preprocessed_var(4);
-    let and = preprocessed_var(5);
-    let or = preprocessed_var(6);
-    let less_than = preprocessed_var(7);
-    let mul_lo = preprocessed_var(8);
-    let mul_hi = preprocessed_var(9);
-    let chain_rotr7_o0 = preprocessed_var(10);
-    let chain_rotr7_o1 = preprocessed_var(11);
-    let chain_rotr7_o2 = preprocessed_var(12);
-    let chain_rotr4_o0 = preprocessed_var(13);
-    let chain_rotr4_o1 = preprocessed_var(14);
-    let chain_rotr4_o2 = preprocessed_var(15);
+    let i = Expr::preprocessed(0);
+    let j = Expr::preprocessed(1);
+    let xor = Expr::preprocessed(2);
+    let add_r = Expr::preprocessed(3);
+    let sub_r = Expr::preprocessed(4);
+    let and = Expr::preprocessed(5);
+    let or = Expr::preprocessed(6);
+    let less_than = Expr::preprocessed(7);
+    let mul_lo = Expr::preprocessed(8);
+    let mul_hi = Expr::preprocessed(9);
+    let chain_rotr7_o0 = Expr::preprocessed(10);
+    let chain_rotr7_o1 = Expr::preprocessed(11);
+    let chain_rotr7_o2 = Expr::preprocessed(12);
+    let chain_rotr4_o0 = Expr::preprocessed(13);
+    let chain_rotr4_o1 = Expr::preprocessed(14);
+    let chain_rotr4_o2 = Expr::preprocessed(15);
 
-    let pull_xor = Lookup::pull(
-      xor_multiplicity,
-      vec![xor_channel, i.clone(), j.clone(), xor],
-    );
+    // pull = negated multiplicity.
+    let pull_xor = Lookup {
+      multiplicity: -xor_multiplicity,
+      args: vec![xor_channel, i.clone(), j.clone(), xor],
+    };
 
-    let pull_add = Lookup::pull(
-      add_multiplicity,
-      vec![add_channel, i.clone(), j.clone(), add_r],
-    );
+    let pull_add = Lookup {
+      multiplicity: -add_multiplicity,
+      args: vec![add_channel, i.clone(), j.clone(), add_r],
+    };
 
-    let pull_sub = Lookup::pull(
-      sub_multiplicity,
-      vec![sub_channel, i.clone(), j.clone(), sub_r],
-    );
+    let pull_sub = Lookup {
+      multiplicity: -sub_multiplicity,
+      args: vec![sub_channel, i.clone(), j.clone(), sub_r],
+    };
 
-    let pull_and = Lookup::pull(
-      and_multiplicity,
-      vec![and_channel, i.clone(), j.clone(), and],
-    );
+    let pull_and = Lookup {
+      multiplicity: -and_multiplicity,
+      args: vec![and_channel, i.clone(), j.clone(), and],
+    };
 
-    let pull_or =
-      Lookup::pull(or_multiplicity, vec![or_channel, i.clone(), j.clone(), or]);
+    let pull_or = Lookup {
+      multiplicity: -or_multiplicity,
+      args: vec![or_channel, i.clone(), j.clone(), or],
+    };
 
-    let pull_less_than = Lookup::pull(
-      less_than_multiplicity,
-      vec![less_than_channel, i.clone(), j.clone(), less_than],
-    );
+    let pull_less_than = Lookup {
+      multiplicity: -less_than_multiplicity,
+      args: vec![less_than_channel, i.clone(), j.clone(), less_than],
+    };
 
-    let pull_mul = Lookup::pull(
-      mul_multiplicity,
-      vec![mul_channel, i.clone(), j.clone(), mul_lo, mul_hi],
-    );
+    let pull_mul = Lookup {
+      multiplicity: -mul_multiplicity,
+      args: vec![mul_channel, i.clone(), j.clone(), mul_lo, mul_hi],
+    };
 
-    let pull_range_check = Lookup::pull(
-      range_check_multiplicity,
-      vec![range_check_channel, i.clone(), j.clone()],
-    );
+    let pull_range_check = Lookup {
+      multiplicity: -range_check_multiplicity,
+      args: vec![range_check_channel, i.clone(), j.clone()],
+    };
 
-    let pull_chain_rotr7 = Lookup::pull(
-      chain_rotr7_multiplicity,
-      vec![
+    let pull_chain_rotr7 = Lookup {
+      multiplicity: -chain_rotr7_multiplicity,
+      args: vec![
         chain_rotr7_channel,
         i.clone(),
         j.clone(),
@@ -282,11 +277,11 @@ impl AiurGadget for Bytes2 {
         chain_rotr7_o1,
         chain_rotr7_o2,
       ],
-    );
+    };
 
-    let pull_chain_rotr4 = Lookup::pull(
-      chain_rotr4_multiplicity,
-      vec![
+    let pull_chain_rotr4 = Lookup {
+      multiplicity: -chain_rotr4_multiplicity,
+      args: vec![
         chain_rotr4_channel,
         i,
         j,
@@ -294,7 +289,7 @@ impl AiurGadget for Bytes2 {
         chain_rotr4_o1,
         chain_rotr4_o2,
       ],
-    );
+    };
 
     vec![
       pull_xor,

--- a/crates/aiur/src/memory.rs
+++ b/crates/aiur/src/memory.rs
@@ -1,7 +1,6 @@
 use multi_stark::{
-  builder::symbolic::{SymbolicExpression, var},
+  expr::Expr,
   lookup::{Lookup, LookupValues},
-  p3_air::{Air, AirBuilder, BaseAir, WindowAccess},
   p3_field::PrimeCharacteristicRing,
   p3_matrix::dense::RowMajorMatrix,
 };
@@ -31,19 +30,40 @@ impl Memory {
     3 + size
   }
 
-  pub fn build(size: usize) -> (Self, Vec<Lookup<SymbolicExpression<G>>>) {
-    let multiplicity = var(0);
-    let selector = var(1);
-    let pointer = var(2);
+  /// Returns the memory circuit together with its base-field constraints and
+  /// its (single) lookup.
+  pub fn build(size: usize) -> (Self, Vec<Expr<G>>, Vec<Lookup<Expr<G>>>) {
+    let multiplicity = Expr::main(0);
+    let selector = Expr::main(1);
+    let pointer = Expr::main(2);
     let mut args = Vec::with_capacity(3 + size);
-    args.push(selector.clone() * memory_channel());
-    args.push(selector.clone() * G::from_usize(size));
+    args.push(selector.clone() * Expr::constant(memory_channel()));
+    args.push(selector.clone() * Expr::constant(G::from_usize(size)));
     args.push(selector.clone() * pointer);
     for val_idx in 0..size {
-      args.push(selector.clone() * var(3 + val_idx));
+      let col = u32::try_from(3 + val_idx).expect("column index exceeds u32");
+      args.push(selector.clone() * Expr::main(col));
     }
     let width = Self::width(size);
-    (Self { width }, vec![Lookup::pull(multiplicity, args)])
+    // pull = negated multiplicity.
+    let lookups = vec![Lookup { multiplicity: -multiplicity, args }];
+
+    // Transition constraints (formerly the `Air::eval` body): the selector is
+    // boolean; a real next row implies a real current row; and the pointer
+    // increments by one across a real transition.
+    let is_real = Expr::main(1);
+    let is_real_next = Expr::main_next(1);
+    let ptr = Expr::main(2);
+    let ptr_next = Expr::main_next(2);
+    let one = || Expr::constant(G::ONE);
+    let is_real_transition = is_real_next * Expr::IsTransition;
+    let constraints = vec![
+      is_real.clone() * (is_real.clone() - one()),
+      is_real_transition.clone() * (is_real - one()),
+      is_real_transition * (ptr + one() - ptr_next),
+    ];
+
+    (Self { width }, constraints, lookups)
   }
 
   pub fn witness_data(
@@ -88,39 +108,5 @@ impl Memory {
 
     let trace = RowMajorMatrix::new(rows, width);
     (trace, builder.finish())
-  }
-}
-
-impl BaseAir<G> for Memory {
-  fn width(&self) -> usize {
-    self.width
-  }
-}
-
-impl<AB> Air<AB> for Memory
-where
-  AB: AirBuilder<F = G>,
-{
-  fn eval(&self, builder: &mut AB) {
-    let main = builder.main();
-    let local = main.current_slice();
-    let next = main.next_slice();
-
-    let (is_real, ptr) = (local[1], local[2]);
-    let (is_real_next, ptr_next) = (next[1], next[2]);
-
-    builder.assert_bool(is_real);
-
-    // Whether the next row is real.
-    let is_real_transition = is_real_next * builder.is_transition();
-
-    // If the next row is real, the current row is real.
-    builder.when(is_real_transition.clone()).assert_one(is_real);
-
-    // Is this necessary?
-    // builder.when_first_row().when(is_real).assert_zero(ptr);
-
-    // Pointer increases by one
-    builder.when(is_real_transition).assert_eq(ptr + AB::Expr::ONE, ptr_next);
   }
 }

--- a/crates/aiur/src/synthesis.rs
+++ b/crates/aiur/src/synthesis.rs
@@ -345,6 +345,122 @@ mod tests {
     Toplevel { functions: vec![function], memory_sizes: vec![] }
   }
 
+  /// Hand-build a toplevel exercising the two migrated integration paths that
+  /// the `Mul` test does not: the cross-circuit **function-channel** lookup (a
+  /// function calling another) and the **memory circuit** (a `Store` followed
+  /// by a `Load`, which adds a `Memory` circuit and proves its migrated
+  /// transition + memory-channel-lookup constraints).
+  ///
+  /// Functions:
+  /// - `f` (idx 0, entry): `f(a, b) = g(a) * b`, but routing `b` through
+  ///   memory so the memory path is live:
+  ///   - `Call(1, [a], 1, false)` → `g(a)` at value idx 2, allocating one
+  ///     output auxiliary + one function-channel lookup slot.
+  ///   - `Store([b])` → pointer at value idx 3, allocating one pointer
+  ///     auxiliary + one memory-channel lookup slot (multiplicity pushed).
+  ///   - `Load(1, 3)` → the loaded `b` at value idx 4, allocating one value
+  ///     auxiliary + one memory-channel lookup slot.
+  ///   - `Mul(2, 4)` → `g(a) * b` (both degree 1 ⇒ degree 2 ⇒ spilled into a
+  ///     fresh auxiliary at value idx 5).
+  ///   - `Return(0, [5])`.
+  ///
+  ///   Layout for `f` — matched against how `constraints.rs`/`trace.rs` walk
+  ///   the block:
+  ///   - `input_size = 2` (`a`, `b`).
+  ///   - `selectors = 1` (the single `Return`).
+  ///   - `auxiliaries = 5`: multiplicity(1) + call output(1) + store ptr(1) +
+  ///     load value(1) + mul spill(1).
+  ///   - `lookups = 4`: return(slot 0) + call(1) + store(1) + load(1).
+  ///
+  /// - `g` (idx 1): `g(x) = x + 1`:
+  ///   - `Const(1)` at value idx 1, `Add(0, 1)` at value idx 2,
+  ///     `Return(0, [2])`. `Const`/`Add` allocate no auxiliaries.
+  ///   - Layout: `input_size = 1`, `selectors = 1`, `auxiliaries = 1`
+  ///     (multiplicity only), `lookups = 1` (return only).
+  ///
+  /// `memory_sizes = [1]`: a memory of size-1 values, which materializes one
+  /// `Memory` circuit. The single `Store` inserts the entry (memory
+  /// multiplicity 1); the `Load` bumps it to 2. The function circuit pushes
+  /// `+1` for the store lookup and `+1` for the load lookup; the memory circuit
+  /// pulls `-2`. The whole system balances across the function↔function and
+  /// function↔memory channels.
+  fn call_and_memory_toplevel() -> Toplevel {
+    let f_body = Block {
+      ops: vec![
+        Op::Call(1, vec![0], 1, false),
+        Op::Store(vec![1]),
+        Op::Load(1, 3),
+        Op::Mul(2, 4),
+      ],
+      ctrl: Ctrl::Return(0, vec![5]),
+    };
+    let f = Function {
+      body: f_body,
+      layout: FunctionLayout {
+        input_size: 2,
+        selectors: 1,
+        auxiliaries: 5,
+        lookups: 4,
+      },
+      entry: true,
+      constrained: true,
+    };
+
+    let g_body = Block {
+      ops: vec![Op::Const(G::ONE), Op::Add(0, 1)],
+      ctrl: Ctrl::Return(0, vec![2]),
+    };
+    let g = Function {
+      body: g_body,
+      layout: FunctionLayout {
+        input_size: 1,
+        selectors: 1,
+        auxiliaries: 1,
+        lookups: 1,
+      },
+      entry: false,
+      constrained: true,
+    };
+
+    Toplevel { functions: vec![f, g], memory_sizes: vec![1] }
+  }
+
+  #[test]
+  fn prove_verify_call_and_memory_roundtrip() {
+    let (cp, fp) = test_parameters();
+    let system = AiurSystem::build(call_and_memory_toplevel(), cp, fp);
+
+    let a = G::from_u64(3);
+    let b = G::from_u64(5);
+    let input = [a, b];
+    let mut io_buffer = empty_io_buffer();
+
+    // f(a, b) = g(a) * b = (a + 1) * b, with b routed through a Store/Load.
+    let expected = (a + G::ONE) * b;
+    let (claim, proof) = system.prove(0, &input, &mut io_buffer);
+
+    // Claim layout is [function_channel(), fun_idx, input.., output..].
+    assert_eq!(
+      claim,
+      vec![function_channel(), G::from_usize(0), a, b, expected],
+      "unexpected claim layout / computed output"
+    );
+
+    system
+      .verify(&claim, &proof)
+      .expect("valid proof over Call + Store/Load must verify");
+
+    // Negative check: tampering with the output element must make the claim
+    // inconsistent with the (honest) proof, so verification must fail.
+    let mut bad_claim = claim.clone();
+    let last = bad_claim.len() - 1;
+    bad_claim[last] += G::ONE;
+    assert!(
+      system.verify(&bad_claim, &proof).is_err(),
+      "verification must reject a tampered claim"
+    );
+  }
+
   #[test]
   fn prove_verify_mul_roundtrip() {
     let (cp, fp) = test_parameters();

--- a/crates/aiur/src/synthesis.rs
+++ b/crates/aiur/src/synthesis.rs
@@ -1,10 +1,10 @@
 use multi_stark::{
-  lookup::LookupAir,
-  p3_air::{Air, AirBuilder, BaseAir},
+  expr::Expr,
+  lookup::Lookup,
   p3_field::PrimeCharacteristicRing,
   p3_matrix::dense::RowMajorMatrix,
   prover::Proof,
-  system::{ProverKey, System, SystemWitness},
+  system::{CircuitInputs, ProverKey, System, SystemWitness},
   types::{
     CommitmentParameters, FriParameters, GoldilocksBlake3Config, PcsError,
   },
@@ -17,7 +17,6 @@ use rayon::iter::{
 use crate::{
   G,
   bytecode::{FunIdx, Toplevel},
-  constraints::Constraints,
   execute::{ExecError, IOBuffer, QueryRecord},
   function_channel,
   gadgets::{AiurGadget, bytes1::Bytes1, bytes2::Bytes2},
@@ -37,48 +36,11 @@ pub struct AiurSystem {
   /// verifying-key codec (the config itself doesn't expose them back).
   pub(crate) commitment_parameters: CommitmentParameters,
   pub(crate) fri_parameters: FriParameters,
-  pub(crate) system: System<AiurConfig, AiurCircuit>,
-}
-
-pub(crate) enum AiurCircuit {
-  Function(Constraints),
-  Memory(Memory),
-  Bytes1,
-  Bytes2,
-}
-
-impl BaseAir<G> for AiurCircuit {
-  fn width(&self) -> usize {
-    match self {
-      Self::Function(constraints) => constraints.width(),
-      Self::Memory(memory) => memory.width(),
-      Self::Bytes1 => Bytes1.width(),
-      Self::Bytes2 => Bytes2.width(),
-    }
-  }
-
-  fn preprocessed_trace(&self) -> Option<RowMajorMatrix<G>> {
-    match self {
-      Self::Function(constraints) => constraints.preprocessed_trace(),
-      Self::Memory(memory) => memory.preprocessed_trace(),
-      Self::Bytes1 => Bytes1.preprocessed_trace(),
-      Self::Bytes2 => Bytes2.preprocessed_trace(),
-    }
-  }
-}
-
-impl<AB> Air<AB> for AiurCircuit
-where
-  AB: AirBuilder<F = G>,
-{
-  fn eval(&self, builder: &mut AB) {
-    match self {
-      Self::Function(constraints) => constraints.eval(builder),
-      Self::Memory(memory) => memory.eval(builder),
-      Self::Bytes1 => Bytes1.eval(builder),
-      Self::Bytes2 => Bytes2.eval(builder),
-    }
-  }
+  pub(crate) system: System<AiurConfig>,
+  /// Per-circuit lookup-slot argument widths (in system order), retained so
+  /// the witness builder can size its `LookupValues` without reading them
+  /// back off the (now AIR-free) compiled circuits.
+  slot_widths: Vec<Vec<usize>>,
 }
 
 enum CircuitType {
@@ -94,32 +56,61 @@ impl AiurSystem {
     commitment_parameters: CommitmentParameters,
     fri_parameters: FriParameters,
   ) -> Self {
-    let function_circuits = (0..toplevel.functions.len()).filter_map(|i| {
-      if !toplevel.functions[i].constrained {
-        None
-      } else {
-        let (constraints, lookups) = toplevel.build_constraints(i);
-        Some(LookupAir::new(AiurCircuit::Function(constraints), lookups))
-      }
-    });
-    let memory_circuits = toplevel.memory_sizes.iter().map(|&width| {
-      let (memory, lookups) = Memory::build(width);
-      LookupAir::new(AiurCircuit::Memory(memory), lookups)
-    });
+    let mut circuit_inputs: Vec<CircuitInputs<G>> = Vec::new();
+    let mut slot_widths: Vec<Vec<usize>> = Vec::new();
 
-    // Gadgets attached
-    let gadget_circuits = [
-      LookupAir::new(AiurCircuit::Bytes1, Bytes1.lookups()),
-      LookupAir::new(AiurCircuit::Bytes2, Bytes2.lookups()),
-    ]
-    .into_iter();
+    let mut push_circuit =
+      |main_width: usize,
+       preprocessed: Option<RowMajorMatrix<G>>,
+       constraints: Vec<Expr<G>>,
+       lookups: Vec<Lookup<Expr<G>>>| {
+        slot_widths.push(lookups.iter().map(|l| l.args.len()).collect());
+        circuit_inputs.push(CircuitInputs {
+          main_width,
+          preprocessed,
+          constraints,
+          ext_constraints: vec![],
+          lookups,
+        });
+      };
+
+    // Constrained functions (ascending index).
+    for i in 0..toplevel.functions.len() {
+      if !toplevel.functions[i].constrained {
+        continue;
+      }
+      let (constraints, lookups) = toplevel.build_constraints(i);
+      push_circuit(constraints.width, None, constraints.zeros, lookups);
+    }
+    // Memories.
+    for &size in &toplevel.memory_sizes {
+      let (memory, constraints, lookups) = Memory::build(size);
+      push_circuit(memory.width, None, constraints, lookups);
+    }
+    // Gadgets.
+    push_circuit(
+      Bytes1.main_width(),
+      Bytes1.preprocessed(),
+      vec![],
+      Bytes1.lookups(),
+    );
+    push_circuit(
+      Bytes2.main_width(),
+      Bytes2.preprocessed(),
+      vec![],
+      Bytes2.lookups(),
+    );
 
     let config = AiurConfig::new(commitment_parameters, fri_parameters);
-    let (system, key) = System::new(
-      config,
-      function_circuits.chain(memory_circuits).chain(gadget_circuits),
-    );
-    AiurSystem { system, key, toplevel, commitment_parameters, fri_parameters }
+    let (system, key) = System::new(config, circuit_inputs);
+    AiurSystem {
+      system,
+      key,
+      toplevel,
+      commitment_parameters,
+      fri_parameters,
+      slot_widths,
+    }
   }
 
   /// The circuit list in system order: constrained functions (ascending
@@ -142,14 +133,10 @@ impl AiurSystem {
   }
 
   /// The argument width of each lookup slot of circuit `circuit_idx`, taken
-  /// from its symbolic lookups so the witness layout always matches the AIR.
+  /// from the lookups built at construction so the witness layout always
+  /// matches the compiled circuit.
   fn slot_arg_widths(&self, circuit_idx: usize) -> Vec<usize> {
-    self.system.circuits[circuit_idx]
-      .air
-      .lookups
-      .iter()
-      .map(|lookup| lookup.args.len())
-      .collect()
+    self.slot_widths[circuit_idx].clone()
   }
 
   #[tracing::instrument(level = "info", skip_all, name = "aiur/prove")]
@@ -292,5 +279,101 @@ impl AiurSystem {
     proof: &AiurProof,
   ) -> Result<(), VerificationError<PcsError>> {
     self.system.verify(claim, proof)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::{
+    bytecode::{Block, Ctrl, Function, FunctionLayout, Op, Toplevel},
+    execute::IOBuffer,
+  };
+  use multi_stark::{
+    p3_field::PrimeCharacteristicRing,
+    types::{CommitmentParameters, FriParameters},
+  };
+  use rustc_hash::FxHashMap;
+
+  /// Small FRI parameters mirroring `vk_codec`'s test config: cheap to prove
+  /// while still exercising the full FRI pipeline (log_blowup 1, 64 queries,
+  /// no proof-of-work).
+  fn test_parameters() -> (CommitmentParameters, FriParameters) {
+    let cp = CommitmentParameters { log_blowup: 1, cap_height: 0 };
+    let fp = FriParameters {
+      log_final_poly_len: 0,
+      max_log_arity: 1,
+      num_queries: 64,
+      commit_proof_of_work_bits: 0,
+      query_proof_of_work_bits: 0,
+    };
+    (cp, fp)
+  }
+
+  fn empty_io_buffer() -> IOBuffer {
+    IOBuffer { data: FxHashMap::default(), map: FxHashMap::default() }
+  }
+
+  /// Hand-build the toplevel for a single constrained function `f(a, b) = a*b`.
+  ///
+  /// Body: `Mul(0, 1)` (multiplies the two inputs, which live at value indices
+  /// 0 and 1, producing value index 2), then `Return(0, [2])`.
+  ///
+  /// Layout — matched against how `constraints.rs`/`trace.rs` walk the block:
+  /// - `input_size = 2`: the two inputs `a`, `b`.
+  /// - `selectors = 1`: the single `Return` (selector index 0).
+  /// - `auxiliaries = 2`: the multiplicity column (allocated first for every
+  ///   function) plus one auxiliary for the `Mul` — `a` and `b` each have
+  ///   degree 1, so `a*b` has degree 2 and `constraints.rs` spills it into a
+  ///   fresh auxiliary column pinned by `sel * (col - a*b)`.
+  /// - `lookups = 1`: the function-provide (return) lookup in slot 0, which
+  ///   pulls the claim `[function_channel, fun_idx, a, b, a*b]`.
+  fn mul_toplevel() -> Toplevel {
+    let body =
+      Block { ops: vec![Op::Mul(0, 1)], ctrl: Ctrl::Return(0, vec![2]) };
+    let function = Function {
+      body,
+      layout: FunctionLayout {
+        input_size: 2,
+        selectors: 1,
+        auxiliaries: 2,
+        lookups: 1,
+      },
+      entry: true,
+      constrained: true,
+    };
+    Toplevel { functions: vec![function], memory_sizes: vec![] }
+  }
+
+  #[test]
+  fn prove_verify_mul_roundtrip() {
+    let (cp, fp) = test_parameters();
+    let system = AiurSystem::build(mul_toplevel(), cp, fp);
+
+    let a = G::from_u64(3);
+    let b = G::from_u64(5);
+    let input = [a, b];
+    let mut io_buffer = empty_io_buffer();
+
+    let (claim, proof) = system.prove(0, &input, &mut io_buffer);
+
+    // Claim layout is [function_channel(), fun_idx, input.., output..].
+    assert_eq!(
+      claim,
+      vec![function_channel(), G::from_usize(0), a, b, a * b],
+      "unexpected claim layout / computed output"
+    );
+
+    system.verify(&claim, &proof).expect("valid proof must verify");
+
+    // Negative check: tampering with the output element must make the claim
+    // inconsistent with the (honest) proof, so verification must fail.
+    let mut bad_claim = claim.clone();
+    let last = bad_claim.len() - 1;
+    bad_claim[last] += G::ONE;
+    assert!(
+      system.verify(&bad_claim, &proof).is_err(),
+      "verification must reject a tampered claim"
+    );
   }
 }

--- a/crates/aiur/src/vk_codec.rs
+++ b/crates/aiur/src/vk_codec.rs
@@ -148,9 +148,13 @@ fn encode_circuit(buf: &mut Vec<u8>, circuit: &Circuit<Val>) {
   push_u32(buf, circuit.main_width);
   push_u32(buf, circuit.preprocessed_width);
   push_u32(buf, circuit.preprocessed_height);
-  push_u32(buf, circuit.num_publics);
+  // Total folded constraint count (user roots + directly-evaluated logUp),
+  // the value `observe_shape` binds. Replaces the old `num_publics` slot
+  // (which is a constant, `4·D`, and is derived on decode).
+  push_u32(buf, circuit.constraint_count);
   push_u32(buf, circuit.stage_2_width);
-  push_u32(buf, compiled.max_constraint_degree as usize);
+  // Combined max degree (user graph + analytic logUp), as observed.
+  push_u32(buf, circuit.max_constraint_degree);
   push_u32(buf, compiled.lookup_prefix_len);
   push_u32(buf, compiled.nodes.len());
   for node in &compiled.nodes {
@@ -326,10 +330,9 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
   let main_width = seg.u32_usize()?;
   let preprocessed_width = seg.u32_usize()?;
   let preprocessed_height = seg.u32_usize()?;
-  let num_publics = seg.u32_usize()?;
+  let constraint_count = seg.u32_usize()?;
   let stage_2_width = seg.u32_usize()?;
-  let max_constraint_degree =
-    u32::try_from(seg.u32_usize()?).expect("degree exceeds u32");
+  let max_constraint_degree = seg.u32_usize()?;
   let lookup_prefix_len = seg.u32_usize()?;
   let node_count = seg.u32_usize()?;
   let mut nodes = Vec::with_capacity(node_count.min(1 << 20));
@@ -355,15 +358,26 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
   seg.done("circuit record")?;
 
   let degrees = recompute_degrees(&nodes);
+  // The graph's own max degree covers only the user roots (the serialized
+  // `max_constraint_degree` is the combined user + analytic-logUp value).
+  let user_max_degree = zeros
+    .iter()
+    .map(|z| degrees[usize::try_from(z.0).expect("node id")])
+    .max()
+    .unwrap_or(0);
   let graph = ConstraintGraph {
     nodes,
     degrees,
     zeros,
     lookups,
     lookup_prefix_len,
-    max_constraint_degree,
+    max_constraint_degree: user_max_degree,
   };
   let num_lookups = graph.lookups.len();
+  let ext_degree =
+    <multi_stark::types::ExtVal as multi_stark::p3_field::BasedVectorSpace<
+      Val,
+    >>::DIMENSION;
   Ok(Circuit {
     graph,
     main_width,
@@ -372,7 +386,9 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
     preprocessed_height,
     num_lookups,
     stage_2_width,
-    num_publics,
+    num_publics: multi_stark::lookup::num_publics(ext_degree),
+    constraint_count,
+    max_constraint_degree,
   })
 }
 

--- a/crates/aiur/src/vk_codec.rs
+++ b/crates/aiur/src/vk_codec.rs
@@ -11,16 +11,16 @@
 //! `System`, `system::Circuit`, `graph::ConstraintGraph`, `Node`, `NodeId`,
 //! `ColRef`, `Lookup`, `CommitmentParameters`, `FriParameters`.
 //!
-//! # ⚠️ Wire format changed with the multi-stark constraint-IR migration
+//! The recursive verifier hashes every vk byte (digest binding) and parses
+//! them in-circuit, so the format optimizes for density: u16 node ids
+//! (per-circuit graphs are far below 65k nodes), the Var (source, offset)
+//! packed into the tag byte, a small/big constant split, and u16 zeros and
+//! lookup references. The logUp constraints are never serialized — they are
+//! evaluated directly by both verifiers from the compiled lookups.
+//! The Lean mirror is `Ix/MultiStark/SystemDeserialize.lean`; the two must
+//! stay byte-identical.
 //!
-//! The previous format serialized a per-circuit *symbolic* AIR
-//! (`SymbolicExpression` trees + `LookupAir` + the `AiurCircuit` tag). The new
-//! multi-stark compiles circuits to a flat base-field node graph, so this
-//! codec now serializes that compiled form instead. **The Lean mirror
-//! `Ix/MultiStark/SystemDeserialize.lean` must be rewritten to match this new
-//! format** (it is NOT updated here). See "Wire format (v3)" below.
-//!
-//! # Wire format (v3)
+//! # Wire format (v5, dense)
 //!
 //! ```text
 //! GLOBAL HEADER
@@ -31,21 +31,22 @@
 //! PER-CIRCUIT RECORDS (circuit count times; each is `u32 LE len` + `len` bytes
 //!                      so a record is a contiguous byte range)
 //!   8 x u32 LE   main_width, preprocessed_width, preprocessed_height,
-//!                num_publics, stage_2_width, max_constraint_degree,
+//!                constraint_count (user roots + (L+3)*D), stage_2_width,
+//!                max_constraint_degree (combined user + logUp),
 //!                lookup_prefix_len, node_count
-//!   node_count nodes, each:
-//!     u8 tag  0 Const 1 Var 2 Public 3 IsFirstRow 4 IsLastRow
-//!             5 IsTransition 6 Add 7 Sub 8 Mul 9 Neg
-//!     Const:  u64 LE canonical value
-//!     Var:    u8 source (0 Preprocessed 1 Main 2 Stage2), u8 offset
-//!             (0 current 1 next), u32 LE column index
-//!     Public: u32 LE index
-//!     Add/Sub/Mul: u32 LE, u32 LE child node ids
-//!     Neg:    u32 LE child node id
-//!   u32 zero_count, then zero_count x u32 LE constraint-root node ids
+//!   node_count nodes, each a u8 tag then payload:
+//!     0  ConstSmall: u16 LE canonical value
+//!     1  ConstBig:   u64 LE canonical value
+//!     2  Public:     u8 index
+//!     3 IsFirstRow · 4 IsLastRow · 5 IsTransition (no payload)
+//!     6 Add · 7 Sub · 8 Mul: u16 LE, u16 LE child node ids
+//!     9  Neg: u16 LE child node id
+//!     10..=15  Var (tag = 10 + 2*source + offset; source 0 Preprocessed
+//!              1 Main 2 Stage2, offset 0 current 1 next): u16 LE column
+//!   u32 zero_count, then zero_count x u16 LE constraint-root node ids
 //!   u32 lookup_count, then per lookup:
-//!     u32 LE multiplicity node id
-//!     u32 LE arg count, then arg_count x u32 LE arg node ids
+//!     u16 LE multiplicity node id
+//!     u16 LE arg count, then arg_count x u16 LE arg node ids
 //! TRAILER
 //!   u8           preprocessed commit flag (0 = None / 1 = Some)
 //!   [u16 + 32-byte digests]   MerkleCap, if flag = 1
@@ -56,7 +57,7 @@
 //! IsTransition = 0, Var/IsFirstRow/IsLastRow = 1, Add/Sub = max of children,
 //! Mul = sum, Neg = child) and recomputed on decode in node order (children
 //! precede parents in the compiled vector). Goldilocks constants are written
-//! as `as_canonical_u64()` and read back with `from_u64`.
+//! canonically and reduced on read.
 
 // The codec is exercised by tests and wired to the FFI / Aiur port.
 #![allow(dead_code)]
@@ -89,18 +90,29 @@ fn push_u32(buf: &mut Vec<u8>, v: usize) {
   buf.extend_from_slice(&v.to_le_bytes());
 }
 
+/// Node ids on the wire are u16: per-circuit graphs are far below 65k
+/// nodes (the whole kernel system is ~140k across 800+ circuits).
 fn push_node_id(buf: &mut Vec<u8>, id: NodeId) {
-  buf.extend_from_slice(&id.0.to_le_bytes());
+  let id = u16::try_from(id.0).expect("node id exceeds u16 (vk wire format)");
+  buf.extend_from_slice(&id.to_le_bytes());
 }
 
 fn push_node(buf: &mut Vec<u8>, node: &Node<Val>) {
   match node {
     Node::Const(c) => {
-      buf.push(0);
-      buf.extend_from_slice(&c.as_canonical_u64().to_le_bytes());
+      // Small/big constant split: most constants (selector weights, small
+      // literals) fit u16.
+      let v = c.as_canonical_u64();
+      if let Ok(small) = u16::try_from(v) {
+        buf.push(0);
+        buf.extend_from_slice(&small.to_le_bytes());
+      } else {
+        buf.push(1);
+        buf.extend_from_slice(&v.to_le_bytes());
+      }
     },
     Node::Var(col) => {
-      buf.push(1);
+      // Var tag packs (source, offset): 10 + 2·source + offset.
       let source = match col.source {
         Source::Preprocessed => 0u8,
         Source::Main => 1,
@@ -110,13 +122,14 @@ fn push_node(buf: &mut Vec<u8>, node: &Node<Val>) {
         RowOffset::Current => 0u8,
         RowOffset::Next => 1,
       };
-      buf.push(source);
-      buf.push(offset);
-      buf.extend_from_slice(&col.index.to_le_bytes());
+      buf.push(10 + 2 * source + offset);
+      let index = u16::try_from(col.index)
+        .expect("column index exceeds u16 (vk wire format)");
+      buf.extend_from_slice(&index.to_le_bytes());
     },
     Node::Public(i) => {
       buf.push(2);
-      buf.extend_from_slice(&i.to_le_bytes());
+      buf.push(u8::try_from(*i).expect("public index exceeds u8"));
     },
     Node::IsFirstRow => buf.push(3),
     Node::IsLastRow => buf.push(4),
@@ -167,7 +180,7 @@ fn encode_circuit(buf: &mut Vec<u8>, circuit: &Circuit<Val>) {
   push_u32(buf, compiled.lookups.len());
   for lookup in &compiled.lookups {
     push_node_id(buf, lookup.multiplicity);
-    push_u32(buf, lookup.args.len());
+    push_u16(buf, lookup.args.len());
     for &arg in &lookup.args {
       push_node_id(buf, arg);
     }
@@ -259,7 +272,7 @@ impl<'a> Seg<'a> {
     Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()) as usize)
   }
   fn node_id(&mut self) -> Result<NodeId, String> {
-    Ok(NodeId(u32::from_le_bytes(self.take(4)?.try_into().unwrap())))
+    Ok(NodeId(u32::from(self.u16()?)))
   }
   fn u64(&mut self) -> Result<u64, String> {
     Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
@@ -278,23 +291,9 @@ impl<'a> Seg<'a> {
 
 fn decode_node(seg: &mut Seg<'_>) -> Result<Node<Val>, String> {
   Ok(match seg.u8()? {
-    0 => Node::Const(Val::from_u64(seg.u64()?)),
-    1 => {
-      let source = match seg.u8()? {
-        0 => Source::Preprocessed,
-        1 => Source::Main,
-        2 => Source::Stage2,
-        s => return Err(format!("bad source {s}")),
-      };
-      let offset = match seg.u8()? {
-        0 => RowOffset::Current,
-        1 => RowOffset::Next,
-        o => return Err(format!("bad row offset {o}")),
-      };
-      let index = u32::from_le_bytes(seg.take(4)?.try_into().unwrap());
-      Node::Var(ColRef { source, offset, index })
-    },
-    2 => Node::Public(u32::from_le_bytes(seg.take(4)?.try_into().unwrap())),
+    0 => Node::Const(Val::from_u16(seg.u16()?)),
+    1 => Node::Const(Val::from_u64(seg.u64()?)),
+    2 => Node::Public(u32::from(seg.u8()?)),
     3 => Node::IsFirstRow,
     4 => Node::IsLastRow,
     5 => Node::IsTransition,
@@ -302,6 +301,18 @@ fn decode_node(seg: &mut Seg<'_>) -> Result<Node<Val>, String> {
     7 => Node::Sub(seg.node_id()?, seg.node_id()?),
     8 => Node::Mul(seg.node_id()?, seg.node_id()?),
     9 => Node::Neg(seg.node_id()?),
+    t @ 10..=15 => {
+      let v = t - 10;
+      let source = match v / 2 {
+        0 => Source::Preprocessed,
+        1 => Source::Main,
+        _ => Source::Stage2,
+      };
+      let offset =
+        if v % 2 == 0 { RowOffset::Current } else { RowOffset::Next };
+      let index = u32::from(seg.u16()?);
+      Node::Var(ColRef { source, offset, index })
+    },
     t => return Err(format!("bad node tag {t}")),
   })
 }
@@ -348,7 +359,7 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
   let mut lookups = Vec::with_capacity(lookup_count.min(1 << 16));
   for _ in 0..lookup_count {
     let multiplicity = seg.node_id()?;
-    let arg_count = seg.u32_usize()?;
+    let arg_count = seg.u16()? as usize;
     let mut args = Vec::with_capacity(arg_count.min(1 << 16));
     for _ in 0..arg_count {
       args.push(seg.node_id()?);

--- a/crates/aiur/src/vk_codec.rs
+++ b/crates/aiur/src/vk_codec.rs
@@ -1,27 +1,26 @@
-//! (De)serialization of the verifier's key: `System<AiurCircuit>`.
+//! (De)serialization of the verifier's key: `System<AiurConfig>`.
 //!
-//! The verifier needs the system's per-circuit AIR (symbolic constraints +
-//! lookups + widths), the shared preprocessed commitment, the preprocessed
+//! The verifier needs each circuit's *compiled* constraint data (the flat,
+//! interned node vector, the constraint roots, the compiled lookups, and the
+//! widths/degrees), the shared preprocessed commitment, the preprocessed
 //! index map, and the commitment + FRI parameters (which seed the config's
-//! challenger) — i.e. everything in [`System<AiurCircuit>`] except the
-//! prover-only preprocessed traces (the large gadget tables in each
-//! `LookupAir.preprocessed`), which are reconstructed/committed separately
-//! and so are *not* serialized.
+//! challenger). The prover-only preprocessed *traces* (the large gadget
+//! tables) are reconstructed/committed separately and are NOT serialized.
 //!
-//! This is a **hand-written, serde-free** codec. `multi-stark` does not derive
-//! `serde` on its types, so the encoder and decoder are written by hand against
-//! the public fields of `System`, `Circuit`, `LookupAir`, `Lookup`,
-//! `SymbolicExpression`, `SymbolicVariable`, `Entry`, `CommitmentParameters`,
-//! `FriParameters` and the Ix `AiurCircuit`/`Constraints`/`Memory`. The Aiur
-//! port (`Ix/MultiStark/SystemDeserialize.lean`) reads the same bytes
-//! in-circuit; the two must stay mirror images.
+//! This is a **hand-written, serde-free** codec against the public fields of
+//! `System`, `system::Circuit`, `graph::ConstraintGraph`, `Node`, `NodeId`,
+//! `ColRef`, `Lookup`, `CommitmentParameters`, `FriParameters`.
 //!
-//! # Split-streams wire format (v2)
+//! # ⚠️ Wire format changed with the multi-stark constraint-IR migration
 //!
-//! The recursive verifier hashes every vk byte (digest binding) and reads them
-//! with fixed-size `io_read` chunks, so the format optimizes for (a) few bytes
-//! and (b) fixed-width fields only — no varints. Each field class lives in its
-//! own per-circuit byte segment with a single width:
+//! The previous format serialized a per-circuit *symbolic* AIR
+//! (`SymbolicExpression` trees + `LookupAir` + the `AiurCircuit` tag). The new
+//! multi-stark compiles circuits to a flat base-field node graph, so this
+//! codec now serializes that compiled form instead. **The Lean mirror
+//! `Ix/MultiStark/SystemDeserialize.lean` must be rewritten to match this new
+//! format** (it is NOT updated here). See "Wire format (v3)" below.
+//!
+//! # Wire format (v3)
 //!
 //! ```text
 //! GLOBAL HEADER
@@ -29,197 +28,154 @@
 //!                log_final_poly_len, max_log_arity, num_queries,
 //!                commit_proof_of_work_bits, query_proof_of_work_bits)
 //!   u16          circuit count
-//! PER-CIRCUIT RECORDS (circuit count times; each record is a contiguous
-//!                      byte range — a future Merkle leaf)
-//!   5 x u32 LE   segment lengths: TAGS, IDX, C2, C8, META
-//!   TAGS   1 byte per node: low nibble = kind, high nibble = aux
-//!   IDX    2 bytes per Variable: column index (u16 LE)
-//!   C2     2 bytes per small constant (canonical value < 2^16, u16 LE)
-//!   C8     8 bytes per large constant (canonical u64 LE)
-//!   META   4 bytes per count/metadata field (u32 LE)
+//! PER-CIRCUIT RECORDS (circuit count times; each is `u32 LE len` + `len` bytes
+//!                      so a record is a contiguous byte range)
+//!   8 x u32 LE   main_width, preprocessed_width, preprocessed_height,
+//!                num_publics, stage_2_width, max_constraint_degree,
+//!                lookup_prefix_len, node_count
+//!   node_count nodes, each:
+//!     u8 tag  0 Const 1 Var 2 Public 3 IsFirstRow 4 IsLastRow
+//!             5 IsTransition 6 Add 7 Sub 8 Mul 9 Neg
+//!     Const:  u64 LE canonical value
+//!     Var:    u8 source (0 Preprocessed 1 Main 2 Stage2), u8 offset
+//!             (0 current 1 next), u32 LE column index
+//!     Public: u32 LE index
+//!     Add/Sub/Mul: u32 LE, u32 LE child node ids
+//!     Neg:    u32 LE child node id
+//!   u32 zero_count, then zero_count x u32 LE constraint-root node ids
+//!   u32 lookup_count, then per lookup:
+//!     u32 LE multiplicity node id
+//!     u32 LE arg count, then arg_count x u32 LE arg node ids
 //! TRAILER
 //!   u8           preprocessed commit flag (0 = None / 1 = Some)
 //!   [u16 + 32-byte digests]   MerkleCap, if flag = 1
 //!   u16 x circuit count       preprocessed indices (0xFFFF = None)
 //! ```
 //!
-//! TAGS byte: kind 0 = Variable, 1 = IsFirstRow, 2 = IsLastRow,
-//! 3 = IsTransition, 4 = Constant, 5 = Add, 6 = Sub, 7 = Neg, 8 = Mul.
-//! Aux for Variable = entry kind (0 = Preprocessed, 1 = Main, 2 = Stage2,
-//! 3 = Public, 4 = Stage2Public, 5 = Challenge) + 8 * rotation offset (the
-//! rotation is only 0/1: current or next row). Aux for Constant = size class
-//! (0 -> C2, 1 -> C8). A record's first TAGS byte is the `AiurCircuit`
-//! variant tag (0 = Function, 1 = Memory, 2 = Bytes1, 3 = Bytes2), then
-//! expression nodes in preorder.
-//!
-//! Record content order (defines each segment's fill order):
-//! aircircuit tag; [Function: zeros count (META), zero exprs, selectors
-//! start/end + width (META) | Memory: width (META)]; lookups count (META);
-//! per lookup: multiplicity expr, args count (META), arg exprs; then the 6
-//! circuit metadata fields (constraint_count, max_constraint_degree,
-//! preprocessed_height, preprocessed_width, stage_1_width, stage_2_width)
-//! (META).
-//!
-//! `degree_multiple` is NOT serialized: it is fully derivable (variables by
-//! entry kind, add/sub = max of children, mul = sum, neg = child) and the
-//! decoder recomputes it via the library's own `degree_multiple()` on the
-//! reconstructed children. Dropping it, the u32 enum tags, and the u64
-//! fixed-width scaffolding shrinks the kernel vk ~7x, which directly cuts the
-//! recursive verifier's dominant blake3 cost.
-//!
-//! Goldilocks note: constants are written as `as_canonical_u64()` (the raw
-//! internal repr is `pub(crate)` in `p3_goldilocks`) and read back with
-//! `from_u64`; verifying-key constants are canonical so the round-trip is
-//! exact, and the Lean reader reduces mod p regardless.
+//! Per-node `degrees` are NOT serialized: they are derived (Const/Public/
+//! IsTransition = 0, Var/IsFirstRow/IsLastRow = 1, Add/Sub = max of children,
+//! Mul = sum, Neg = child) and recomputed on decode in node order (children
+//! precede parents in the compiled vector). Goldilocks constants are written
+//! as `as_canonical_u64()` and read back with `from_u64`.
 
 // The codec is exercised by tests and wired to the FFI / Aiur port.
 #![allow(dead_code)]
 
 use multi_stark::{
-  builder::symbolic::{Entry, SymbolicExpression, SymbolicVariable},
-  lookup::{Lookup, LookupAir},
+  expr::{ColRef, RowOffset, Source},
+  graph::{ConstraintGraph, Node, NodeId},
+  lookup::Lookup,
   p3_field::{PrimeCharacteristicRing, PrimeField64},
   system::{Circuit, System},
   types::{Commitment, CommitmentParameters, FriParameters, Val},
 };
 
-use crate::{
-  constraints::Constraints,
-  memory::Memory,
-  synthesis::{AiurCircuit, AiurConfig, AiurSystem},
-};
-
-type Expr = SymbolicExpression<Val>;
+use crate::synthesis::{AiurConfig, AiurSystem};
 
 /// Sentinel for `None` in the preprocessed-index trailer.
 const NO_PREP_INDEX: u16 = u16::MAX;
 
 // ════════════════════════════════════════════════════════════════════════════
-// Encoder — System<AiurCircuit> -> bytes
+// Encoder — System<AiurConfig> -> bytes
 // ════════════════════════════════════════════════════════════════════════════
-
-/// One circuit's five segments, filled in record-content order.
-#[derive(Default)]
-struct RecordBufs {
-  tags: Vec<u8>,
-  idx: Vec<u8>,
-  c2: Vec<u8>,
-  c8: Vec<u8>,
-  meta: Vec<u8>,
-}
-
-impl RecordBufs {
-  fn tag(&mut self, kind: u8, aux: u8) {
-    debug_assert!(kind < 16 && aux < 16);
-    self.tags.push(kind | (aux << 4));
-  }
-  fn index_u16(&mut self, v: usize) {
-    let v = u16::try_from(v).expect("variable column index exceeds u16");
-    self.idx.extend_from_slice(&v.to_le_bytes());
-  }
-  fn meta_u32(&mut self, v: usize) {
-    let v = u32::try_from(v).expect("vk metadata field exceeds u32");
-    self.meta.extend_from_slice(&v.to_le_bytes());
-  }
-  fn constant(&mut self, v: Val) {
-    let c = v.as_canonical_u64();
-    if let Ok(c2) = u16::try_from(c) {
-      self.c2.extend_from_slice(&c2.to_le_bytes());
-      self.tag(4, 0);
-    } else {
-      self.c8.extend_from_slice(&c.to_le_bytes());
-      self.tag(4, 1);
-    }
-  }
-  fn variable(&mut self, v: &SymbolicVariable<Val>) {
-    let (kind, offset) = match v.entry {
-      Entry::Preprocessed { offset } => (0u8, offset),
-      Entry::Main { offset } => (1, offset),
-      Entry::Stage2 { offset } => (2, offset),
-      Entry::Public => (3, 0),
-      Entry::Stage2Public => (4, 0),
-      Entry::Challenge => (5, 0),
-    };
-    let offset = u8::try_from(offset).expect("rotation offset exceeds u8");
-    assert!(offset <= 1, "rotation offset {offset} not in {{0, 1}}");
-    self.tag(0, kind + 8 * offset);
-    self.index_u16(v.index);
-  }
-  fn expr(&mut self, e: &Expr) {
-    match e {
-      SymbolicExpression::Variable(v) => self.variable(v),
-      SymbolicExpression::IsFirstRow => self.tag(1, 0),
-      SymbolicExpression::IsLastRow => self.tag(2, 0),
-      SymbolicExpression::IsTransition => self.tag(3, 0),
-      SymbolicExpression::Constant(c) => self.constant(*c),
-      SymbolicExpression::Add { x, y, .. } => {
-        self.tag(5, 0);
-        self.expr(x);
-        self.expr(y);
-      },
-      SymbolicExpression::Sub { x, y, .. } => {
-        self.tag(6, 0);
-        self.expr(x);
-        self.expr(y);
-      },
-      SymbolicExpression::Neg { x, .. } => {
-        self.tag(7, 0);
-        self.expr(x);
-      },
-      SymbolicExpression::Mul { x, y, .. } => {
-        self.tag(8, 0);
-        self.expr(x);
-        self.expr(y);
-      },
-    }
-  }
-  fn circuit(&mut self, c: &Circuit<AiurCircuit, Val>) {
-    match &c.air.inner_air {
-      AiurCircuit::Function(Constraints { zeros, selectors, width }) => {
-        self.tag(0, 0);
-        self.meta_u32(zeros.len());
-        for z in zeros {
-          self.expr(z);
-        }
-        self.meta_u32(selectors.start);
-        self.meta_u32(selectors.end);
-        self.meta_u32(*width);
-      },
-      AiurCircuit::Memory(Memory { width }) => {
-        self.tag(1, 0);
-        self.meta_u32(*width);
-      },
-      AiurCircuit::Bytes1 => self.tag(2, 0),
-      AiurCircuit::Bytes2 => self.tag(3, 0),
-    }
-    self.meta_u32(c.air.lookups.len());
-    for l in &c.air.lookups {
-      self.expr(&l.multiplicity);
-      self.meta_u32(l.args.len());
-      for a in &l.args {
-        self.expr(a);
-      }
-    }
-    self.meta_u32(c.constraint_count);
-    self.meta_u32(c.max_constraint_degree);
-    self.meta_u32(c.preprocessed_height);
-    self.meta_u32(c.preprocessed_width);
-    self.meta_u32(c.stage_1_width);
-    self.meta_u32(c.stage_2_width);
-  }
-}
 
 fn push_u16(buf: &mut Vec<u8>, v: usize) {
   let v = u16::try_from(v).expect("vk header field exceeds u16");
   buf.extend_from_slice(&v.to_le_bytes());
 }
 
-/// Serialize the verifying key `System<AiurCircuit>` (preprocessed traces are
+fn push_u32(buf: &mut Vec<u8>, v: usize) {
+  let v = u32::try_from(v).expect("vk field exceeds u32");
+  buf.extend_from_slice(&v.to_le_bytes());
+}
+
+fn push_node_id(buf: &mut Vec<u8>, id: NodeId) {
+  buf.extend_from_slice(&id.0.to_le_bytes());
+}
+
+fn push_node(buf: &mut Vec<u8>, node: &Node<Val>) {
+  match node {
+    Node::Const(c) => {
+      buf.push(0);
+      buf.extend_from_slice(&c.as_canonical_u64().to_le_bytes());
+    },
+    Node::Var(col) => {
+      buf.push(1);
+      let source = match col.source {
+        Source::Preprocessed => 0u8,
+        Source::Main => 1,
+        Source::Stage2 => 2,
+      };
+      let offset = match col.offset {
+        RowOffset::Current => 0u8,
+        RowOffset::Next => 1,
+      };
+      buf.push(source);
+      buf.push(offset);
+      buf.extend_from_slice(&col.index.to_le_bytes());
+    },
+    Node::Public(i) => {
+      buf.push(2);
+      buf.extend_from_slice(&i.to_le_bytes());
+    },
+    Node::IsFirstRow => buf.push(3),
+    Node::IsLastRow => buf.push(4),
+    Node::IsTransition => buf.push(5),
+    Node::Add(a, b) => {
+      buf.push(6);
+      push_node_id(buf, *a);
+      push_node_id(buf, *b);
+    },
+    Node::Sub(a, b) => {
+      buf.push(7);
+      push_node_id(buf, *a);
+      push_node_id(buf, *b);
+    },
+    Node::Mul(a, b) => {
+      buf.push(8);
+      push_node_id(buf, *a);
+      push_node_id(buf, *b);
+    },
+    Node::Neg(a) => {
+      buf.push(9);
+      push_node_id(buf, *a);
+    },
+  }
+}
+
+fn encode_circuit(buf: &mut Vec<u8>, circuit: &Circuit<Val>) {
+  let compiled = &circuit.graph;
+  push_u32(buf, circuit.main_width);
+  push_u32(buf, circuit.preprocessed_width);
+  push_u32(buf, circuit.preprocessed_height);
+  push_u32(buf, circuit.num_publics);
+  push_u32(buf, circuit.stage_2_width);
+  push_u32(buf, compiled.max_constraint_degree as usize);
+  push_u32(buf, compiled.lookup_prefix_len);
+  push_u32(buf, compiled.nodes.len());
+  for node in &compiled.nodes {
+    push_node(buf, node);
+  }
+  push_u32(buf, compiled.zeros.len());
+  for &z in &compiled.zeros {
+    push_node_id(buf, z);
+  }
+  push_u32(buf, compiled.lookups.len());
+  for lookup in &compiled.lookups {
+    push_node_id(buf, lookup.multiplicity);
+    push_u32(buf, lookup.args.len());
+    for &arg in &lookup.args {
+      push_node_id(buf, arg);
+    }
+  }
+}
+
+/// Serialize the verifying key `System<AiurConfig>` (preprocessed traces are
 /// skipped — see the module docs). The config's construction parameters are
 /// passed alongside because [`AiurConfig`] doesn't expose them back; they are
 /// written first so the decoder can rebuild the config.
 pub(crate) fn to_bytes(
-  system: &System<AiurConfig, AiurCircuit>,
+  system: &System<AiurConfig>,
   commitment_parameters: CommitmentParameters,
   fri_parameters: FriParameters,
 ) -> Vec<u8> {
@@ -232,16 +188,11 @@ pub(crate) fn to_bytes(
   push_u16(&mut buf, fri_parameters.commit_proof_of_work_bits);
   push_u16(&mut buf, fri_parameters.query_proof_of_work_bits);
   push_u16(&mut buf, system.circuits.len());
-  for c in &system.circuits {
-    let mut r = RecordBufs::default();
-    r.circuit(c);
-    for seg in [&r.tags, &r.idx, &r.c2, &r.c8, &r.meta] {
-      let len = u32::try_from(seg.len()).expect("vk segment exceeds u32");
-      buf.extend_from_slice(&len.to_le_bytes());
-    }
-    for seg in [&r.tags, &r.idx, &r.c2, &r.c8, &r.meta] {
-      buf.extend_from_slice(seg);
-    }
+  for circuit in &system.circuits {
+    let mut record = Vec::new();
+    encode_circuit(&mut record, circuit);
+    push_u32(&mut buf, record.len());
+    buf.extend_from_slice(&record);
   }
   match &system.preprocessed_commit {
     None => buf.push(0),
@@ -275,12 +226,7 @@ pub fn aiur_system_to_bytes(sys: &AiurSystem) -> Result<Vec<u8>, String> {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// Decoder — bytes -> System<AiurCircuit>
-//
-// A hand-written reader matching the bytes `to_bytes` produces, decoding
-// straight into the real `System<AiurCircuit>`. This is the reference
-// re-implemented in Aiur (`Ix/MultiStark/SystemDeserialize.lean`).
-// `degree_multiple` is recomputed from the reconstructed children.
+// Decoder — bytes -> System<AiurConfig>
 // ════════════════════════════════════════════════════════════════════════════
 
 /// Cursor over one byte region.
@@ -305,8 +251,11 @@ impl<'a> Seg<'a> {
   fn u16(&mut self) -> Result<u16, String> {
     Ok(u16::from_le_bytes(self.take(2)?.try_into().unwrap()))
   }
-  fn u32(&mut self) -> Result<u32, String> {
-    Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+  fn u32_usize(&mut self) -> Result<usize, String> {
+    Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()) as usize)
+  }
+  fn node_id(&mut self) -> Result<NodeId, String> {
+    Ok(NodeId(u32::from_le_bytes(self.take(4)?.try_into().unwrap())))
   }
   fn u64(&mut self) -> Result<u64, String> {
     Ok(u64::from_le_bytes(self.take(8)?.try_into().unwrap()))
@@ -323,136 +272,116 @@ impl<'a> Seg<'a> {
   }
 }
 
-/// One record's five segment cursors.
-struct RecordReader<'a> {
-  tags: Seg<'a>,
-  idx: Seg<'a>,
-  c2: Seg<'a>,
-  c8: Seg<'a>,
-  meta: Seg<'a>,
+fn decode_node(seg: &mut Seg<'_>) -> Result<Node<Val>, String> {
+  Ok(match seg.u8()? {
+    0 => Node::Const(Val::from_u64(seg.u64()?)),
+    1 => {
+      let source = match seg.u8()? {
+        0 => Source::Preprocessed,
+        1 => Source::Main,
+        2 => Source::Stage2,
+        s => return Err(format!("bad source {s}")),
+      };
+      let offset = match seg.u8()? {
+        0 => RowOffset::Current,
+        1 => RowOffset::Next,
+        o => return Err(format!("bad row offset {o}")),
+      };
+      let index = u32::from_le_bytes(seg.take(4)?.try_into().unwrap());
+      Node::Var(ColRef { source, offset, index })
+    },
+    2 => Node::Public(u32::from_le_bytes(seg.take(4)?.try_into().unwrap())),
+    3 => Node::IsFirstRow,
+    4 => Node::IsLastRow,
+    5 => Node::IsTransition,
+    6 => Node::Add(seg.node_id()?, seg.node_id()?),
+    7 => Node::Sub(seg.node_id()?, seg.node_id()?),
+    8 => Node::Mul(seg.node_id()?, seg.node_id()?),
+    9 => Node::Neg(seg.node_id()?),
+    t => return Err(format!("bad node tag {t}")),
+  })
 }
 
-impl<'a> RecordReader<'a> {
-  fn meta_usize(&mut self) -> Result<usize, String> {
-    Ok(self.meta.u32()? as usize)
-  }
-  fn expr(&mut self) -> Result<Expr, String> {
-    let byte = self.tags.u8()?;
-    let (kind, aux) = (byte & 0xF, byte >> 4);
-    Ok(match kind {
-      0 => {
-        let offset = (aux >> 3) as usize;
-        let entry = match aux & 0x7 {
-          0 => Entry::Preprocessed { offset },
-          1 => Entry::Main { offset },
-          2 => Entry::Stage2 { offset },
-          3 => Entry::Public,
-          4 => Entry::Stage2Public,
-          5 => Entry::Challenge,
-          k => return Err(format!("bad entry kind {k}")),
-        };
-        let index = self.idx.u16()? as usize;
-        SymbolicExpression::Variable(SymbolicVariable::new(entry, index))
+/// Recompute per-node degree multiples in node order (children precede parents
+/// in the compiled vector).
+fn recompute_degrees(nodes: &[Node<Val>]) -> Vec<u32> {
+  let mut degrees: Vec<u32> = Vec::with_capacity(nodes.len());
+  for node in nodes {
+    let d = match *node {
+      Node::Const(_) | Node::Public(_) | Node::IsTransition => 0,
+      Node::Var(_) | Node::IsFirstRow | Node::IsLastRow => 1,
+      Node::Add(a, b) | Node::Sub(a, b) => {
+        degrees[a.0 as usize].max(degrees[b.0 as usize])
       },
-      1 => SymbolicExpression::IsFirstRow,
-      2 => SymbolicExpression::IsLastRow,
-      3 => SymbolicExpression::IsTransition,
-      4 => {
-        let c = match aux {
-          0 => u64::from(self.c2.u16()?),
-          1 => self.c8.u64()?,
-          a => return Err(format!("bad constant size class {a}")),
-        };
-        SymbolicExpression::Constant(Val::from_u64(c))
-      },
-      5 => {
-        let x = Box::new(self.expr()?);
-        let y = Box::new(self.expr()?);
-        let degree_multiple = x.degree_multiple().max(y.degree_multiple());
-        SymbolicExpression::Add { x, y, degree_multiple }
-      },
-      6 => {
-        let x = Box::new(self.expr()?);
-        let y = Box::new(self.expr()?);
-        let degree_multiple = x.degree_multiple().max(y.degree_multiple());
-        SymbolicExpression::Sub { x, y, degree_multiple }
-      },
-      7 => {
-        let x = Box::new(self.expr()?);
-        let degree_multiple = x.degree_multiple();
-        SymbolicExpression::Neg { x, degree_multiple }
-      },
-      8 => {
-        let x = Box::new(self.expr()?);
-        let y = Box::new(self.expr()?);
-        let degree_multiple = x.degree_multiple() + y.degree_multiple();
-        SymbolicExpression::Mul { x, y, degree_multiple }
-      },
-      t => return Err(format!("bad expr kind {t}")),
-    })
-  }
-  fn circuit(&mut self) -> Result<Circuit<AiurCircuit, Val>, String> {
-    let inner_air = match self.tags.u8()? {
-      0 => {
-        let n = self.meta_usize()?;
-        let mut zeros = Vec::with_capacity(n.min(1 << 16));
-        for _ in 0..n {
-          zeros.push(self.expr()?);
-        }
-        let start = self.meta_usize()?;
-        let end = self.meta_usize()?;
-        let width = self.meta_usize()?;
-        AiurCircuit::Function(Constraints {
-          zeros,
-          selectors: start..end,
-          width,
-        })
-      },
-      1 => AiurCircuit::Memory(Memory { width: self.meta_usize()? }),
-      2 => AiurCircuit::Bytes1,
-      3 => AiurCircuit::Bytes2,
-      t => return Err(format!("bad aircircuit tag {t}")),
+      Node::Mul(a, b) => degrees[a.0 as usize] + degrees[b.0 as usize],
+      Node::Neg(a) => degrees[a.0 as usize],
     };
-    let n = self.meta_usize()?;
-    let mut lookups = Vec::with_capacity(n.min(1 << 16));
-    for _ in 0..n {
-      let multiplicity = self.expr()?;
-      let a = self.meta_usize()?;
-      let mut args = Vec::with_capacity(a.min(1 << 16));
-      for _ in 0..a {
-        args.push(self.expr()?);
-      }
-      lookups.push(Lookup { multiplicity, args });
+    degrees.push(d);
+  }
+  degrees
+}
+
+fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
+  let mut seg = Seg { buf: bytes, pos: 0 };
+  let main_width = seg.u32_usize()?;
+  let preprocessed_width = seg.u32_usize()?;
+  let preprocessed_height = seg.u32_usize()?;
+  let num_publics = seg.u32_usize()?;
+  let stage_2_width = seg.u32_usize()?;
+  let max_constraint_degree =
+    u32::try_from(seg.u32_usize()?).expect("degree exceeds u32");
+  let lookup_prefix_len = seg.u32_usize()?;
+  let node_count = seg.u32_usize()?;
+  let mut nodes = Vec::with_capacity(node_count.min(1 << 20));
+  for _ in 0..node_count {
+    nodes.push(decode_node(&mut seg)?);
+  }
+  let zero_count = seg.u32_usize()?;
+  let mut zeros = Vec::with_capacity(zero_count.min(1 << 20));
+  for _ in 0..zero_count {
+    zeros.push(seg.node_id()?);
+  }
+  let lookup_count = seg.u32_usize()?;
+  let mut lookups = Vec::with_capacity(lookup_count.min(1 << 16));
+  for _ in 0..lookup_count {
+    let multiplicity = seg.node_id()?;
+    let arg_count = seg.u32_usize()?;
+    let mut args = Vec::with_capacity(arg_count.min(1 << 16));
+    for _ in 0..arg_count {
+      args.push(seg.node_id()?);
     }
-    let air = LookupAir { inner_air, lookups, preprocessed: None };
-    let c = Circuit {
-      air,
-      constraint_count: self.meta_usize()?,
-      max_constraint_degree: self.meta_usize()?,
-      preprocessed_height: self.meta_usize()?,
-      preprocessed_width: self.meta_usize()?,
-      stage_1_width: self.meta_usize()?,
-      stage_2_width: self.meta_usize()?,
-    };
-    self.tags.done("TAGS segment")?;
-    self.idx.done("IDX segment")?;
-    self.c2.done("C2 segment")?;
-    self.c8.done("C8 segment")?;
-    self.meta.done("META segment")?;
-    Ok(c)
+    lookups.push(Lookup { multiplicity, args });
   }
+  seg.done("circuit record")?;
+
+  let degrees = recompute_degrees(&nodes);
+  let graph = ConstraintGraph {
+    nodes,
+    degrees,
+    zeros,
+    lookups,
+    lookup_prefix_len,
+    max_constraint_degree,
+  };
+  let num_lookups = graph.lookups.len();
+  Ok(Circuit {
+    graph,
+    main_width,
+    preprocessed: None,
+    preprocessed_width,
+    preprocessed_height,
+    num_lookups,
+    stage_2_width,
+    num_publics,
+  })
 }
 
-/// Deserialize a `System<AiurCircuit>` from [`to_bytes`] output, requiring that
-/// every byte (globally and within each record segment) is consumed. Also
-/// returns the config's construction parameters, which the `System` itself
-/// doesn't expose.
+/// Deserialize a `System<AiurConfig>` from [`to_bytes`] output, requiring that
+/// every byte is consumed. Also returns the config's construction parameters,
+/// which the `System` itself doesn't expose.
 pub(crate) fn from_bytes(
   bytes: &[u8],
-) -> Result<
-  (System<AiurConfig, AiurCircuit>, CommitmentParameters, FriParameters),
-  String,
-> {
+) -> Result<(System<AiurConfig>, CommitmentParameters, FriParameters), String> {
   let mut r = Seg { buf: bytes, pos: 0 };
   let commitment_parameters = CommitmentParameters {
     log_blowup: r.u16()? as usize,
@@ -468,20 +397,9 @@ pub(crate) fn from_bytes(
   let n_circuits = r.u16()? as usize;
   let mut circuits = Vec::with_capacity(n_circuits);
   for _ in 0..n_circuits {
-    let lens: [usize; 5] = [
-      r.u32()? as usize,
-      r.u32()? as usize,
-      r.u32()? as usize,
-      r.u32()? as usize,
-      r.u32()? as usize,
-    ];
-    let tags = Seg { buf: r.take(lens[0])?, pos: 0 };
-    let idx = Seg { buf: r.take(lens[1])?, pos: 0 };
-    let c2 = Seg { buf: r.take(lens[2])?, pos: 0 };
-    let c8 = Seg { buf: r.take(lens[3])?, pos: 0 };
-    let meta = Seg { buf: r.take(lens[4])?, pos: 0 };
-    let mut rec = RecordReader { tags, idx, c2, c8, meta };
-    circuits.push(rec.circuit()?);
+    let len = r.u32_usize()?;
+    let record = r.take(len)?;
+    circuits.push(decode_circuit(record)?);
   }
   let preprocessed_commit = match r.u8()? {
     0 => None,
@@ -520,7 +438,7 @@ pub(crate) fn from_bytes(
 mod tests {
   use super::*;
   use crate::gadgets::{AiurGadget, bytes1::Bytes1, bytes2::Bytes2};
-  use multi_stark::{lookup::LookupAir, types::CommitmentParameters};
+  use multi_stark::system::CircuitInputs;
 
   fn test_parameters() -> (CommitmentParameters, FriParameters) {
     let cp = CommitmentParameters { log_blowup: 1, cap_height: 0 };
@@ -534,47 +452,31 @@ mod tests {
     (cp, fp)
   }
 
-  fn test_system()
-  -> (System<AiurConfig, AiurCircuit>, CommitmentParameters, FriParameters) {
+  fn test_system() -> (System<AiurConfig>, CommitmentParameters, FriParameters)
+  {
     let (cp, fp) = test_parameters();
-    let (system, _key) = System::new(
-      AiurConfig::new(cp, fp),
-      [
-        LookupAir::new(AiurCircuit::Bytes1, Bytes1.lookups()),
-        LookupAir::new(AiurCircuit::Bytes2, Bytes2.lookups()),
-      ],
-    );
+    let inputs = [
+      CircuitInputs {
+        main_width: Bytes1.main_width(),
+        preprocessed: Bytes1.preprocessed(),
+        constraints: vec![],
+        ext_constraints: vec![],
+        lookups: Bytes1.lookups(),
+      },
+      CircuitInputs {
+        main_width: Bytes2.main_width(),
+        preprocessed: Bytes2.preprocessed(),
+        constraints: vec![],
+        ext_constraints: vec![],
+        lookups: Bytes2.lookups(),
+      },
+    ];
+    let (system, _key) = System::new(AiurConfig::new(cp, fp), inputs);
     (system, cp, fp)
   }
 
-  /// Structural equality of expressions INCLUDING the recomputed
-  /// `degree_multiple` — validates the decoder's degree reconstruction
-  /// node by node.
-  fn expr_eq(a: &Expr, b: &Expr) -> bool {
-    use SymbolicExpression as E;
-    if a.degree_multiple() != b.degree_multiple() {
-      return false;
-    }
-    match (a, b) {
-      (E::Variable(u), E::Variable(v)) => {
-        u.entry == v.entry && u.index == v.index
-      },
-      (E::IsFirstRow, E::IsFirstRow)
-      | (E::IsLastRow, E::IsLastRow)
-      | (E::IsTransition, E::IsTransition) => true,
-      (E::Constant(c), E::Constant(d)) => c == d,
-      (E::Add { x: ax, y: ay, .. }, E::Add { x: bx, y: by, .. })
-      | (E::Sub { x: ax, y: ay, .. }, E::Sub { x: bx, y: by, .. })
-      | (E::Mul { x: ax, y: ay, .. }, E::Mul { x: bx, y: by, .. }) => {
-        expr_eq(ax, bx) && expr_eq(ay, by)
-      },
-      (E::Neg { x: ax, .. }, E::Neg { x: bx, .. }) => expr_eq(ax, bx),
-      _ => false,
-    }
-  }
-
-  /// Round-trip: decode(encode(x)) re-encodes to the same bytes AND every
-  /// expression (with its recomputed degrees) matches the original.
+  /// Round-trip: decode(encode(x)) re-encodes to the same bytes, with matching
+  /// compiled node graphs, constraint roots, and lookups.
   #[test]
   fn system_vk_round_trips() {
     let (system, cp, fp) = test_system();
@@ -584,25 +486,18 @@ mod tests {
     assert_eq!(bytes, reencoded, "verifying-key codec round-trip mismatch");
     assert_eq!(system.circuits.len(), back.circuits.len());
     for (a, b) in system.circuits.iter().zip(&back.circuits) {
-      assert_eq!(a.air.lookups.len(), b.air.lookups.len());
-      for (la, lb) in a.air.lookups.iter().zip(&b.air.lookups) {
-        assert!(
-          expr_eq(&la.multiplicity, &lb.multiplicity),
-          "lookup multiplicity mismatch (degree recomputation?)"
-        );
-        assert_eq!(la.args.len(), lb.args.len());
-        for (ea, eb) in la.args.iter().zip(&lb.args) {
-          assert!(expr_eq(ea, eb), "lookup arg mismatch");
-        }
+      assert_eq!(a.graph.nodes, b.graph.nodes, "nodes mismatch");
+      assert_eq!(a.graph.zeros, b.graph.zeros, "zeros mismatch");
+      assert_eq!(a.graph.lookups.len(), b.graph.lookups.len());
+      for (la, lb) in a.graph.lookups.iter().zip(&b.graph.lookups) {
+        assert_eq!(la.multiplicity, lb.multiplicity);
+        assert_eq!(la.args, lb.args);
       }
-      if let (AiurCircuit::Function(fa), AiurCircuit::Function(fb)) =
-        (&a.air.inner_air, &b.air.inner_air)
-      {
-        assert_eq!(fa.zeros.len(), fb.zeros.len());
-        for (ea, eb) in fa.zeros.iter().zip(&fb.zeros) {
-          assert!(expr_eq(ea, eb), "constraint mismatch");
-        }
-      }
+      assert_eq!(a.main_width, b.main_width);
+      assert_eq!(a.stage_2_width, b.stage_2_width);
+      assert_eq!(a.num_publics, b.num_publics);
+      assert_eq!(a.preprocessed_width, b.preprocessed_width);
+      assert_eq!(a.preprocessed_height, b.preprocessed_height);
     }
   }
 
@@ -614,16 +509,15 @@ mod tests {
     assert!(from_bytes(&bytes).is_err(), "should reject trailing data");
   }
 
-  /// A tampered segment length must be rejected (the record readers enforce
-  /// exact per-segment consumption).
+  /// A tampered per-circuit record length must be rejected (the record reader
+  /// enforces exact consumption).
   #[test]
-  fn rejects_bad_segment_length() {
+  fn rejects_bad_record_length() {
     let (system, cp, fp) = test_system();
     let mut bytes = to_bytes(&system, cp, fp);
-    // First record header starts right after the 16-byte global header;
-    // bump the TAGS segment length by one.
-    let tags_len = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
-    bytes[16..20].copy_from_slice(&(tags_len + 1).to_le_bytes());
-    assert!(from_bytes(&bytes).is_err(), "should reject bad segment length");
+    // First record length is the u32 right after the 16-byte global header.
+    let len = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
+    bytes[16..20].copy_from_slice(&(len + 1).to_le_bytes());
+    assert!(from_bytes(&bytes).is_err(), "should reject bad record length");
   }
 }

--- a/crates/aiur/src/vk_codec.rs
+++ b/crates/aiur/src/vk_codec.rs
@@ -156,28 +156,29 @@ fn push_node(buf: &mut Vec<u8>, node: &Node<Val>) {
   }
 }
 
+/// One circuit record. Nothing derivable is serialized: `constraint_count`
+/// (= zeros + (L+3)·D), `stage_2_width` (= (1+L)·D), `num_publics` (= 4·D),
+/// and `lookup_prefix_len` (= 1 + max node id reachable from the lookups)
+/// are all recomputed on decode, and the Lean reader derives the observed
+/// shape limbs the same way.
 fn encode_circuit(buf: &mut Vec<u8>, circuit: &Circuit<Val>) {
   let compiled = &circuit.graph;
-  push_u32(buf, circuit.main_width);
-  push_u32(buf, circuit.preprocessed_width);
+  push_u16(buf, circuit.main_width);
+  push_u16(buf, circuit.preprocessed_width);
+  // u32: the Bytes2 table height is exactly 65536.
   push_u32(buf, circuit.preprocessed_height);
-  // Total folded constraint count (user roots + directly-evaluated logUp),
-  // the value `observe_shape` binds. Replaces the old `num_publics` slot
-  // (which is a constant, `4·D`, and is derived on decode).
-  push_u32(buf, circuit.constraint_count);
-  push_u32(buf, circuit.stage_2_width);
-  // Combined max degree (user graph + analytic logUp), as observed.
-  push_u32(buf, circuit.max_constraint_degree);
-  push_u32(buf, compiled.lookup_prefix_len);
-  push_u32(buf, compiled.nodes.len());
+  // Combined max degree (user graph + analytic logUp), as observed. Not
+  // derivable cheaply in-circuit (it would need a full degree pass).
+  push_u16(buf, circuit.max_constraint_degree);
+  push_u16(buf, compiled.nodes.len());
   for node in &compiled.nodes {
     push_node(buf, node);
   }
-  push_u32(buf, compiled.zeros.len());
+  push_u16(buf, compiled.zeros.len());
   for &z in &compiled.zeros {
     push_node_id(buf, z);
   }
-  push_u32(buf, compiled.lookups.len());
+  push_u16(buf, compiled.lookups.len());
   for lookup in &compiled.lookups {
     push_node_id(buf, lookup.multiplicity);
     push_u16(buf, lookup.args.len());
@@ -206,10 +207,7 @@ pub(crate) fn to_bytes(
   push_u16(&mut buf, fri_parameters.query_proof_of_work_bits);
   push_u16(&mut buf, system.circuits.len());
   for circuit in &system.circuits {
-    let mut record = Vec::new();
-    encode_circuit(&mut record, circuit);
-    push_u32(&mut buf, record.len());
-    buf.extend_from_slice(&record);
+    encode_circuit(&mut buf, circuit);
   }
   match &system.preprocessed_commit {
     None => buf.push(0),
@@ -336,27 +334,23 @@ fn recompute_degrees(nodes: &[Node<Val>]) -> Vec<u32> {
   degrees
 }
 
-fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
-  let mut seg = Seg { buf: bytes, pos: 0 };
-  let main_width = seg.u32_usize()?;
-  let preprocessed_width = seg.u32_usize()?;
+fn decode_circuit(seg: &mut Seg<'_>) -> Result<Circuit<Val>, String> {
+  let main_width = seg.u16()? as usize;
+  let preprocessed_width = seg.u16()? as usize;
   let preprocessed_height = seg.u32_usize()?;
-  let constraint_count = seg.u32_usize()?;
-  let stage_2_width = seg.u32_usize()?;
-  let max_constraint_degree = seg.u32_usize()?;
-  let lookup_prefix_len = seg.u32_usize()?;
-  let node_count = seg.u32_usize()?;
-  let mut nodes = Vec::with_capacity(node_count.min(1 << 20));
+  let max_constraint_degree = seg.u16()? as usize;
+  let node_count = seg.u16()? as usize;
+  let mut nodes = Vec::with_capacity(node_count);
   for _ in 0..node_count {
-    nodes.push(decode_node(&mut seg)?);
+    nodes.push(decode_node(seg)?);
   }
-  let zero_count = seg.u32_usize()?;
-  let mut zeros = Vec::with_capacity(zero_count.min(1 << 20));
+  let zero_count = seg.u16()? as usize;
+  let mut zeros = Vec::with_capacity(zero_count);
   for _ in 0..zero_count {
     zeros.push(seg.node_id()?);
   }
-  let lookup_count = seg.u32_usize()?;
-  let mut lookups = Vec::with_capacity(lookup_count.min(1 << 16));
+  let lookup_count = seg.u16()? as usize;
+  let mut lookups = Vec::with_capacity(lookup_count);
   for _ in 0..lookup_count {
     let multiplicity = seg.node_id()?;
     let arg_count = seg.u16()? as usize;
@@ -366,7 +360,6 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
     }
     lookups.push(Lookup { multiplicity, args });
   }
-  seg.done("circuit record")?;
 
   let degrees = recompute_degrees(&nodes);
   // The graph's own max degree covers only the user roots (the serialized
@@ -374,6 +367,15 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
   let user_max_degree = zeros
     .iter()
     .map(|z| degrees[usize::try_from(z.0).expect("node id")])
+    .max()
+    .unwrap_or(0);
+  // The lookup prefix is exactly the nodes interned while compiling the
+  // lookup expressions, all of which are reachable from (and bounded by)
+  // the lookup roots — children always precede parents.
+  let lookup_prefix_len = lookups
+    .iter()
+    .flat_map(|l| std::iter::once(l.multiplicity).chain(l.args.iter().copied()))
+    .map(|id| id.0 as usize + 1)
     .max()
     .unwrap_or(0);
   let graph = ConstraintGraph {
@@ -396,11 +398,17 @@ fn decode_circuit(bytes: &[u8]) -> Result<Circuit<Val>, String> {
     preprocessed_width,
     preprocessed_height,
     num_lookups,
-    stage_2_width,
+    stage_2_width: multi_stark::lookup::stage2_width(num_lookups, ext_degree),
     num_publics: multi_stark::lookup::num_publics(ext_degree),
-    constraint_count,
+    constraint_count: zeros_plus_logup(zero_count, num_lookups, ext_degree),
     max_constraint_degree,
   })
+}
+
+/// The folded constraint count: user roots + the directly-evaluated logUp
+/// values (mirrors `multi_stark::lookup::logup_constraint_count`).
+fn zeros_plus_logup(zero_count: usize, num_lookups: usize, d: usize) -> usize {
+  zero_count + multi_stark::lookup::logup_constraint_count(num_lookups, d)
 }
 
 /// Deserialize a `System<AiurConfig>` from [`to_bytes`] output, requiring that
@@ -424,9 +432,7 @@ pub(crate) fn from_bytes(
   let n_circuits = r.u16()? as usize;
   let mut circuits = Vec::with_capacity(n_circuits);
   for _ in 0..n_circuits {
-    let len = r.u32_usize()?;
-    let record = r.take(len)?;
-    circuits.push(decode_circuit(record)?);
+    circuits.push(decode_circuit(&mut r)?);
   }
   let preprocessed_commit = match r.u8()? {
     0 => None,
@@ -541,10 +547,16 @@ mod tests {
   #[test]
   fn rejects_bad_record_length() {
     let (system, cp, fp) = test_system();
-    let mut bytes = to_bytes(&system, cp, fp);
-    // First record length is the u32 right after the 16-byte global header.
-    let len = u32::from_le_bytes(bytes[16..20].try_into().unwrap());
-    bytes[16..20].copy_from_slice(&(len + 1).to_le_bytes());
-    assert!(from_bytes(&bytes).is_err(), "should reject bad record length");
+    let bytes = to_bytes(&system, cp, fp);
+    // Records carry no length prefix (nothing derivable is serialized), so
+    // the malformation guards are the full-consumption check and read
+    // overflow: truncated and padded inputs must both be rejected.
+    assert!(
+      from_bytes(&bytes[..bytes.len() - 1]).is_err(),
+      "should reject truncated vk"
+    );
+    let mut padded = bytes.clone();
+    padded.push(0);
+    assert!(from_bytes(&padded).is_err(), "should reject padded vk");
   }
 }

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4341,7 +4341,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4499,10 +4499,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -7258,7 +7258,7 @@ fn aiur_fn_91(
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = { let __values: [G; 10] = [__v_28, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_21]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __ret: [G; OUT_91] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
     record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -10276,7 +10276,7 @@ fn aiur_fn_111(
     let __v_36: G = __r_arr[30];
     let __v_37: G = __r_arr[31];
     let __v_38: G = __r_arr[32];
-    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10997,7 +10997,7 @@ fn aiur_fn_125(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_1 - __v_4);
         let __v_7: G = (__v_5 + __v_6);
@@ -11275,7 +11275,7 @@ fn aiur_fn_130(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
     let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
@@ -11286,9 +11286,9 @@ fn aiur_fn_130(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
     let __v_17: G = __r_arr[1];
-    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_19: G = __r_arr[0];
     let __v_20: G = (__v_18 - __v_19);
     let __v_21: G = G::from_bool((__v_20 == G::ZERO));
@@ -11326,10 +11326,10 @@ fn aiur_fn_131(
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
     let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
     let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
@@ -11377,14 +11377,14 @@ fn aiur_fn_132(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
@@ -11432,17 +11432,17 @@ fn aiur_fn_133(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
         let __v_20: G = __r_arr[0];
@@ -11492,7 +11492,7 @@ fn aiur_fn_134(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         match __v_15.as_canonical_u64() {
@@ -11508,14 +11508,14 @@ fn aiur_fn_134(
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
             let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_19: G = __r_arr[0];
             let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
             let __v_22: G = __r_arr[0];
@@ -11573,14 +11573,14 @@ fn aiur_fn_135(
       },
       1u64 => {
         let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
         match __v_16.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
             let __v_19: G = __r_arr[0];
             let __v_20: G = (__v_18 - __v_19);
             let __v_21: G = G::from_bool((__v_20 == G::ZERO));
@@ -11639,7 +11639,7 @@ fn aiur_fn_136(
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_5 + __v_1);
         let __v_7: G = G::from_u64(1);
@@ -11682,7 +11682,7 @@ fn aiur_fn_137(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         match __v_5.as_canonical_u64() {
@@ -11699,7 +11699,7 @@ fn aiur_fn_137(
           },
           1u64 => {
             let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = (__v_8 + __v_1);
             let __v_10: G = G::from_u64(1);
@@ -11919,7 +11919,7 @@ fn aiur_fn_141(
         if (__v_15 != __v_16) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_15.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
@@ -11954,7 +11954,7 @@ fn aiur_fn_141(
                         let __v_24: G = G::from_u64(1);
                         let __v_25: G = (__v_6 - __v_24);
                         let __v_26: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                         let __v_27: G = __r_arr[0];
                         let __v_28: G = __r_arr[1];
                         let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
@@ -11969,7 +11969,7 @@ fn aiur_fn_141(
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = __r_arr[1];
                         let __v_37: G = __r_arr[2];
-                        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
                         let __v_39: G = G::from_u64(1);
                         if (__v_38 != __v_39) {
@@ -12064,7 +12064,7 @@ fn aiur_fn_142(
         let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
         let __v_25: G = __r_arr[0];
         let __v_26: G = G::from_u64(0);
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         let __v_28: G = __r_arr[1];
         match __v_27.as_canonical_u64() {
@@ -12073,7 +12073,7 @@ fn aiur_fn_142(
             let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
             let __v_30: G = __r_arr[0];
             let __v_31: G = G::from_u64(1);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
             let __v_32: G = __r_arr[0];
             let __v_33: G = __r_arr[1];
             match __v_32.as_canonical_u64() {
@@ -12082,7 +12082,7 @@ fn aiur_fn_142(
                 let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
                 let __v_35: G = __r_arr[0];
                 let __v_36: G = G::from_u64(2);
-                let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 let __v_38: G = __r_arr[1];
                 match __v_37.as_canonical_u64() {
@@ -12109,7 +12109,7 @@ fn aiur_fn_142(
                             let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                             let __v_50: G = __r_arr[0];
                             let __v_51: G = __r_arr[1];
-                            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                             let __v_52: G = __r_arr[0];
                             let __v_53: G = (__v_52 - __v_24);
                             let __v_54: G = G::from_bool((__v_53 == G::ZERO));
@@ -12117,7 +12117,7 @@ fn aiur_fn_142(
                             if (__v_54 != __v_55) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                             let __v_56: G = __r_arr[0];
                             let __v_57: G = G::from_u64(3);
                             let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
@@ -12129,7 +12129,7 @@ fn aiur_fn_142(
                             if (__v_61 != __v_62) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
                             let __v_63: G = __r_arr[0];
                             let __v_64: G = (__v_63 - __v_18);
                             let __v_65: G = G::from_bool((__v_64 == G::ZERO));
@@ -12146,7 +12146,7 @@ fn aiur_fn_142(
                             if (__v_69 != __v_70) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
                             let __v_71: G = __r_arr[0];
                             let __v_72: G = (__v_71 - __v_18);
                             let __v_73: G = G::from_bool((__v_72 == G::ZERO));
@@ -12163,7 +12163,7 @@ fn aiur_fn_142(
                             if (__v_77 != __v_78) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
                             let __v_79: G = __r_arr[0];
                             let __v_80: G = (__v_79 - __v_18);
                             let __v_81: G = G::from_bool((__v_80 == G::ZERO));
@@ -12187,7 +12187,7 @@ fn aiur_fn_142(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
                             }
                             let __v_90: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                             let __v_91: G = __r_arr[0];
                             let __v_92: G = __r_arr[1];
                             let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
@@ -12328,7 +12328,7 @@ fn aiur_fn_144(
     let __v_30: G = inp[30];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
         let __v_31: G = __r_arr[0];
         let __v_32: G = G::from_u64(1);
         let __v_33: G = G::from_u64(1);
@@ -12341,7 +12341,7 @@ fn aiur_fn_144(
         let __v_37: G = __r_arr[0];
         let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = G::from_u64(1);
         let __v_41: G = G::from_u64(1);
@@ -12377,7 +12377,7 @@ fn aiur_fn_144(
         let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
         let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
         let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
@@ -12385,7 +12385,7 @@ fn aiur_fn_144(
         let __v_71: G = __r_arr[0];
         let __v_72: G = __r_arr[1];
         let __v_73: G = (__v_31 + __v_27);
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_74: G = __r_arr[0];
         let __v_75: G = (__v_74 - __v_31);
         let __v_76: G = G::from_bool((__v_75 == G::ZERO));
@@ -12393,7 +12393,7 @@ fn aiur_fn_144(
         if (__v_76 != __v_77) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_78: G = __r_arr[0];
         let __v_79: G = (__v_78 - __v_28);
         let __v_80: G = G::from_bool((__v_79 == G::ZERO));
@@ -12401,7 +12401,7 @@ fn aiur_fn_144(
         if (__v_80 != __v_81) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_82: G = __r_arr[0];
         let __v_83: G = G::from_u64(1);
         if (__v_82 != __v_83) {
@@ -13152,7 +13152,7 @@ fn aiur_fn_158(
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
     let __ret: [G; OUT_158] = [__v_13];
     record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -13177,7 +13177,7 @@ fn aiur_fn_159(
     let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __ret: [G; OUT_159] = [__v_6];
     record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -13253,7 +13253,7 @@ fn aiur_fn_161(
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = __r_arr[2];
@@ -13291,7 +13291,7 @@ fn aiur_fn_162(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13497,7 +13497,7 @@ fn aiur_fn_165(
     let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_70: G = __r_arr[0];
     let __v_71: G = G::from_u64(1);
     let __v_72: G = G::from_u64(1);
@@ -13927,24 +13927,24 @@ fn aiur_fn_170(
     let __v_22: G = inp[22];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = G::from_bool((__v_23 == G::ZERO));
         let __v_25: G = G::from_u64(0);
         if (__v_24 != __v_25) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         if (__v_26 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         if (__v_28 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
@@ -14076,8 +14076,8 @@ fn aiur_fn_173(
   })
 }
 
-const INPUT_SIZE_174: usize = 2;
-const IN_174: usize = 2;
+const INPUT_SIZE_174: usize = 15;
+const IN_174: usize = 15;
 const OUT_174: usize = 2;
 fn aiur_fn_174(
   inp: [G; IN_174],
@@ -14088,17 +14088,170 @@ fn aiur_fn_174(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __v_3: G = __r_arr[1];
-    let __ret: [G; OUT_174] = [__v_2, __v_3];
-    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __v_15: G = __r_arr[0];
+    let __v_16: G = __r_arr[1];
+    let __v_17: G = __r_arr[2];
+    let __v_18: G = __r_arr[3];
+    match __v_15.as_canonical_u64() {
+      0u64 => {
+        let __v_19: G = G::from_u64(0);
+        let __ret: [G; OUT_174] = [__v_16, __v_19];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_19: G = (__v_16 + __v_17);
+        let __v_20: G = (__v_16 + __v_19);
+        match __v_20.as_canonical_u64() {
+          0u64 => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = __r_arr[1];
+            let __ret: [G; OUT_174] = [__v_21, __v_22];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = __r_arr[1];
+            let __ret: [G; OUT_174] = [__v_21, __v_22];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          2u64 => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = __r_arr[1];
+            let __ret: [G; OUT_174] = [__v_21, __v_22];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          3u64 => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = __r_arr[1];
+            let __ret: [G; OUT_174] = [__v_21, __v_22];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          4u64 => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = __r_arr[1];
+            let __ret: [G; OUT_174] = [__v_21, __v_22];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = __r_arr[1];
+            let __ret: [G; OUT_174] = [__v_21, __v_22];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+        }
+      },
+      2u64 => {
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __v_20: G = __r_arr[1];
+        let __ret: [G; OUT_174] = [__v_19, __v_20];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __ret: [G; OUT_174] = [__v_9, __v_10];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __ret: [G; OUT_174] = [__v_11, __v_12];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __ret: [G; OUT_174] = [__v_13, __v_14];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __v_20: G = __r_arr[1];
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_21: G = __r_arr[0];
+        let __v_22: G = __r_arr[1];
+        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __v_24: G = __r_arr[1];
+        let __ret: [G; OUT_174] = [__v_23, __v_24];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __v_20: G = __r_arr[1];
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_21: G = __r_arr[0];
+        let __v_22: G = __r_arr[1];
+        let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __v_24: G = __r_arr[1];
+        let __ret: [G; OUT_174] = [__v_23, __v_24];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __v_20: G = __r_arr[1];
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_21: G = __r_arr[0];
+        let __v_22: G = __r_arr[1];
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __v_24: G = __r_arr[1];
+        let __ret: [G; OUT_174] = [__v_23, __v_24];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __v_20: G = __r_arr[1];
+        let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
+        let __v_21: G = __r_arr[0];
+        let __v_22: G = __r_arr[1];
+        let __ret: [G; OUT_174] = [__v_21, __v_22];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
+      },
+    }
   })
 }
 
-const INPUT_SIZE_175: usize = 18;
-const IN_175: usize = 18;
+const INPUT_SIZE_175: usize = 19;
+const IN_175: usize = 19;
 const OUT_175: usize = 2;
 fn aiur_fn_175(
   inp: [G; IN_175],
@@ -14125,153 +14278,41 @@ fn aiur_fn_175(
     let __v_15: G = inp[15];
     let __v_16: G = inp[16];
     let __v_17: G = inp[17];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_175] = [__v_1, __v_18];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
+    let __v_18: G = inp[18];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_19: G = __loaded[0];
+    let __v_20: G = __loaded[1];
+    let __v_21: G = __loaded[2];
+    match __v_19.as_canonical_u64() {
       1u64 => {
-        let __v_18: G = (__v_1 + __v_2);
-        let __v_19: G = (__v_1 + __v_18);
-        match __v_19.as_canonical_u64() {
-          0u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_7, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_20, __v_21];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_20, __v_21];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          2u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_5, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_20, __v_21];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          3u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_20, __v_21];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          4u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_20, __v_21];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_10, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __v_21: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_20, __v_21];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-      2u64 => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_18, __v_19];
+        let __ret: [G; OUT_175] = [__v_0, __v_1];
         record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      3u64 => {
-        let __ret: [G; OUT_175] = [__v_12, __v_13];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __ret: [G; OUT_175] = [__v_14, __v_15];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __ret: [G; OUT_175] = [__v_16, __v_17];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = __r_arr[1];
-        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+      0u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_22, __v_23];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = __r_arr[1];
-        let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-        let __v_22: G = __r_arr[0];
-        let __v_23: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_22, __v_23];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = __r_arr[1];
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_22: G = __r_arr[0];
-        let __v_23: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_22, __v_23];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_20, __v_21];
+        let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+        let __v_24: G = __r_arr[0];
+        let __v_25: G = __r_arr[1];
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __v_26: G = __r_arr[0];
+        let __v_27: G = __r_arr[1];
+        let __ret: [G; OUT_175] = [__v_26, __v_27];
         record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_19.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_176: usize = 15;
-const IN_176: usize = 15;
-const OUT_176: usize = 1;
+const INPUT_SIZE_176: usize = 17;
+const IN_176: usize = 17;
+const OUT_176: usize = 2;
 fn aiur_fn_176(
   inp: [G; IN_176],
   record: &mut QueryRecord,
@@ -14294,142 +14335,28 @@ fn aiur_fn_176(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-    let __v_15: G = __loaded[0];
-    let __v_16: G = __loaded[1];
-    let __v_17: G = __loaded[2];
-    let __v_18: G = __loaded[3];
-    let __v_19: G = __loaded[4];
-    let __v_20: G = __loaded[5];
-    match __v_15.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_176] = [__v_1];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_16, __v_17, __v_18, __v_19, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
-        let __v_21: G = __r_arr[0];
-        let __v_22: G = __r_arr[1];
-        let __v_23: G = G::from_u64(0);
-        let __v_24: G = G::from_u64(1);
-        let __v_25: G = G::from_u64(1);
-        let __v_26: G = { let __values: [G; 4] = [__v_24, __v_25, __v_25, __v_25]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_27: G = { let __values: [G; 4] = [__v_23, __v_21, __v_22, __v_26]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_28: G = __r_arr[0];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_20, __v_28, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_29: G = __r_arr[0];
-        let __ret: [G; OUT_176] = [__v_29];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-      },
-    }
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = G::from_u64(0);
+    let __v_18: G = G::from_u64(0);
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_17, __v_18, __v_15, __v_16, __v_1, __v_0, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __v_20: G = __r_arr[1];
+    let __ret: [G; OUT_176] = [__v_19, __v_20];
+    record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_177: usize = 6;
-const IN_177: usize = 6;
-const OUT_177: usize = 2;
+const INPUT_SIZE_177: usize = 8;
+const IN_177: usize = 8;
+const OUT_177: usize = 1;
 fn aiur_fn_177(
   inp: [G; IN_177],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_177], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_6: G = __loaded[0];
-    let __v_7: G = __loaded[1];
-    let __v_8: G = __loaded[2];
-    match __v_6.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_177] = [__v_0, __v_1];
-        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_5, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_9: G = __r_arr[0];
-        let __v_10: G = __r_arr[1];
-        let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_0, __v_1, __v_2, __v_3, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_11, __v_12, __v_2, __v_3, __v_8, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = __r_arr[1];
-        let __ret: [G; OUT_177] = [__v_13, __v_14];
-        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_6.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_178: usize = 17;
-const IN_178: usize = 17;
-const OUT_178: usize = 2;
-fn aiur_fn_178(
-  inp: [G; IN_178],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_178], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = G::from_u64(1);
-    let __v_18: G = G::from_u64(1);
-    let __v_19: G = { let __values: [G; 4] = [__v_17, __v_18, __v_18, __v_18]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_19, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __v_21: G = G::from_u64(0);
-    let __v_22: G = G::from_u64(0);
-    let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_21, __v_22, __v_15, __v_16, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __v_24: G = __r_arr[1];
-    let __ret: [G; OUT_178] = [__v_23, __v_24];
-    record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_179: usize = 8;
-const IN_179: usize = 8;
-const OUT_179: usize = 1;
-fn aiur_fn_179(
-  inp: [G; IN_179],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14466,21 +14393,21 @@ fn aiur_fn_179(
     let __v_32: G = { let __values: [G; 4] = [__v_12, __v_2, __v_13, __v_31]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_33: G = { let __values: [G; 4] = [__v_10, __v_1, __v_11, __v_32]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_34: G = { let __values: [G; 4] = [__v_8, __v_0, __v_9, __v_33]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_179] = [__v_34];
-    record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_177] = [__v_34];
+    record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_180: usize = 5;
-const IN_180: usize = 5;
-const OUT_180: usize = 2;
-fn aiur_fn_180(
-  inp: [G; IN_180],
+const INPUT_SIZE_178: usize = 5;
+const IN_178: usize = 5;
+const OUT_178: usize = 2;
+fn aiur_fn_178(
+  inp: [G; IN_178],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_180], ExecError> {
+) -> Result<[G; OUT_178], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14496,8 +14423,8 @@ fn aiur_fn_180(
       1u64 => {
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_180] = [__v_9, __v_10];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_178] = [__v_9, __v_10];
+        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14507,14 +14434,14 @@ fn aiur_fn_180(
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
-        let __ret: [G; OUT_180] = [__v_15, __v_16];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_178] = [__v_15, __v_16];
+        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14524,145 +14451,145 @@ fn aiur_fn_180(
   })
 }
 
-const INPUT_SIZE_181: usize = 1;
-const IN_181: usize = 1;
-const OUT_181: usize = 1;
-fn aiur_fn_181(
-  inp: [G; IN_181],
+const INPUT_SIZE_179: usize = 1;
+const IN_179: usize = 1;
+const OUT_179: usize = 1;
+fn aiur_fn_179(
+  inp: [G; IN_179],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
+) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     match __v_0.as_canonical_u64() {
       0u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       10u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       11u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       12u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       13u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       14u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       15u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       16u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       17u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_181] = [__v_1];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_1];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_182: usize = 4;
-const IN_182: usize = 4;
-const OUT_182: usize = 2;
-fn aiur_fn_182(
-  inp: [G; IN_182],
+const INPUT_SIZE_180: usize = 4;
+const IN_180: usize = 4;
+const OUT_180: usize = 2;
+fn aiur_fn_180(
+  inp: [G; IN_180],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
+) -> Result<[G; OUT_180], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14676,8 +14603,8 @@ fn aiur_fn_182(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_182] = [__v_6, __v_9];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_180] = [__v_6, __v_9];
+        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -14689,21 +14616,21 @@ fn aiur_fn_182(
             let __v_7: G = G::from_u64(1);
             let __v_8: G = G::from_u64(1);
             let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_182] = [__v_6, __v_9];
-            record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_180] = [__v_6, __v_9];
+            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = G::from_u64(1);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_182] = [__v_6, __v_8];
-            record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_180] = [__v_6, __v_8];
+            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14718,15 +14645,15 @@ fn aiur_fn_182(
   })
 }
 
-const INPUT_SIZE_183: usize = 20;
-const IN_183: usize = 20;
-const OUT_183: usize = 1;
-fn aiur_fn_183(
-  inp: [G; IN_183],
+const INPUT_SIZE_181: usize = 20;
+const IN_181: usize = 20;
+const OUT_181: usize = 1;
+fn aiur_fn_181(
+  inp: [G; IN_181],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
+) -> Result<[G; OUT_181], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14758,40 +14685,40 @@ fn aiur_fn_183(
     match __v_20.as_canonical_u64() {
       1u64 => {
         let __v_26: G = G::from_u64(1);
-        let __ret: [G; OUT_183] = [__v_26];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_26];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         match __v_21.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_26: G = __r_arr[0];
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
             let __v_27: G = __r_arr[0];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
             let __v_29: G = __r_arr[1];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_30: G = __r_arr[0];
             let __v_31: G = G::from_u64(0);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_32: G = __r_arr[0];
             let __v_33: G = G::from_u64(1);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_30, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_30, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_34: G = __r_arr[0];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_35: G = __r_arr[0];
             let __v_36: G = G::from_u64(0);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_37: G = __r_arr[0];
             let __v_38: G = G::from_u64(1);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_35, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_35, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_39: G = __r_arr[0];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
             let __v_40: G = __r_arr[0];
             let __v_41: G = __r_arr[1];
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_6, __v_7, __v_40, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_6, __v_7, __v_40, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
             let __v_42: G = __r_arr[0];
             let __v_43: G = __r_arr[1];
             let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_18, __v_19, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
@@ -14803,15 +14730,15 @@ fn aiur_fn_183(
             let __v_49: G = __r_arr[5];
             let __v_50: G = __r_arr[6];
             let __v_51: G = __r_arr[7];
-            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
             let __v_52: G = __r_arr[0];
-            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_21, __v_23, __v_32, __v_34, __v_42, __v_43, __v_37, __v_39, __v_52, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_21, __v_23, __v_32, __v_34, __v_42, __v_43, __v_37, __v_39, __v_52, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
             let __v_53: G = __r_arr[0];
             let __v_54: G = __r_arr[1];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_55: G = __r_arr[0];
             let __v_56: G = G::from_u64(0);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_57: G = __r_arr[0];
             let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_58: G = __r_arr[0];
@@ -14820,10 +14747,10 @@ fn aiur_fn_183(
             let __v_60: G = __r_arr[1];
             let __v_61: G = G::from_u64(1);
             let __v_62: G = G::from_u64(0);
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_58, __v_59, __v_60, __v_61, __v_62]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_58, __v_59, __v_60, __v_61, __v_62]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
             let __v_63: G = __r_arr[0];
             let __v_64: G = __r_arr[1];
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_65: G = __r_arr[0];
             let __v_66: G = (__v_65 - __v_27);
             let __v_67: G = G::from_bool((__v_66 == G::ZERO));
@@ -14842,10 +14769,10 @@ fn aiur_fn_183(
             }
             let __v_73: G = G::from_u64(1);
             let __v_74: G = (__v_9 + __v_73);
-            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_25, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_74, __v_28, __v_29, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_25, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_74, __v_28, __v_29, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
             let __v_75: G = __r_arr[0];
-            let __ret: [G; OUT_183] = [__v_75];
-            record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_181] = [__v_75];
+            record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -14857,15 +14784,15 @@ fn aiur_fn_183(
   })
 }
 
-const INPUT_SIZE_184: usize = 3;
-const IN_184: usize = 3;
-const OUT_184: usize = 2;
-fn aiur_fn_184(
-  inp: [G; IN_184],
+const INPUT_SIZE_182: usize = 3;
+const IN_182: usize = 3;
+const OUT_182: usize = 2;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_184], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14885,15 +14812,15 @@ fn aiur_fn_184(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_184] = [__v_13, __v_14];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_182] = [__v_13, __v_14];
+        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = G::from_u64(0);
-        let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -14902,8 +14829,8 @@ fn aiur_fn_184(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_184] = [__v_19, __v_20];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_182] = [__v_19, __v_20];
+        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14913,15 +14840,15 @@ fn aiur_fn_184(
   })
 }
 
-const INPUT_SIZE_185: usize = 7;
-const IN_185: usize = 7;
-const OUT_185: usize = 2;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_183: usize = 7;
+const IN_183: usize = 7;
+const OUT_183: usize = 2;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14936,12 +14863,12 @@ fn aiur_fn_185(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_185] = [__v_0, __v_1];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_0, __v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_3, __v_4, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -14953,11 +14880,11 @@ fn aiur_fn_185(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_185] = [__v_18, __v_19];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_18, __v_19];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14967,15 +14894,15 @@ fn aiur_fn_185(
   })
 }
 
-const INPUT_SIZE_186: usize = 36;
-const IN_186: usize = 36;
-const OUT_186: usize = 1;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_184: usize = 36;
+const IN_184: usize = 36;
+const OUT_184: usize = 1;
+fn aiur_fn_184(
+  inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
+) -> Result<[G; OUT_184], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15019,9 +14946,9 @@ fn aiur_fn_186(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
@@ -15039,21 +14966,21 @@ fn aiur_fn_186(
                     let __v_47: G = __r_arr[8];
                     let __v_48: G = G::from_u64(0);
                     let __v_49: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
                     let __v_51: G = __r_arr[1];
                     let __v_52: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
                     let __v_53: G = __r_arr[0];
-                    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
                     let __v_54: G = __r_arr[0];
                     let __v_55: G = G::from_u64(1);
                     if (__v_54 != __v_55) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
                     let __v_56: G = __r_arr[0];
-                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                     let __v_57: G = __r_arr[0];
                     let __v_58: G = (__v_56 - __v_57);
                     let __v_59: G = G::from_bool((__v_58 == G::ZERO));
@@ -15061,9 +14988,9 @@ fn aiur_fn_186(
                     if (__v_59 != __v_60) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_59.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                     let __v_61: G = __r_arr[0];
-                    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                     let __v_62: G = __r_arr[0];
                     let __v_63: G = (__v_61 - __v_62);
                     let __v_64: G = G::from_bool((__v_63 == G::ZERO));
@@ -15071,12 +14998,12 @@ fn aiur_fn_186(
                     if (__v_64 != __v_65) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                     let __v_66: G = __r_arr[0];
                     let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
                     let __v_67: G = __r_arr[0];
-                    let __ret: [G; OUT_186] = [__v_67];
-                    record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_184] = [__v_67];
+                    record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -15089,15 +15016,15 @@ fn aiur_fn_186(
   })
 }
 
-const INPUT_SIZE_187: usize = 1;
-const IN_187: usize = 1;
-const OUT_187: usize = 1;
-fn aiur_fn_187(
-  inp: [G; IN_187],
+const INPUT_SIZE_185: usize = 1;
+const IN_185: usize = 1;
+const OUT_185: usize = 1;
+fn aiur_fn_185(
+  inp: [G; IN_185],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15107,8 +15034,8 @@ fn aiur_fn_187(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_187] = [__v_4];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_4];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15119,10 +15046,10 @@ fn aiur_fn_187(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_187] = [__v_8];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_8];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15132,15 +15059,15 @@ fn aiur_fn_187(
   })
 }
 
-const INPUT_SIZE_188: usize = 2;
-const IN_188: usize = 2;
-const OUT_188: usize = 1;
-fn aiur_fn_188(
-  inp: [G; IN_188],
+const INPUT_SIZE_186: usize = 2;
+const IN_186: usize = 2;
+const OUT_186: usize = 1;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15156,8 +15083,8 @@ fn aiur_fn_188(
         let __v_8: G = G::from_u64(1);
         let __v_9: G = G::from_u64(1);
         let __v_10: G = { let __values: [G; 6] = [__v_8, __v_9, __v_9, __v_9, __v_9, __v_9]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_188] = [__v_10];
-        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_186] = [__v_10];
+        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15169,19 +15096,19 @@ fn aiur_fn_188(
           0u64 => {
             match __v_9.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_188] = [__v_11];
-                record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_186] = [__v_11];
+                record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_11: G = G::from_u64(0);
-                let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
                 let __v_12: G = __r_arr[0];
                 let __v_13: G = { let __values: [G; 6] = [__v_11, __v_3, __v_4, __v_5, __v_6, __v_12]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_188] = [__v_13];
-                record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_186] = [__v_13];
+                record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15198,15 +15125,15 @@ fn aiur_fn_188(
   })
 }
 
-const INPUT_SIZE_189: usize = 2;
-const IN_189: usize = 2;
-const OUT_189: usize = 1;
-fn aiur_fn_189(
-  inp: [G; IN_189],
+const INPUT_SIZE_187: usize = 2;
+const IN_187: usize = 2;
+const OUT_187: usize = 1;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15220,8 +15147,8 @@ fn aiur_fn_189(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_189] = [__v_8];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_8];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15233,19 +15160,19 @@ fn aiur_fn_189(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_189] = [__v_9];
-                record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_187] = [__v_9];
+                record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_189] = [__v_11];
-                record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_187] = [__v_11];
+                record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15257,6 +15184,69 @@ fn aiur_fn_189(
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_188: usize = 1;
+const IN_188: usize = 1;
+const OUT_188: usize = 2;
+fn aiur_fn_188(
+  inp: [G; IN_188],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_188], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_188] = [__v_3, __v_4];
+    record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_189: usize = 2;
+const IN_189: usize = 2;
+const OUT_189: usize = 2;
+fn aiur_fn_189(
+  inp: [G; IN_189],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_189], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_189] = [__v_4, __v_0];
+        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = (__v_1 - __v_4);
+        let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = __r_arr[1];
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_189] = [__v_9, __v_7];
+        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
@@ -15301,72 +15291,9 @@ fn aiur_fn_191(
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
         let __ret: [G; OUT_191] = [__v_4, __v_0];
         record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
-        let __v_2: G = __r_arr[0];
-        let __v_3: G = __r_arr[1];
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_9, __v_7];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_192: usize = 1;
-const IN_192: usize = 1;
-const OUT_192: usize = 2;
-fn aiur_fn_192(
-  inp: [G; IN_192],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_192] = [__v_3, __v_4];
-    record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_193: usize = 2;
-const IN_193: usize = 2;
-const OUT_193: usize = 2;
-fn aiur_fn_193(
-  inp: [G; IN_193],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_193], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_193] = [__v_4, __v_0];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15382,28 +15309,28 @@ fn aiur_fn_193(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_193] = [__v_16, __v_14];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_191] = [__v_16, __v_14];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_194: usize = 64;
-const IN_194: usize = 64;
-const OUT_194: usize = 0;
-fn aiur_fn_194(
-  inp: [G; IN_194],
+const INPUT_SIZE_192: usize = 64;
+const IN_192: usize = 64;
+const OUT_192: usize = 0;
+fn aiur_fn_192(
+  inp: [G; IN_192],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_194], ExecError> {
+) -> Result<[G; OUT_192], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15526,7 +15453,7 @@ fn aiur_fn_194(
     let __v_113: G = G::from_u64(2);
     let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = __r_arr[1];
     let __v_117: G = (__v_66 + __v_67);
@@ -15883,27 +15810,27 @@ fn aiur_fn_194(
     if (__v_253 != __v_254) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
     let __v_255: G = __r_arr[0];
     let __v_256: G = G::from_u64(1);
     if (__v_255 != __v_256) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
-    let __ret: [G; OUT_194] = [];
-    record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_192] = [];
+    record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_195: usize = 1;
-const IN_195: usize = 1;
-const OUT_195: usize = 1;
-fn aiur_fn_195(
-  inp: [G; IN_195],
+const INPUT_SIZE_193: usize = 1;
+const IN_193: usize = 1;
+const OUT_193: usize = 1;
+fn aiur_fn_193(
+  inp: [G; IN_193],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_195], ExecError> {
+) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15913,17 +15840,17 @@ fn aiur_fn_195(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_195] = [__v_4];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_193] = [__v_4];
+        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = G::from_u64(1);
         let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_195] = [__v_6];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_193] = [__v_6];
+        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15933,15 +15860,15 @@ fn aiur_fn_195(
   })
 }
 
-const INPUT_SIZE_196: usize = 1;
-const IN_196: usize = 1;
-const OUT_196: usize = 1;
-fn aiur_fn_196(
-  inp: [G; IN_196],
+const INPUT_SIZE_194: usize = 1;
+const IN_194: usize = 1;
+const OUT_194: usize = 1;
+fn aiur_fn_194(
+  inp: [G; IN_194],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
+) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15951,14 +15878,14 @@ fn aiur_fn_196(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_196] = [__v_4];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_194] = [__v_4];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_196] = [__v_4];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_194] = [__v_4];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15968,19 +15895,19 @@ fn aiur_fn_196(
   })
 }
 
-const INPUT_SIZE_197: usize = 2;
-const IN_197: usize = 2;
-const OUT_197: usize = 2;
-fn aiur_fn_197(
-  inp: [G; IN_197],
+const INPUT_SIZE_195: usize = 2;
+const IN_195: usize = 2;
+const OUT_195: usize = 2;
+fn aiur_fn_195(
+  inp: [G; IN_195],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
+) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -15989,8 +15916,8 @@ fn aiur_fn_197(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_197] = [__v_4, __v_5];
-        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_195] = [__v_4, __v_5];
+        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16000,15 +15927,15 @@ fn aiur_fn_197(
   })
 }
 
-const INPUT_SIZE_198: usize = 1;
-const IN_198: usize = 1;
-const OUT_198: usize = 8;
-fn aiur_fn_198(
-  inp: [G; IN_198],
+const INPUT_SIZE_196: usize = 1;
+const IN_196: usize = 1;
+const OUT_196: usize = 8;
+fn aiur_fn_196(
+  inp: [G; IN_196],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_198], ExecError> {
+) -> Result<[G; OUT_196], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -16032,12 +15959,12 @@ fn aiur_fn_198(
         let __v_16: G = G::from_u64(0);
         let __v_17: G = G::from_u64(0);
         let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_198] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
-        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
         let __v_13: G = __r_arr[2];
@@ -16055,7 +15982,78 @@ fn aiur_fn_198(
         let __v_24: G = __r_arr[5];
         let __v_25: G = __r_arr[6];
         let __v_26: G = __r_arr[7];
-        let __ret: [G; OUT_198] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
+        let __ret: [G; OUT_196] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_197: usize = 2;
+const IN_197: usize = 2;
+const OUT_197: usize = 1;
+fn aiur_fn_197(
+  inp: [G; IN_197],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_197], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_197] = [__v_4];
+        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_198: usize = 1;
+const IN_198: usize = 1;
+const OUT_198: usize = 1;
+fn aiur_fn_198(
+  inp: [G; IN_198],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_198], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_198] = [__v_6];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_6 + __v_7);
+        let __ret: [G; OUT_198] = [__v_8];
         record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16066,8 +16064,8 @@ fn aiur_fn_198(
   })
 }
 
-const INPUT_SIZE_199: usize = 2;
-const IN_199: usize = 2;
+const INPUT_SIZE_199: usize = 1;
+const IN_199: usize = 1;
 const OUT_199: usize = 1;
 fn aiur_fn_199(
   inp: [G; IN_199],
@@ -16077,21 +16075,29 @@ fn aiur_fn_199(
 ) -> Result<[G; OUT_199], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    match __v_3.as_canonical_u64() {
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_199] = [__v_5];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
       0u64 => {
-        let __ret: [G; OUT_199] = [__v_4];
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = (__v_5 + __v_6);
+        let __ret: [G; OUT_199] = [__v_7];
         record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -16109,124 +16115,6 @@ fn aiur_fn_200(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_200] = [__v_1];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = { let __values: [G; 4] = [__v_6, __v_3, __v_4, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_200] = [__v_8];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_201: usize = 1;
-const IN_201: usize = 1;
-const OUT_201: usize = 1;
-fn aiur_fn_201(
-  inp: [G; IN_201],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_201], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_201] = [__v_6];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_201] = [__v_8];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_202: usize = 1;
-const IN_202: usize = 1;
-const OUT_202: usize = 1;
-fn aiur_fn_202(
-  inp: [G; IN_202],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_202], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_202] = [__v_5];
-        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_202] = [__v_7];
-        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_203: usize = 2;
-const IN_203: usize = 2;
-const OUT_203: usize = 1;
-fn aiur_fn_203(
-  inp: [G; IN_203],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_203], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
@@ -16240,17 +16128,17 @@ fn aiur_fn_203(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_203] = [__v_1];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_1];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_203] = [__v_14];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_14];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16260,15 +16148,15 @@ fn aiur_fn_203(
   })
 }
 
-const INPUT_SIZE_204: usize = 1;
-const IN_204: usize = 1;
-const OUT_204: usize = 8;
-fn aiur_fn_204(
-  inp: [G; IN_204],
+const INPUT_SIZE_201: usize = 1;
+const IN_201: usize = 1;
+const OUT_201: usize = 8;
+fn aiur_fn_201(
+  inp: [G; IN_201],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_204], ExecError> {
+) -> Result<[G; OUT_201], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16285,12 +16173,12 @@ fn aiur_fn_204(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_204] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = __r_arr[1];
         let __v_6: G = __r_arr[2];
@@ -16308,8 +16196,8 @@ fn aiur_fn_204(
         let __v_17: G = __r_arr[5];
         let __v_18: G = __r_arr[6];
         let __v_19: G = __r_arr[7];
-        let __ret: [G; OUT_204] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16319,15 +16207,15 @@ fn aiur_fn_204(
   })
 }
 
-const INPUT_SIZE_205: usize = 2;
-const IN_205: usize = 2;
-const OUT_205: usize = 1;
-fn aiur_fn_205(
-  inp: [G; IN_205],
+const INPUT_SIZE_202: usize = 2;
+const IN_202: usize = 2;
+const OUT_202: usize = 1;
+fn aiur_fn_202(
+  inp: [G; IN_202],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_205], ExecError> {
+) -> Result<[G; OUT_202], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16337,17 +16225,17 @@ fn aiur_fn_205(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_205] = [__v_1];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_202] = [__v_1];
+        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_205] = [__v_7];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_202] = [__v_7];
+        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16357,28 +16245,28 @@ fn aiur_fn_205(
   })
 }
 
-const INPUT_SIZE_206: usize = 2;
-const IN_206: usize = 2;
-const OUT_206: usize = 1;
-fn aiur_fn_206(
-  inp: [G; IN_206],
+const INPUT_SIZE_203: usize = 2;
+const IN_203: usize = 2;
+const OUT_203: usize = 1;
+fn aiur_fn_203(
+  inp: [G; IN_203],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_206], ExecError> {
+) -> Result<[G; OUT_203], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_206] = [__v_0];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_203] = [__v_0];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -16386,8 +16274,8 @@ fn aiur_fn_206(
         let __v_7: G = __loaded[2];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_206] = [__v_7];
-            record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_203] = [__v_7];
+            record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -16399,15 +16287,15 @@ fn aiur_fn_206(
   })
 }
 
-const INPUT_SIZE_207: usize = 1;
-const IN_207: usize = 1;
-const OUT_207: usize = 1;
-fn aiur_fn_207(
-  inp: [G; IN_207],
+const INPUT_SIZE_204: usize = 1;
+const IN_204: usize = 1;
+const OUT_204: usize = 1;
+fn aiur_fn_204(
+  inp: [G; IN_204],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_207], ExecError> {
+) -> Result<[G; OUT_204], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
@@ -16421,17 +16309,17 @@ fn aiur_fn_207(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_207] = [__v_8];
-        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_204] = [__v_8];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
         let __v_9: G = G::from_u64(1);
         let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_207] = [__v_10];
-        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_204] = [__v_10];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16441,15 +16329,15 @@ fn aiur_fn_207(
   })
 }
 
-const INPUT_SIZE_208: usize = 1;
-const IN_208: usize = 1;
-const OUT_208: usize = 1;
-fn aiur_fn_208(
-  inp: [G; IN_208],
+const INPUT_SIZE_205: usize = 1;
+const IN_205: usize = 1;
+const OUT_205: usize = 1;
+fn aiur_fn_205(
+  inp: [G; IN_205],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_208], ExecError> {
+) -> Result<[G; OUT_205], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -16466,17 +16354,17 @@ fn aiur_fn_208(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_208] = [__v_11];
-        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_11];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_u64(1);
         let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_208] = [__v_13];
-        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_13];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16486,15 +16374,49 @@ fn aiur_fn_208(
   })
 }
 
-const INPUT_SIZE_209: usize = 1;
-const IN_209: usize = 1;
-const OUT_209: usize = 1;
-fn aiur_fn_209(
-  inp: [G; IN_209],
+const INPUT_SIZE_206: usize = 2;
+const IN_206: usize = 2;
+const OUT_206: usize = 4;
+fn aiur_fn_206(
+  inp: [G; IN_206],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_209], ExecError> {
+) -> Result<[G; OUT_206], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    let __v_6: G = __loaded[3];
+    let __v_7: G = __loaded[4];
+    let __v_8: G = __loaded[5];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_207: usize = 1;
+const IN_207: usize = 1;
+const OUT_207: usize = 1;
+fn aiur_fn_207(
+  inp: [G; IN_207],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_207], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
@@ -16507,17 +16429,17 @@ fn aiur_fn_209(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_209] = [__v_7];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_207] = [__v_7];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
         let __v_8: G = G::from_u64(1);
         let __v_9: G = (__v_7 + __v_8);
-        let __ret: [G; OUT_209] = [__v_9];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_207] = [__v_9];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16527,19 +16449,19 @@ fn aiur_fn_209(
   })
 }
 
-const INPUT_SIZE_210: usize = 2;
-const IN_210: usize = 2;
-const OUT_210: usize = 32;
-fn aiur_fn_210(
-  inp: [G; IN_210],
+const INPUT_SIZE_208: usize = 2;
+const IN_208: usize = 2;
+const OUT_208: usize = 32;
+fn aiur_fn_208(
+  inp: [G; IN_208],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_210], ExecError> {
+) -> Result<[G; OUT_208], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16578,12 +16500,100 @@ fn aiur_fn_210(
     let __v_36: G = __loaded[33];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_210] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_208] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
+        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_209: usize = 2;
+const IN_209: usize = 2;
+const OUT_209: usize = 1;
+fn aiur_fn_209(
+  inp: [G; IN_209],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_209], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_209] = [__v_0];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        let __v_8: G = __loaded[3];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_209] = [__v_8];
+            record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_210: usize = 2;
+const IN_210: usize = 2;
+const OUT_210: usize = 1;
+fn aiur_fn_210(
+  inp: [G; IN_210],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_210], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_210] = [__v_0];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        let __v_8: G = __loaded[3];
+        let __v_9: G = __loaded[4];
+        let __v_10: G = __loaded[5];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_210] = [__v_10];
+            record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
@@ -16611,49 +16621,6 @@ fn aiur_fn_211(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
         let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        let __v_8: G = __loaded[3];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_211] = [__v_8];
-            record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_212: usize = 2;
-const IN_212: usize = 2;
-const OUT_212: usize = 1;
-fn aiur_fn_212(
-  inp: [G; IN_212],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_212], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_212] = [__v_0];
-        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -16692,8 +16659,8 @@ fn aiur_fn_212(
         let __v_38: G = __loaded[33];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_212] = [__v_38];
-            record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_211] = [__v_38];
+            record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -17770,11 +17737,6 @@ pub(crate) fn execute_generated(
     211u64 => {
       let __inp: [G; IN_211] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_211(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    212u64 => {
-      let __inp: [G; IN_212] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_212(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4341,7 +4341,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4499,10 +4499,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -6271,7 +6271,7 @@ fn aiur_fn_75(
 
 const INPUT_SIZE_76: usize = 1;
 const IN_76: usize = 1;
-const OUT_76: usize = 2;
+const OUT_76: usize = 10;
 fn aiur_fn_76(
   inp: [G; IN_76],
   record: &mut QueryRecord,
@@ -6295,9 +6295,13 @@ fn aiur_fn_76(
     let __v_12: G = (__v_9 + __v_11);
     let __v_13: G = (__v_7 + __v_12);
     let __v_14: G = (__v_2 + __v_13);
-    let __v_15: G = G::from_u64(4);
-    let __v_16: G = (__v_0 + __v_15);
-    let __ret: [G; OUT_76] = [__v_14, __v_16];
+    let __v_15: G = G::from_u64(0);
+    let __v_16: G = G::from_u64(0);
+    let __v_17: G = G::from_u64(0);
+    let __v_18: G = G::from_u64(0);
+    let __v_19: G = G::from_u64(4);
+    let __v_20: G = (__v_0 + __v_19);
+    let __ret: [G; OUT_76] = [__v_14, __v_2, __v_3, __v_4, __v_5, __v_15, __v_16, __v_17, __v_18, __v_20];
     record.function_queries[76].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
@@ -6305,51 +6309,13 @@ fn aiur_fn_76(
 
 const INPUT_SIZE_77: usize = 1;
 const IN_77: usize = 1;
-const OUT_77: usize = 10;
+const OUT_77: usize = 9;
 fn aiur_fn_77(
   inp: [G; IN_77],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_77], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = G::from_u64(1);
-    let __io_read: [G; 4] = { let __idx_u64 = __v_0.as_canonical_u64(); let __idx = usize::try_from(__idx_u64).ok().ok_or(ExecError::IndexTooLarge(__idx_u64))?; let __data = io_buffer.read(__v_1, __idx, 4)?; let __arr: [G; 4] = __data[..4].try_into().unwrap(); __arr };
-    let __v_2: G = __io_read[0];
-    let __v_3: G = __io_read[1];
-    let __v_4: G = __io_read[2];
-    let __v_5: G = __io_read[3];
-    let __v_6: G = G::from_u64(256);
-    let __v_7: G = (__v_6 * __v_3);
-    let __v_8: G = G::from_u64(65536);
-    let __v_9: G = (__v_8 * __v_4);
-    let __v_10: G = G::from_u64(16777216);
-    let __v_11: G = (__v_10 * __v_5);
-    let __v_12: G = (__v_9 + __v_11);
-    let __v_13: G = (__v_7 + __v_12);
-    let __v_14: G = (__v_2 + __v_13);
-    let __v_15: G = G::from_u64(0);
-    let __v_16: G = G::from_u64(0);
-    let __v_17: G = G::from_u64(0);
-    let __v_18: G = G::from_u64(0);
-    let __v_19: G = G::from_u64(4);
-    let __v_20: G = (__v_0 + __v_19);
-    let __ret: [G; OUT_77] = [__v_14, __v_2, __v_3, __v_4, __v_5, __v_15, __v_16, __v_17, __v_18, __v_20];
-    record.function_queries[77].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_78: usize = 1;
-const IN_78: usize = 1;
-const OUT_78: usize = 9;
-fn aiur_fn_78(
-  inp: [G; IN_78],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_78], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(1);
@@ -6364,24 +6330,24 @@ fn aiur_fn_78(
     let __v_9: G = __io_read[7];
     let __v_10: G = G::from_u64(8);
     let __v_11: G = (__v_0 + __v_10);
-    let __ret: [G; OUT_78] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_11];
-    record.function_queries[78].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_77] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_11];
+    record.function_queries[77].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_79: usize = 1;
-const IN_79: usize = 1;
-const OUT_79: usize = 2;
-fn aiur_fn_79(
-  inp: [G; IN_79],
+const INPUT_SIZE_78: usize = 1;
+const IN_78: usize = 1;
+const OUT_78: usize = 2;
+fn aiur_fn_78(
+  inp: [G; IN_78],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_79], ExecError> {
+) -> Result<[G; OUT_78], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_78] = { let __args: [G; IN_78] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[78].get_mut(&__args[..]) { let __ret: [G; OUT_78] = unsafe { *(result.output.as_ptr() as *const [G; OUT_78]) }; __ret } else { aiur_fn_78(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
     let __v_3: G = __r_arr[2];
@@ -6393,24 +6359,24 @@ fn aiur_fn_79(
     let __v_9: G = __r_arr[8];
     let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __ret: [G; OUT_79] = [__v_10, __v_9];
-    record.function_queries[79].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_78] = [__v_10, __v_9];
+    record.function_queries[78].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_80: usize = 1;
-const IN_80: usize = 1;
-const OUT_80: usize = 33;
-fn aiur_fn_80(
-  inp: [G; IN_80],
+const INPUT_SIZE_79: usize = 1;
+const IN_79: usize = 1;
+const OUT_79: usize = 33;
+fn aiur_fn_79(
+  inp: [G; IN_79],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_80], ExecError> {
+) -> Result<[G; OUT_79], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_78] = { let __args: [G; IN_78] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[78].get_mut(&__args[..]) { let __ret: [G; OUT_78] = unsafe { *(result.output.as_ptr() as *const [G; OUT_78]) }; __ret } else { aiur_fn_78(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
     let __v_3: G = __r_arr[2];
@@ -6420,7 +6386,7 @@ fn aiur_fn_80(
     let __v_7: G = __r_arr[6];
     let __v_8: G = __r_arr[7];
     let __v_9: G = __r_arr[8];
-    let __r_arr: [G; OUT_78] = { let __args: [G; IN_78] = [__v_9]; let __cu = true; if let Some(result) = record.function_queries[78].get_mut(&__args[..]) { let __ret: [G; OUT_78] = unsafe { *(result.output.as_ptr() as *const [G; OUT_78]) }; __ret } else { aiur_fn_78(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_9]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = __r_arr[1];
     let __v_12: G = __r_arr[2];
@@ -6430,7 +6396,7 @@ fn aiur_fn_80(
     let __v_16: G = __r_arr[6];
     let __v_17: G = __r_arr[7];
     let __v_18: G = __r_arr[8];
-    let __r_arr: [G; OUT_78] = { let __args: [G; IN_78] = [__v_18]; let __cu = true; if let Some(result) = record.function_queries[78].get_mut(&__args[..]) { let __ret: [G; OUT_78] = unsafe { *(result.output.as_ptr() as *const [G; OUT_78]) }; __ret } else { aiur_fn_78(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_18]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
     let __v_19: G = __r_arr[0];
     let __v_20: G = __r_arr[1];
     let __v_21: G = __r_arr[2];
@@ -6440,7 +6406,7 @@ fn aiur_fn_80(
     let __v_25: G = __r_arr[6];
     let __v_26: G = __r_arr[7];
     let __v_27: G = __r_arr[8];
-    let __r_arr: [G; OUT_78] = { let __args: [G; IN_78] = [__v_27]; let __cu = true; if let Some(result) = record.function_queries[78].get_mut(&__args[..]) { let __ret: [G; OUT_78] = unsafe { *(result.output.as_ptr() as *const [G; OUT_78]) }; __ret } else { aiur_fn_78(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_27]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
     let __v_28: G = __r_arr[0];
     let __v_29: G = __r_arr[1];
     let __v_30: G = __r_arr[2];
@@ -6450,21 +6416,21 @@ fn aiur_fn_80(
     let __v_34: G = __r_arr[6];
     let __v_35: G = __r_arr[7];
     let __v_36: G = __r_arr[8];
-    let __ret: [G; OUT_80] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36];
-    record.function_queries[80].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_79] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36];
+    record.function_queries[79].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_81: usize = 2;
-const IN_81: usize = 2;
-const OUT_81: usize = 2;
-fn aiur_fn_81(
-  inp: [G; IN_81],
+const INPUT_SIZE_80: usize = 2;
+const IN_80: usize = 2;
+const OUT_80: usize = 2;
+fn aiur_fn_80(
+  inp: [G; IN_80],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_81], ExecError> {
+) -> Result<[G; OUT_80], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -6473,12 +6439,12 @@ fn aiur_fn_81(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 34] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_81] = [__v_4, __v_0];
-        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_80] = [__v_4, __v_0];
+        record.function_queries[80].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_80] = { let __args: [G; IN_80] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[80].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_80] = unsafe { *(result.output.as_ptr() as *const [G; OUT_80]) }; __ret } else { aiur_fn_80(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_79] = { let __args: [G; IN_79] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[79].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_79] = unsafe { *(result.output.as_ptr() as *const [G; OUT_79]) }; __ret } else { aiur_fn_79(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = __r_arr[2];
@@ -6514,28 +6480,28 @@ fn aiur_fn_81(
         let __v_34: G = __r_arr[32];
         let __v_35: G = G::from_u64(1);
         let __v_36: G = (__v_1 - __v_35);
-        let __r_arr: [G; OUT_81] = { let __args: [G; IN_81] = [__v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[81].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_81] = unsafe { *(result.output.as_ptr() as *const [G; OUT_81]) }; __ret } else { aiur_fn_81(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_80] = { let __args: [G; IN_80] = [__v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[80].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_80] = unsafe { *(result.output.as_ptr() as *const [G; OUT_80]) }; __ret } else { aiur_fn_80(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
         let __v_38: G = __r_arr[1];
         let __v_39: G = G::from_u64(0);
         let __v_40: G = { let __values: [G; 34] = [__v_39, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_37]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_81] = [__v_40, __v_38];
-        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_80] = [__v_40, __v_38];
+        record.function_queries[80].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_82: usize = 1;
-const IN_82: usize = 1;
-const OUT_82: usize = 5;
-fn aiur_fn_82(
-  inp: [G; IN_82],
+const INPUT_SIZE_81: usize = 1;
+const IN_81: usize = 1;
+const OUT_81: usize = 5;
+fn aiur_fn_81(
+  inp: [G; IN_81],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_82], ExecError> {
+) -> Result<[G; OUT_81], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
@@ -6548,18 +6514,18 @@ fn aiur_fn_82(
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(0);
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_3, __v_6, __v_6, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __r_arr: [G; OUT_79] = { let __args: [G; IN_79] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[79].get_mut(&__args[..]) { let __ret: [G; OUT_79] = unsafe { *(result.output.as_ptr() as *const [G; OUT_79]) }; __ret } else { aiur_fn_79(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_78] = { let __args: [G; IN_78] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[78].get_mut(&__args[..]) { let __ret: [G; OUT_78] = unsafe { *(result.output.as_ptr() as *const [G; OUT_78]) }; __ret } else { aiur_fn_78(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(0);
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_3, __v_6, __v_6, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
@@ -6568,29 +6534,29 @@ fn aiur_fn_82(
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(2);
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_3, __v_6, __v_6, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_3: G = G::from_u64(3);
         let __v_4: G = G::from_u64(3);
-        let __ret: [G; OUT_82] = [__v_3, __v_4, __v_4, __v_4, __v_2];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_3, __v_4, __v_4, __v_4, __v_2];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_3: G = G::from_u64(4);
         let __v_4: G = G::from_u64(4);
-        let __ret: [G; OUT_82] = [__v_3, __v_4, __v_4, __v_4, __v_2];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_3, __v_4, __v_4, __v_4, __v_2];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
         let __v_3: G = G::from_u64(5);
         let __v_4: G = G::from_u64(5);
-        let __ret: [G; OUT_82] = [__v_3, __v_4, __v_4, __v_4, __v_2];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_3, __v_4, __v_4, __v_4, __v_2];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
@@ -6602,8 +6568,8 @@ fn aiur_fn_82(
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(6);
         let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_7, __v_3, __v_5, __v_8, __v_6];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_7, __v_3, __v_5, __v_8, __v_6];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
@@ -6615,8 +6581,8 @@ fn aiur_fn_82(
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(7);
         let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_7, __v_3, __v_5, __v_8, __v_6];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_7, __v_3, __v_5, __v_8, __v_6];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
@@ -6628,8 +6594,8 @@ fn aiur_fn_82(
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(8);
         let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_7, __v_3, __v_5, __v_8, __v_6];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_7, __v_3, __v_5, __v_8, __v_6];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
@@ -6638,8 +6604,8 @@ fn aiur_fn_82(
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(9);
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_3, __v_6, __v_6, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       10u64 => {
@@ -6649,8 +6615,8 @@ fn aiur_fn_82(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(0);
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       11u64 => {
@@ -6660,8 +6626,8 @@ fn aiur_fn_82(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(0);
         let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       12u64 => {
@@ -6671,8 +6637,8 @@ fn aiur_fn_82(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       13u64 => {
@@ -6682,8 +6648,8 @@ fn aiur_fn_82(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       14u64 => {
@@ -6693,8 +6659,8 @@ fn aiur_fn_82(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(2);
         let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_81] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -6704,7 +6670,50 @@ fn aiur_fn_82(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(2);
         let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        let __ret: [G; OUT_81] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[81].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_82: usize = 2;
+const IN_82: usize = 2;
+const OUT_82: usize = 2;
+fn aiur_fn_82(
+  inp: [G; IN_82],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_82], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 6] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_82] = [__v_4, __v_0];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_81] = { let __args: [G; IN_81] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[81].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_81] = unsafe { *(result.output.as_ptr() as *const [G; OUT_81]) }; __ret } else { aiur_fn_81(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = __r_arr[2];
+        let __v_5: G = __r_arr[3];
+        let __v_6: G = __r_arr[4];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_1 - __v_7);
+        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
+        let __v_9: G = __r_arr[0];
+        let __v_10: G = __r_arr[1];
+        let __v_11: G = G::from_u64(0);
+        let __v_12: G = { let __values: [G; 6] = [__v_11, __v_2, __v_3, __v_4, __v_5, __v_9]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_82] = [__v_12, __v_10];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -6728,52 +6737,9 @@ fn aiur_fn_83(
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 6] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
         let __ret: [G; OUT_83] = [__v_4, __v_0];
         record.function_queries[83].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_2: G = __r_arr[0];
-        let __v_3: G = __r_arr[1];
-        let __v_4: G = __r_arr[2];
-        let __v_5: G = __r_arr[3];
-        let __v_6: G = __r_arr[4];
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_1 - __v_7);
-        let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
-        let __v_9: G = __r_arr[0];
-        let __v_10: G = __r_arr[1];
-        let __v_11: G = G::from_u64(0);
-        let __v_12: G = { let __values: [G; 6] = [__v_11, __v_2, __v_3, __v_4, __v_5, __v_9]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_83] = [__v_12, __v_10];
-        record.function_queries[83].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_84: usize = 2;
-const IN_84: usize = 2;
-const OUT_84: usize = 2;
-fn aiur_fn_84(
-  inp: [G; IN_84],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_84], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_84] = [__v_4, __v_0];
-        record.function_queries[84].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -6782,28 +6748,28 @@ fn aiur_fn_84(
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
         let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = __r_arr[1];
         let __v_8: G = G::from_u64(0);
         let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_84] = [__v_9, __v_7];
-        record.function_queries[84].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_83] = [__v_9, __v_7];
+        record.function_queries[83].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_85: usize = 1;
-const IN_85: usize = 1;
-const OUT_85: usize = 3;
-fn aiur_fn_85(
-  inp: [G; IN_85],
+const INPUT_SIZE_84: usize = 1;
+const IN_84: usize = 1;
+const OUT_84: usize = 3;
+fn aiur_fn_84(
+  inp: [G; IN_84],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_85], ExecError> {
+) -> Result<[G; OUT_84], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
@@ -6812,24 +6778,24 @@ fn aiur_fn_85(
     let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
-    let __ret: [G; OUT_85] = [__v_1, __v_5, __v_6];
-    record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_84] = [__v_1, __v_5, __v_6];
+    record.function_queries[84].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_86: usize = 2;
-const IN_86: usize = 2;
-const OUT_86: usize = 2;
-fn aiur_fn_86(
-  inp: [G; IN_86],
+const INPUT_SIZE_85: usize = 2;
+const IN_85: usize = 2;
+const OUT_85: usize = 2;
+fn aiur_fn_85(
+  inp: [G; IN_85],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_86], ExecError> {
+) -> Result<[G; OUT_85], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -6838,152 +6804,145 @@ fn aiur_fn_86(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 4] = [__v_2, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_86] = [__v_4, __v_0];
-        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_85] = [__v_4, __v_0];
+        record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = __r_arr[2];
         let __v_5: G = G::from_u64(1);
         let __v_6: G = (__v_1 - __v_5);
-        let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
         let __v_8: G = __r_arr[1];
         let __v_9: G = G::from_u64(0);
         let __v_10: G = { let __values: [G; 4] = [__v_9, __v_2, __v_3, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_86] = [__v_10, __v_8];
-        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_85] = [__v_10, __v_8];
+        record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_87: usize = 1;
-const IN_87: usize = 1;
-const OUT_87: usize = 54;
+const INPUT_SIZE_86: usize = 1;
+const IN_86: usize = 1;
+const OUT_86: usize = 54;
+fn aiur_fn_86(
+  inp: [G; IN_86],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_86], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_75] = { let __args: [G; IN_75] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[75].get_mut(&__args[..]) { let __ret: [G; OUT_75] = unsafe { *(result.output.as_ptr() as *const [G; OUT_75]) }; __ret } else { aiur_fn_75(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __v_3: G = __r_arr[2];
+    let __v_4: G = __r_arr[3];
+    let __v_5: G = __r_arr[4];
+    let __v_6: G = __r_arr[5];
+    let __v_7: G = __r_arr[6];
+    let __v_8: G = __r_arr[7];
+    let __v_9: G = __r_arr[8];
+    let __v_10: G = __r_arr[9];
+    let __r_arr: [G; OUT_75] = { let __args: [G; IN_75] = [__v_10]; let __cu = true; if let Some(result) = record.function_queries[75].get_mut(&__args[..]) { let __ret: [G; OUT_75] = unsafe { *(result.output.as_ptr() as *const [G; OUT_75]) }; __ret } else { aiur_fn_75(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __v_12: G = __r_arr[1];
+    let __v_13: G = __r_arr[2];
+    let __v_14: G = __r_arr[3];
+    let __v_15: G = __r_arr[4];
+    let __v_16: G = __r_arr[5];
+    let __v_17: G = __r_arr[6];
+    let __v_18: G = __r_arr[7];
+    let __v_19: G = __r_arr[8];
+    let __v_20: G = __r_arr[9];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_20]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_21: G = __r_arr[0];
+    let __v_22: G = __r_arr[1];
+    let __v_23: G = __r_arr[2];
+    let __v_24: G = __r_arr[3];
+    let __v_25: G = __r_arr[4];
+    let __v_26: G = __r_arr[5];
+    let __v_27: G = __r_arr[6];
+    let __v_28: G = __r_arr[7];
+    let __v_29: G = __r_arr[8];
+    let __v_30: G = __r_arr[9];
+    let __r_arr: [G; OUT_75] = { let __args: [G; IN_75] = [__v_30]; let __cu = true; if let Some(result) = record.function_queries[75].get_mut(&__args[..]) { let __ret: [G; OUT_75] = unsafe { *(result.output.as_ptr() as *const [G; OUT_75]) }; __ret } else { aiur_fn_75(__args, record, io_buffer, __cu)? } };
+    let __v_31: G = __r_arr[0];
+    let __v_32: G = __r_arr[1];
+    let __v_33: G = __r_arr[2];
+    let __v_34: G = __r_arr[3];
+    let __v_35: G = __r_arr[4];
+    let __v_36: G = __r_arr[5];
+    let __v_37: G = __r_arr[6];
+    let __v_38: G = __r_arr[7];
+    let __v_39: G = __r_arr[8];
+    let __v_40: G = __r_arr[9];
+    let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_40]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+    let __v_41: G = __r_arr[0];
+    let __v_42: G = __r_arr[1];
+    let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_42, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
+    let __v_43: G = __r_arr[0];
+    let __v_44: G = __r_arr[1];
+    let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_44]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+    let __v_45: G = __r_arr[0];
+    let __v_46: G = __r_arr[1];
+    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_46, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
+    let __v_47: G = __r_arr[0];
+    let __v_48: G = __r_arr[1];
+    let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_48]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+    let __v_49: G = __r_arr[0];
+    let __v_50: G = __r_arr[1];
+    let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_50, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
+    let __v_51: G = __r_arr[0];
+    let __v_52: G = __r_arr[1];
+    let __v_53: G = G::from_u64(2);
+    let __v_54: G = G::from_u64(3);
+    let __v_55: G = (__v_49 + __v_54);
+    let __v_56: G = (__v_53 * __v_55);
+    let __v_57: G = (__v_45 + __v_56);
+    let __r_arr: [G; OUT_12] = { let __args: [G; IN_12] = [__v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[12].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_12] = unsafe { *(result.output.as_ptr() as *const [G; OUT_12]) }; __ret } else { aiur_fn_12(__args, record, io_buffer, __cu)? } };
+    let __v_58: G = __r_arr[0];
+    let __v_59: G = __r_arr[1];
+    let __v_60: G = __r_arr[2];
+    let __v_61: G = __r_arr[3];
+    let __v_62: G = __r_arr[4];
+    let __v_63: G = __r_arr[5];
+    let __v_64: G = __r_arr[6];
+    let __v_65: G = __r_arr[7];
+    let __v_66: G = G::from_u64(2);
+    let __v_67: G = G::from_u64(1);
+    let __v_68: G = (__v_67 + __v_49);
+    let __v_69: G = (__v_66 * __v_68);
+    let __r_arr: [G; OUT_12] = { let __args: [G; IN_12] = [__v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[12].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_12] = unsafe { *(result.output.as_ptr() as *const [G; OUT_12]) }; __ret } else { aiur_fn_12(__args, record, io_buffer, __cu)? } };
+    let __v_70: G = __r_arr[0];
+    let __v_71: G = __r_arr[1];
+    let __v_72: G = __r_arr[2];
+    let __v_73: G = __r_arr[3];
+    let __v_74: G = __r_arr[4];
+    let __v_75: G = __r_arr[5];
+    let __v_76: G = __r_arr[6];
+    let __v_77: G = __r_arr[7];
+    let __ret: [G; OUT_86] = [__v_43, __v_41, __v_47, __v_31, __v_51, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_52];
+    record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_87: usize = 49;
+const IN_87: usize = 49;
+const OUT_87: usize = 1;
 fn aiur_fn_87(
   inp: [G; IN_87],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_87], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __v_5: G = __r_arr[2];
-    let __v_6: G = __r_arr[3];
-    let __v_7: G = __r_arr[4];
-    let __v_8: G = __r_arr[5];
-    let __v_9: G = __r_arr[6];
-    let __v_10: G = __r_arr[7];
-    let __v_11: G = __r_arr[8];
-    let __v_12: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_12]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_13: G = __r_arr[0];
-    let __v_14: G = __r_arr[1];
-    let __v_15: G = __r_arr[2];
-    let __v_16: G = __r_arr[3];
-    let __v_17: G = __r_arr[4];
-    let __v_18: G = __r_arr[5];
-    let __v_19: G = __r_arr[6];
-    let __v_20: G = __r_arr[7];
-    let __v_21: G = __r_arr[8];
-    let __v_22: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_22]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __v_24: G = __r_arr[1];
-    let __v_25: G = __r_arr[2];
-    let __v_26: G = __r_arr[3];
-    let __v_27: G = __r_arr[4];
-    let __v_28: G = __r_arr[5];
-    let __v_29: G = __r_arr[6];
-    let __v_30: G = __r_arr[7];
-    let __v_31: G = __r_arr[8];
-    let __v_32: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_32]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_33: G = __r_arr[0];
-    let __v_34: G = __r_arr[1];
-    let __v_35: G = __r_arr[2];
-    let __v_36: G = __r_arr[3];
-    let __v_37: G = __r_arr[4];
-    let __v_38: G = __r_arr[5];
-    let __v_39: G = __r_arr[6];
-    let __v_40: G = __r_arr[7];
-    let __v_41: G = __r_arr[8];
-    let __v_42: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_42]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_43: G = __r_arr[0];
-    let __v_44: G = __r_arr[1];
-    let __v_45: G = __r_arr[2];
-    let __v_46: G = __r_arr[3];
-    let __v_47: G = __r_arr[4];
-    let __v_48: G = __r_arr[5];
-    let __v_49: G = __r_arr[6];
-    let __v_50: G = __r_arr[7];
-    let __v_51: G = __r_arr[8];
-    let __v_52: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_52]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_53: G = __r_arr[0];
-    let __v_54: G = __r_arr[1];
-    let __v_55: G = __r_arr[2];
-    let __v_56: G = __r_arr[3];
-    let __v_57: G = __r_arr[4];
-    let __v_58: G = __r_arr[5];
-    let __v_59: G = __r_arr[6];
-    let __v_60: G = __r_arr[7];
-    let __v_61: G = __r_arr[8];
-    let __v_62: G = __r_arr[9];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_62]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_63: G = __r_arr[0];
-    let __v_64: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_64]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_65: G = __r_arr[0];
-    let __v_66: G = __r_arr[1];
-    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_66, __v_65]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
-    let __v_67: G = __r_arr[0];
-    let __v_68: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_68]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_69: G = __r_arr[0];
-    let __v_70: G = __r_arr[1];
-    let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_70, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
-    let __v_71: G = __r_arr[0];
-    let __v_72: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_72]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_73: G = __r_arr[0];
-    let __v_74: G = __r_arr[1];
-    let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_74, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
-    let __v_75: G = __r_arr[0];
-    let __v_76: G = __r_arr[1];
-    let __v_77: G = (__v_2 + __v_1);
-    let __v_78: G = (__v_77 - __v_76);
-    let __v_79: G = G::from_u64(0);
-    if (__v_78 != __v_79) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_78.as_canonical_u64(), rhs: __v_79.as_canonical_u64() });
-    }
-    let __ret: [G; OUT_87] = [__v_67, __v_65, __v_71, __v_53, __v_75, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_77];
-    record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_88: usize = 49;
-const IN_88: usize = 49;
-const OUT_88: usize = 1;
-fn aiur_fn_88(
-  inp: [G; IN_88],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_88], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7046,21 +7005,21 @@ fn aiur_fn_88(
     let __v_58: G = { let __values: [G; 10] = [__v_51, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_57]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_59: G = { let __values: [G; 10] = [__v_50, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_58]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_60: G = { let __values: [G; 10] = [__v_49, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_59]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_88] = [__v_60];
-    record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_87] = [__v_60];
+    record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_89: usize = 2;
-const IN_89: usize = 2;
-const OUT_89: usize = 3;
-fn aiur_fn_89(
-  inp: [G; IN_89],
+const INPUT_SIZE_88: usize = 2;
+const IN_88: usize = 2;
+const OUT_88: usize = 3;
+fn aiur_fn_88(
+  inp: [G; IN_88],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_89], ExecError> {
+) -> Result<[G; OUT_88], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7072,12 +7031,12 @@ fn aiur_fn_89(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 10] = [__v_5, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_89] = [__v_4, __v_7, __v_0];
-        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_88] = [__v_4, __v_7, __v_0];
+        record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = __r_arr[2];
@@ -7134,31 +7093,31 @@ fn aiur_fn_89(
         let __v_55: G = __r_arr[53];
         let __v_56: G = G::from_u64(1);
         let __v_57: G = (__v_1 - __v_56);
-        let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_55, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_55, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
         let __v_58: G = __r_arr[0];
         let __v_59: G = __r_arr[1];
         let __v_60: G = __r_arr[2];
         let __v_61: G = G::from_u64(0);
         let __v_62: G = { let __values: [G; 7] = [__v_61, __v_2, __v_3, __v_4, __v_5, __v_6, __v_58]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
         let __v_63: G = __r_arr[0];
-        let __ret: [G; OUT_89] = [__v_62, __v_63, __v_60];
-        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_88] = [__v_62, __v_63, __v_60];
+        record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_90: usize = 1;
-const IN_90: usize = 1;
-const OUT_90: usize = 3;
-fn aiur_fn_90(
-  inp: [G; IN_90],
+const INPUT_SIZE_89: usize = 1;
+const IN_89: usize = 1;
+const OUT_89: usize = 3;
+fn aiur_fn_89(
+  inp: [G; IN_89],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_90], ExecError> {
+) -> Result<[G; OUT_89], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
@@ -7168,35 +7127,35 @@ fn aiur_fn_90(
       0u64 => {
         let __v_3: G = G::from_u64(0);
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_90] = [__v_3, __v_4, __v_2];
-        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_89] = [__v_3, __v_4, __v_2];
+        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
-        let __r_arr: [G; OUT_81] = { let __args: [G; IN_81] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[81].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_81] = unsafe { *(result.output.as_ptr() as *const [G; OUT_81]) }; __ret } else { aiur_fn_81(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_80] = { let __args: [G; IN_80] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[80].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_80] = unsafe { *(result.output.as_ptr() as *const [G; OUT_80]) }; __ret } else { aiur_fn_80(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_90] = [__v_7, __v_5, __v_6];
-        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_89] = [__v_7, __v_5, __v_6];
+        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_91: usize = 2;
-const IN_91: usize = 2;
-const OUT_91: usize = 2;
-fn aiur_fn_91(
-  inp: [G; IN_91],
+const INPUT_SIZE_90: usize = 2;
+const IN_90: usize = 2;
+const OUT_90: usize = 2;
+fn aiur_fn_90(
+  inp: [G; IN_90],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_91], ExecError> {
+) -> Result<[G; OUT_90], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7205,8 +7164,8 @@ fn aiur_fn_91(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 4] = [__v_2, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_91] = [__v_4, __v_0];
-        record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_90] = [__v_4, __v_0];
+        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7215,7 +7174,7 @@ fn aiur_fn_91(
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
         let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = __r_arr[1];
         match __v_2.as_canonical_u64() {
@@ -7224,16 +7183,16 @@ fn aiur_fn_91(
             let __v_9: G = G::from_u64(0);
             let __v_10: G = G::from_u64(0);
             let __v_11: G = { let __values: [G; 4] = [__v_8, __v_9, __v_10, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_91] = [__v_11, __v_7];
-            record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_90] = [__v_11, __v_7];
+            record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
             let __v_8: G = G::from_u64(0);
             let __v_9: G = G::from_u64(1);
             let __v_10: G = { let __values: [G; 4] = [__v_8, __v_9, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_91] = [__v_10, __v_7];
-            record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_90] = [__v_10, __v_7];
+            record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -7242,15 +7201,15 @@ fn aiur_fn_91(
   })
 }
 
-const INPUT_SIZE_92: usize = 1;
-const IN_92: usize = 1;
-const OUT_92: usize = 9;
-fn aiur_fn_92(
-  inp: [G; IN_92],
+const INPUT_SIZE_91: usize = 1;
+const IN_91: usize = 1;
+const OUT_91: usize = 9;
+fn aiur_fn_91(
+  inp: [G; IN_91],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_92], ExecError> {
+) -> Result<[G; OUT_91], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_75] = { let __args: [G; IN_75] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[75].get_mut(&__args[..]) { let __ret: [G; OUT_75] = unsafe { *(result.output.as_ptr() as *const [G; OUT_75]) }; __ret } else { aiur_fn_75(__args, record, io_buffer, __cu)? } };
@@ -7347,24 +7306,24 @@ fn aiur_fn_92(
     let __v_85: G = { let __values: [G; 10] = [__v_73, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_84]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_86: G = { let __values: [G; 10] = [__v_72, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_85]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_87: G = { let __values: [G; 10] = [__v_71, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_86]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_92] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_87, __v_70];
-    record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_91] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_87, __v_70];
+    record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_93: usize = 1;
-const IN_93: usize = 1;
-const OUT_93: usize = 13;
-fn aiur_fn_93(
-  inp: [G; IN_93],
+const INPUT_SIZE_92: usize = 1;
+const IN_92: usize = 1;
+const OUT_92: usize = 13;
+fn aiur_fn_92(
+  inp: [G; IN_92],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_93], ExecError> {
+) -> Result<[G; OUT_92], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
     let __v_3: G = __r_arr[2];
@@ -7385,36 +7344,36 @@ fn aiur_fn_93(
     let __v_17: G = __r_arr[7];
     let __v_18: G = __r_arr[8];
     let __v_19: G = __r_arr[9];
-    let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_19, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_19, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = __r_arr[2];
-    let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_25, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_25, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
     let __v_26: G = __r_arr[0];
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = { let __values: [G; 10] = [__v_28, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_21]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
-    let __ret: [G; OUT_93] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
-    record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_92] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
+    record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_94: usize = 5;
-const IN_94: usize = 5;
-const OUT_94: usize = 1;
-fn aiur_fn_94(
-  inp: [G; IN_94],
+const INPUT_SIZE_93: usize = 5;
+const IN_93: usize = 5;
+const OUT_93: usize = 1;
+fn aiur_fn_93(
+  inp: [G; IN_93],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_94], ExecError> {
+) -> Result<[G; OUT_93], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7429,15 +7388,80 @@ fn aiur_fn_94(
     let __v_10: G = { let __values: [G; 3] = [__v_7, __v_2, __v_9]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_11: G = { let __values: [G; 3] = [__v_6, __v_1, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_12: G = { let __values: [G; 3] = [__v_5, __v_0, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_94] = [__v_12];
+    let __ret: [G; OUT_93] = [__v_12];
+    record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_94: usize = 33;
+const IN_94: usize = 33;
+const OUT_94: usize = 1;
+fn aiur_fn_94(
+  inp: [G; IN_94],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_94], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
+    let __v_18: G = inp[18];
+    let __v_19: G = inp[19];
+    let __v_20: G = inp[20];
+    let __v_21: G = inp[21];
+    let __v_22: G = inp[22];
+    let __v_23: G = inp[23];
+    let __v_24: G = inp[24];
+    let __v_25: G = inp[25];
+    let __v_26: G = inp[26];
+    let __v_27: G = inp[27];
+    let __v_28: G = inp[28];
+    let __v_29: G = inp[29];
+    let __v_30: G = inp[30];
+    let __v_31: G = inp[31];
+    let __v_32: G = inp[32];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_33: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_24, __v_25, __v_26, __v_27, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_34: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_20, __v_21, __v_22, __v_23, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_35: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_16, __v_17, __v_18, __v_19, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_36: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_12, __v_13, __v_14, __v_15, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_37: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_8, __v_9, __v_10, __v_11, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_38: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_4, __v_5, __v_6, __v_7, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_39: G = __r_arr[0];
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_0, __v_1, __v_2, __v_3, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __v_40: G = __r_arr[0];
+    let __ret: [G; OUT_94] = [__v_40];
     record.function_queries[94].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_95: usize = 33;
-const IN_95: usize = 33;
-const OUT_95: usize = 1;
+const INPUT_SIZE_95: usize = 32;
+const IN_95: usize = 32;
+const OUT_95: usize = 32;
 fn aiur_fn_95(
   inp: [G; IN_95],
   record: &mut QueryRecord,
@@ -7477,32 +7501,15 @@ fn aiur_fn_95(
     let __v_29: G = inp[29];
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
-    let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_24, __v_25, __v_26, __v_27, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_20, __v_21, __v_22, __v_23, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_16, __v_17, __v_18, __v_19, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_36: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_12, __v_13, __v_14, __v_15, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_37: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_8, __v_9, __v_10, __v_11, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_38: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_4, __v_5, __v_6, __v_7, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_39: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_0, __v_1, __v_2, __v_3, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
-    let __v_40: G = __r_arr[0];
-    let __ret: [G; OUT_95] = [__v_40];
+    let __ret: [G; OUT_95] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31];
     record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_96: usize = 32;
-const IN_96: usize = 32;
-const OUT_96: usize = 32;
+const INPUT_SIZE_96: usize = 4;
+const IN_96: usize = 4;
+const OUT_96: usize = 1;
 fn aiur_fn_96(
   inp: [G; IN_96],
   record: &mut QueryRecord,
@@ -7514,58 +7521,10 @@ fn aiur_fn_96(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = inp[17];
-    let __v_18: G = inp[18];
-    let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
-    let __v_21: G = inp[21];
-    let __v_22: G = inp[22];
-    let __v_23: G = inp[23];
-    let __v_24: G = inp[24];
-    let __v_25: G = inp[25];
-    let __v_26: G = inp[26];
-    let __v_27: G = inp[27];
-    let __v_28: G = inp[28];
-    let __v_29: G = inp[29];
-    let __v_30: G = inp[30];
-    let __v_31: G = inp[31];
-    let __ret: [G; OUT_96] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31];
-    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_97: usize = 4;
-const IN_97: usize = 4;
-const OUT_97: usize = 1;
-fn aiur_fn_97(
-  inp: [G; IN_97],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_97], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_97] = [__v_3];
-        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_96] = [__v_3];
+        record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7577,25 +7536,25 @@ fn aiur_fn_97(
         let __v_8: G = (__v_2 - __v_7);
         let __v_9: G = G::from_u64(0);
         let __v_10: G = { let __values: [G; 3] = [__v_9, __v_4, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_6, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_6, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
-        let __ret: [G; OUT_97] = [__v_11];
-        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_96] = [__v_11];
+        record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_98: usize = 7;
-const IN_98: usize = 7;
-const OUT_98: usize = 1;
-fn aiur_fn_98(
-  inp: [G; IN_98],
+const INPUT_SIZE_97: usize = 7;
+const IN_97: usize = 7;
+const OUT_97: usize = 1;
+fn aiur_fn_97(
+  inp: [G; IN_97],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_98], ExecError> {
+) -> Result<[G; OUT_97], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7781,8 +7740,8 @@ fn aiur_fn_98(
           1u64 => {
             let __v_172: G = G::from_u64(0);
             let __v_173: G = { let __values: [G; 34] = [__v_172, __v_6, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_98] = [__v_173];
-            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_97] = [__v_173];
+            record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -7847,10 +7806,10 @@ fn aiur_fn_98(
                 let __v_226: G = { let __values: [G; 32] = [__v_172, __v_173, __v_174, __v_175, __v_176, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_227: G = G::from_u64(0);
                 let __v_228: G = { let __values: [G; 34] = [__v_227, __v_6, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_205, __v_207, __v_208, __v_225, __v_226, __v_228]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_205, __v_207, __v_208, __v_225, __v_226, __v_228]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
                 let __v_229: G = __r_arr[0];
-                let __ret: [G; OUT_98] = [__v_229];
-                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_97] = [__v_229];
+                record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
@@ -7861,10 +7820,10 @@ fn aiur_fn_98(
                 let __v_176: G = G::from_u64(1);
                 let __v_177: G = (__v_3 + __v_176);
                 let __v_178: G = { let __values: [G; 32] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_173, __v_175, __v_177, __v_4, __v_178, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_173, __v_175, __v_177, __v_4, __v_178, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
                 let __v_179: G = __r_arr[0];
-                let __ret: [G; OUT_98] = [__v_179];
-                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_97] = [__v_179];
+                record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -8042,62 +8001,62 @@ fn aiur_fn_98(
                                             let __v_154: G = __r_arr[30];
                                             let __v_155: G = __r_arr[31];
                                             let __v_156: G = { let __values: [G; 34] = [__v_17, __v_6, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                            let __ret: [G; OUT_98] = [__v_156];
-                                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                            let __ret: [G; OUT_97] = [__v_156];
+                                            record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                             return Ok(__ret);
                                           },
                                           _ => {
-                                            let __ret: [G; OUT_98] = [__v_6];
-                                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                            let __ret: [G; OUT_97] = [__v_6];
+                                            record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                             return Ok(__ret);
                                           },
                                         }
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_98] = [__v_6];
-                                        record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_97] = [__v_6];
+                                        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_98] = [__v_6];
-                                    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                    let __ret: [G; OUT_97] = [__v_6];
+                                    record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_98] = [__v_6];
-                                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                let __ret: [G; OUT_97] = [__v_6];
+                                record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_98] = [__v_6];
-                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_97] = [__v_6];
+                            record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_98] = [__v_6];
-                        record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_97] = [__v_6];
+                        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_98] = [__v_6];
-                    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_97] = [__v_6];
+                    record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_98] = [__v_6];
-                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_97] = [__v_6];
+                record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -8106,7 +8065,7 @@ fn aiur_fn_98(
             let __v_9: G = G::from_u64(1);
             let __v_10: G = G::from_u64(1);
             let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_1, __v_2, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_1, __v_2, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = G::from_u64(64);
             let __v_14: G = (__v_13 - __v_2);
@@ -8271,8 +8230,8 @@ fn aiur_fn_98(
             let __v_166: G = __r_arr[30];
             let __v_167: G = __r_arr[31];
             let __v_168: G = { let __values: [G; 34] = [__v_95, __v_6, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_98] = [__v_168];
-            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_97] = [__v_168];
+            record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -8281,15 +8240,15 @@ fn aiur_fn_98(
   })
 }
 
-const INPUT_SIZE_99: usize = 3;
-const IN_99: usize = 3;
-const OUT_99: usize = 32;
-fn aiur_fn_99(
-  inp: [G; IN_99],
+const INPUT_SIZE_98: usize = 3;
+const IN_98: usize = 3;
+const OUT_98: usize = 32;
+fn aiur_fn_98(
+  inp: [G; IN_98],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_99], ExecError> {
+) -> Result<[G; OUT_98], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8340,7 +8299,7 @@ fn aiur_fn_99(
     let __v_46: G = G::from_u64(1);
     let __v_47: G = G::from_u64(1);
     let __v_48: G = { let __values: [G; 34] = [__v_46, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_1, __v_2, __v_35, __v_44, __v_45, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_1, __v_2, __v_35, __v_44, __v_45, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
     let __v_49: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_49.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_50: G = __loaded[0];
@@ -8410,21 +8369,21 @@ fn aiur_fn_99(
     let __v_113: G = __r_arr[29];
     let __v_114: G = __r_arr[30];
     let __v_115: G = __r_arr[31];
-    let __ret: [G; OUT_99] = [__v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115];
-    record.function_queries[99].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_98] = [__v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115];
+    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_100: usize = 64;
-const IN_100: usize = 64;
-const OUT_100: usize = 32;
-fn aiur_fn_100(
-  inp: [G; IN_100],
+const INPUT_SIZE_99: usize = 64;
+const IN_99: usize = 64;
+const OUT_99: usize = 32;
+fn aiur_fn_99(
+  inp: [G; IN_99],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_100], ExecError> {
+) -> Result<[G; OUT_99], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8565,7 +8524,7 @@ fn aiur_fn_100(
     let __v_135: G = __r_arr[29];
     let __v_136: G = __r_arr[30];
     let __v_137: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
     let __v_138: G = __r_arr[0];
     let __v_139: G = __r_arr[1];
     let __v_140: G = __r_arr[2];
@@ -8598,21 +8557,21 @@ fn aiur_fn_100(
     let __v_167: G = __r_arr[29];
     let __v_168: G = __r_arr[30];
     let __v_169: G = __r_arr[31];
-    let __ret: [G; OUT_100] = [__v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169];
-    record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_99] = [__v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169];
+    record.function_queries[99].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_101: usize = 64;
-const IN_101: usize = 64;
-const OUT_101: usize = 1;
-fn aiur_fn_101(
-  inp: [G; IN_101],
+const INPUT_SIZE_100: usize = 64;
+const IN_100: usize = 64;
+const OUT_100: usize = 1;
+fn aiur_fn_100(
+  inp: [G; IN_100],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_101], ExecError> {
+) -> Result<[G; OUT_100], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8705,21 +8664,21 @@ fn aiur_fn_101(
     let __v_80: G = (__v_75 * __v_79);
     let __v_81: G = (__v_71 * __v_80);
     let __v_82: G = (__v_67 * __v_81);
-    let __ret: [G; OUT_101] = [__v_82];
-    record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_100] = [__v_82];
+    record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_102: usize = 65;
-const IN_102: usize = 65;
-const OUT_102: usize = 32;
-fn aiur_fn_102(
-  inp: [G; IN_102],
+const INPUT_SIZE_101: usize = 65;
+const IN_101: usize = 65;
+const OUT_101: usize = 32;
+fn aiur_fn_101(
+  inp: [G; IN_101],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_102], ExecError> {
+) -> Result<[G; OUT_101], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8788,7 +8747,7 @@ fn aiur_fn_102(
     let __v_64: G = inp[64];
     match __v_0.as_canonical_u64() {
       0u64 => {
-        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
         let __v_65: G = __r_arr[0];
         let __v_66: G = __r_arr[1];
         let __v_67: G = __r_arr[2];
@@ -8821,12 +8780,12 @@ fn aiur_fn_102(
         let __v_94: G = __r_arr[29];
         let __v_95: G = __r_arr[30];
         let __v_96: G = __r_arr[31];
-        let __ret: [G; OUT_102] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
-        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_101] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
+        record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
         let __v_65: G = __r_arr[0];
         let __v_66: G = __r_arr[1];
         let __v_67: G = __r_arr[2];
@@ -8859,23 +8818,23 @@ fn aiur_fn_102(
         let __v_94: G = __r_arr[29];
         let __v_95: G = __r_arr[30];
         let __v_96: G = __r_arr[31];
-        let __ret: [G; OUT_102] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
-        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_101] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
+        record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_103: usize = 2;
-const IN_103: usize = 2;
-const OUT_103: usize = 1;
-fn aiur_fn_103(
-  inp: [G; IN_103],
+const INPUT_SIZE_102: usize = 2;
+const IN_102: usize = 2;
+const OUT_102: usize = 1;
+fn aiur_fn_102(
+  inp: [G; IN_102],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_103], ExecError> {
+) -> Result<[G; OUT_102], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8886,8 +8845,8 @@ fn aiur_fn_103(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_103] = [__v_5];
-        record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_102] = [__v_5];
+        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -8896,15 +8855,15 @@ fn aiur_fn_103(
         match __v_6.as_canonical_u64() {
           1u64 => {
             let __v_7: G = G::from_u64(1);
-            let __ret: [G; OUT_103] = [__v_7];
-            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_102] = [__v_7];
+            record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
             let __v_7: G = __r_arr[0];
-            let __ret: [G; OUT_103] = [__v_7];
-            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_102] = [__v_7];
+            record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -8916,15 +8875,15 @@ fn aiur_fn_103(
   })
 }
 
-const INPUT_SIZE_104: usize = 3;
-const IN_104: usize = 3;
-const OUT_104: usize = 1;
-fn aiur_fn_104(
-  inp: [G; IN_104],
+const INPUT_SIZE_103: usize = 3;
+const IN_103: usize = 3;
+const OUT_103: usize = 1;
+fn aiur_fn_103(
+  inp: [G; IN_103],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_104], ExecError> {
+) -> Result<[G; OUT_103], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8938,8 +8897,8 @@ fn aiur_fn_104(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 3] = [__v_6, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_104] = [__v_8];
-        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_103] = [__v_8];
+        record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -8953,10 +8912,10 @@ fn aiur_fn_104(
             let __v_10: G = G::from_bool((__v_9 == G::ZERO));
             match __v_10.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_104] = [__v_11];
-                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_103] = [__v_11];
+                record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
@@ -8973,19 +8932,19 @@ fn aiur_fn_104(
                 let __v_20: G = __loaded[9];
                 match __v_11.as_canonical_u64() {
                   1u64 => {
-                    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
                     let __v_21: G = __r_arr[0];
-                    let __ret: [G; OUT_104] = [__v_21];
-                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_103] = [__v_21];
+                    record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                   _ => {
                     let __v_21: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
                     let __v_22: G = __r_arr[0];
                     let __v_23: G = { let __values: [G; 3] = [__v_21, __v_4, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __ret: [G; OUT_104] = [__v_23];
-                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_103] = [__v_23];
+                    record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -9004,15 +8963,15 @@ fn aiur_fn_104(
   })
 }
 
-const INPUT_SIZE_105: usize = 2;
-const IN_105: usize = 2;
-const OUT_105: usize = 11;
-fn aiur_fn_105(
-  inp: [G; IN_105],
+const INPUT_SIZE_104: usize = 2;
+const IN_104: usize = 2;
+const OUT_104: usize = 11;
+fn aiur_fn_104(
+  inp: [G; IN_104],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_105], ExecError> {
+) -> Result<[G; OUT_104], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9041,8 +9000,8 @@ fn aiur_fn_105(
         let __v_19: G = __r_arr[6];
         let __v_20: G = __r_arr[7];
         let __v_21: G = G::from_u64(1);
-        let __ret: [G; OUT_105] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_11, __v_1, __v_21];
-        record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_104] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_11, __v_1, __v_21];
+        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -9061,12 +9020,12 @@ fn aiur_fn_105(
             let __v_21: G = G::from_u64(0);
             let __v_22: G = G::from_u64(0);
             let __v_23: G = G::from_u64(0);
-            let __ret: [G; OUT_105] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
-            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_104] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
+            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
             let __v_15: G = __r_arr[0];
             let __v_16: G = __r_arr[1];
             let __v_17: G = __r_arr[2];
@@ -9078,8 +9037,8 @@ fn aiur_fn_105(
             let __v_23: G = __r_arr[8];
             let __v_24: G = __r_arr[9];
             let __v_25: G = __r_arr[10];
-            let __ret: [G; OUT_105] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
-            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_104] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
+            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -9094,15 +9053,15 @@ fn aiur_fn_105(
   })
 }
 
-const INPUT_SIZE_106: usize = 6;
-const IN_106: usize = 6;
-const OUT_106: usize = 1;
-fn aiur_fn_106(
-  inp: [G; IN_106],
+const INPUT_SIZE_105: usize = 6;
+const IN_105: usize = 6;
+const OUT_105: usize = 1;
+fn aiur_fn_105(
+  inp: [G; IN_105],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_106], ExecError> {
+) -> Result<[G; OUT_105], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9110,7 +9069,7 @@ fn aiur_fn_106(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -9292,68 +9251,68 @@ fn aiur_fn_106(
                                         let __v_162: G = __r_arr[30];
                                         let __v_163: G = __r_arr[31];
                                         let __v_164: G = { let __values: [G; 34] = [__v_25, __v_5, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                        let __ret: [G; OUT_106] = [__v_164];
-                                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_105] = [__v_164];
+                                        record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_106] = [__v_5];
-                                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_105] = [__v_5];
+                                        record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_106] = [__v_5];
-                                    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                    let __ret: [G; OUT_105] = [__v_5];
+                                    record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_106] = [__v_5];
-                                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                let __ret: [G; OUT_105] = [__v_5];
+                                record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_106] = [__v_5];
-                            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_105] = [__v_5];
+                            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_106] = [__v_5];
-                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_105] = [__v_5];
+                        record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_106] = [__v_5];
-                    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_105] = [__v_5];
+                    record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_106] = [__v_5];
-                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_105] = [__v_5];
+                record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
           },
           _ => {
-            let __ret: [G; OUT_106] = [__v_5];
-            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_105] = [__v_5];
+            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
       _ => {
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = __r_arr[1];
         let __v_19: G = __r_arr[2];
@@ -9365,7 +9324,7 @@ fn aiur_fn_106(
         let __v_25: G = __r_arr[8];
         let __v_26: G = __r_arr[9];
         let __v_27: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         let __v_29: G = __r_arr[1];
         let __v_30: G = __r_arr[2];
@@ -9377,7 +9336,7 @@ fn aiur_fn_106(
         let __v_36: G = __r_arr[8];
         let __v_37: G = __r_arr[9];
         let __v_38: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = __r_arr[1];
         let __v_41: G = __r_arr[2];
@@ -9389,7 +9348,7 @@ fn aiur_fn_106(
         let __v_47: G = __r_arr[8];
         let __v_48: G = __r_arr[9];
         let __v_49: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_50: G = __r_arr[0];
         let __v_51: G = __r_arr[1];
         let __v_52: G = __r_arr[2];
@@ -9401,7 +9360,7 @@ fn aiur_fn_106(
         let __v_58: G = __r_arr[8];
         let __v_59: G = __r_arr[9];
         let __v_60: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_61: G = __r_arr[0];
         let __v_62: G = __r_arr[1];
         let __v_63: G = __r_arr[2];
@@ -9413,7 +9372,7 @@ fn aiur_fn_106(
         let __v_69: G = __r_arr[8];
         let __v_70: G = __r_arr[9];
         let __v_71: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_72: G = __r_arr[0];
         let __v_73: G = __r_arr[1];
         let __v_74: G = __r_arr[2];
@@ -9425,7 +9384,7 @@ fn aiur_fn_106(
         let __v_80: G = __r_arr[8];
         let __v_81: G = __r_arr[9];
         let __v_82: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
         let __v_83: G = __r_arr[0];
         let __v_84: G = __r_arr[1];
         let __v_85: G = __r_arr[2];
@@ -9585,8 +9544,8 @@ fn aiur_fn_106(
           1u64 => {
             let __v_209: G = G::from_u64(0);
             let __v_210: G = { let __values: [G; 34] = [__v_209, __v_5, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_106] = [__v_210];
-            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_105] = [__v_210];
+            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -9647,20 +9606,20 @@ fn aiur_fn_106(
                 let __v_259: G = { let __values: [G; 32] = [__v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218, __v_219, __v_220, __v_221, __v_222, __v_223, __v_224, __v_225, __v_226, __v_227, __v_228, __v_229, __v_230, __v_231, __v_232, __v_233, __v_234, __v_235, __v_236, __v_237, __v_238, __v_239, __v_240]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_260: G = G::from_u64(0);
                 let __v_261: G = { let __values: [G; 34] = [__v_260, __v_5, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_91, __v_92, __v_241, __v_258, __v_259, __v_261]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_91, __v_92, __v_241, __v_258, __v_259, __v_261]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
                 let __v_262: G = __r_arr[0];
-                let __ret: [G; OUT_106] = [__v_262];
-                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_105] = [__v_262];
+                record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_209: G = G::from_u64(1);
                 let __v_210: G = (__v_2 + __v_209);
                 let __v_211: G = { let __values: [G; 32] = [__v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_91, __v_92, __v_210, __v_3, __v_211, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_91, __v_92, __v_210, __v_3, __v_211, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
                 let __v_212: G = __r_arr[0];
-                let __ret: [G; OUT_106] = [__v_212];
-                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_105] = [__v_212];
+                record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -9671,15 +9630,15 @@ fn aiur_fn_106(
   })
 }
 
-const INPUT_SIZE_107: usize = 1;
-const IN_107: usize = 1;
-const OUT_107: usize = 32;
-fn aiur_fn_107(
-  inp: [G; IN_107],
+const INPUT_SIZE_106: usize = 1;
+const IN_106: usize = 1;
+const OUT_106: usize = 32;
+fn aiur_fn_106(
+  inp: [G; IN_106],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_107], ExecError> {
+) -> Result<[G; OUT_106], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(103);
@@ -9731,7 +9690,7 @@ fn aiur_fn_107(
     let __v_47: G = G::from_u64(1);
     let __v_48: G = G::from_u64(1);
     let __v_49: G = { let __values: [G; 34] = [__v_47, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_50.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_51: G = __loaded[0];
@@ -9801,28 +9760,28 @@ fn aiur_fn_107(
     let __v_114: G = __r_arr[29];
     let __v_115: G = __r_arr[30];
     let __v_116: G = __r_arr[31];
-    let __ret: [G; OUT_107] = [__v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116];
-    record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_106] = [__v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116];
+    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_108: usize = 3;
-const IN_108: usize = 3;
-const OUT_108: usize = 32;
-fn aiur_fn_108(
-  inp: [G; IN_108],
+const INPUT_SIZE_107: usize = 3;
+const IN_107: usize = 3;
+const OUT_107: usize = 32;
+fn aiur_fn_107(
+  inp: [G; IN_107],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_108], ExecError> {
+) -> Result<[G; OUT_107], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
-    let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
     let __v_4: G = __r_arr[0];
     let __v_5: G = __r_arr[1];
     let __v_6: G = __r_arr[2];
@@ -9855,7 +9814,7 @@ fn aiur_fn_108(
     let __v_33: G = __r_arr[29];
     let __v_34: G = __r_arr[30];
     let __v_35: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
     let __v_37: G = __r_arr[1];
     let __v_38: G = __r_arr[2];
@@ -9888,21 +9847,21 @@ fn aiur_fn_108(
     let __v_65: G = __r_arr[29];
     let __v_66: G = __r_arr[30];
     let __v_67: G = __r_arr[31];
-    let __ret: [G; OUT_108] = [__v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67];
-    record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_107] = [__v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67];
+    record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_109: usize = 35;
-const IN_109: usize = 35;
-const OUT_109: usize = 32;
-fn aiur_fn_109(
-  inp: [G; IN_109],
+const INPUT_SIZE_108: usize = 35;
+const IN_108: usize = 35;
+const OUT_108: usize = 32;
+fn aiur_fn_108(
+  inp: [G; IN_108],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_109], ExecError> {
+) -> Result<[G; OUT_108], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9939,16 +9898,16 @@ fn aiur_fn_109(
     let __v_32: G = inp[32];
     let __v_33: G = inp[33];
     let __v_34: G = inp[34];
-    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
     match __v_35.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_109] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34];
-        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_108] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34];
+        record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
         let __v_37: G = __r_arr[1];
         let __v_38: G = __r_arr[2];
@@ -9981,7 +9940,7 @@ fn aiur_fn_109(
         let __v_65: G = __r_arr[29];
         let __v_66: G = __r_arr[30];
         let __v_67: G = __r_arr[31];
-        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
         let __v_69: G = __r_arr[1];
         let __v_70: G = __r_arr[2];
@@ -10014,23 +9973,23 @@ fn aiur_fn_109(
         let __v_97: G = __r_arr[29];
         let __v_98: G = __r_arr[30];
         let __v_99: G = __r_arr[31];
-        let __ret: [G; OUT_109] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99];
-        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_108] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99];
+        record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_110: usize = 1;
-const IN_110: usize = 1;
-const OUT_110: usize = 1;
-fn aiur_fn_110(
-  inp: [G; IN_110],
+const INPUT_SIZE_109: usize = 1;
+const IN_109: usize = 1;
+const OUT_109: usize = 1;
+fn aiur_fn_109(
+  inp: [G; IN_109],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_110], ExecError> {
+) -> Result<[G; OUT_109], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -10040,18 +9999,18 @@ fn aiur_fn_110(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_110] = [__v_4];
-        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_109] = [__v_4];
+        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(2);
-        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_4 * __v_5);
         let __v_7: G = (__v_2 + __v_6);
-        let __ret: [G; OUT_110] = [__v_7];
-        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_109] = [__v_7];
+        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10061,15 +10020,15 @@ fn aiur_fn_110(
   })
 }
 
-const INPUT_SIZE_111: usize = 37;
-const IN_111: usize = 37;
-const OUT_111: usize = 33;
-fn aiur_fn_111(
-  inp: [G; IN_111],
+const INPUT_SIZE_110: usize = 37;
+const IN_110: usize = 37;
+const OUT_110: usize = 33;
+fn aiur_fn_110(
+  inp: [G; IN_110],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_111], ExecError> {
+) -> Result<[G; OUT_110], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10145,10 +10104,10 @@ fn aiur_fn_111(
     let __v_70: G = __loaded[33];
     match __v_37.as_canonical_u64() {
       1u64 => {
-        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
-        let __ret: [G; OUT_111] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_71];
-        record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_110] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_71];
+        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10158,7 +10117,7 @@ fn aiur_fn_111(
         let __v_73: G = __loaded[2];
         match __v_71.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_72, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_72, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
             let __v_74: G = __r_arr[0];
             let __v_75: G = __r_arr[1];
             let __v_76: G = __r_arr[2];
@@ -10191,7 +10150,7 @@ fn aiur_fn_111(
             let __v_103: G = __r_arr[29];
             let __v_104: G = __r_arr[30];
             let __v_105: G = __r_arr[31];
-            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_32, __v_33, __v_36, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_32, __v_33, __v_36, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
             let __v_106: G = __r_arr[0];
             let __v_107: G = __r_arr[1];
             let __v_108: G = __r_arr[2];
@@ -10226,7 +10185,7 @@ fn aiur_fn_111(
             let __v_137: G = __r_arr[31];
             let __v_138: G = G::from_u64(1);
             let __v_139: G = (__v_36 - __v_138);
-            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_32, __v_33, __v_70, __v_73, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_32, __v_33, __v_70, __v_73, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
             let __v_140: G = __r_arr[0];
             let __v_141: G = __r_arr[1];
             let __v_142: G = __r_arr[2];
@@ -10260,8 +10219,8 @@ fn aiur_fn_111(
             let __v_170: G = __r_arr[30];
             let __v_171: G = __r_arr[31];
             let __v_172: G = __r_arr[32];
-            let __ret: [G; OUT_111] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172];
-            record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_110] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172];
+            record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10276,22 +10235,22 @@ fn aiur_fn_111(
   })
 }
 
-const INPUT_SIZE_112: usize = 5;
-const IN_112: usize = 5;
-const OUT_112: usize = 33;
-fn aiur_fn_112(
-  inp: [G; IN_112],
+const INPUT_SIZE_111: usize = 5;
+const IN_111: usize = 5;
+const OUT_111: usize = 33;
+fn aiur_fn_111(
+  inp: [G; IN_111],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_112], ExecError> {
+) -> Result<[G; OUT_111], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_0, __v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
     let __v_7: G = __r_arr[2];
@@ -10326,7 +10285,7 @@ fn aiur_fn_112(
     let __v_36: G = __r_arr[31];
     let __v_37: G = G::from_u64(1);
     let __v_38: G = (__v_4 - __v_37);
-    let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_0, __v_1, __v_3, __v_2, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_0, __v_1, __v_3, __v_2, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10360,21 +10319,21 @@ fn aiur_fn_112(
     let __v_69: G = __r_arr[30];
     let __v_70: G = __r_arr[31];
     let __v_71: G = __r_arr[32];
-    let __ret: [G; OUT_112] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71];
-    record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_111] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71];
+    record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_113: usize = 6;
-const IN_113: usize = 6;
-const OUT_113: usize = 1;
-fn aiur_fn_113(
-  inp: [G; IN_113],
+const INPUT_SIZE_112: usize = 6;
+const IN_112: usize = 6;
+const OUT_112: usize = 1;
+fn aiur_fn_112(
+  inp: [G; IN_112],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_113], ExecError> {
+) -> Result<[G; OUT_112], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10382,7 +10341,7 @@ fn aiur_fn_113(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_1, __v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_1, __v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -10416,7 +10375,7 @@ fn aiur_fn_113(
     let __v_36: G = __r_arr[30];
     let __v_37: G = __r_arr[31];
     let __v_38: G = __r_arr[32];
-    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10449,11 +10408,49 @@ fn aiur_fn_113(
     let __v_68: G = __r_arr[29];
     let __v_69: G = __r_arr[30];
     let __v_70: G = __r_arr[31];
-    let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
     let __v_71: G = __r_arr[0];
-    let __ret: [G; OUT_113] = [__v_71];
-    record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_112] = [__v_71];
+    record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_113: usize = 2;
+const IN_113: usize = 2;
+const OUT_113: usize = 1;
+fn aiur_fn_113(
+  inp: [G; IN_113],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_113], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_113] = [__v_1];
+        record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = { let __values: [G; 3] = [__v_5, __v_3, __v_1]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __ret: [G; OUT_113] = [__v_7];
+        record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
   })
 }
 
@@ -10469,44 +10466,6 @@ fn aiur_fn_114(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_114] = [__v_1];
-        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = { let __values: [G; 3] = [__v_5, __v_3, __v_1]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __ret: [G; OUT_114] = [__v_7];
-        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_115: usize = 2;
-const IN_115: usize = 2;
-const OUT_115: usize = 1;
-fn aiur_fn_115(
-  inp: [G; IN_115],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_115], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
@@ -10514,26 +10473,26 @@ fn aiur_fn_115(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(1);
-        let __ret: [G; OUT_115] = [__v_5];
-        record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_114] = [__v_5];
+        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_15] = { let __args: [G; IN_15] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[15].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_15] = unsafe { *(result.output.as_ptr() as *const [G; OUT_15]) }; __ret } else { aiur_fn_15(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         match __v_3.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_115] = [__v_6];
-            record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_114] = [__v_6];
+            record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
             let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
             let __v_7: G = __r_arr[0];
-            let __ret: [G; OUT_115] = [__v_7];
-            record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_114] = [__v_7];
+            record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -10545,15 +10504,15 @@ fn aiur_fn_115(
   })
 }
 
-const INPUT_SIZE_116: usize = 8;
-const IN_116: usize = 8;
-const OUT_116: usize = 2;
-fn aiur_fn_116(
-  inp: [G; IN_116],
+const INPUT_SIZE_115: usize = 8;
+const IN_115: usize = 8;
+const OUT_115: usize = 2;
+fn aiur_fn_115(
+  inp: [G; IN_115],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_116], ExecError> {
+) -> Result<[G; OUT_115], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10565,14 +10524,14 @@ fn aiur_fn_116(
     let __v_7: G = inp[7];
     let __v_8: G = G::from_u64(1);
     let __v_9: G = (__v_1 + __v_8);
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = G::from_u64(1);
     let __v_12: G = G::from_u64(1);
     let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __r_arr: [G; OUT_13] = { let __args: [G; IN_13] = [__v_15, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[13].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_13] = unsafe { *(result.output.as_ptr() as *const [G; OUT_13]) }; __ret } else { aiur_fn_13(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
@@ -10597,14 +10556,44 @@ fn aiur_fn_116(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_21, __v_22, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __v_31: G = __r_arr[1];
-    let __ret: [G; OUT_116] = [__v_30, __v_31];
+    let __ret: [G; OUT_115] = [__v_30, __v_31];
+    record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_116: usize = 2;
+const IN_116: usize = 2;
+const OUT_116: usize = 1;
+fn aiur_fn_116(
+  inp: [G; IN_116],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_116], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_u64(7);
+    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = G::from_u64(1);
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_2, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
+    let __v_9: G = __r_arr[0];
+    let __ret: [G; OUT_116] = [__v_9];
     record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_117: usize = 2;
-const IN_117: usize = 2;
+const INPUT_SIZE_117: usize = 1;
+const IN_117: usize = 1;
 const OUT_117: usize = 1;
 fn aiur_fn_117(
   inp: [G; IN_117],
@@ -10612,36 +10601,6 @@ fn aiur_fn_117(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_117], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_u64(7);
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = G::from_u64(1);
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
-    let __v_8: G = __r_arr[0];
-    let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_2, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
-    let __v_9: G = __r_arr[0];
-    let __ret: [G; OUT_117] = [__v_9];
-    record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_118: usize = 1;
-const IN_118: usize = 1;
-const OUT_118: usize = 1;
-fn aiur_fn_118(
-  inp: [G; IN_118],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_118], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -10660,19 +10619,19 @@ fn aiur_fn_118(
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_118] = [__v_13];
-        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_117] = [__v_13];
+        record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_11: G = G::from_u64(0);
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 3] = [__v_11, __v_12, __v_13]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_118] = [__v_14];
-        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_117] = [__v_14];
+        record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10682,15 +10641,15 @@ fn aiur_fn_118(
   })
 }
 
-const INPUT_SIZE_119: usize = 10;
-const IN_119: usize = 10;
-const OUT_119: usize = 4;
-fn aiur_fn_119(
-  inp: [G; IN_119],
+const INPUT_SIZE_118: usize = 10;
+const IN_118: usize = 10;
+const OUT_118: usize = 4;
+fn aiur_fn_118(
+  inp: [G; IN_118],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_119], ExecError> {
+) -> Result<[G; OUT_118], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10708,8 +10667,8 @@ fn aiur_fn_119(
     let __v_12: G = __loaded[2];
     match __v_10.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_119] = [__v_6, __v_7, __v_8, __v_9];
-        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_118] = [__v_6, __v_7, __v_8, __v_9];
+        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10736,13 +10695,13 @@ fn aiur_fn_119(
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
             let __v_26: G = __r_arr[0];
             let __v_27: G = __r_arr[1];
-            let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_12, __v_16, __v_2, __v_3, __v_4, __v_5, __v_24, __v_25, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_12, __v_16, __v_2, __v_3, __v_4, __v_5, __v_24, __v_25, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
             let __v_29: G = __r_arr[1];
             let __v_30: G = __r_arr[2];
             let __v_31: G = __r_arr[3];
-            let __ret: [G; OUT_119] = [__v_28, __v_29, __v_30, __v_31];
-            record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_118] = [__v_28, __v_29, __v_30, __v_31];
+            record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10757,15 +10716,15 @@ fn aiur_fn_119(
   })
 }
 
-const INPUT_SIZE_120: usize = 2;
-const IN_120: usize = 2;
-const OUT_120: usize = 1;
-fn aiur_fn_120(
-  inp: [G; IN_120],
+const INPUT_SIZE_119: usize = 2;
+const IN_119: usize = 2;
+const OUT_119: usize = 1;
+fn aiur_fn_119(
+  inp: [G; IN_119],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_120], ExecError> {
+) -> Result<[G; OUT_119], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10776,8 +10735,8 @@ fn aiur_fn_120(
     let __v_5: G = __loaded[3];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_120] = [__v_1];
-        record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_119] = [__v_1];
+        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10799,13 +10758,51 @@ fn aiur_fn_120(
         let __v_19: G = __r_arr[5];
         let __v_20: G = __r_arr[6];
         let __v_21: G = __r_arr[7];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
-        let __ret: [G; OUT_120] = [__v_24];
+        let __ret: [G; OUT_119] = [__v_24];
+        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_120: usize = 2;
+const IN_120: usize = 2;
+const OUT_120: usize = 1;
+fn aiur_fn_120(
+  inp: [G; IN_120],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_120], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_120] = [__v_1];
+        record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_120] = [__v_6];
         record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -10854,8 +10851,8 @@ fn aiur_fn_121(
   })
 }
 
-const INPUT_SIZE_122: usize = 2;
-const IN_122: usize = 2;
+const INPUT_SIZE_122: usize = 3;
+const IN_122: usize = 3;
 const OUT_122: usize = 1;
 fn aiur_fn_122(
   inp: [G; IN_122],
@@ -10866,34 +10863,29 @@ fn aiur_fn_122(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_122] = [__v_1];
+    let __v_2: G = inp[2];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_122] = [__v_2];
         record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      0u64 => {
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_122] = [__v_6];
+      1u64 => {
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __ret: [G; OUT_122] = [__v_3];
         record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_123: usize = 3;
-const IN_123: usize = 3;
+const INPUT_SIZE_123: usize = 2;
+const IN_123: usize = 2;
 const OUT_123: usize = 1;
 fn aiur_fn_123(
   inp: [G; IN_123],
@@ -10904,47 +10896,14 @@ fn aiur_fn_123(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_123] = [__v_2];
-        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __ret: [G; OUT_123] = [__v_3];
-        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_124: usize = 2;
-const IN_124: usize = 2;
-const OUT_124: usize = 1;
-fn aiur_fn_124(
-  inp: [G; IN_124],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_124], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_124] = [__v_0];
-        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_123] = [__v_0];
+        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10956,12 +10915,12 @@ fn aiur_fn_124(
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __ret: [G; OUT_124] = [__v_14];
-        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_123] = [__v_14];
+        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10971,15 +10930,15 @@ fn aiur_fn_124(
   })
 }
 
-const INPUT_SIZE_125: usize = 10;
-const IN_125: usize = 10;
-const OUT_125: usize = 2;
-fn aiur_fn_125(
-  inp: [G; IN_125],
+const INPUT_SIZE_124: usize = 10;
+const IN_124: usize = 10;
+const OUT_124: usize = 2;
+fn aiur_fn_124(
+  inp: [G; IN_124],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_125], ExecError> {
+) -> Result<[G; OUT_124], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10996,43 +10955,43 @@ fn aiur_fn_125(
         let __v_10: G = G::from_u64(1);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = { let __values: [G; 3] = [__v_10, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_125] = [__v_0, __v_12];
-        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_124] = [__v_0, __v_12];
+        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
         let __v_15: G = __r_arr[1];
         let __v_16: G = __r_arr[2];
-        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_125] = [__v_15, __v_16];
-        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_124] = [__v_15, __v_16];
+        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_126: usize = 4;
-const IN_126: usize = 4;
-const OUT_126: usize = 2;
-fn aiur_fn_126(
-  inp: [G; IN_126],
+const INPUT_SIZE_125: usize = 4;
+const IN_125: usize = 4;
+const OUT_125: usize = 2;
+fn aiur_fn_125(
+  inp: [G; IN_125],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_126], ExecError> {
+) -> Result<[G; OUT_125], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11047,8 +11006,8 @@ fn aiur_fn_126(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_126] = [__v_9, __v_0];
-        record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_125] = [__v_9, __v_0];
+        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11065,12 +11024,12 @@ fn aiur_fn_126(
         let __v_16: G = __loaded[9];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
-            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
             let __v_19: G = __r_arr[1];
-            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
             let __v_21: G = __r_arr[1];
             let __v_22: G = __r_arr[2];
@@ -11089,7 +11048,7 @@ fn aiur_fn_126(
             let __v_35: G = __r_arr[15];
             let __v_36: G = __r_arr[16];
             let __v_37: G = __r_arr[17];
-            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = __r_arr[1];
             let __v_40: G = G::from_u64(0);
@@ -11098,8 +11057,8 @@ fn aiur_fn_126(
             let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
             let __v_42: G = __r_arr[0];
             let __v_43: G = { let __values: [G; 4] = [__v_40, __v_41, __v_42, __v_38]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_126] = [__v_43, __v_39];
-            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_125] = [__v_43, __v_39];
+            record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11114,8 +11073,60 @@ fn aiur_fn_126(
   })
 }
 
-const INPUT_SIZE_127: usize = 5;
-const IN_127: usize = 5;
+const INPUT_SIZE_126: usize = 5;
+const IN_126: usize = 5;
+const OUT_126: usize = 1;
+fn aiur_fn_126(
+  inp: [G; IN_126],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_126], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_2.as_canonical_u64() {
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_126] = [__v_5];
+        record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_1 - __v_4);
+        let __v_7: G = (__v_5 + __v_6);
+        let __v_8: G = G::from_bool((__v_7 == G::ZERO));
+        match __v_8.as_canonical_u64() {
+          1u64 => {
+            let __v_9: G = G::from_u64(1);
+            let __ret: [G; OUT_126] = [__v_9];
+            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_2 - __v_9);
+            let __v_11: G = G::from_u64(1);
+            let __v_12: G = (__v_3 + __v_11);
+            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+            let __v_13: G = __r_arr[0];
+            let __ret: [G; OUT_126] = [__v_13];
+            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_127: usize = 4;
+const IN_127: usize = 4;
 const OUT_127: usize = 1;
 fn aiur_fn_127(
   inp: [G; IN_127],
@@ -11128,79 +11139,27 @@ fn aiur_fn_127(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_127] = [__v_5];
-        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_1 - __v_4);
-        let __v_7: G = (__v_5 + __v_6);
-        let __v_8: G = G::from_bool((__v_7 == G::ZERO));
-        match __v_8.as_canonical_u64() {
-          1u64 => {
-            let __v_9: G = G::from_u64(1);
-            let __ret: [G; OUT_127] = [__v_9];
-            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_2 - __v_9);
-            let __v_11: G = G::from_u64(1);
-            let __v_12: G = (__v_3 + __v_11);
-            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
-            let __v_13: G = __r_arr[0];
-            let __ret: [G; OUT_127] = [__v_13];
-            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_128: usize = 4;
-const IN_128: usize = 4;
-const OUT_128: usize = 1;
-fn aiur_fn_128(
-  inp: [G; IN_128],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_128], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 7] = [__v_4, __v_5, __v_5, __v_5, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_128] = [__v_6];
-        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_127] = [__v_6];
+        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_3 - __v_6);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_128] = [__v_8];
-            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_127] = [__v_8];
+            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11211,11 +11170,11 @@ fn aiur_fn_128(
             let __v_10: G = G::from_u64(0);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 - __v_11);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = { let __values: [G; 7] = [__v_6, __v_3, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_128] = [__v_14];
-            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_127] = [__v_14];
+            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -11224,15 +11183,15 @@ fn aiur_fn_128(
   })
 }
 
-const INPUT_SIZE_129: usize = 8;
-const IN_129: usize = 8;
-const OUT_129: usize = 1;
-fn aiur_fn_129(
-  inp: [G; IN_129],
+const INPUT_SIZE_128: usize = 8;
+const IN_128: usize = 8;
+const OUT_128: usize = 1;
+fn aiur_fn_128(
+  inp: [G; IN_128],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_129], ExecError> {
+) -> Result<[G; OUT_128], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11255,8 +11214,8 @@ fn aiur_fn_129(
         let __v_15: G = G::from_u64(1);
         let __v_16: G = G::from_u64(1);
         let __v_17: G = { let __values: [G; 7] = [__v_15, __v_16, __v_16, __v_16, __v_16, __v_16, __v_16]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_129] = [__v_17];
-        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_128] = [__v_17];
+        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11266,24 +11225,24 @@ fn aiur_fn_129(
             let __v_16: G = G::from_bool((__v_15 == G::ZERO));
             match __v_16.as_canonical_u64() {
               1u64 => {
-                let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_12, __v_13, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_12, __v_13, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
                 let __v_17: G = __r_arr[0];
                 let __v_18: G = __r_arr[1];
                 let __v_19: G = __r_arr[2];
                 let __v_20: G = __r_arr[3];
                 let __v_21: G = G::from_u64(0);
                 let __v_22: G = { let __values: [G; 7] = [__v_21, __v_9, __v_19, __v_20, __v_17, __v_18, __v_14]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_129] = [__v_22];
-                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_128] = [__v_22];
+                record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_17: G = G::from_u64(0);
-                let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
                 let __v_18: G = __r_arr[0];
                 let __v_19: G = { let __values: [G; 7] = [__v_17, __v_9, __v_10, __v_11, __v_12, __v_13, __v_18]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_129] = [__v_19];
-                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_128] = [__v_19];
+                record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11297,15 +11256,15 @@ fn aiur_fn_129(
   })
 }
 
-const INPUT_SIZE_130: usize = 2;
-const IN_130: usize = 2;
-const OUT_130: usize = 1;
-fn aiur_fn_130(
-  inp: [G; IN_130],
+const INPUT_SIZE_129: usize = 2;
+const IN_129: usize = 2;
+const OUT_129: usize = 1;
+fn aiur_fn_129(
+  inp: [G; IN_129],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_130], ExecError> {
+) -> Result<[G; OUT_129], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11320,8 +11279,8 @@ fn aiur_fn_130(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_9: G = G::from_u64(1);
-        let __ret: [G; OUT_130] = [__v_9];
-        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_129] = [__v_9];
+        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11340,15 +11299,15 @@ fn aiur_fn_130(
                   return Err(ExecError::AssertEqMismatch { lhs: __v_13.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
                 }
                 let __v_15: G = G::from_u64(1);
-                let __ret: [G; OUT_130] = [__v_15];
-                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_129] = [__v_15];
+                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_130] = [__v_11];
-                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_129] = [__v_11];
+                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11362,8 +11321,40 @@ fn aiur_fn_130(
   })
 }
 
-const INPUT_SIZE_131: usize = 2;
-const IN_131: usize = 2;
+const INPUT_SIZE_130: usize = 2;
+const IN_130: usize = 2;
+const OUT_130: usize = 1;
+fn aiur_fn_130(
+  inp: [G; IN_130],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_130], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(0);
+        let __ret: [G; OUT_130] = [__v_2];
+        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __ret: [G; OUT_130] = [__v_2];
+        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_131: usize = 10;
+const IN_131: usize = 10;
 const OUT_131: usize = 1;
 fn aiur_fn_131(
   inp: [G; IN_131],
@@ -11374,28 +11365,46 @@ fn aiur_fn_131(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(0);
-        let __ret: [G; OUT_131] = [__v_2];
-        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __ret: [G; OUT_131] = [__v_2];
-        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = (__v_3 - __v_1);
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
+    let __v_16: G = __r_arr[0];
+    let __v_17: G = __r_arr[1];
+    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+    let __v_18: G = __r_arr[0];
+    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __v_20: G = (__v_18 - __v_19);
+    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+    let __v_22: G = G::from_u64(1);
+    if (__v_21 != __v_22) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
     }
+    let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __ret: [G; OUT_131] = [__v_23];
+    record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_132: usize = 10;
-const IN_132: usize = 10;
+const INPUT_SIZE_132: usize = 11;
+const IN_132: usize = 11;
 const OUT_132: usize = 1;
 fn aiur_fn_132(
   inp: [G; IN_132],
@@ -11414,38 +11423,31 @@ fn aiur_fn_132(
     let __v_7: G = inp[7];
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
-    let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+    let __v_10: G = inp[10];
+    let __v_11: G = G::from_u64(0);
+    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_13: G = G::from_u64(1);
+    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __v_15: G = __r_arr[1];
-    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
-    let __v_16: G = __r_arr[0];
-    let __v_17: G = __r_arr[1];
-    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-    let __v_18: G = __r_arr[0];
-    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __v_15: G = __r_arr[0];
+    let __v_16: G = G::from_u64(0);
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_17: G = __r_arr[0];
+    let __v_18: G = __r_arr[1];
+    let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
     let __v_19: G = __r_arr[0];
-    let __v_20: G = (__v_18 - __v_19);
-    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-    let __v_22: G = G::from_u64(1);
-    if (__v_21 != __v_22) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-    }
-    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __ret: [G; OUT_132] = [__v_23];
+    let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __ret: [G; OUT_132] = [__v_20];
     record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_133: usize = 11;
-const IN_133: usize = 11;
+const INPUT_SIZE_133: usize = 13;
+const IN_133: usize = 13;
 const OUT_133: usize = 1;
 fn aiur_fn_133(
   inp: [G; IN_133],
@@ -11465,25 +11467,37 @@ fn aiur_fn_133(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
-    let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
-    let __v_15: G = __r_arr[0];
-    let __v_16: G = G::from_u64(0);
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_17: G = __r_arr[0];
-    let __v_18: G = __r_arr[1];
-    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __ret: [G; OUT_133] = [__v_20];
-    record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    match __v_5.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_133] = [__v_0];
+        record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = G::from_u64(1);
+        let __v_20: G = (__v_4 + __v_19);
+        let __v_21: G = G::from_u64(1);
+        let __v_22: G = (__v_5 - __v_21);
+        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __ret: [G; OUT_133] = [__v_23];
+        record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
@@ -11517,24 +11531,27 @@ fn aiur_fn_134(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
-        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = G::from_u64(1);
-        let __v_20: G = (__v_4 + __v_19);
+        let __v_18: G = G::from_u64(0);
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
         let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_5 - __v_21);
-        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-        let __v_23: G = __r_arr[0];
-        let __ret: [G; OUT_134] = [__v_23];
+        let __v_22: G = (__v_4 + __v_21);
+        let __v_23: G = G::from_u64(1);
+        let __v_24: G = (__v_5 - __v_23);
+        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __ret: [G; OUT_134] = [__v_25];
         record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -11542,8 +11559,8 @@ fn aiur_fn_134(
   })
 }
 
-const INPUT_SIZE_135: usize = 13;
-const IN_135: usize = 13;
+const INPUT_SIZE_135: usize = 15;
+const IN_135: usize = 15;
 const OUT_135: usize = 1;
 fn aiur_fn_135(
   inp: [G; IN_135],
@@ -11565,6 +11582,8 @@ fn aiur_fn_135(
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
     match __v_5.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_135] = [__v_0];
@@ -11572,29 +11591,49 @@ fn aiur_fn_135(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = G::from_u64(0);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_19: G = __r_arr[0];
-        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_4 + __v_21);
-        let __v_23: G = G::from_u64(1);
-        let __v_24: G = (__v_5 - __v_23);
-        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-        let __v_25: G = __r_arr[0];
-        let __ret: [G; OUT_135] = [__v_25];
-        record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __v_16: G = __r_arr[1];
+        match __v_15.as_canonical_u64() {
+          0u64 => {
+            let __v_17: G = G::from_u64(1);
+            let __v_18: G = (__v_4 + __v_17);
+            let __v_19: G = G::from_u64(1);
+            let __v_20: G = (__v_5 - __v_19);
+            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __ret: [G; OUT_135] = [__v_21];
+            record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __v_17: G = __r_arr[0];
+            let __v_18: G = (__v_17 + __v_3);
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+            let __v_22: G = __r_arr[0];
+            let __v_23: G = G::from_u64(1);
+            let __v_24: G = (__v_4 + __v_23);
+            let __v_25: G = G::from_u64(1);
+            let __v_26: G = (__v_5 - __v_25);
+            let __v_27: G = G::from_u64(1);
+            let __v_28: G = (__v_6 + __v_27);
+            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_135] = [__v_29];
+            record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
+          },
+        }
       },
     }
   })
@@ -11625,63 +11664,57 @@ fn aiur_fn_136(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    match __v_5.as_canonical_u64() {
+    match __v_3.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_136] = [__v_0];
         record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        match __v_15.as_canonical_u64() {
-          0u64 => {
-            let __v_17: G = G::from_u64(1);
-            let __v_18: G = (__v_4 + __v_17);
-            let __v_19: G = G::from_u64(1);
-            let __v_20: G = (__v_5 - __v_19);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __ret: [G; OUT_136] = [__v_21];
-            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-            let __v_17: G = __r_arr[0];
-            let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+      1u64 => {
+        let __v_15: G = G::from_u64(3);
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __v_17: G = __r_arr[1];
+        match __v_16.as_canonical_u64() {
+          _ => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_18: G = __r_arr[0];
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-            let __v_22: G = __r_arr[0];
-            let __v_23: G = G::from_u64(1);
-            let __v_24: G = (__v_4 + __v_23);
-            let __v_25: G = G::from_u64(1);
-            let __v_26: G = (__v_5 - __v_25);
-            let __v_27: G = G::from_u64(1);
-            let __v_28: G = (__v_6 + __v_27);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = (__v_18 - __v_19);
+            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+            let __v_22: G = G::from_u64(1);
+            if (__v_21 != __v_22) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+            }
+            let __v_23: G = G::from_u64(0);
+            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+            let __v_24: G = __r_arr[0];
+            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+            let __v_25: G = __r_arr[0];
+            let __v_26: G = G::from_u64(1);
+            if (__v_25 != __v_26) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
+            }
+            let __v_27: G = G::from_u64(0);
+            let __v_28: G = G::from_u64(0);
+            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
             let __v_29: G = __r_arr[0];
             let __ret: [G; OUT_136] = [__v_29];
             record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-          },
         }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_137: usize = 15;
-const IN_137: usize = 15;
+const INPUT_SIZE_137: usize = 4;
+const IN_137: usize = 4;
 const OUT_137: usize = 1;
 fn aiur_fn_137(
   inp: [G; IN_137],
@@ -11694,68 +11727,37 @@ fn aiur_fn_137(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    match __v_3.as_canonical_u64() {
+    match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_137] = [__v_0];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_137] = [__v_6];
         record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      1u64 => {
-        let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        match __v_16.as_canonical_u64() {
-          _ => {
-            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-            let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __v_20: G = (__v_18 - __v_19);
-            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-            let __v_22: G = G::from_u64(1);
-            if (__v_21 != __v_22) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-            }
-            let __v_23: G = G::from_u64(0);
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
-            let __v_24: G = __r_arr[0];
-            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __v_26: G = G::from_u64(1);
-            if (__v_25 != __v_26) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
-            }
-            let __v_27: G = G::from_u64(0);
-            let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_137] = [__v_29];
-            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+        let __v_4: G = G::from_u64(0);
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_5 + __v_1);
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_2 - __v_7);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_3 + __v_9);
+        let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_137] = [__v_12];
+        record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_138: usize = 4;
-const IN_138: usize = 4;
+const INPUT_SIZE_138: usize = 5;
+const IN_138: usize = 5;
 const OUT_138: usize = 1;
 fn aiur_fn_138(
   inp: [G; IN_138],
@@ -11768,30 +11770,52 @@ fn aiur_fn_138(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    match __v_2.as_canonical_u64() {
+    let __v_4: G = inp[4];
+    match __v_3.as_canonical_u64() {
       0u64 => {
-        let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_6];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_138] = [__v_7];
         record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_5 + __v_1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_2 - __v_7);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_3 + __v_9);
-        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_12];
-        record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __v_6: G = __r_arr[1];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __v_7: G = G::from_u64(1);
+            let __v_8: G = (__v_3 - __v_7);
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_4 + __v_9);
+            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+            let __v_11: G = __r_arr[0];
+            let __ret: [G; OUT_138] = [__v_11];
+            record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __v_7: G = G::from_u64(0);
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __v_9: G = (__v_8 + __v_1);
+            let __v_10: G = G::from_u64(1);
+            let __v_11: G = (__v_3 - __v_10);
+            let __v_12: G = G::from_u64(1);
+            let __v_13: G = (__v_4 + __v_12);
+            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+            let __v_14: G = __r_arr[0];
+            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_138] = [__v_15];
+            record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
@@ -11799,7 +11823,7 @@ fn aiur_fn_138(
 
 const INPUT_SIZE_139: usize = 5;
 const IN_139: usize = 5;
-const OUT_139: usize = 1;
+const OUT_139: usize = 4;
 fn aiur_fn_139(
   inp: [G; IN_139],
   record: &mut QueryRecord,
@@ -11812,95 +11836,30 @@ fn aiur_fn_139(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    match __v_3.as_canonical_u64() {
+    match __v_0.as_canonical_u64() {
       0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_139] = [__v_7];
+        let __ret: [G; OUT_139] = [__v_1, __v_2, __v_3, __v_4];
         record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __v_7: G = G::from_u64(1);
-            let __v_8: G = (__v_3 - __v_7);
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_4 + __v_9);
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
-            let __v_11: G = __r_arr[0];
-            let __ret: [G; OUT_139] = [__v_11];
-            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-            let __v_8: G = __r_arr[0];
-            let __v_9: G = (__v_8 + __v_1);
-            let __v_10: G = G::from_u64(1);
-            let __v_11: G = (__v_3 - __v_10);
-            let __v_12: G = G::from_u64(1);
-            let __v_13: G = (__v_4 + __v_12);
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
-            let __v_14: G = __r_arr[0];
-            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_139] = [__v_15];
-            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        let __ret: [G; OUT_139] = [__v_3, __v_4, __v_1, __v_2];
+        record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_140: usize = 5;
-const IN_140: usize = 5;
-const OUT_140: usize = 4;
+const INPUT_SIZE_140: usize = 4;
+const IN_140: usize = 4;
+const OUT_140: usize = 1;
 fn aiur_fn_140(
   inp: [G; IN_140],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_140], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_140] = [__v_1, __v_2, __v_3, __v_4];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __ret: [G; OUT_140] = [__v_3, __v_4, __v_1, __v_2];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_141: usize = 4;
-const IN_141: usize = 4;
-const OUT_141: usize = 1;
-fn aiur_fn_141(
-  inp: [G; IN_141],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_141], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11953,21 +11912,21 @@ fn aiur_fn_141(
     let __v_44: G = { let __values: [G; 10] = [__v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_43]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_45: G = { let __values: [G; 10] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_44]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_46: G = { let __values: [G; 10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_45]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_141] = [__v_46];
-    record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_140] = [__v_46];
+    record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_142: usize = 6;
-const IN_142: usize = 6;
-const OUT_142: usize = 3;
-fn aiur_fn_142(
-  inp: [G; IN_142],
+const INPUT_SIZE_141: usize = 6;
+const IN_141: usize = 6;
+const OUT_141: usize = 3;
+fn aiur_fn_141(
+  inp: [G; IN_141],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_142], ExecError> {
+) -> Result<[G; OUT_141], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11985,8 +11944,8 @@ fn aiur_fn_142(
     let __v_12: G = __loaded[6];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
-        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_141] = [__v_0, __v_1, __v_5];
+        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11997,7 +11956,7 @@ fn aiur_fn_142(
             match __v_14.as_canonical_u64() {
               1u64 => {
                 let __v_15: G = G::from_u64(1);
-                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
                 let __v_16: G = __r_arr[0];
                 let __v_17: G = __r_arr[1];
                 let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_16, __v_17, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -12006,13 +11965,13 @@ fn aiur_fn_142(
                 let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 let __v_21: G = __r_arr[1];
-                let __ret: [G; OUT_142] = [__v_20, __v_21, __v_12];
-                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_141] = [__v_20, __v_21, __v_12];
+                record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
-                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_141] = [__v_0, __v_1, __v_5];
+                record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -12026,15 +11985,15 @@ fn aiur_fn_142(
   })
 }
 
-const INPUT_SIZE_143: usize = 9;
-const IN_143: usize = 9;
-const OUT_143: usize = 2;
-fn aiur_fn_143(
-  inp: [G; IN_143],
+const INPUT_SIZE_142: usize = 9;
+const IN_142: usize = 9;
+const OUT_142: usize = 2;
+fn aiur_fn_142(
+  inp: [G; IN_142],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_143], ExecError> {
+) -> Result<[G; OUT_142], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12059,14 +12018,14 @@ fn aiur_fn_143(
         if (__v_15 != __v_16) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_15.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_143] = [__v_0, __v_1];
-        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_142] = [__v_0, __v_1];
+        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12094,29 +12053,29 @@ fn aiur_fn_143(
                         let __v_24: G = G::from_u64(1);
                         let __v_25: G = (__v_6 - __v_24);
                         let __v_26: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                         let __v_27: G = __r_arr[0];
                         let __v_28: G = __r_arr[1];
-                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
                         let __v_29: G = __r_arr[0];
                         let __v_30: G = __r_arr[1];
                         let __v_31: G = __r_arr[2];
                         let __v_32: G = __r_arr[3];
-                        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                         let __v_33: G = __r_arr[0];
                         let __v_34: G = __r_arr[1];
-                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = __r_arr[1];
                         let __v_37: G = __r_arr[2];
-                        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
                         let __v_39: G = G::from_u64(1);
                         if (__v_38 != __v_39) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_38.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
                         }
                         let __v_40: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
                         let __v_41: G = __r_arr[0];
                         let __v_42: G = G::from_u64(1);
                         let __v_43: G = G::from_u64(1);
@@ -12127,17 +12086,17 @@ fn aiur_fn_143(
                         let __v_48: G = G::from_u64(1);
                         let __v_49: G = { let __values: [G; 3] = [__v_47, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                         let __v_50: G = { let __values: [G; 3] = [__v_46, __v_25, __v_49]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_19, __v_45, __v_50, __v_23, __v_12, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_19, __v_45, __v_50, __v_23, __v_12, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
                         let __v_51: G = __r_arr[0];
                         let __v_52: G = G::from_u64(1);
                         if (__v_51 != __v_52) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_51.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
                         }
-                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
                         let __v_53: G = __r_arr[0];
                         let __v_54: G = __r_arr[1];
-                        let __ret: [G; OUT_143] = [__v_53, __v_54];
-                        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_142] = [__v_53, __v_54];
+                        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                       _ => {
@@ -12159,6 +12118,200 @@ fn aiur_fn_143(
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_143: usize = 25;
+const IN_143: usize = 25;
+const OUT_143: usize = 1;
+fn aiur_fn_143(
+  inp: [G; IN_143],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_143], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
+    let __v_18: G = inp[18];
+    let __v_19: G = inp[19];
+    let __v_20: G = inp[20];
+    let __v_21: G = inp[21];
+    let __v_22: G = inp[22];
+    let __v_23: G = inp[23];
+    let __v_24: G = inp[24];
+    match __v_1.as_canonical_u64() {
+      _ => {
+        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __v_26: G = G::from_u64(0);
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_27: G = __r_arr[0];
+        let __v_28: G = __r_arr[1];
+        match __v_27.as_canonical_u64() {
+          _ => {
+            let __v_29: G = G::from_u64(0);
+            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+            let __v_30: G = __r_arr[0];
+            let __v_31: G = G::from_u64(1);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_32: G = __r_arr[0];
+            let __v_33: G = __r_arr[1];
+            match __v_32.as_canonical_u64() {
+              _ => {
+                let __v_34: G = G::from_u64(0);
+                let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+                let __v_35: G = __r_arr[0];
+                let __v_36: G = G::from_u64(2);
+                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                let __v_37: G = __r_arr[0];
+                let __v_38: G = __r_arr[1];
+                match __v_37.as_canonical_u64() {
+                  _ => {
+                    let __v_39: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+                    let __v_40: G = __r_arr[0];
+                    let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+                    let __v_41: G = __r_arr[0];
+                    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+                    let __v_42: G = __r_arr[0];
+                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+                    let __v_43: G = __loaded[0];
+                    let __v_44: G = __loaded[1];
+                    let __v_45: G = __loaded[2];
+                    let __v_46: G = __loaded[3];
+                    let __v_47: G = __loaded[4];
+                    let __v_48: G = __loaded[5];
+                    let __v_49: G = __loaded[6];
+                    match __v_43.as_canonical_u64() {
+                      0u64 => {
+                        match __v_44.as_canonical_u64() {
+                          _ => {
+                            let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+                            let __v_50: G = __r_arr[0];
+                            let __v_51: G = __r_arr[1];
+                            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+                            let __v_52: G = __r_arr[0];
+                            let __v_53: G = (__v_52 - __v_24);
+                            let __v_54: G = G::from_bool((__v_53 == G::ZERO));
+                            let __v_55: G = G::from_u64(1);
+                            if (__v_54 != __v_55) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+                            let __v_56: G = __r_arr[0];
+                            let __v_57: G = G::from_u64(3);
+                            let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                            let __v_58: G = __r_arr[0];
+                            let __v_59: G = (__v_57 + __v_58);
+                            let __v_60: G = (__v_56 - __v_59);
+                            let __v_61: G = G::from_bool((__v_60 == G::ZERO));
+                            let __v_62: G = G::from_u64(1);
+                            if (__v_61 != __v_62) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                            let __v_63: G = __r_arr[0];
+                            let __v_64: G = (__v_63 - __v_18);
+                            let __v_65: G = G::from_bool((__v_64 == G::ZERO));
+                            let __v_66: G = G::from_u64(1);
+                            if (__v_65 != __v_66) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
+                            }
+                            let __v_67: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                            let __v_68: G = __r_arr[0];
+                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                            let __v_69: G = __r_arr[0];
+                            let __v_70: G = G::from_u64(1);
+                            if (__v_69 != __v_70) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                            let __v_71: G = __r_arr[0];
+                            let __v_72: G = (__v_71 - __v_18);
+                            let __v_73: G = G::from_bool((__v_72 == G::ZERO));
+                            let __v_74: G = G::from_u64(1);
+                            if (__v_73 != __v_74) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
+                            }
+                            let __v_75: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                            let __v_76: G = __r_arr[0];
+                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                            let __v_77: G = __r_arr[0];
+                            let __v_78: G = G::from_u64(1);
+                            if (__v_77 != __v_78) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                            let __v_79: G = __r_arr[0];
+                            let __v_80: G = (__v_79 - __v_18);
+                            let __v_81: G = G::from_bool((__v_80 == G::ZERO));
+                            let __v_82: G = G::from_u64(1);
+                            if (__v_81 != __v_82) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
+                            }
+                            let __v_83: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                            let __v_84: G = __r_arr[0];
+                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                            let __v_85: G = __r_arr[0];
+                            let __v_86: G = G::from_u64(1);
+                            if (__v_85 != __v_86) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64() });
+                            }
+                            let __v_87: G = (__v_44 - __v_20);
+                            let __v_88: G = G::from_bool((__v_87 == G::ZERO));
+                            let __v_89: G = G::from_u64(1);
+                            if (__v_88 != __v_89) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
+                            }
+                            let __v_90: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                            let __v_91: G = __r_arr[0];
+                            let __v_92: G = __r_arr[1];
+                            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
+                            let __v_93: G = __r_arr[0];
+                            let __v_94: G = G::from_u64(1);
+                            if (__v_93 != __v_94) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
+                            }
+                            let __v_95: G = G::from_u64(1);
+                            let __ret: [G; OUT_143] = [__v_95];
+                            record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            return Ok(__ret);
+                          },
+                        }
+                      },
+                      _ => {
+                        return Err(ExecError::MatchNoCase(__v_43.as_canonical_u64()));
+                      },
+                    }
+                  },
+                }
+              },
+            }
+          },
+        }
       },
     }
   })
@@ -12199,200 +12352,6 @@ fn aiur_fn_144(
     let __v_22: G = inp[22];
     let __v_23: G = inp[23];
     let __v_24: G = inp[24];
-    match __v_1.as_canonical_u64() {
-      _ => {
-        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
-        let __v_25: G = __r_arr[0];
-        let __v_26: G = G::from_u64(0);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_27: G = __r_arr[0];
-        let __v_28: G = __r_arr[1];
-        match __v_27.as_canonical_u64() {
-          _ => {
-            let __v_29: G = G::from_u64(0);
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-            let __v_30: G = __r_arr[0];
-            let __v_31: G = G::from_u64(1);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_32: G = __r_arr[0];
-            let __v_33: G = __r_arr[1];
-            match __v_32.as_canonical_u64() {
-              _ => {
-                let __v_34: G = G::from_u64(0);
-                let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-                let __v_35: G = __r_arr[0];
-                let __v_36: G = G::from_u64(2);
-                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-                let __v_37: G = __r_arr[0];
-                let __v_38: G = __r_arr[1];
-                match __v_37.as_canonical_u64() {
-                  _ => {
-                    let __v_39: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-                    let __v_40: G = __r_arr[0];
-                    let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-                    let __v_41: G = __r_arr[0];
-                    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-                    let __v_42: G = __r_arr[0];
-                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-                    let __v_43: G = __loaded[0];
-                    let __v_44: G = __loaded[1];
-                    let __v_45: G = __loaded[2];
-                    let __v_46: G = __loaded[3];
-                    let __v_47: G = __loaded[4];
-                    let __v_48: G = __loaded[5];
-                    let __v_49: G = __loaded[6];
-                    match __v_43.as_canonical_u64() {
-                      0u64 => {
-                        match __v_44.as_canonical_u64() {
-                          _ => {
-                            let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
-                            let __v_50: G = __r_arr[0];
-                            let __v_51: G = __r_arr[1];
-                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-                            let __v_52: G = __r_arr[0];
-                            let __v_53: G = (__v_52 - __v_24);
-                            let __v_54: G = G::from_bool((__v_53 == G::ZERO));
-                            let __v_55: G = G::from_u64(1);
-                            if (__v_54 != __v_55) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-                            let __v_56: G = __r_arr[0];
-                            let __v_57: G = G::from_u64(3);
-                            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
-                            let __v_58: G = __r_arr[0];
-                            let __v_59: G = (__v_57 + __v_58);
-                            let __v_60: G = (__v_56 - __v_59);
-                            let __v_61: G = G::from_bool((__v_60 == G::ZERO));
-                            let __v_62: G = G::from_u64(1);
-                            if (__v_61 != __v_62) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-                            let __v_63: G = __r_arr[0];
-                            let __v_64: G = (__v_63 - __v_18);
-                            let __v_65: G = G::from_bool((__v_64 == G::ZERO));
-                            let __v_66: G = G::from_u64(1);
-                            if (__v_65 != __v_66) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
-                            }
-                            let __v_67: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-                            let __v_68: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-                            let __v_69: G = __r_arr[0];
-                            let __v_70: G = G::from_u64(1);
-                            if (__v_69 != __v_70) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-                            let __v_71: G = __r_arr[0];
-                            let __v_72: G = (__v_71 - __v_18);
-                            let __v_73: G = G::from_bool((__v_72 == G::ZERO));
-                            let __v_74: G = G::from_u64(1);
-                            if (__v_73 != __v_74) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
-                            }
-                            let __v_75: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-                            let __v_76: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-                            let __v_77: G = __r_arr[0];
-                            let __v_78: G = G::from_u64(1);
-                            if (__v_77 != __v_78) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-                            let __v_79: G = __r_arr[0];
-                            let __v_80: G = (__v_79 - __v_18);
-                            let __v_81: G = G::from_bool((__v_80 == G::ZERO));
-                            let __v_82: G = G::from_u64(1);
-                            if (__v_81 != __v_82) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
-                            }
-                            let __v_83: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-                            let __v_84: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-                            let __v_85: G = __r_arr[0];
-                            let __v_86: G = G::from_u64(1);
-                            if (__v_85 != __v_86) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64() });
-                            }
-                            let __v_87: G = (__v_44 - __v_20);
-                            let __v_88: G = G::from_bool((__v_87 == G::ZERO));
-                            let __v_89: G = G::from_u64(1);
-                            if (__v_88 != __v_89) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
-                            }
-                            let __v_90: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-                            let __v_91: G = __r_arr[0];
-                            let __v_92: G = __r_arr[1];
-                            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
-                            let __v_93: G = __r_arr[0];
-                            let __v_94: G = G::from_u64(1);
-                            if (__v_93 != __v_94) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
-                            }
-                            let __v_95: G = G::from_u64(1);
-                            let __ret: [G; OUT_144] = [__v_95];
-                            record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                            return Ok(__ret);
-                          },
-                        }
-                      },
-                      _ => {
-                        return Err(ExecError::MatchNoCase(__v_43.as_canonical_u64()));
-                      },
-                    }
-                  },
-                }
-              },
-            }
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_145: usize = 25;
-const IN_145: usize = 25;
-const OUT_145: usize = 1;
-fn aiur_fn_145(
-  inp: [G; IN_145],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_145], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = inp[17];
-    let __v_18: G = inp[18];
-    let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
-    let __v_21: G = inp[21];
-    let __v_22: G = inp[22];
-    let __v_23: G = inp[23];
-    let __v_24: G = inp[24];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_25: G = __loaded[0];
     let __v_26: G = __loaded[1];
@@ -12401,21 +12360,21 @@ fn aiur_fn_145(
     match __v_25.as_canonical_u64() {
       1u64 => {
         let __v_29: G = G::from_u64(1);
-        let __ret: [G; OUT_145] = [__v_29];
-        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_144] = [__v_29];
+        record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = __r_arr[1];
         let __v_31: G = __r_arr[2];
-        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
-        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
         let __v_33: G = __r_arr[0];
-        let __ret: [G; OUT_145] = [__v_33];
-        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_144] = [__v_33];
+        record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12425,15 +12384,15 @@ fn aiur_fn_145(
   })
 }
 
-const INPUT_SIZE_146: usize = 31;
-const IN_146: usize = 31;
-const OUT_146: usize = 1;
-fn aiur_fn_146(
-  inp: [G; IN_146],
+const INPUT_SIZE_145: usize = 31;
+const IN_145: usize = 31;
+const OUT_145: usize = 1;
+fn aiur_fn_145(
+  inp: [G; IN_145],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_146], ExecError> {
+) -> Result<[G; OUT_145], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12468,25 +12427,25 @@ fn aiur_fn_146(
     let __v_30: G = inp[30];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_31: G = __r_arr[0];
         let __v_32: G = G::from_u64(1);
         let __v_33: G = G::from_u64(1);
         let __v_34: G = { let __values: [G; 3] = [__v_32, __v_33, __v_33]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_35: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = G::from_u64(1);
         let __v_41: G = G::from_u64(1);
         let __v_42: G = { let __values: [G; 3] = [__v_40, __v_41, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
         let __v_43: G = __r_arr[0];
         let __v_44: G = __r_arr[1];
         let __v_45: G = __r_arr[2];
@@ -12509,23 +12468,23 @@ fn aiur_fn_146(
         let __v_61: G = __r_arr[0];
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_62: G = __r_arr[0];
-        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_63: G = __r_arr[0];
         let __v_64: G = __r_arr[1];
         let __v_65: G = G::from_u64(1);
         let __v_66: G = G::from_u64(1);
         let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
-        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
         let __v_72: G = __r_arr[1];
         let __v_73: G = (__v_31 + __v_27);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_74: G = __r_arr[0];
         let __v_75: G = (__v_74 - __v_31);
         let __v_76: G = G::from_bool((__v_75 == G::ZERO));
@@ -12533,7 +12492,7 @@ fn aiur_fn_146(
         if (__v_76 != __v_77) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_78: G = __r_arr[0];
         let __v_79: G = (__v_78 - __v_28);
         let __v_80: G = G::from_bool((__v_79 == G::ZERO));
@@ -12541,24 +12500,45 @@ fn aiur_fn_146(
         if (__v_80 != __v_81) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_82: G = __r_arr[0];
         let __v_83: G = G::from_u64(1);
         if (__v_82 != __v_83) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_82.as_canonical_u64(), rhs: __v_83.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
         let __v_84: G = __r_arr[0];
-        let __ret: [G; OUT_146] = [__v_84];
-        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_145] = [__v_84];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_147: usize = 2;
-const IN_147: usize = 2;
+const INPUT_SIZE_146: usize = 2;
+const IN_146: usize = 2;
+const OUT_146: usize = 1;
+fn aiur_fn_146(
+  inp: [G; IN_146],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_146], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_bool((__v_0 == G::ZERO));
+    let __v_3: G = G::from_bool((__v_1 == G::ZERO));
+    let __v_4: G = (__v_2 * __v_3);
+    let __ret: [G; OUT_146] = [__v_4];
+    record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_147: usize = 1;
+const IN_147: usize = 1;
 const OUT_147: usize = 1;
 fn aiur_fn_147(
   inp: [G; IN_147],
@@ -12566,27 +12546,6 @@ fn aiur_fn_147(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_147], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_bool((__v_0 == G::ZERO));
-    let __v_3: G = G::from_bool((__v_1 == G::ZERO));
-    let __v_4: G = (__v_2 * __v_3);
-    let __ret: [G; OUT_147] = [__v_4];
-    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_148: usize = 1;
-const IN_148: usize = 1;
-const OUT_148: usize = 1;
-fn aiur_fn_148(
-  inp: [G; IN_148],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_148], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -12597,8 +12556,8 @@ fn aiur_fn_148(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_148] = [__v_5];
-        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_147] = [__v_5];
+        record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12609,17 +12568,17 @@ fn aiur_fn_148(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           1u64 => {
-            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_148] = [__v_9];
-            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_147] = [__v_9];
+            record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_148] = [__v_9];
-            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_147] = [__v_9];
+            record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -12631,15 +12590,15 @@ fn aiur_fn_148(
   })
 }
 
-const INPUT_SIZE_149: usize = 9;
-const IN_149: usize = 9;
-const OUT_149: usize = 1;
-fn aiur_fn_149(
-  inp: [G; IN_149],
+const INPUT_SIZE_148: usize = 9;
+const IN_148: usize = 9;
+const OUT_148: usize = 1;
+fn aiur_fn_148(
+  inp: [G; IN_148],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_149], ExecError> {
+) -> Result<[G; OUT_148], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12666,21 +12625,21 @@ fn aiur_fn_149(
     let __v_22: G = { let __values: [G; 3] = [__v_11, __v_2, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_23: G = { let __values: [G; 3] = [__v_10, __v_1, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_24: G = { let __values: [G; 3] = [__v_9, __v_0, __v_23]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_149] = [__v_24];
-    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_148] = [__v_24];
+    record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_150: usize = 33;
-const IN_150: usize = 33;
-const OUT_150: usize = 1;
-fn aiur_fn_150(
-  inp: [G; IN_150],
+const INPUT_SIZE_149: usize = 33;
+const IN_149: usize = 33;
+const OUT_149: usize = 1;
+fn aiur_fn_149(
+  inp: [G; IN_149],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_150], ExecError> {
+) -> Result<[G; OUT_149], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12715,29 +12674,29 @@ fn aiur_fn_150(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __ret: [G; OUT_150] = [__v_36];
-    record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_149] = [__v_36];
+    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_151: usize = 2;
-const IN_151: usize = 2;
-const OUT_151: usize = 1;
-fn aiur_fn_151(
-  inp: [G; IN_151],
+const INPUT_SIZE_150: usize = 2;
+const IN_150: usize = 2;
+const OUT_150: usize = 1;
+fn aiur_fn_150(
+  inp: [G; IN_150],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_151], ExecError> {
+) -> Result<[G; OUT_150], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12778,16 +12737,61 @@ fn aiur_fn_151(
     let __v_35: G = __loaded[33];
     match __v_2.as_canonical_u64() {
       1u64 => {
+        let __ret: [G; OUT_150] = [__v_1];
+        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+        let __v_36: G = __r_arr[0];
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __v_37: G = __r_arr[0];
+        let __ret: [G; OUT_150] = [__v_37];
+        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_151: usize = 2;
+const IN_151: usize = 2;
+const OUT_151: usize = 1;
+fn aiur_fn_151(
+  inp: [G; IN_151],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_151], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
         let __ret: [G; OUT_151] = [__v_1];
         record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
-        let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
-        let __v_37: G = __r_arr[0];
-        let __ret: [G; OUT_151] = [__v_37];
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(0);
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = G::from_u64(0);
+        let __v_11: G = G::from_u64(0);
+        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __ret: [G; OUT_151] = [__v_13];
         record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -12800,7 +12804,7 @@ fn aiur_fn_151(
 
 const INPUT_SIZE_152: usize = 2;
 const IN_152: usize = 2;
-const OUT_152: usize = 1;
+const OUT_152: usize = 3;
 fn aiur_fn_152(
   inp: [G; IN_152],
   record: &mut QueryRecord,
@@ -12810,59 +12814,14 @@ fn aiur_fn_152(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_152] = [__v_1];
-        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(0);
-        let __v_11: G = G::from_u64(0);
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_152] = [__v_13];
-        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_153: usize = 2;
-const IN_153: usize = 2;
-const OUT_153: usize = 3;
-fn aiur_fn_153(
-  inp: [G; IN_153],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_153], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_153] = [__v_3, __v_0, __v_4];
-        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_152] = [__v_3, __v_0, __v_4];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -12902,12 +12861,12 @@ fn aiur_fn_153(
         let __v_37: G = G::from_u64(1);
         let __v_38: G = G::from_u64(1);
         let __v_39: G = { let __values: [G; 3] = [__v_37, __v_38, __v_38]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
         let __v_40: G = __r_arr[0];
         let __v_41: G = G::from_u64(1);
         let __v_42: G = G::from_u64(1);
         let __v_43: G = { let __values: [G; 3] = [__v_41, __v_42, __v_42]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
         let __v_44: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_44.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_45: G = __loaded[0];
@@ -12915,8 +12874,8 @@ fn aiur_fn_153(
         let __v_47: G = __loaded[2];
         match __v_45.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_153] = [__v_46, __v_40, __v_47];
-            record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_152] = [__v_46, __v_40, __v_47];
+            record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -12928,6 +12887,56 @@ fn aiur_fn_153(
         return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
+  })
+}
+
+const INPUT_SIZE_153: usize = 2;
+const IN_153: usize = 2;
+const OUT_153: usize = 10;
+fn aiur_fn_153(
+  inp: [G; IN_153],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_153], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __v_3: G = __r_arr[1];
+    let __v_4: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __v_6: G = __r_arr[1];
+    let __v_7: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __v_9: G = __r_arr[1];
+    let __v_10: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __v_12: G = __r_arr[1];
+    let __v_13: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __v_16: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_17: G = __r_arr[0];
+    let __v_18: G = __r_arr[1];
+    let __v_19: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __v_21: G = __r_arr[1];
+    let __v_22: G = __r_arr[2];
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __v_24: G = __r_arr[1];
+    let __v_25: G = __r_arr[2];
+    let __ret: [G; OUT_153] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
+    record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
@@ -12947,43 +12956,44 @@ fn aiur_fn_154(
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __v_6: G = __r_arr[1];
-    let __v_7: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_8: G = __r_arr[0];
-    let __v_9: G = __r_arr[1];
-    let __v_10: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __v_12: G = __r_arr[1];
-    let __v_13: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __v_15: G = __r_arr[1];
-    let __v_16: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_17: G = __r_arr[0];
-    let __v_18: G = __r_arr[1];
-    let __v_19: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __v_21: G = __r_arr[1];
-    let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __v_24: G = __r_arr[1];
-    let __v_25: G = __r_arr[2];
-    let __ret: [G; OUT_154] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
-    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_5: G = __r_arr[3];
+    let __v_6: G = __r_arr[4];
+    let __v_7: G = __r_arr[5];
+    let __v_8: G = __r_arr[6];
+    let __v_9: G = __r_arr[7];
+    let __v_10: G = __r_arr[8];
+    let __v_11: G = __r_arr[9];
+    let __r_arr: [G; OUT_11] = { let __args: [G; IN_11] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[11].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_11] = unsafe { *(result.output.as_ptr() as *const [G; OUT_11]) }; __ret } else { aiur_fn_11(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    match __v_12.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_154] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = __r_arr[1];
+        let __v_15: G = __r_arr[2];
+        let __v_16: G = __r_arr[3];
+        let __v_17: G = __r_arr[4];
+        let __v_18: G = __r_arr[5];
+        let __v_19: G = __r_arr[6];
+        let __v_20: G = __r_arr[7];
+        let __v_21: G = __r_arr[8];
+        let __v_22: G = __r_arr[9];
+        let __ret: [G; OUT_154] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
+        record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
 const INPUT_SIZE_155: usize = 2;
 const IN_155: usize = 2;
-const OUT_155: usize = 10;
+const OUT_155: usize = 18;
 fn aiur_fn_155(
   inp: [G; IN_155],
   record: &mut QueryRecord,
@@ -13004,58 +13014,7 @@ fn aiur_fn_155(
     let __v_9: G = __r_arr[7];
     let __v_10: G = __r_arr[8];
     let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_11] = { let __args: [G; IN_11] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[11].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_11] = unsafe { *(result.output.as_ptr() as *const [G; OUT_11]) }; __ret } else { aiur_fn_11(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    match __v_12.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = __r_arr[1];
-        let __v_15: G = __r_arr[2];
-        let __v_16: G = __r_arr[3];
-        let __v_17: G = __r_arr[4];
-        let __v_18: G = __r_arr[5];
-        let __v_19: G = __r_arr[6];
-        let __v_20: G = __r_arr[7];
-        let __v_21: G = __r_arr[8];
-        let __v_22: G = __r_arr[9];
-        let __ret: [G; OUT_155] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
-        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_156: usize = 2;
-const IN_156: usize = 2;
-const OUT_156: usize = 18;
-fn aiur_fn_156(
-  inp: [G; IN_156],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_156], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __v_3: G = __r_arr[1];
-    let __v_4: G = __r_arr[2];
-    let __v_5: G = __r_arr[3];
-    let __v_6: G = __r_arr[4];
-    let __v_7: G = __r_arr[5];
-    let __v_8: G = __r_arr[6];
-    let __v_9: G = __r_arr[7];
-    let __v_10: G = __r_arr[8];
-    let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = __r_arr[1];
     let __v_14: G = __r_arr[2];
@@ -13066,21 +13025,21 @@ fn aiur_fn_156(
     let __v_19: G = __r_arr[7];
     let __v_20: G = __r_arr[8];
     let __v_21: G = __r_arr[9];
-    let __ret: [G; OUT_156] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
-    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
+    record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_157: usize = 8;
-const IN_157: usize = 8;
-const OUT_157: usize = 1;
-fn aiur_fn_157(
-  inp: [G; IN_157],
+const INPUT_SIZE_156: usize = 8;
+const IN_156: usize = 8;
+const OUT_156: usize = 1;
+fn aiur_fn_156(
+  inp: [G; IN_156],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_157], ExecError> {
+) -> Result<[G; OUT_156], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13165,37 +13124,37 @@ fn aiur_fn_157(
     let __v_72: G = G::from_u64(1);
     let __v_73: G = G::from_u64(1);
     let __v_74: G = { let __values: [G; 3] = [__v_72, __v_73, __v_73]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_76: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_77: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_78: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_80: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_82: G = __r_arr[0];
-    let __ret: [G; OUT_157] = [__v_82];
-    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_156] = [__v_82];
+    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_158: usize = 2;
-const IN_158: usize = 2;
-const OUT_158: usize = 1;
-fn aiur_fn_158(
-  inp: [G; IN_158],
+const INPUT_SIZE_157: usize = 2;
+const IN_157: usize = 2;
+const OUT_157: usize = 1;
+fn aiur_fn_157(
+  inp: [G; IN_157],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_158], ExecError> {
+) -> Result<[G; OUT_157], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13204,8 +13163,8 @@ fn aiur_fn_158(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_158] = [__v_4];
-        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_157] = [__v_4];
+        record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13218,11 +13177,11 @@ fn aiur_fn_158(
             let __v_5: G = G::from_u64(0);
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_1 - __v_6);
-            let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_158] = [__v_9];
-            record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_157] = [__v_9];
+            record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -13234,20 +13193,20 @@ fn aiur_fn_158(
   })
 }
 
-const INPUT_SIZE_159: usize = 3;
-const IN_159: usize = 3;
-const OUT_159: usize = 3;
-fn aiur_fn_159(
-  inp: [G; IN_159],
+const INPUT_SIZE_158: usize = 3;
+const IN_158: usize = 3;
+const OUT_158: usize = 3;
+fn aiur_fn_158(
+  inp: [G; IN_158],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_159], ExecError> {
+) -> Result<[G; OUT_158], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __v_5: G = __r_arr[2];
@@ -13258,25 +13217,25 @@ fn aiur_fn_159(
     let __v_10: G = __r_arr[7];
     let __v_11: G = __r_arr[8];
     let __v_12: G = __r_arr[9];
-    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __ret: [G; OUT_159] = [__v_14, __v_11, __v_12];
-    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_158] = [__v_14, __v_11, __v_12];
+    record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_160: usize = 9;
-const IN_160: usize = 9;
-const OUT_160: usize = 1;
-fn aiur_fn_160(
-  inp: [G; IN_160],
+const INPUT_SIZE_159: usize = 9;
+const IN_159: usize = 9;
+const OUT_159: usize = 1;
+fn aiur_fn_159(
+  inp: [G; IN_159],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_160], ExecError> {
+) -> Result<[G; OUT_159], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13290,11 +13249,36 @@ fn aiur_fn_160(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __ret: [G; OUT_160] = [__v_13];
+    let __ret: [G; OUT_159] = [__v_13];
+    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_160: usize = 2;
+const IN_160: usize = 2;
+const OUT_160: usize = 1;
+fn aiur_fn_160(
+  inp: [G; IN_160],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_160], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_u64(1);
+    let __v_3: G = G::from_u64(1);
+    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __v_6: G = __r_arr[0];
+    let __ret: [G; OUT_160] = [__v_6];
     record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
@@ -13312,16 +13296,36 @@ fn aiur_fn_161(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = G::from_u64(1);
-    let __v_3: G = G::from_u64(1);
-    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-    let __v_6: G = __r_arr[0];
-    let __ret: [G; OUT_161] = [__v_6];
-    record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    let __v_9: G = __loaded[7];
+    let __v_10: G = __loaded[8];
+    let __v_11: G = __loaded[9];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_161] = [__v_1];
+        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __ret: [G; OUT_161] = [__v_13];
+        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
   })
 }
 
@@ -13337,17 +13341,10 @@ fn aiur_fn_162(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    let __v_9: G = __loaded[7];
-    let __v_10: G = __loaded[8];
-    let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __ret: [G; OUT_162] = [__v_1];
@@ -13355,11 +13352,22 @@ fn aiur_fn_162(
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        let __v_7: G = __r_arr[2];
+        let __v_8: G = __r_arr[3];
+        let __v_9: G = __r_arr[4];
+        let __v_10: G = __r_arr[5];
+        let __v_11: G = __r_arr[6];
+        let __v_12: G = __r_arr[7];
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_162] = [__v_13];
+        let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+        let __v_14: G = __r_arr[0];
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __ret: [G; OUT_162] = [__v_15];
         record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -13382,56 +13390,7 @@ fn aiur_fn_163(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_163] = [__v_1];
-        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        let __v_7: G = __r_arr[2];
-        let __v_8: G = __r_arr[3];
-        let __v_9: G = __r_arr[4];
-        let __v_10: G = __r_arr[5];
-        let __v_11: G = __r_arr[6];
-        let __v_12: G = __r_arr[7];
-        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __ret: [G; OUT_163] = [__v_15];
-        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_164: usize = 2;
-const IN_164: usize = 2;
-const OUT_164: usize = 1;
-fn aiur_fn_164(
-  inp: [G; IN_164],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_164], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13440,25 +13399,25 @@ fn aiur_fn_164(
     let __v_7: G = __r_arr[5];
     let __v_8: G = __r_arr[6];
     let __v_9: G = __r_arr[7];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
-    let __ret: [G; OUT_164] = [__v_11];
-    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_163] = [__v_11];
+    record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_165: usize = 1;
-const IN_165: usize = 1;
-const OUT_165: usize = 1;
-fn aiur_fn_165(
-  inp: [G; IN_165],
+const INPUT_SIZE_164: usize = 1;
+const IN_164: usize = 1;
+const OUT_164: usize = 1;
+fn aiur_fn_164(
+  inp: [G; IN_164],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_165], ExecError> {
+) -> Result<[G; OUT_164], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(0);
@@ -13503,21 +13462,21 @@ fn aiur_fn_165(
     let __v_40: G = { let __values: [G; 3] = [__v_5, __v_6, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_41: G = { let __values: [G; 3] = [__v_3, __v_4, __v_40]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_42: G = { let __values: [G; 3] = [__v_1, __v_2, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_165] = [__v_42];
-    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_164] = [__v_42];
+    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_166: usize = 2;
-const IN_166: usize = 2;
-const OUT_166: usize = 1;
-fn aiur_fn_166(
-  inp: [G; IN_166],
+const INPUT_SIZE_165: usize = 2;
+const IN_165: usize = 2;
+const OUT_165: usize = 1;
+fn aiur_fn_165(
+  inp: [G; IN_165],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_166], ExecError> {
+) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13526,13 +13485,13 @@ fn aiur_fn_166(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 34] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_166] = [__v_4];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_165] = [__v_4];
+        record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __ret: [G; OUT_166] = [__v_1];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_165] = [__v_1];
+        record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13542,15 +13501,15 @@ fn aiur_fn_166(
   })
 }
 
-const INPUT_SIZE_167: usize = 9;
-const IN_167: usize = 9;
-const OUT_167: usize = 9;
-fn aiur_fn_167(
-  inp: [G; IN_167],
+const INPUT_SIZE_166: usize = 9;
+const IN_166: usize = 9;
+const OUT_166: usize = 9;
+fn aiur_fn_166(
+  inp: [G; IN_166],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_167], ExecError> {
+) -> Result<[G; OUT_166], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13564,24 +13523,24 @@ fn aiur_fn_167(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
-    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
-    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
     let __v_19: G = G::from_u64(1);
     let __v_20: G = G::from_u64(1);
     let __v_21: G = { let __values: [G; 3] = [__v_19, __v_20, __v_20]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
     let __v_24: G = __r_arr[2];
@@ -13600,14 +13559,14 @@ fn aiur_fn_167(
     let __v_37: G = __r_arr[15];
     let __v_38: G = __r_arr[16];
     let __v_39: G = __r_arr[17];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = G::from_u64(1);
     let __v_43: G = G::from_u64(1);
     let __v_44: G = { let __values: [G; 3] = [__v_42, __v_43, __v_43]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
     let __v_46: G = __r_arr[1];
     let __v_47: G = __r_arr[2];
@@ -13626,23 +13585,23 @@ fn aiur_fn_167(
     let __v_60: G = __r_arr[15];
     let __v_61: G = __r_arr[16];
     let __v_62: G = __r_arr[17];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_63: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_64: G = __r_arr[0];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_65: G = __r_arr[0];
     let __v_66: G = G::from_u64(1);
     let __v_67: G = G::from_u64(1);
     let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_70: G = __r_arr[0];
     let __v_71: G = G::from_u64(1);
     let __v_72: G = G::from_u64(1);
     let __v_73: G = { let __values: [G; 3] = [__v_71, __v_72, __v_72]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_74: G = __r_arr[0];
     let __v_75: G = __r_arr[1];
     let __v_76: G = __r_arr[2];
@@ -13661,12 +13620,12 @@ fn aiur_fn_167(
     let __v_89: G = __r_arr[15];
     let __v_90: G = __r_arr[16];
     let __v_91: G = __r_arr[17];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_92: G = __r_arr[0];
     let __v_93: G = G::from_u64(1);
     let __v_94: G = G::from_u64(1);
     let __v_95: G = { let __values: [G; 3] = [__v_93, __v_94, __v_94]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -13701,29 +13660,29 @@ fn aiur_fn_167(
     let __v_120: G = __r_arr[0];
     let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
     let __v_121: G = __r_arr[0];
-    let __ret: [G; OUT_167] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
-    record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_166] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
+    record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_168: usize = 3;
-const IN_168: usize = 3;
-const OUT_168: usize = 2;
-fn aiur_fn_168(
-  inp: [G; IN_168],
+const INPUT_SIZE_167: usize = 3;
+const IN_167: usize = 3;
+const OUT_167: usize = 2;
+fn aiur_fn_167(
+  inp: [G; IN_167],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_168], ExecError> {
+) -> Result<[G; OUT_167], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_168] = [__v_0, __v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_167] = [__v_0, __v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13732,10 +13691,224 @@ fn aiur_fn_168(
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(1);
         let __v_6: G = (__v_2 - __v_5);
-        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
         let __v_8: G = __r_arr[1];
-        let __ret: [G; OUT_168] = [__v_7, __v_8];
+        let __ret: [G; OUT_167] = [__v_7, __v_8];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_168: usize = 1;
+const IN_168: usize = 1;
+const OUT_168: usize = 1;
+fn aiur_fn_168(
+  inp: [G; IN_168],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_168], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(18446744069414584320);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(281474976710656);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(18446744069397807105);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(17293822564807737345);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(70368744161280);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(549755813888);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(17870292113338400769);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(13797081185216407910);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(1803076106186727246);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(11353340290879379826);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(455906449640507599);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(17492915097719143606);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(1532612707718625687);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16207902636198568418);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(17776499369601055404);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(6115771955107415310);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(12380578893860276750);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      18u64 => {
+        let __v_1: G = G::from_u64(9306717745644682924);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      19u64 => {
+        let __v_1: G = G::from_u64(18146160046829613826);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      20u64 => {
+        let __v_1: G = G::from_u64(3511170319078647661);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      21u64 => {
+        let __v_1: G = G::from_u64(17654865857378133588);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      22u64 => {
+        let __v_1: G = G::from_u64(5416168637041100469);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      23u64 => {
+        let __v_1: G = G::from_u64(16905767614792059275);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      24u64 => {
+        let __v_1: G = G::from_u64(9713644485405565297);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      25u64 => {
+        let __v_1: G = G::from_u64(5456943929260765144);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      26u64 => {
+        let __v_1: G = G::from_u64(17096174751763063430);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      27u64 => {
+        let __v_1: G = G::from_u64(1213594585890690845);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      28u64 => {
+        let __v_1: G = G::from_u64(6414415596519834757);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      29u64 => {
+        let __v_1: G = G::from_u64(16116352524544190054);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      30u64 => {
+        let __v_1: G = G::from_u64(9123114210336311365);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      31u64 => {
+        let __v_1: G = G::from_u64(4614640910117430873);
+        let __ret: [G; OUT_168] = [__v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(1753635133440165772);
+        let __ret: [G; OUT_168] = [__v_1];
         record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -13743,9 +13916,9 @@ fn aiur_fn_168(
   })
 }
 
-const INPUT_SIZE_169: usize = 1;
-const IN_169: usize = 1;
-const OUT_169: usize = 1;
+const INPUT_SIZE_169: usize = 3;
+const IN_169: usize = 3;
+const OUT_169: usize = 2;
 fn aiur_fn_169(
   inp: [G; IN_169],
   record: &mut QueryRecord,
@@ -13754,212 +13927,25 @@ fn aiur_fn_169(
 ) -> Result<[G; OUT_169], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(18446744069414584320);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(281474976710656);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(18446744069397807105);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(17293822564807737345);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(70368744161280);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(549755813888);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(17870292113338400769);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(13797081185216407910);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(1803076106186727246);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(11353340290879379826);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(455906449640507599);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(17492915097719143606);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(1532612707718625687);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16207902636198568418);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(17776499369601055404);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(6115771955107415310);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(12380578893860276750);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      18u64 => {
-        let __v_1: G = G::from_u64(9306717745644682924);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      19u64 => {
-        let __v_1: G = G::from_u64(18146160046829613826);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      20u64 => {
-        let __v_1: G = G::from_u64(3511170319078647661);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      21u64 => {
-        let __v_1: G = G::from_u64(17654865857378133588);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      22u64 => {
-        let __v_1: G = G::from_u64(5416168637041100469);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      23u64 => {
-        let __v_1: G = G::from_u64(16905767614792059275);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      24u64 => {
-        let __v_1: G = G::from_u64(9713644485405565297);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      25u64 => {
-        let __v_1: G = G::from_u64(5456943929260765144);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      26u64 => {
-        let __v_1: G = G::from_u64(17096174751763063430);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      27u64 => {
-        let __v_1: G = G::from_u64(1213594585890690845);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      28u64 => {
-        let __v_1: G = G::from_u64(6414415596519834757);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      29u64 => {
-        let __v_1: G = G::from_u64(16116352524544190054);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      30u64 => {
-        let __v_1: G = G::from_u64(9123114210336311365);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      31u64 => {
-        let __v_1: G = G::from_u64(4614640910117430873);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(1753635133440165772);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __v_8: G = __r_arr[1];
+    let __ret: [G; OUT_169] = [__v_7, __v_8];
+    record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
 const INPUT_SIZE_170: usize = 3;
 const IN_170: usize = 3;
-const OUT_170: usize = 2;
+const OUT_170: usize = 8;
 fn aiur_fn_170(
   inp: [G; IN_170],
   record: &mut QueryRecord,
@@ -13970,37 +13956,10 @@ fn aiur_fn_170(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __ret: [G; OUT_170] = [__v_7, __v_8];
-    record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_171: usize = 3;
-const IN_171: usize = 3;
-const OUT_171: usize = 8;
-fn aiur_fn_171(
-  inp: [G; IN_171],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_171], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __r_arr: [G; OUT_16] = { let __args: [G; IN_16] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[16].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_16] = unsafe { *(result.output.as_ptr() as *const [G; OUT_16]) }; __ret } else { aiur_fn_16(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
@@ -14026,21 +13985,21 @@ fn aiur_fn_171(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_21: G = __r_arr[0];
     let __v_22: G = __r_arr[1];
-    let __ret: [G; OUT_171] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
-    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_170] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
+    record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_172: usize = 23;
-const IN_172: usize = 23;
-const OUT_172: usize = 1;
-fn aiur_fn_172(
-  inp: [G; IN_172],
+const INPUT_SIZE_171: usize = 23;
+const IN_171: usize = 23;
+const OUT_171: usize = 1;
+fn aiur_fn_171(
+  inp: [G; IN_171],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_172], ExecError> {
+) -> Result<[G; OUT_171], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14067,52 +14026,52 @@ fn aiur_fn_172(
     let __v_22: G = inp[22];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = G::from_bool((__v_23 == G::ZERO));
         let __v_25: G = G::from_u64(0);
         if (__v_24 != __v_25) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         if (__v_26 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         if (__v_28 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = G::from_u64(1);
         if (__v_29 != __v_30) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
         }
         let __v_31: G = G::from_u64(1);
-        let __ret: [G; OUT_172] = [__v_31];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_171] = [__v_31];
+        record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_173: usize = 6;
-const IN_173: usize = 6;
-const OUT_173: usize = 2;
-fn aiur_fn_173(
-  inp: [G; IN_173],
+const INPUT_SIZE_172: usize = 6;
+const IN_172: usize = 6;
+const OUT_172: usize = 2;
+fn aiur_fn_172(
+  inp: [G; IN_172],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_173], ExecError> {
+) -> Result<[G; OUT_172], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14126,21 +14085,21 @@ fn aiur_fn_173(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_173] = [__v_8, __v_9];
-    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_172] = [__v_8, __v_9];
+    record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_174: usize = 4;
-const IN_174: usize = 4;
-const OUT_174: usize = 2;
-fn aiur_fn_174(
-  inp: [G; IN_174],
+const INPUT_SIZE_173: usize = 4;
+const IN_173: usize = 4;
+const OUT_173: usize = 2;
+fn aiur_fn_173(
+  inp: [G; IN_173],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_174], ExecError> {
+) -> Result<[G; OUT_173], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14154,21 +14113,21 @@ fn aiur_fn_174(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_174] = [__v_8, __v_9];
-    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_173] = [__v_8, __v_9];
+    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_175: usize = 1;
-const IN_175: usize = 1;
-const OUT_175: usize = 1;
-fn aiur_fn_175(
-  inp: [G; IN_175],
+const INPUT_SIZE_174: usize = 1;
+const IN_174: usize = 1;
+const OUT_174: usize = 1;
+fn aiur_fn_174(
+  inp: [G; IN_174],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_175], ExecError> {
+) -> Result<[G; OUT_174], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14181,8 +14140,8 @@ fn aiur_fn_175(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_175] = [__v_7];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_174] = [__v_7];
+        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14194,14 +14153,14 @@ fn aiur_fn_175(
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_9: G = G::from_u64(0);
-            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_10: G = __r_arr[0];
             let __v_11: G = __r_arr[1];
-            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_175] = [__v_13];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_174] = [__v_13];
+            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14216,15 +14175,15 @@ fn aiur_fn_175(
   })
 }
 
-const INPUT_SIZE_176: usize = 15;
-const IN_176: usize = 15;
-const OUT_176: usize = 2;
-fn aiur_fn_176(
-  inp: [G; IN_176],
+const INPUT_SIZE_175: usize = 15;
+const IN_175: usize = 15;
+const OUT_175: usize = 2;
+fn aiur_fn_175(
+  inp: [G; IN_175],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_176], ExecError> {
+) -> Result<[G; OUT_175], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14241,7 +14200,7 @@ fn aiur_fn_176(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __v_16: G = __r_arr[1];
     let __v_17: G = __r_arr[2];
@@ -14249,8 +14208,8 @@ fn aiur_fn_176(
     match __v_15.as_canonical_u64() {
       0u64 => {
         let __v_19: G = G::from_u64(0);
-        let __ret: [G; OUT_176] = [__v_16, __v_19];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_16, __v_19];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -14258,129 +14217,129 @@ fn aiur_fn_176(
         let __v_20: G = (__v_16 + __v_19);
         match __v_20.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_21, __v_22];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_21, __v_22];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_21, __v_22];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_21, __v_22];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           2u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_21, __v_22];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_21, __v_22];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           3u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_21, __v_22];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_21, __v_22];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           4u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_21, __v_22];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_21, __v_22];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_21, __v_22];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_21, __v_22];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
       2u64 => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_19, __v_20];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_19, __v_20];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
-        let __ret: [G; OUT_176] = [__v_9, __v_10];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_9, __v_10];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
-        let __ret: [G; OUT_176] = [__v_11, __v_12];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_11, __v_12];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
-        let __ret: [G; OUT_176] = [__v_13, __v_14];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_13, __v_14];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_23, __v_24];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_23, __v_24];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_23, __v_24];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_23, __v_24];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_23, __v_24];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_23, __v_24];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
         let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_21, __v_22];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_21, __v_22];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14390,15 +14349,15 @@ fn aiur_fn_176(
   })
 }
 
-const INPUT_SIZE_177: usize = 19;
-const IN_177: usize = 19;
-const OUT_177: usize = 2;
-fn aiur_fn_177(
-  inp: [G; IN_177],
+const INPUT_SIZE_176: usize = 19;
+const IN_176: usize = 19;
+const OUT_176: usize = 2;
+fn aiur_fn_176(
+  inp: [G; IN_176],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_177], ExecError> {
+) -> Result<[G; OUT_176], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14425,22 +14384,22 @@ fn aiur_fn_177(
     let __v_21: G = __loaded[2];
     match __v_19.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_177] = [__v_0, __v_1];
-        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_0, __v_1];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
-        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __v_25: G = __r_arr[1];
-        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
-        let __ret: [G; OUT_177] = [__v_26, __v_27];
-        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_26, __v_27];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14450,15 +14409,15 @@ fn aiur_fn_177(
   })
 }
 
-const INPUT_SIZE_178: usize = 8;
-const IN_178: usize = 8;
-const OUT_178: usize = 4;
-fn aiur_fn_178(
-  inp: [G; IN_178],
+const INPUT_SIZE_177: usize = 8;
+const IN_177: usize = 8;
+const OUT_177: usize = 4;
+fn aiur_fn_177(
+  inp: [G; IN_177],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_178], ExecError> {
+) -> Result<[G; OUT_177], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14491,21 +14450,21 @@ fn aiur_fn_178(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
-    let __ret: [G; OUT_178] = [__v_16, __v_17, __v_22, __v_23];
-    record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_177] = [__v_16, __v_17, __v_22, __v_23];
+    record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_179: usize = 19;
-const IN_179: usize = 19;
-const OUT_179: usize = 4;
-fn aiur_fn_179(
-  inp: [G; IN_179],
+const INPUT_SIZE_178: usize = 19;
+const IN_178: usize = 19;
+const OUT_178: usize = 4;
+fn aiur_fn_178(
+  inp: [G; IN_178],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_179], ExecError> {
+) -> Result<[G; OUT_178], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14536,29 +14495,29 @@ fn aiur_fn_179(
         let __v_23: G = G::from_u64(0);
         let __v_24: G = G::from_u64(0);
         let __v_25: G = G::from_u64(0);
-        let __ret: [G; OUT_179] = [__v_22, __v_23, __v_24, __v_25];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_178] = [__v_22, __v_23, __v_24, __v_25];
+        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
         let __v_24: G = __r_arr[2];
         let __v_25: G = __r_arr[3];
-        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
         let __v_28: G = __r_arr[2];
         let __v_29: G = __r_arr[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
         let __v_30: G = __r_arr[0];
         let __v_31: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_26, __v_27, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
         let __v_33: G = __r_arr[1];
-        let __ret: [G; OUT_179] = [__v_32, __v_33, __v_28, __v_29];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_178] = [__v_32, __v_33, __v_28, __v_29];
+        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14568,15 +14527,15 @@ fn aiur_fn_179(
   })
 }
 
-const INPUT_SIZE_180: usize = 32;
-const IN_180: usize = 32;
-const OUT_180: usize = 6;
-fn aiur_fn_180(
-  inp: [G; IN_180],
+const INPUT_SIZE_179: usize = 32;
+const IN_179: usize = 32;
+const OUT_179: usize = 6;
+fn aiur_fn_179(
+  inp: [G; IN_179],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_180], ExecError> {
+) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14617,8 +14576,8 @@ fn aiur_fn_180(
     let __v_35: G = __loaded[3];
     match __v_32.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_180] = [__v_0, __v_1, __v_6, __v_7, __v_8, __v_9];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_0, __v_1, __v_6, __v_7, __v_8, __v_9];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14627,16 +14586,16 @@ fn aiur_fn_180(
             let __v_36: G = G::from_u64(2);
             let __v_37: G = (__v_5 + __v_5);
             let __v_38: G = (__v_36 + __v_37);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_23, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_39: G = __r_arr[0];
             let __v_40: G = __r_arr[1];
             let __v_41: G = G::from_u64(3);
             let __v_42: G = (__v_5 + __v_5);
             let __v_43: G = (__v_41 + __v_42);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_23, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_44: G = __r_arr[0];
             let __v_45: G = __r_arr[1];
-            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_34, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_34, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
             let __v_46: G = __r_arr[0];
             let __v_47: G = __r_arr[1];
             let __v_48: G = __r_arr[2];
@@ -14647,7 +14606,7 @@ fn aiur_fn_180(
             let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_48, __v_49, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
             let __v_52: G = __r_arr[0];
             let __v_53: G = __r_arr[1];
-            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_50, __v_51, __v_52, __v_53, __v_39, __v_40, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_50, __v_51, __v_52, __v_53, __v_39, __v_40, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
             let __v_54: G = __r_arr[0];
             let __v_55: G = __r_arr[1];
             let __v_56: G = __r_arr[2];
@@ -14657,13 +14616,13 @@ fn aiur_fn_180(
             let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_54, __v_55, __v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
             let __v_60: G = __r_arr[0];
             let __v_61: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_60, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_0, __v_1, __v_2, __v_3, __v_60, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
             let __v_62: G = __r_arr[0];
             let __v_63: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_62, __v_63, __v_2, __v_3, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_62, __v_63, __v_2, __v_3, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
             let __v_64: G = __r_arr[0];
             let __v_65: G = __r_arr[1];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_18, __v_33, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_18, __v_33, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_66: G = __r_arr[0];
             let __v_67: G = __r_arr[1];
             let __v_68: G = G::from_u64(1);
@@ -14680,15 +14639,15 @@ fn aiur_fn_180(
             let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_8, __v_9, __v_74, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
             let __v_76: G = __r_arr[0];
             let __v_77: G = __r_arr[1];
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_64, __v_65, __v_2, __v_3, __v_35, __v_69, __v_72, __v_73, __v_76, __v_77, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_64, __v_65, __v_2, __v_3, __v_35, __v_69, __v_72, __v_73, __v_76, __v_77, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
             let __v_78: G = __r_arr[0];
             let __v_79: G = __r_arr[1];
             let __v_80: G = __r_arr[2];
             let __v_81: G = __r_arr[3];
             let __v_82: G = __r_arr[4];
             let __v_83: G = __r_arr[5];
-            let __ret: [G; OUT_180] = [__v_78, __v_79, __v_80, __v_81, __v_82, __v_83];
-            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_179] = [__v_78, __v_79, __v_80, __v_81, __v_82, __v_83];
+            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -14700,15 +14659,15 @@ fn aiur_fn_180(
   })
 }
 
-const INPUT_SIZE_181: usize = 18;
-const IN_181: usize = 18;
-const OUT_181: usize = 2;
-fn aiur_fn_181(
-  inp: [G; IN_181],
+const INPUT_SIZE_180: usize = 18;
+const IN_180: usize = 18;
+const OUT_180: usize = 2;
+fn aiur_fn_180(
+  inp: [G; IN_180],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
+) -> Result<[G; OUT_180], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14730,59 +14689,59 @@ fn aiur_fn_181(
     let __v_17: G = inp[17];
     let __v_18: G = G::from_u64(0);
     let __v_19: G = G::from_u64(0);
-    let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_18, __v_19, __v_16, __v_17, __v_1, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_18, __v_19, __v_16, __v_17, __v_1, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = G::from_u64(0);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = G::from_u64(1);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_26: G = __r_arr[0];
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(2);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_29: G = __r_arr[0];
     let __v_30: G = __r_arr[1];
     let __v_31: G = G::from_u64(3);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_32: G = __r_arr[0];
     let __v_33: G = __r_arr[1];
     let __v_34: G = G::from_u64(4);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
     let __v_36: G = __r_arr[1];
     let __v_37: G = G::from_u64(5);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_38: G = __r_arr[0];
     let __v_39: G = __r_arr[1];
     let __v_40: G = G::from_u64(6);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = __r_arr[1];
     let __v_43: G = G::from_u64(7);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_44: G = __r_arr[0];
     let __v_45: G = __r_arr[1];
     let __v_46: G = G::from_u64(0);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_47: G = __r_arr[0];
     let __v_48: G = __r_arr[1];
     let __v_49: G = G::from_u64(1);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
     let __v_51: G = __r_arr[1];
     let __v_52: G = G::from_u64(0);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_53: G = __r_arr[0];
     let __v_54: G = __r_arr[1];
     let __v_55: G = G::from_u64(1);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
     let __v_56: G = __r_arr[0];
     let __v_57: G = __r_arr[1];
     let __v_58: G = G::from_u64(0);
-    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_20, __v_21, __v_16, __v_17, __v_2, __v_58, __v_47, __v_48, __v_50, __v_51, __v_23, __v_24, __v_26, __v_27, __v_29, __v_30, __v_32, __v_33, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_20, __v_21, __v_16, __v_17, __v_2, __v_58, __v_47, __v_48, __v_50, __v_51, __v_23, __v_24, __v_26, __v_27, __v_29, __v_30, __v_32, __v_33, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
     let __v_59: G = __r_arr[0];
     let __v_60: G = __r_arr[1];
     let __v_61: G = __r_arr[2];
@@ -14795,7 +14754,7 @@ fn aiur_fn_181(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_67: G = __r_arr[0];
     let __v_68: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_59, __v_60, __v_16, __v_17, __v_67, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_59, __v_60, __v_16, __v_17, __v_67, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
     let __v_70: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_50, __v_51, __v_38, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14804,7 +14763,7 @@ fn aiur_fn_181(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_71, __v_72]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_73: G = __r_arr[0];
     let __v_74: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_69, __v_70, __v_16, __v_17, __v_73, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_69, __v_70, __v_16, __v_17, __v_73, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
     let __v_76: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_53, __v_54]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14813,7 +14772,7 @@ fn aiur_fn_181(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_14, __v_15, __v_77, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
     let __v_80: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_75, __v_76, __v_16, __v_17, __v_79, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_75, __v_76, __v_16, __v_17, __v_79, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
     let __v_82: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_63, __v_64, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14822,7 +14781,7 @@ fn aiur_fn_181(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_14, __v_15, __v_83, __v_84]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_85: G = __r_arr[0];
     let __v_86: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_81, __v_82, __v_16, __v_17, __v_85, __v_86]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_81, __v_82, __v_16, __v_17, __v_85, __v_86]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_87: G = __r_arr[0];
     let __v_88: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14831,7 +14790,7 @@ fn aiur_fn_181(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_12, __v_13, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_91: G = __r_arr[0];
     let __v_92: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_87, __v_88, __v_16, __v_17, __v_91, __v_92]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_87, __v_88, __v_16, __v_17, __v_91, __v_92]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_93: G = __r_arr[0];
     let __v_94: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_63, __v_64, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14840,24 +14799,24 @@ fn aiur_fn_181(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_12, __v_13, __v_95, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_97: G = __r_arr[0];
     let __v_98: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_93, __v_94, __v_16, __v_17, __v_97, __v_98]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_93, __v_94, __v_16, __v_17, __v_97, __v_98]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_99: G = __r_arr[0];
     let __v_100: G = __r_arr[1];
-    let __ret: [G; OUT_181] = [__v_99, __v_100];
-    record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_180] = [__v_99, __v_100];
+    record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_182: usize = 8;
-const IN_182: usize = 8;
-const OUT_182: usize = 1;
-fn aiur_fn_182(
-  inp: [G; IN_182],
+const INPUT_SIZE_181: usize = 8;
+const IN_181: usize = 8;
+const OUT_181: usize = 1;
+fn aiur_fn_181(
+  inp: [G; IN_181],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
+) -> Result<[G; OUT_181], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14894,21 +14853,21 @@ fn aiur_fn_182(
     let __v_32: G = { let __values: [G; 4] = [__v_12, __v_2, __v_13, __v_31]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_33: G = { let __values: [G; 4] = [__v_10, __v_1, __v_11, __v_32]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_34: G = { let __values: [G; 4] = [__v_8, __v_0, __v_9, __v_33]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_182] = [__v_34];
-    record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_181] = [__v_34];
+    record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_183: usize = 5;
-const IN_183: usize = 5;
-const OUT_183: usize = 2;
-fn aiur_fn_183(
-  inp: [G; IN_183],
+const INPUT_SIZE_182: usize = 5;
+const IN_182: usize = 5;
+const OUT_182: usize = 2;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14924,8 +14883,8 @@ fn aiur_fn_183(
       1u64 => {
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_183] = [__v_9, __v_10];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_182] = [__v_9, __v_10];
+        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14935,14 +14894,14 @@ fn aiur_fn_183(
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
-        let __ret: [G; OUT_183] = [__v_15, __v_16];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_182] = [__v_15, __v_16];
+        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14952,145 +14911,145 @@ fn aiur_fn_183(
   })
 }
 
-const INPUT_SIZE_184: usize = 1;
-const IN_184: usize = 1;
-const OUT_184: usize = 1;
-fn aiur_fn_184(
-  inp: [G; IN_184],
+const INPUT_SIZE_183: usize = 1;
+const IN_183: usize = 1;
+const OUT_183: usize = 1;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_184], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     match __v_0.as_canonical_u64() {
       0u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       10u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       11u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       12u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       13u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       14u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       15u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       16u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       17u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_1];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_185: usize = 4;
-const IN_185: usize = 4;
-const OUT_185: usize = 2;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_184: usize = 4;
+const IN_184: usize = 4;
+const OUT_184: usize = 2;
+fn aiur_fn_184(
+  inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_184], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15104,8 +15063,8 @@ fn aiur_fn_185(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_185] = [__v_6, __v_9];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_6, __v_9];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -15117,21 +15076,21 @@ fn aiur_fn_185(
             let __v_7: G = G::from_u64(1);
             let __v_8: G = G::from_u64(1);
             let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_185] = [__v_6, __v_9];
-            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_184] = [__v_6, __v_9];
+            record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = G::from_u64(1);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_185] = [__v_6, __v_8];
-            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_184] = [__v_6, __v_8];
+            record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -15146,15 +15105,15 @@ fn aiur_fn_185(
   })
 }
 
-const INPUT_SIZE_186: usize = 20;
-const IN_186: usize = 20;
-const OUT_186: usize = 1;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_185: usize = 20;
+const IN_185: usize = 20;
+const OUT_185: usize = 1;
+fn aiur_fn_185(
+  inp: [G; IN_185],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15187,43 +15146,43 @@ fn aiur_fn_186(
     match __v_20.as_canonical_u64() {
       1u64 => {
         let __v_27: G = G::from_u64(1);
-        let __ret: [G; OUT_186] = [__v_27];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_27];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         match __v_21.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_27: G = __r_arr[0];
-            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_29: G = __r_arr[0];
             let __v_30: G = __r_arr[1];
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_31: G = __r_arr[0];
             let __v_32: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_33: G = __r_arr[0];
             let __v_34: G = G::from_u64(1);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_31, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_31, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_35: G = __r_arr[0];
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_36: G = __r_arr[0];
             let __v_37: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = G::from_u64(1);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_40: G = __r_arr[0];
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_41: G = __r_arr[0];
             let __v_42: G = __r_arr[1];
-            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_6, __v_7, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_6, __v_7, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
             let __v_43: G = __r_arr[0];
             let __v_44: G = __r_arr[1];
-            let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
             let __v_45: G = __r_arr[0];
             let __v_46: G = __r_arr[1];
             let __v_47: G = __r_arr[2];
@@ -15232,27 +15191,27 @@ fn aiur_fn_186(
             let __v_50: G = __r_arr[5];
             let __v_51: G = __r_arr[6];
             let __v_52: G = __r_arr[7];
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_29, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_29, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
             let __v_53: G = __r_arr[0];
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_21, __v_23, __v_25, __v_33, __v_35, __v_43, __v_44, __v_38, __v_40, __v_53, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_21, __v_23, __v_25, __v_33, __v_35, __v_43, __v_44, __v_38, __v_40, __v_53, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
             let __v_54: G = __r_arr[0];
             let __v_55: G = __r_arr[1];
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_56: G = __r_arr[0];
             let __v_57: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
             let __v_58: G = __r_arr[0];
-            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
             let __v_59: G = __r_arr[0];
-            let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
             let __v_60: G = __r_arr[0];
             let __v_61: G = __r_arr[1];
             let __v_62: G = G::from_u64(1);
             let __v_63: G = G::from_u64(0);
-            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_59, __v_60, __v_61, __v_62, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_59, __v_60, __v_61, __v_62, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_64: G = __r_arr[0];
             let __v_65: G = __r_arr[1];
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
             let __v_66: G = __r_arr[0];
             let __v_67: G = (__v_66 - __v_28);
             let __v_68: G = G::from_bool((__v_67 == G::ZERO));
@@ -15271,10 +15230,10 @@ fn aiur_fn_186(
             }
             let __v_74: G = G::from_u64(1);
             let __v_75: G = (__v_9 + __v_74);
-            let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_26, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_75, __v_29, __v_30, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_26, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_75, __v_29, __v_30, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
             let __v_76: G = __r_arr[0];
-            let __ret: [G; OUT_186] = [__v_76];
-            record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_76];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -15286,15 +15245,15 @@ fn aiur_fn_186(
   })
 }
 
-const INPUT_SIZE_187: usize = 3;
-const IN_187: usize = 3;
-const OUT_187: usize = 2;
-fn aiur_fn_187(
-  inp: [G; IN_187],
+const INPUT_SIZE_186: usize = 3;
+const IN_186: usize = 3;
+const OUT_186: usize = 2;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15314,15 +15273,15 @@ fn aiur_fn_187(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_187] = [__v_13, __v_14];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_186] = [__v_13, __v_14];
+        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = G::from_u64(0);
-        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -15331,8 +15290,8 @@ fn aiur_fn_187(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_187] = [__v_19, __v_20];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_186] = [__v_19, __v_20];
+        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15342,15 +15301,15 @@ fn aiur_fn_187(
   })
 }
 
-const INPUT_SIZE_188: usize = 7;
-const IN_188: usize = 7;
-const OUT_188: usize = 2;
-fn aiur_fn_188(
-  inp: [G; IN_188],
+const INPUT_SIZE_187: usize = 7;
+const IN_187: usize = 7;
+const OUT_187: usize = 2;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15365,12 +15324,12 @@ fn aiur_fn_188(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_188] = [__v_0, __v_1];
-        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_0, __v_1];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_3, __v_4, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -15382,11 +15341,11 @@ fn aiur_fn_188(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_188] = [__v_18, __v_19];
-        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_18, __v_19];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15396,15 +15355,15 @@ fn aiur_fn_188(
   })
 }
 
-const INPUT_SIZE_189: usize = 36;
-const IN_189: usize = 36;
-const OUT_189: usize = 1;
-fn aiur_fn_189(
-  inp: [G; IN_189],
+const INPUT_SIZE_188: usize = 36;
+const IN_188: usize = 36;
+const OUT_188: usize = 1;
+fn aiur_fn_188(
+  inp: [G; IN_188],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
+) -> Result<[G; OUT_188], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15448,15 +15407,15 @@ fn aiur_fn_189(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
-                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_38: G = __r_arr[0];
-                    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
                     let __v_39: G = __r_arr[0];
                     let __v_40: G = __r_arr[1];
                     let __v_41: G = __r_arr[2];
@@ -15468,21 +15427,21 @@ fn aiur_fn_189(
                     let __v_47: G = __r_arr[8];
                     let __v_48: G = G::from_u64(0);
                     let __v_49: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
                     let __v_51: G = __r_arr[1];
                     let __v_52: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
                     let __v_53: G = __r_arr[0];
-                    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
                     let __v_54: G = __r_arr[0];
                     let __v_55: G = G::from_u64(1);
                     if (__v_54 != __v_55) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
                     let __v_56: G = __r_arr[0];
-                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_57: G = __r_arr[0];
                     let __v_58: G = (__v_56 - __v_57);
                     let __v_59: G = G::from_bool((__v_58 == G::ZERO));
@@ -15490,9 +15449,9 @@ fn aiur_fn_189(
                     if (__v_59 != __v_60) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_59.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_61: G = __r_arr[0];
-                    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
                     let __v_62: G = __r_arr[0];
                     let __v_63: G = (__v_61 - __v_62);
                     let __v_64: G = G::from_bool((__v_63 == G::ZERO));
@@ -15500,12 +15459,12 @@ fn aiur_fn_189(
                     if (__v_64 != __v_65) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_66: G = __r_arr[0];
-                    let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
                     let __v_67: G = __r_arr[0];
-                    let __ret: [G; OUT_189] = [__v_67];
-                    record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_188] = [__v_67];
+                    record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -15518,15 +15477,15 @@ fn aiur_fn_189(
   })
 }
 
-const INPUT_SIZE_190: usize = 1;
-const IN_190: usize = 1;
-const OUT_190: usize = 1;
-fn aiur_fn_190(
-  inp: [G; IN_190],
+const INPUT_SIZE_189: usize = 1;
+const IN_189: usize = 1;
+const OUT_189: usize = 1;
+fn aiur_fn_189(
+  inp: [G; IN_189],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_190], ExecError> {
+) -> Result<[G; OUT_189], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15536,8 +15495,8 @@ fn aiur_fn_190(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_4];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_189] = [__v_4];
+        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15548,14 +15507,81 @@ fn aiur_fn_190(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_190] = [__v_8];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_189] = [__v_8];
+        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_190: usize = 2;
+const IN_190: usize = 2;
+const OUT_190: usize = 1;
+fn aiur_fn_190(
+  inp: [G; IN_190],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_190], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = G::from_u64(1);
+        let __v_11: G = { let __values: [G; 7] = [__v_9, __v_10, __v_10, __v_10, __v_10, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_190] = [__v_11];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_9: G = __loaded[0];
+        let __v_10: G = __loaded[1];
+        let __v_11: G = __loaded[2];
+        match __v_9.as_canonical_u64() {
+          0u64 => {
+            match __v_10.as_canonical_u64() {
+              0u64 => {
+                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+                let __v_12: G = __r_arr[0];
+                let __ret: [G; OUT_190] = [__v_12];
+                record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                return Ok(__ret);
+              },
+              _ => {
+                let __v_12: G = G::from_u64(0);
+                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+                let __v_13: G = __r_arr[0];
+                let __v_14: G = { let __values: [G; 7] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                let __ret: [G; OUT_190] = [__v_14];
+                record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                return Ok(__ret);
+              },
+            }
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -15573,73 +15599,6 @@ fn aiur_fn_191(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = G::from_u64(1);
-        let __v_11: G = { let __values: [G; 7] = [__v_9, __v_10, __v_10, __v_10, __v_10, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_11];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_9: G = __loaded[0];
-        let __v_10: G = __loaded[1];
-        let __v_11: G = __loaded[2];
-        match __v_9.as_canonical_u64() {
-          0u64 => {
-            match __v_10.as_canonical_u64() {
-              0u64 => {
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
-                let __v_12: G = __r_arr[0];
-                let __ret: [G; OUT_191] = [__v_12];
-                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                return Ok(__ret);
-              },
-              _ => {
-                let __v_12: G = G::from_u64(0);
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
-                let __v_13: G = __r_arr[0];
-                let __v_14: G = { let __values: [G; 7] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_191] = [__v_14];
-                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                return Ok(__ret);
-              },
-            }
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
-          },
-        }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_192: usize = 2;
-const IN_192: usize = 2;
-const OUT_192: usize = 1;
-fn aiur_fn_192(
-  inp: [G; IN_192],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
@@ -15650,8 +15609,8 @@ fn aiur_fn_192(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_192] = [__v_8];
-        record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_191] = [__v_8];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15663,19 +15622,19 @@ fn aiur_fn_192(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_192] = [__v_9];
-                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_191] = [__v_9];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_192] = [__v_11];
-                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_191] = [__v_11];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15692,8 +15651,31 @@ fn aiur_fn_192(
   })
 }
 
-const INPUT_SIZE_193: usize = 1;
-const IN_193: usize = 1;
+const INPUT_SIZE_192: usize = 1;
+const IN_192: usize = 1;
+const OUT_192: usize = 2;
+fn aiur_fn_192(
+  inp: [G; IN_192],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_192], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_192] = [__v_3, __v_4];
+    record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_193: usize = 2;
+const IN_193: usize = 2;
 const OUT_193: usize = 2;
 fn aiur_fn_193(
   inp: [G; IN_193],
@@ -15703,20 +15685,37 @@ fn aiur_fn_193(
 ) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_193] = [__v_3, __v_4];
-    record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_193] = [__v_4, __v_0];
+        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = (__v_1 - __v_4);
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = __r_arr[1];
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_193] = [__v_9, __v_7];
+        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_194: usize = 2;
-const IN_194: usize = 2;
+const INPUT_SIZE_194: usize = 1;
+const IN_194: usize = 1;
 const OUT_194: usize = 2;
 fn aiur_fn_194(
   inp: [G; IN_194],
@@ -15726,37 +15725,20 @@ fn aiur_fn_194(
 ) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_194] = [__v_4, __v_0];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
-        let __v_2: G = __r_arr[0];
-        let __v_3: G = __r_arr[1];
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_194] = [__v_9, __v_7];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_194] = [__v_3, __v_4];
+    record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_195: usize = 1;
-const IN_195: usize = 1;
+const INPUT_SIZE_195: usize = 2;
+const IN_195: usize = 2;
 const OUT_195: usize = 2;
 fn aiur_fn_195(
   inp: [G; IN_195],
@@ -15766,37 +15748,14 @@ fn aiur_fn_195(
 ) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_195] = [__v_3, __v_4];
-    record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_196: usize = 2;
-const IN_196: usize = 2;
-const OUT_196: usize = 2;
-fn aiur_fn_196(
-  inp: [G; IN_196],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_196] = [__v_4, __v_0];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_195] = [__v_4, __v_0];
+        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15812,28 +15771,28 @@ fn aiur_fn_196(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_196] = [__v_16, __v_14];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_195] = [__v_16, __v_14];
+        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_197: usize = 64;
-const IN_197: usize = 64;
-const OUT_197: usize = 0;
-fn aiur_fn_197(
-  inp: [G; IN_197],
+const INPUT_SIZE_196: usize = 64;
+const IN_196: usize = 64;
+const OUT_196: usize = 0;
+fn aiur_fn_196(
+  inp: [G; IN_196],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
+) -> Result<[G; OUT_196], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15934,7 +15893,7 @@ fn aiur_fn_197(
     let __io_pair: (G, G) = { let __key: [G; 1] = [__v_93]; let __info = io_buffer.get_info(__v_92, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
     let __v_94: G = __io_pair.0;
     let __v_95: G = __io_pair.1;
-    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -15956,7 +15915,7 @@ fn aiur_fn_197(
     let __v_113: G = G::from_u64(2);
     let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = __r_arr[1];
     let __v_117: G = (__v_66 + __v_67);
@@ -15964,7 +15923,7 @@ fn aiur_fn_197(
       return Err(ExecError::AssertEqMismatch { lhs: __v_91.as_canonical_u64(), rhs: __v_117.as_canonical_u64() });
     }
     let __v_118: G = G::from_u64(1);
-    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
     let __v_119: G = __r_arr[0];
     let __v_120: G = __r_arr[1];
     let __v_121: G = __r_arr[2];
@@ -15997,7 +15956,7 @@ fn aiur_fn_197(
     let __v_148: G = __r_arr[29];
     let __v_149: G = __r_arr[30];
     let __v_150: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
     let __v_151: G = __r_arr[0];
     let __v_152: G = __r_arr[1];
     let __v_153: G = __r_arr[2];
@@ -16163,7 +16122,7 @@ fn aiur_fn_197(
     let __v_213: G = __r_arr[29];
     let __v_214: G = __r_arr[30];
     let __v_215: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
     let __v_216: G = __r_arr[0];
     let __v_217: G = __r_arr[1];
     let __v_218: G = __r_arr[2];
@@ -16307,21 +16266,59 @@ fn aiur_fn_197(
     if (__v_250 != __v_252) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
     let __v_253: G = __r_arr[0];
     let __v_254: G = G::from_u64(1);
     if (__v_253 != __v_254) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
     let __v_255: G = __r_arr[0];
     let __v_256: G = G::from_u64(1);
     if (__v_255 != __v_256) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
-    let __ret: [G; OUT_197] = [];
-    record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_196] = [];
+    record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_197: usize = 1;
+const IN_197: usize = 1;
+const OUT_197: usize = 1;
+fn aiur_fn_197(
+  inp: [G; IN_197],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_197], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_4: G = G::from_u64(0);
+        let __ret: [G; OUT_197] = [__v_4];
+        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_4 + __v_5);
+        let __ret: [G; OUT_197] = [__v_6];
+        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
   })
 }
 
@@ -16342,17 +16339,14 @@ fn aiur_fn_198(
     let __v_3: G = __loaded[2];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __v_4: G = G::from_u64(0);
+        let __v_4: G = G::from_u64(1);
         let __ret: [G; OUT_198] = [__v_4];
         record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_198] = [__v_6];
+        let __v_4: G = G::from_u64(0);
+        let __ret: [G; OUT_198] = [__v_4];
         record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16363,9 +16357,9 @@ fn aiur_fn_198(
   })
 }
 
-const INPUT_SIZE_199: usize = 1;
-const IN_199: usize = 1;
-const OUT_199: usize = 1;
+const INPUT_SIZE_199: usize = 2;
+const IN_199: usize = 2;
+const OUT_199: usize = 2;
 fn aiur_fn_199(
   inp: [G; IN_199],
   record: &mut QueryRecord,
@@ -16374,43 +16368,8 @@ fn aiur_fn_199(
 ) -> Result<[G; OUT_199], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_199] = [__v_4];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_199] = [__v_4];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_200: usize = 2;
-const IN_200: usize = 2;
-const OUT_200: usize = 2;
-fn aiur_fn_200(
-  inp: [G; IN_200],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_200], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16419,8 +16378,8 @@ fn aiur_fn_200(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_200] = [__v_4, __v_5];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_199] = [__v_4, __v_5];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16430,15 +16389,15 @@ fn aiur_fn_200(
   })
 }
 
-const INPUT_SIZE_201: usize = 1;
-const IN_201: usize = 1;
-const OUT_201: usize = 8;
-fn aiur_fn_201(
-  inp: [G; IN_201],
+const INPUT_SIZE_200: usize = 1;
+const IN_200: usize = 1;
+const OUT_200: usize = 8;
+fn aiur_fn_200(
+  inp: [G; IN_200],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_201], ExecError> {
+) -> Result<[G; OUT_200], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -16462,12 +16421,12 @@ fn aiur_fn_201(
         let __v_16: G = G::from_u64(0);
         let __v_17: G = G::from_u64(0);
         let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_201] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
         let __v_13: G = __r_arr[2];
@@ -16485,8 +16444,8 @@ fn aiur_fn_201(
         let __v_24: G = __r_arr[5];
         let __v_25: G = __r_arr[6];
         let __v_26: G = __r_arr[7];
-        let __ret: [G; OUT_201] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16496,8 +16455,39 @@ fn aiur_fn_201(
   })
 }
 
-const INPUT_SIZE_202: usize = 2;
-const IN_202: usize = 2;
+const INPUT_SIZE_201: usize = 2;
+const IN_201: usize = 2;
+const OUT_201: usize = 1;
+fn aiur_fn_201(
+  inp: [G; IN_201],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_201], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_201] = [__v_4];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_202: usize = 1;
+const IN_202: usize = 1;
 const OUT_202: usize = 1;
 fn aiur_fn_202(
   inp: [G; IN_202],
@@ -16507,21 +16497,30 @@ fn aiur_fn_202(
 ) -> Result<[G; OUT_202], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    match __v_3.as_canonical_u64() {
+    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_202] = [__v_6];
+        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
       0u64 => {
-        let __ret: [G; OUT_202] = [__v_4];
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_6 + __v_7);
+        let __ret: [G; OUT_202] = [__v_8];
         record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -16538,46 +16537,6 @@ fn aiur_fn_203(
 ) -> Result<[G; OUT_203], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_203] = [__v_6];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_203] = [__v_8];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_204: usize = 1;
-const IN_204: usize = 1;
-const OUT_204: usize = 1;
-fn aiur_fn_204(
-  inp: [G; IN_204],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_204], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -16586,17 +16545,17 @@ fn aiur_fn_204(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_204] = [__v_5];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_203] = [__v_5];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = G::from_u64(1);
         let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_204] = [__v_7];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_203] = [__v_7];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16606,15 +16565,15 @@ fn aiur_fn_204(
   })
 }
 
-const INPUT_SIZE_205: usize = 2;
-const IN_205: usize = 2;
-const OUT_205: usize = 1;
-fn aiur_fn_205(
-  inp: [G; IN_205],
+const INPUT_SIZE_204: usize = 2;
+const IN_204: usize = 2;
+const OUT_204: usize = 1;
+fn aiur_fn_204(
+  inp: [G; IN_204],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_205], ExecError> {
+) -> Result<[G; OUT_204], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16631,17 +16590,17 @@ fn aiur_fn_205(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_205] = [__v_1];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_204] = [__v_1];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_205] = [__v_14];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_204] = [__v_14];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16651,15 +16610,15 @@ fn aiur_fn_205(
   })
 }
 
-const INPUT_SIZE_206: usize = 1;
-const IN_206: usize = 1;
-const OUT_206: usize = 8;
-fn aiur_fn_206(
-  inp: [G; IN_206],
+const INPUT_SIZE_205: usize = 1;
+const IN_205: usize = 1;
+const OUT_205: usize = 8;
+fn aiur_fn_205(
+  inp: [G; IN_205],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_206], ExecError> {
+) -> Result<[G; OUT_205], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16676,12 +16635,12 @@ fn aiur_fn_206(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = __r_arr[1];
         let __v_6: G = __r_arr[2];
@@ -16699,12 +16658,50 @@ fn aiur_fn_206(
         let __v_17: G = __r_arr[5];
         let __v_18: G = __r_arr[6];
         let __v_19: G = __r_arr[7];
-        let __ret: [G; OUT_206] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_206: usize = 2;
+const IN_206: usize = 2;
+const OUT_206: usize = 1;
+fn aiur_fn_206(
+  inp: [G; IN_206],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_206], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_206] = [__v_1];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_206] = [__v_7];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -16722,34 +16719,38 @@ fn aiur_fn_207(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_207] = [__v_1];
-        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
+    match __v_1.as_canonical_u64() {
       0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_207] = [__v_7];
+        let __ret: [G; OUT_207] = [__v_0];
         record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_207] = [__v_7];
+            record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_208: usize = 2;
-const IN_208: usize = 2;
+const INPUT_SIZE_208: usize = 1;
+const IN_208: usize = 1;
 const OUT_208: usize = 1;
 fn aiur_fn_208(
   inp: [G; IN_208],
@@ -16759,32 +16760,32 @@ fn aiur_fn_208(
 ) -> Result<[G; OUT_208], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    let __v_6: G = __loaded[5];
+    let __v_7: G = __loaded[6];
     match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_208] = [__v_8];
+        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
       0u64 => {
-        let __ret: [G; OUT_208] = [__v_0];
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __v_8: G = __r_arr[0];
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_8 + __v_9);
+        let __ret: [G; OUT_208] = [__v_10];
         record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_208] = [__v_7];
-            record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -16801,48 +16802,6 @@ fn aiur_fn_209(
 ) -> Result<[G; OUT_209], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    let __v_6: G = __loaded[5];
-    let __v_7: G = __loaded[6];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_209] = [__v_8];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
-        let __v_8: G = __r_arr[0];
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_209] = [__v_10];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_210: usize = 1;
-const IN_210: usize = 1;
-const OUT_210: usize = 1;
-fn aiur_fn_210(
-  inp: [G; IN_210],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_210], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -16857,17 +16816,17 @@ fn aiur_fn_210(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_210] = [__v_11];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_209] = [__v_11];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_u64(1);
         let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_210] = [__v_13];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_209] = [__v_13];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16877,19 +16836,19 @@ fn aiur_fn_210(
   })
 }
 
-const INPUT_SIZE_211: usize = 2;
-const IN_211: usize = 2;
-const OUT_211: usize = 4;
-fn aiur_fn_211(
-  inp: [G; IN_211],
+const INPUT_SIZE_210: usize = 2;
+const IN_210: usize = 2;
+const OUT_210: usize = 4;
+fn aiur_fn_210(
+  inp: [G; IN_210],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_211], ExecError> {
+) -> Result<[G; OUT_210], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16900,8 +16859,8 @@ fn aiur_fn_211(
     let __v_8: G = __loaded[5];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_211] = [__v_4, __v_5, __v_6, __v_7];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_4, __v_5, __v_6, __v_7];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16911,19 +16870,19 @@ fn aiur_fn_211(
   })
 }
 
-const INPUT_SIZE_212: usize = 2;
-const IN_212: usize = 2;
-const OUT_212: usize = 32;
-fn aiur_fn_212(
-  inp: [G; IN_212],
+const INPUT_SIZE_211: usize = 2;
+const IN_211: usize = 2;
+const OUT_211: usize = 32;
+fn aiur_fn_211(
+  inp: [G; IN_211],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_212], ExecError> {
+) -> Result<[G; OUT_211], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16962,12 +16921,55 @@ fn aiur_fn_212(
     let __v_36: G = __loaded[33];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_212] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
-        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_211] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
+        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_212: usize = 2;
+const IN_212: usize = 2;
+const OUT_212: usize = 1;
+fn aiur_fn_212(
+  inp: [G; IN_212],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_212], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_212] = [__v_0];
+        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        let __v_8: G = __loaded[3];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_212] = [__v_8];
+            record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
@@ -16996,14 +16998,16 @@ fn aiur_fn_213(
         let __v_3: G = (__v_1 - __v_2);
         let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+        let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
         let __v_6: G = __loaded[1];
         let __v_7: G = __loaded[2];
         let __v_8: G = __loaded[3];
+        let __v_9: G = __loaded[4];
+        let __v_10: G = __loaded[5];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_213] = [__v_8];
+            let __ret: [G; OUT_213] = [__v_10];
             record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
@@ -17038,51 +17042,6 @@ fn aiur_fn_214(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
         let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        let __v_8: G = __loaded[3];
-        let __v_9: G = __loaded[4];
-        let __v_10: G = __loaded[5];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_214] = [__v_10];
-            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_215: usize = 2;
-const IN_215: usize = 2;
-const OUT_215: usize = 1;
-fn aiur_fn_215(
-  inp: [G; IN_215],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_215], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_215] = [__v_0];
-        record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17121,8 +17080,8 @@ fn aiur_fn_215(
         let __v_38: G = __loaded[33];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_215] = [__v_38];
-            record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_214] = [__v_38];
+            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -18214,11 +18173,6 @@ pub(crate) fn execute_generated(
     214u64 => {
       let __inp: [G; IN_214] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_214(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    215u64 => {
-      let __inp: [G; IN_215] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_215(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4341,7 +4341,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4499,10 +4499,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -6527,9 +6527,9 @@ fn aiur_fn_81(
   })
 }
 
-const INPUT_SIZE_82: usize = 4;
-const IN_82: usize = 4;
-const OUT_82: usize = 8;
+const INPUT_SIZE_82: usize = 1;
+const IN_82: usize = 1;
+const OUT_82: usize = 5;
 fn aiur_fn_82(
   inp: [G; IN_82],
   record: &mut QueryRecord,
@@ -6538,248 +6538,112 @@ fn aiur_fn_82(
 ) -> Result<[G; OUT_82], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
     let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
-    let __v_4: G = __r_arr[0];
-    let __v_5: G = __r_arr[1];
-    match __v_4.as_canonical_u64() {
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    match __v_1.as_canonical_u64() {
       0u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      32u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(2);
-        let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      48u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(3);
-        let __v_10: G = G::from_u64(3);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      64u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(4);
-        let __v_10: G = G::from_u64(4);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      80u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(5);
-        let __v_10: G = G::from_u64(5);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      128u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      144u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      160u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_1]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(2);
-        let __v_10: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_8, __v_9, __v_10, __v_6, __v_5, __v_7, __v_2, __v_3];
+        let __r_arr: [G; OUT_79] = { let __args: [G; IN_79] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[79].get_mut(&__args[..]) { let __ret: [G; OUT_79] = unsafe { *(result.output.as_ptr() as *const [G; OUT_79]) }; __ret } else { aiur_fn_79(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_6, __v_7, __v_7, __v_7, __v_5, __v_1, __v_2, __v_3];
+        let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_6]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = __r_arr[1];
+        let __v_9: G = G::from_u64(1);
+        let __ret: [G; OUT_82] = [__v_9, __v_3, __v_5, __v_7, __v_8];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
-        let __v_6: G = G::from_u64(2);
-        let __v_7: G = G::from_u64(2);
-        let __ret: [G; OUT_82] = [__v_6, __v_7, __v_7, __v_7, __v_5, __v_1, __v_2, __v_3];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(2);
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
-        let __v_6: G = G::from_u64(3);
-        let __v_7: G = G::from_u64(3);
-        let __ret: [G; OUT_82] = [__v_6, __v_7, __v_7, __v_7, __v_5, __v_1, __v_2, __v_3];
+        let __v_3: G = G::from_u64(3);
+        let __v_4: G = G::from_u64(3);
+        let __ret: [G; OUT_82] = [__v_3, __v_4, __v_4, __v_4, __v_2];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
-        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(4);
-        let __v_9: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_8, __v_6, __v_9, __v_9, __v_5, __v_1, __v_7, __v_3];
-        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      20u64 => {
-        let __r_arr: [G; OUT_79] = { let __args: [G; IN_79] = [__v_3]; let __cu = true; if let Some(result) = record.function_queries[79].get_mut(&__args[..]) { let __ret: [G; OUT_79] = unsafe { *(result.output.as_ptr() as *const [G; OUT_79]) }; __ret } else { aiur_fn_79(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(4);
-        let __v_9: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_8, __v_6, __v_9, __v_9, __v_5, __v_1, __v_2, __v_7];
+        let __v_3: G = G::from_u64(4);
+        let __v_4: G = G::from_u64(4);
+        let __ret: [G; OUT_82] = [__v_3, __v_4, __v_4, __v_4, __v_2];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_5, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = __r_arr[2];
-        let __v_9: G = __r_arr[3];
-        let __v_10: G = __r_arr[4];
-        let __v_11: G = __r_arr[5];
-        let __v_12: G = __r_arr[6];
-        let __v_13: G = __r_arr[7];
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_10, __v_11, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __v_15: G = __r_arr[1];
-        let __v_16: G = __r_arr[2];
-        let __v_17: G = __r_arr[3];
-        let __v_18: G = __r_arr[4];
-        let __v_19: G = __r_arr[5];
-        let __v_20: G = __r_arr[6];
-        let __v_21: G = __r_arr[7];
-        let __v_22: G = G::from_u64(5);
-        let __v_23: G = { let __values: [G; 4] = [__v_6, __v_7, __v_8, __v_9]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_24: G = { let __values: [G; 4] = [__v_14, __v_15, __v_16, __v_17]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_25: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_22, __v_23, __v_24, __v_25, __v_18, __v_19, __v_20, __v_21];
+        let __v_3: G = G::from_u64(5);
+        let __v_4: G = G::from_u64(5);
+        let __ret: [G; OUT_82] = [__v_3, __v_4, __v_4, __v_4, __v_2];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_5, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = __r_arr[2];
-        let __v_9: G = __r_arr[3];
-        let __v_10: G = __r_arr[4];
-        let __v_11: G = __r_arr[5];
-        let __v_12: G = __r_arr[6];
-        let __v_13: G = __r_arr[7];
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_10, __v_11, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __v_15: G = __r_arr[1];
-        let __v_16: G = __r_arr[2];
-        let __v_17: G = __r_arr[3];
-        let __v_18: G = __r_arr[4];
-        let __v_19: G = __r_arr[5];
-        let __v_20: G = __r_arr[6];
-        let __v_21: G = __r_arr[7];
-        let __v_22: G = G::from_u64(6);
-        let __v_23: G = { let __values: [G; 4] = [__v_6, __v_7, __v_8, __v_9]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_24: G = { let __values: [G; 4] = [__v_14, __v_15, __v_16, __v_17]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_25: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_22, __v_23, __v_24, __v_25, __v_18, __v_19, __v_20, __v_21];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        let __v_7: G = G::from_u64(6);
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_7, __v_3, __v_5, __v_8, __v_6];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_5, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = __r_arr[2];
-        let __v_9: G = __r_arr[3];
-        let __v_10: G = __r_arr[4];
-        let __v_11: G = __r_arr[5];
-        let __v_12: G = __r_arr[6];
-        let __v_13: G = __r_arr[7];
-        let __v_14: G = G::from_u64(7);
-        let __v_15: G = { let __values: [G; 4] = [__v_6, __v_7, __v_8, __v_9]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_16: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_14, __v_15, __v_16, __v_16, __v_10, __v_11, __v_12, __v_13];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        let __v_7: G = G::from_u64(7);
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_7, __v_3, __v_5, __v_8, __v_6];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        let __v_7: G = G::from_u64(8);
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_7, __v_3, __v_5, __v_8, __v_6];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_5, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = __r_arr[2];
-        let __v_9: G = __r_arr[3];
-        let __v_10: G = __r_arr[4];
-        let __v_11: G = __r_arr[5];
-        let __v_12: G = __r_arr[6];
-        let __v_13: G = __r_arr[7];
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_10, __v_11, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __v_15: G = __r_arr[1];
-        let __v_16: G = __r_arr[2];
-        let __v_17: G = __r_arr[3];
-        let __v_18: G = __r_arr[4];
-        let __v_19: G = __r_arr[5];
-        let __v_20: G = __r_arr[6];
-        let __v_21: G = __r_arr[7];
-        let __v_22: G = G::from_u64(8);
-        let __v_23: G = { let __values: [G; 4] = [__v_6, __v_7, __v_8, __v_9]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_24: G = { let __values: [G; 4] = [__v_14, __v_15, __v_16, __v_17]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_25: G = G::from_u64(0);
-        let __ret: [G; OUT_82] = [__v_22, __v_23, __v_24, __v_25, __v_18, __v_19, __v_20, __v_21];
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(9);
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -6787,9 +6651,9 @@ fn aiur_fn_82(
   })
 }
 
-const INPUT_SIZE_83: usize = 5;
-const IN_83: usize = 5;
-const OUT_83: usize = 5;
+const INPUT_SIZE_83: usize = 2;
+const IN_83: usize = 2;
+const OUT_83: usize = 2;
 fn aiur_fn_83(
   inp: [G; IN_83],
   record: &mut QueryRecord,
@@ -6799,39 +6663,30 @@ fn aiur_fn_83(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_4.as_canonical_u64() {
+    match __v_1.as_canonical_u64() {
       0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 6] = [__v_5, __v_6, __v_6, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_83] = [__v_7, __v_0, __v_1, __v_2, __v_3];
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 6] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_83] = [__v_4, __v_0];
         record.function_queries[83].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_0, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        let __v_7: G = __r_arr[2];
-        let __v_8: G = __r_arr[3];
-        let __v_9: G = __r_arr[4];
-        let __v_10: G = __r_arr[5];
-        let __v_11: G = __r_arr[6];
-        let __v_12: G = __r_arr[7];
-        let __v_13: G = G::from_u64(1);
-        let __v_14: G = (__v_4 - __v_13);
-        let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        let __v_17: G = __r_arr[2];
-        let __v_18: G = __r_arr[3];
-        let __v_19: G = __r_arr[4];
-        let __v_20: G = G::from_u64(0);
-        let __v_21: G = { let __values: [G; 6] = [__v_20, __v_5, __v_6, __v_7, __v_8, __v_15]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_83] = [__v_21, __v_16, __v_17, __v_18, __v_19];
+        let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = __r_arr[2];
+        let __v_5: G = __r_arr[3];
+        let __v_6: G = __r_arr[4];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_1 - __v_7);
+        let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
+        let __v_9: G = __r_arr[0];
+        let __v_10: G = __r_arr[1];
+        let __v_11: G = G::from_u64(0);
+        let __v_12: G = { let __values: [G; 6] = [__v_11, __v_2, __v_3, __v_4, __v_5, __v_9]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_83] = [__v_12, __v_10];
         record.function_queries[83].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -6839,9 +6694,9 @@ fn aiur_fn_83(
   })
 }
 
-const INPUT_SIZE_84: usize = 5;
-const IN_84: usize = 5;
-const OUT_84: usize = 10;
+const INPUT_SIZE_84: usize = 2;
+const IN_84: usize = 2;
+const OUT_84: usize = 2;
 fn aiur_fn_84(
   inp: [G; IN_84],
   record: &mut QueryRecord,
@@ -6851,36 +6706,37 @@ fn aiur_fn_84(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __r_arr: [G; OUT_82] = { let __args: [G; IN_82] = [__v_0, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[82].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_82] = unsafe { *(result.output.as_ptr() as *const [G; OUT_82]) }; __ret } else { aiur_fn_82(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __v_6: G = __r_arr[1];
-    let __v_7: G = __r_arr[2];
-    let __v_8: G = __r_arr[3];
-    let __v_9: G = __r_arr[4];
-    let __v_10: G = __r_arr[5];
-    let __v_11: G = __r_arr[6];
-    let __v_12: G = __r_arr[7];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_13: G = __r_arr[0];
-    let __v_14: G = __r_arr[1];
-    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_9, __v_10, __v_11, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
-    let __v_15: G = __r_arr[0];
-    let __v_16: G = __r_arr[1];
-    let __v_17: G = __r_arr[2];
-    let __v_18: G = __r_arr[3];
-    let __v_19: G = __r_arr[4];
-    let __ret: [G; OUT_84] = [__v_5, __v_6, __v_7, __v_8, __v_15, __v_16, __v_17, __v_18, __v_19, __v_14];
-    record.function_queries[84].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_84] = [__v_4, __v_0];
+        record.function_queries[84].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = (__v_1 - __v_4);
+        let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = __r_arr[1];
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_84] = [__v_9, __v_7];
+        record.function_queries[84].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_85: usize = 6;
-const IN_85: usize = 6;
-const OUT_85: usize = 6;
+const INPUT_SIZE_85: usize = 1;
+const IN_85: usize = 1;
+const OUT_85: usize = 53;
 fn aiur_fn_85(
   inp: [G; IN_85],
   record: &mut QueryRecord,
@@ -6889,270 +6745,106 @@ fn aiur_fn_85(
 ) -> Result<[G; OUT_85], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    match __v_5.as_canonical_u64() {
-      0u64 => {
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = { let __values: [G; 7] = [__v_6, __v_7, __v_7, __v_7, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_85] = [__v_8, __v_0, __v_1, __v_2, __v_3, __v_4];
-        record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_0, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = __r_arr[2];
-        let __v_9: G = __r_arr[3];
-        let __v_10: G = __r_arr[4];
-        let __v_11: G = __r_arr[5];
-        let __v_12: G = __r_arr[6];
-        let __v_13: G = __r_arr[7];
-        let __v_14: G = __r_arr[8];
-        let __v_15: G = __r_arr[9];
-        let __v_16: G = G::from_u64(1);
-        let __v_17: G = (__v_5 - __v_16);
-        let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __v_20: G = __r_arr[2];
-        let __v_21: G = __r_arr[3];
-        let __v_22: G = __r_arr[4];
-        let __v_23: G = __r_arr[5];
-        let __v_24: G = G::from_u64(0);
-        let __v_25: G = { let __values: [G; 7] = [__v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_18]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_85] = [__v_25, __v_19, __v_20, __v_21, __v_22, __v_23];
-        record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __v_5: G = __r_arr[2];
+    let __v_6: G = __r_arr[3];
+    let __v_7: G = __r_arr[4];
+    let __v_8: G = __r_arr[5];
+    let __v_9: G = __r_arr[6];
+    let __v_10: G = __r_arr[7];
+    let __v_11: G = __r_arr[8];
+    let __v_12: G = __r_arr[9];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_12]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_13: G = __r_arr[0];
+    let __v_14: G = __r_arr[1];
+    let __v_15: G = __r_arr[2];
+    let __v_16: G = __r_arr[3];
+    let __v_17: G = __r_arr[4];
+    let __v_18: G = __r_arr[5];
+    let __v_19: G = __r_arr[6];
+    let __v_20: G = __r_arr[7];
+    let __v_21: G = __r_arr[8];
+    let __v_22: G = __r_arr[9];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_22]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __v_24: G = __r_arr[1];
+    let __v_25: G = __r_arr[2];
+    let __v_26: G = __r_arr[3];
+    let __v_27: G = __r_arr[4];
+    let __v_28: G = __r_arr[5];
+    let __v_29: G = __r_arr[6];
+    let __v_30: G = __r_arr[7];
+    let __v_31: G = __r_arr[8];
+    let __v_32: G = __r_arr[9];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_32]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_33: G = __r_arr[0];
+    let __v_34: G = __r_arr[1];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_34]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_35: G = __r_arr[0];
+    let __v_36: G = __r_arr[1];
+    let __v_37: G = __r_arr[2];
+    let __v_38: G = __r_arr[3];
+    let __v_39: G = __r_arr[4];
+    let __v_40: G = __r_arr[5];
+    let __v_41: G = __r_arr[6];
+    let __v_42: G = __r_arr[7];
+    let __v_43: G = __r_arr[8];
+    let __v_44: G = __r_arr[9];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_44]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_45: G = __r_arr[0];
+    let __v_46: G = __r_arr[1];
+    let __v_47: G = __r_arr[2];
+    let __v_48: G = __r_arr[3];
+    let __v_49: G = __r_arr[4];
+    let __v_50: G = __r_arr[5];
+    let __v_51: G = __r_arr[6];
+    let __v_52: G = __r_arr[7];
+    let __v_53: G = __r_arr[8];
+    let __v_54: G = __r_arr[9];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_54]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_55: G = __r_arr[0];
+    let __v_56: G = __r_arr[1];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_56]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_57: G = __r_arr[0];
+    let __v_58: G = __r_arr[1];
+    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_58, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
+    let __v_59: G = __r_arr[0];
+    let __v_60: G = __r_arr[1];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_60]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_61: G = __r_arr[0];
+    let __v_62: G = __r_arr[1];
+    let __v_63: G = __r_arr[2];
+    let __v_64: G = __r_arr[3];
+    let __v_65: G = __r_arr[4];
+    let __v_66: G = __r_arr[5];
+    let __v_67: G = __r_arr[6];
+    let __v_68: G = __r_arr[7];
+    let __v_69: G = __r_arr[8];
+    let __v_70: G = __r_arr[9];
+    let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_70, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
+    let __v_71: G = __r_arr[0];
+    let __v_72: G = __r_arr[1];
+    let __v_73: G = (__v_2 + __v_1);
+    let __ret: [G; OUT_85] = [__v_59, __v_57, __v_71, __v_45, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_73];
+    record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_86: usize = 5;
-const IN_86: usize = 5;
-const OUT_86: usize = 10;
+const INPUT_SIZE_86: usize = 49;
+const IN_86: usize = 49;
+const OUT_86: usize = 1;
 fn aiur_fn_86(
   inp: [G; IN_86],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_86], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __v_6: G = __r_arr[1];
-    match __v_5.as_canonical_u64() {
-      0u64 => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_6, __v_1, __v_2, __v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
-        let __v_9: G = __r_arr[0];
-        let __v_10: G = __r_arr[1];
-        let __v_11: G = __r_arr[2];
-        let __v_12: G = __r_arr[3];
-        let __v_13: G = __r_arr[4];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_8]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __v_15: G = __r_arr[1];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_15]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_17]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __v_20: G = G::from_u64(0);
-        let __ret: [G; OUT_86] = [__v_20, __v_9, __v_14, __v_16, __v_18, __v_10, __v_11, __v_12, __v_13, __v_19];
-        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_86] = [__v_9, __v_7, __v_10, __v_10, __v_10, __v_6, __v_1, __v_2, __v_3, __v_8];
-        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_7: G = G::from_u64(2);
-        let __v_8: G = G::from_u64(2);
-        let __ret: [G; OUT_86] = [__v_7, __v_8, __v_8, __v_8, __v_8, __v_6, __v_1, __v_2, __v_3, __v_4];
-        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_7: G = G::from_u64(3);
-        let __v_8: G = G::from_u64(3);
-        let __ret: [G; OUT_86] = [__v_7, __v_8, __v_8, __v_8, __v_8, __v_6, __v_1, __v_2, __v_3, __v_4];
-        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_87: usize = 1;
-const IN_87: usize = 1;
-const OUT_87: usize = 61;
-fn aiur_fn_87(
-  inp: [G; IN_87],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_87], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __v_6: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_6]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_8]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_9: G = __r_arr[0];
-    let __v_10: G = __r_arr[1];
-    let __v_11: G = (__v_10 + __v_1);
-    let __v_12: G = (__v_11 + __v_3);
-    let __v_13: G = (__v_12 + __v_5);
-    let __v_14: G = (__v_13 + __v_7);
-    let __v_15: G = (__v_14 + __v_9);
-    let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
-    let __v_16: G = __r_arr[0];
-    let __v_17: G = __r_arr[1];
-    let __v_18: G = __r_arr[2];
-    let __v_19: G = __r_arr[3];
-    let __v_20: G = __r_arr[4];
-    let __v_21: G = __r_arr[5];
-    let __v_22: G = __r_arr[6];
-    let __v_23: G = __r_arr[7];
-    let __v_24: G = __r_arr[8];
-    let __v_25: G = __r_arr[9];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_25]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_26: G = __r_arr[0];
-    let __v_27: G = __r_arr[1];
-    let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_21, __v_22, __v_23, __v_24, __v_27, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
-    let __v_28: G = __r_arr[0];
-    let __v_29: G = __r_arr[1];
-    let __v_30: G = __r_arr[2];
-    let __v_31: G = __r_arr[3];
-    let __v_32: G = __r_arr[4];
-    let __v_33: G = __r_arr[5];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_33]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_34: G = __r_arr[0];
-    let __v_35: G = __r_arr[1];
-    let __v_36: G = __r_arr[2];
-    let __v_37: G = __r_arr[3];
-    let __v_38: G = __r_arr[4];
-    let __v_39: G = __r_arr[5];
-    let __v_40: G = __r_arr[6];
-    let __v_41: G = __r_arr[7];
-    let __v_42: G = __r_arr[8];
-    let __v_43: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_43]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_44: G = __r_arr[0];
-    let __v_45: G = __r_arr[1];
-    let __v_46: G = __r_arr[2];
-    let __v_47: G = __r_arr[3];
-    let __v_48: G = __r_arr[4];
-    let __v_49: G = __r_arr[5];
-    let __v_50: G = __r_arr[6];
-    let __v_51: G = __r_arr[7];
-    let __v_52: G = __r_arr[8];
-    let __v_53: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_53]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_54: G = __r_arr[0];
-    let __v_55: G = __r_arr[1];
-    let __v_56: G = __r_arr[2];
-    let __v_57: G = __r_arr[3];
-    let __v_58: G = __r_arr[4];
-    let __v_59: G = __r_arr[5];
-    let __v_60: G = __r_arr[6];
-    let __v_61: G = __r_arr[7];
-    let __v_62: G = __r_arr[8];
-    let __v_63: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_63]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_64: G = __r_arr[0];
-    let __v_65: G = __r_arr[1];
-    let __v_66: G = __r_arr[2];
-    let __v_67: G = __r_arr[3];
-    let __v_68: G = __r_arr[4];
-    let __v_69: G = __r_arr[5];
-    let __v_70: G = __r_arr[6];
-    let __v_71: G = __r_arr[7];
-    let __v_72: G = __r_arr[8];
-    let __v_73: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_73]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_74: G = __r_arr[0];
-    let __v_75: G = __r_arr[1];
-    let __v_76: G = __r_arr[2];
-    let __v_77: G = __r_arr[3];
-    let __v_78: G = __r_arr[4];
-    let __v_79: G = __r_arr[5];
-    let __v_80: G = __r_arr[6];
-    let __v_81: G = __r_arr[7];
-    let __v_82: G = __r_arr[8];
-    let __v_83: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_83]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_84: G = __r_arr[0];
-    let __v_85: G = __r_arr[1];
-    let __v_86: G = __r_arr[2];
-    let __v_87: G = __r_arr[3];
-    let __v_88: G = __r_arr[4];
-    let __v_89: G = __r_arr[5];
-    let __v_90: G = __r_arr[6];
-    let __v_91: G = __r_arr[7];
-    let __v_92: G = __r_arr[8];
-    let __v_93: G = __r_arr[9];
-    if (__v_29 != __v_11) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_11.as_canonical_u64() });
-    }
-    if (__v_30 != __v_12) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_30.as_canonical_u64(), rhs: __v_12.as_canonical_u64() });
-    }
-    if (__v_31 != __v_13) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_31.as_canonical_u64(), rhs: __v_13.as_canonical_u64() });
-    }
-    if (__v_32 != __v_14) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_32.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
-    }
-    if (__v_93 != __v_15) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_15.as_canonical_u64() });
-    }
-    let __ret: [G; OUT_87] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_28, __v_34, __v_44, __v_54, __v_64, __v_74, __v_84, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_15];
-    record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_88: usize = 49;
-const IN_88: usize = 49;
-const OUT_88: usize = 1;
-fn aiur_fn_88(
-  inp: [G; IN_88],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_88], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7215,21 +6907,21 @@ fn aiur_fn_88(
     let __v_58: G = { let __values: [G; 10] = [__v_51, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_57]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_59: G = { let __values: [G; 10] = [__v_50, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_58]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_60: G = { let __values: [G; 10] = [__v_49, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_59]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_88] = [__v_60];
-    record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_86] = [__v_60];
+    record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_89: usize = 2;
-const IN_89: usize = 2;
-const OUT_89: usize = 3;
-fn aiur_fn_89(
-  inp: [G; IN_89],
+const INPUT_SIZE_87: usize = 2;
+const IN_87: usize = 2;
+const OUT_87: usize = 3;
+fn aiur_fn_87(
+  inp: [G; IN_87],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_89], ExecError> {
+) -> Result<[G; OUT_87], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7237,16 +6929,16 @@ fn aiur_fn_89(
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 14] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __v_4: G = { let __values: [G; 6] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 10] = [__v_5, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_89] = [__v_4, __v_7, __v_0];
-        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_87] = [__v_4, __v_7, __v_0];
+        record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = __r_arr[2];
@@ -7300,41 +6992,33 @@ fn aiur_fn_89(
         let __v_52: G = __r_arr[50];
         let __v_53: G = __r_arr[51];
         let __v_54: G = __r_arr[52];
-        let __v_55: G = __r_arr[53];
-        let __v_56: G = __r_arr[54];
-        let __v_57: G = __r_arr[55];
-        let __v_58: G = __r_arr[56];
-        let __v_59: G = __r_arr[57];
-        let __v_60: G = __r_arr[58];
-        let __v_61: G = __r_arr[59];
-        let __v_62: G = __r_arr[60];
-        let __v_63: G = G::from_u64(1);
-        let __v_64: G = (__v_1 - __v_63);
-        let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_62, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
-        let __v_65: G = __r_arr[0];
-        let __v_66: G = __r_arr[1];
-        let __v_67: G = __r_arr[2];
-        let __v_68: G = G::from_u64(0);
-        let __v_69: G = { let __values: [G; 14] = [__v_68, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_65]; let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
-        let __v_70: G = __r_arr[0];
-        let __ret: [G; OUT_89] = [__v_69, __v_70, __v_67];
-        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_55: G = G::from_u64(1);
+        let __v_56: G = (__v_1 - __v_55);
+        let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_54, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
+        let __v_57: G = __r_arr[0];
+        let __v_58: G = __r_arr[1];
+        let __v_59: G = __r_arr[2];
+        let __v_60: G = G::from_u64(0);
+        let __v_61: G = { let __values: [G; 6] = [__v_60, __v_2, __v_3, __v_4, __v_5, __v_57]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
+        let __v_62: G = __r_arr[0];
+        let __ret: [G; OUT_87] = [__v_61, __v_62, __v_59];
+        record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_90: usize = 1;
-const IN_90: usize = 1;
-const OUT_90: usize = 3;
-fn aiur_fn_90(
-  inp: [G; IN_90],
+const INPUT_SIZE_88: usize = 1;
+const IN_88: usize = 1;
+const OUT_88: usize = 3;
+fn aiur_fn_88(
+  inp: [G; IN_88],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_90], ExecError> {
+) -> Result<[G; OUT_88], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
@@ -7344,8 +7028,8 @@ fn aiur_fn_90(
       0u64 => {
         let __v_3: G = G::from_u64(0);
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_90] = [__v_3, __v_4, __v_2];
-        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_88] = [__v_3, __v_4, __v_2];
+        record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7356,23 +7040,23 @@ fn aiur_fn_90(
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_90] = [__v_7, __v_5, __v_6];
-        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_88] = [__v_7, __v_5, __v_6];
+        record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_91: usize = 2;
-const IN_91: usize = 2;
-const OUT_91: usize = 2;
-fn aiur_fn_91(
-  inp: [G; IN_91],
+const INPUT_SIZE_89: usize = 2;
+const IN_89: usize = 2;
+const OUT_89: usize = 2;
+fn aiur_fn_89(
+  inp: [G; IN_89],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_91], ExecError> {
+) -> Result<[G; OUT_89], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7381,8 +7065,8 @@ fn aiur_fn_91(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 4] = [__v_2, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_91] = [__v_4, __v_0];
-        record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_89] = [__v_4, __v_0];
+        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7391,7 +7075,7 @@ fn aiur_fn_91(
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
         let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = __r_arr[1];
         match __v_2.as_canonical_u64() {
@@ -7400,16 +7084,16 @@ fn aiur_fn_91(
             let __v_9: G = G::from_u64(0);
             let __v_10: G = G::from_u64(0);
             let __v_11: G = { let __values: [G; 4] = [__v_8, __v_9, __v_10, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_91] = [__v_11, __v_7];
-            record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_89] = [__v_11, __v_7];
+            record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
             let __v_8: G = G::from_u64(0);
             let __v_9: G = G::from_u64(1);
             let __v_10: G = { let __values: [G; 4] = [__v_8, __v_9, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_91] = [__v_10, __v_7];
-            record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_89] = [__v_10, __v_7];
+            record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -7418,15 +7102,15 @@ fn aiur_fn_91(
   })
 }
 
-const INPUT_SIZE_92: usize = 1;
-const IN_92: usize = 1;
-const OUT_92: usize = 9;
-fn aiur_fn_92(
-  inp: [G; IN_92],
+const INPUT_SIZE_90: usize = 1;
+const IN_90: usize = 1;
+const OUT_90: usize = 9;
+fn aiur_fn_90(
+  inp: [G; IN_90],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_92], ExecError> {
+) -> Result<[G; OUT_90], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_75] = { let __args: [G; IN_75] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[75].get_mut(&__args[..]) { let __ret: [G; OUT_75] = unsafe { *(result.output.as_ptr() as *const [G; OUT_75]) }; __ret } else { aiur_fn_75(__args, record, io_buffer, __cu)? } };
@@ -7523,24 +7207,24 @@ fn aiur_fn_92(
     let __v_85: G = { let __values: [G; 10] = [__v_73, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_84]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_86: G = { let __values: [G; 10] = [__v_72, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_85]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_87: G = { let __values: [G; 10] = [__v_71, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_86]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_92] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_87, __v_70];
-    record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_90] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_87, __v_70];
+    record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_93: usize = 1;
-const IN_93: usize = 1;
-const OUT_93: usize = 13;
-fn aiur_fn_93(
-  inp: [G; IN_93],
+const INPUT_SIZE_91: usize = 1;
+const IN_91: usize = 1;
+const OUT_91: usize = 13;
+fn aiur_fn_91(
+  inp: [G; IN_91],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_93], ExecError> {
+) -> Result<[G; OUT_91], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
     let __v_3: G = __r_arr[2];
@@ -7561,36 +7245,36 @@ fn aiur_fn_93(
     let __v_17: G = __r_arr[7];
     let __v_18: G = __r_arr[8];
     let __v_19: G = __r_arr[9];
-    let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_19, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_19, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = __r_arr[2];
-    let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_25, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_25, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
     let __v_26: G = __r_arr[0];
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = { let __values: [G; 10] = [__v_28, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_21]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
-    let __ret: [G; OUT_93] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
-    record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_91] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
+    record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_94: usize = 5;
-const IN_94: usize = 5;
-const OUT_94: usize = 1;
-fn aiur_fn_94(
-  inp: [G; IN_94],
+const INPUT_SIZE_92: usize = 5;
+const IN_92: usize = 5;
+const OUT_92: usize = 1;
+fn aiur_fn_92(
+  inp: [G; IN_92],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_94], ExecError> {
+) -> Result<[G; OUT_92], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7605,21 +7289,21 @@ fn aiur_fn_94(
     let __v_10: G = { let __values: [G; 3] = [__v_7, __v_2, __v_9]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_11: G = { let __values: [G; 3] = [__v_6, __v_1, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_12: G = { let __values: [G; 3] = [__v_5, __v_0, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_94] = [__v_12];
-    record.function_queries[94].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_92] = [__v_12];
+    record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_95: usize = 33;
-const IN_95: usize = 33;
-const OUT_95: usize = 1;
-fn aiur_fn_95(
-  inp: [G; IN_95],
+const INPUT_SIZE_93: usize = 33;
+const IN_93: usize = 33;
+const OUT_93: usize = 1;
+fn aiur_fn_93(
+  inp: [G; IN_93],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_95], ExecError> {
+) -> Result<[G; OUT_93], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7654,37 +7338,37 @@ fn aiur_fn_95(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_24, __v_25, __v_26, __v_27, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_24, __v_25, __v_26, __v_27, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_20, __v_21, __v_22, __v_23, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_20, __v_21, __v_22, __v_23, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_16, __v_17, __v_18, __v_19, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_16, __v_17, __v_18, __v_19, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_12, __v_13, __v_14, __v_15, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_12, __v_13, __v_14, __v_15, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_37: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_8, __v_9, __v_10, __v_11, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_8, __v_9, __v_10, __v_11, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_38: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_4, __v_5, __v_6, __v_7, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_4, __v_5, __v_6, __v_7, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_0, __v_1, __v_2, __v_3, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_0, __v_1, __v_2, __v_3, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __ret: [G; OUT_95] = [__v_40];
-    record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_93] = [__v_40];
+    record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_96: usize = 32;
-const IN_96: usize = 32;
-const OUT_96: usize = 32;
-fn aiur_fn_96(
-  inp: [G; IN_96],
+const INPUT_SIZE_94: usize = 32;
+const IN_94: usize = 32;
+const OUT_94: usize = 32;
+fn aiur_fn_94(
+  inp: [G; IN_94],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_96], ExecError> {
+) -> Result<[G; OUT_94], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7718,21 +7402,21 @@ fn aiur_fn_96(
     let __v_29: G = inp[29];
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
-    let __ret: [G; OUT_96] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31];
-    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_94] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31];
+    record.function_queries[94].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_97: usize = 4;
-const IN_97: usize = 4;
-const OUT_97: usize = 1;
-fn aiur_fn_97(
-  inp: [G; IN_97],
+const INPUT_SIZE_95: usize = 4;
+const IN_95: usize = 4;
+const OUT_95: usize = 1;
+fn aiur_fn_95(
+  inp: [G; IN_95],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_97], ExecError> {
+) -> Result<[G; OUT_95], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7740,8 +7424,8 @@ fn aiur_fn_97(
     let __v_3: G = inp[3];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_97] = [__v_3];
-        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_95] = [__v_3];
+        record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7753,25 +7437,25 @@ fn aiur_fn_97(
         let __v_8: G = (__v_2 - __v_7);
         let __v_9: G = G::from_u64(0);
         let __v_10: G = { let __values: [G; 3] = [__v_9, __v_4, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_6, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_0, __v_6, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
-        let __ret: [G; OUT_97] = [__v_11];
-        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_95] = [__v_11];
+        record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_98: usize = 7;
-const IN_98: usize = 7;
-const OUT_98: usize = 1;
-fn aiur_fn_98(
-  inp: [G; IN_98],
+const INPUT_SIZE_96: usize = 7;
+const IN_96: usize = 7;
+const OUT_96: usize = 1;
+fn aiur_fn_96(
+  inp: [G; IN_96],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_98], ExecError> {
+) -> Result<[G; OUT_96], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7957,8 +7641,8 @@ fn aiur_fn_98(
           1u64 => {
             let __v_172: G = G::from_u64(0);
             let __v_173: G = { let __values: [G; 34] = [__v_172, __v_6, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_98] = [__v_173];
-            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_96] = [__v_173];
+            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -8023,10 +7707,10 @@ fn aiur_fn_98(
                 let __v_226: G = { let __values: [G; 32] = [__v_172, __v_173, __v_174, __v_175, __v_176, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_227: G = G::from_u64(0);
                 let __v_228: G = { let __values: [G; 34] = [__v_227, __v_6, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_205, __v_207, __v_208, __v_225, __v_226, __v_228]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_205, __v_207, __v_208, __v_225, __v_226, __v_228]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
                 let __v_229: G = __r_arr[0];
-                let __ret: [G; OUT_98] = [__v_229];
-                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_96] = [__v_229];
+                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
@@ -8037,10 +7721,10 @@ fn aiur_fn_98(
                 let __v_176: G = G::from_u64(1);
                 let __v_177: G = (__v_3 + __v_176);
                 let __v_178: G = { let __values: [G; 32] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_173, __v_175, __v_177, __v_4, __v_178, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_173, __v_175, __v_177, __v_4, __v_178, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
                 let __v_179: G = __r_arr[0];
-                let __ret: [G; OUT_98] = [__v_179];
-                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_96] = [__v_179];
+                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -8218,62 +7902,62 @@ fn aiur_fn_98(
                                             let __v_154: G = __r_arr[30];
                                             let __v_155: G = __r_arr[31];
                                             let __v_156: G = { let __values: [G; 34] = [__v_17, __v_6, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                            let __ret: [G; OUT_98] = [__v_156];
-                                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                            let __ret: [G; OUT_96] = [__v_156];
+                                            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                             return Ok(__ret);
                                           },
                                           _ => {
-                                            let __ret: [G; OUT_98] = [__v_6];
-                                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                            let __ret: [G; OUT_96] = [__v_6];
+                                            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                             return Ok(__ret);
                                           },
                                         }
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_98] = [__v_6];
-                                        record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_96] = [__v_6];
+                                        record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_98] = [__v_6];
-                                    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                    let __ret: [G; OUT_96] = [__v_6];
+                                    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_98] = [__v_6];
-                                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                let __ret: [G; OUT_96] = [__v_6];
+                                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_98] = [__v_6];
-                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_96] = [__v_6];
+                            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_98] = [__v_6];
-                        record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_96] = [__v_6];
+                        record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_98] = [__v_6];
-                    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_96] = [__v_6];
+                    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_98] = [__v_6];
-                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_96] = [__v_6];
+                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -8282,7 +7966,7 @@ fn aiur_fn_98(
             let __v_9: G = G::from_u64(1);
             let __v_10: G = G::from_u64(1);
             let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_1, __v_2, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_0, __v_1, __v_2, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = G::from_u64(64);
             let __v_14: G = (__v_13 - __v_2);
@@ -8447,8 +8131,8 @@ fn aiur_fn_98(
             let __v_166: G = __r_arr[30];
             let __v_167: G = __r_arr[31];
             let __v_168: G = { let __values: [G; 34] = [__v_95, __v_6, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_98] = [__v_168];
-            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_96] = [__v_168];
+            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -8457,15 +8141,15 @@ fn aiur_fn_98(
   })
 }
 
-const INPUT_SIZE_99: usize = 3;
-const IN_99: usize = 3;
-const OUT_99: usize = 32;
-fn aiur_fn_99(
-  inp: [G; IN_99],
+const INPUT_SIZE_97: usize = 3;
+const IN_97: usize = 3;
+const OUT_97: usize = 32;
+fn aiur_fn_97(
+  inp: [G; IN_97],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_99], ExecError> {
+) -> Result<[G; OUT_97], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8516,7 +8200,7 @@ fn aiur_fn_99(
     let __v_46: G = G::from_u64(1);
     let __v_47: G = G::from_u64(1);
     let __v_48: G = { let __values: [G; 34] = [__v_46, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_1, __v_2, __v_35, __v_44, __v_45, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_1, __v_2, __v_35, __v_44, __v_45, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
     let __v_49: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_49.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_50: G = __loaded[0];
@@ -8586,21 +8270,21 @@ fn aiur_fn_99(
     let __v_113: G = __r_arr[29];
     let __v_114: G = __r_arr[30];
     let __v_115: G = __r_arr[31];
-    let __ret: [G; OUT_99] = [__v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115];
-    record.function_queries[99].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_97] = [__v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115];
+    record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_100: usize = 64;
-const IN_100: usize = 64;
-const OUT_100: usize = 32;
-fn aiur_fn_100(
-  inp: [G; IN_100],
+const INPUT_SIZE_98: usize = 64;
+const IN_98: usize = 64;
+const OUT_98: usize = 32;
+fn aiur_fn_98(
+  inp: [G; IN_98],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_100], ExecError> {
+) -> Result<[G; OUT_98], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8741,7 +8425,7 @@ fn aiur_fn_100(
     let __v_135: G = __r_arr[29];
     let __v_136: G = __r_arr[30];
     let __v_137: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_138: G = __r_arr[0];
     let __v_139: G = __r_arr[1];
     let __v_140: G = __r_arr[2];
@@ -8774,21 +8458,21 @@ fn aiur_fn_100(
     let __v_167: G = __r_arr[29];
     let __v_168: G = __r_arr[30];
     let __v_169: G = __r_arr[31];
-    let __ret: [G; OUT_100] = [__v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169];
-    record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_98] = [__v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169];
+    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_101: usize = 64;
-const IN_101: usize = 64;
-const OUT_101: usize = 1;
-fn aiur_fn_101(
-  inp: [G; IN_101],
+const INPUT_SIZE_99: usize = 64;
+const IN_99: usize = 64;
+const OUT_99: usize = 1;
+fn aiur_fn_99(
+  inp: [G; IN_99],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_101], ExecError> {
+) -> Result<[G; OUT_99], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8881,21 +8565,21 @@ fn aiur_fn_101(
     let __v_80: G = (__v_75 * __v_79);
     let __v_81: G = (__v_71 * __v_80);
     let __v_82: G = (__v_67 * __v_81);
-    let __ret: [G; OUT_101] = [__v_82];
-    record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_99] = [__v_82];
+    record.function_queries[99].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_102: usize = 65;
-const IN_102: usize = 65;
-const OUT_102: usize = 32;
-fn aiur_fn_102(
-  inp: [G; IN_102],
+const INPUT_SIZE_100: usize = 65;
+const IN_100: usize = 65;
+const OUT_100: usize = 32;
+fn aiur_fn_100(
+  inp: [G; IN_100],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_102], ExecError> {
+) -> Result<[G; OUT_100], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8964,7 +8648,7 @@ fn aiur_fn_102(
     let __v_64: G = inp[64];
     match __v_0.as_canonical_u64() {
       0u64 => {
-        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
         let __v_65: G = __r_arr[0];
         let __v_66: G = __r_arr[1];
         let __v_67: G = __r_arr[2];
@@ -8997,12 +8681,12 @@ fn aiur_fn_102(
         let __v_94: G = __r_arr[29];
         let __v_95: G = __r_arr[30];
         let __v_96: G = __r_arr[31];
-        let __ret: [G; OUT_102] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
-        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_100] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
+        record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
         let __v_65: G = __r_arr[0];
         let __v_66: G = __r_arr[1];
         let __v_67: G = __r_arr[2];
@@ -9035,23 +8719,23 @@ fn aiur_fn_102(
         let __v_94: G = __r_arr[29];
         let __v_95: G = __r_arr[30];
         let __v_96: G = __r_arr[31];
-        let __ret: [G; OUT_102] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
-        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_100] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
+        record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_103: usize = 2;
-const IN_103: usize = 2;
-const OUT_103: usize = 1;
-fn aiur_fn_103(
-  inp: [G; IN_103],
+const INPUT_SIZE_101: usize = 2;
+const IN_101: usize = 2;
+const OUT_101: usize = 1;
+fn aiur_fn_101(
+  inp: [G; IN_101],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_103], ExecError> {
+) -> Result<[G; OUT_101], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9062,8 +8746,8 @@ fn aiur_fn_103(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_103] = [__v_5];
-        record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_101] = [__v_5];
+        record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -9072,15 +8756,15 @@ fn aiur_fn_103(
         match __v_6.as_canonical_u64() {
           1u64 => {
             let __v_7: G = G::from_u64(1);
-            let __ret: [G; OUT_103] = [__v_7];
-            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_101] = [__v_7];
+            record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
             let __v_7: G = __r_arr[0];
-            let __ret: [G; OUT_103] = [__v_7];
-            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_101] = [__v_7];
+            record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -9092,15 +8776,15 @@ fn aiur_fn_103(
   })
 }
 
-const INPUT_SIZE_104: usize = 3;
-const IN_104: usize = 3;
-const OUT_104: usize = 1;
-fn aiur_fn_104(
-  inp: [G; IN_104],
+const INPUT_SIZE_102: usize = 3;
+const IN_102: usize = 3;
+const OUT_102: usize = 1;
+fn aiur_fn_102(
+  inp: [G; IN_102],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_104], ExecError> {
+) -> Result<[G; OUT_102], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9114,8 +8798,8 @@ fn aiur_fn_104(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 3] = [__v_6, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_104] = [__v_8];
-        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_102] = [__v_8];
+        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -9129,10 +8813,10 @@ fn aiur_fn_104(
             let __v_10: G = G::from_bool((__v_9 == G::ZERO));
             match __v_10.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_104] = [__v_11];
-                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_102] = [__v_11];
+                record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
@@ -9149,19 +8833,19 @@ fn aiur_fn_104(
                 let __v_20: G = __loaded[9];
                 match __v_11.as_canonical_u64() {
                   1u64 => {
-                    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
                     let __v_21: G = __r_arr[0];
-                    let __ret: [G; OUT_104] = [__v_21];
-                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_102] = [__v_21];
+                    record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                   _ => {
                     let __v_21: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
                     let __v_22: G = __r_arr[0];
                     let __v_23: G = { let __values: [G; 3] = [__v_21, __v_4, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __ret: [G; OUT_104] = [__v_23];
-                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_102] = [__v_23];
+                    record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -9180,15 +8864,15 @@ fn aiur_fn_104(
   })
 }
 
-const INPUT_SIZE_105: usize = 2;
-const IN_105: usize = 2;
-const OUT_105: usize = 11;
-fn aiur_fn_105(
-  inp: [G; IN_105],
+const INPUT_SIZE_103: usize = 2;
+const IN_103: usize = 2;
+const OUT_103: usize = 11;
+fn aiur_fn_103(
+  inp: [G; IN_103],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_105], ExecError> {
+) -> Result<[G; OUT_103], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9217,8 +8901,8 @@ fn aiur_fn_105(
         let __v_19: G = __r_arr[6];
         let __v_20: G = __r_arr[7];
         let __v_21: G = G::from_u64(1);
-        let __ret: [G; OUT_105] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_11, __v_1, __v_21];
-        record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_103] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_11, __v_1, __v_21];
+        record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -9237,12 +8921,12 @@ fn aiur_fn_105(
             let __v_21: G = G::from_u64(0);
             let __v_22: G = G::from_u64(0);
             let __v_23: G = G::from_u64(0);
-            let __ret: [G; OUT_105] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
-            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_103] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
+            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
             let __v_15: G = __r_arr[0];
             let __v_16: G = __r_arr[1];
             let __v_17: G = __r_arr[2];
@@ -9254,8 +8938,8 @@ fn aiur_fn_105(
             let __v_23: G = __r_arr[8];
             let __v_24: G = __r_arr[9];
             let __v_25: G = __r_arr[10];
-            let __ret: [G; OUT_105] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
-            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_103] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
+            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -9270,15 +8954,15 @@ fn aiur_fn_105(
   })
 }
 
-const INPUT_SIZE_106: usize = 6;
-const IN_106: usize = 6;
-const OUT_106: usize = 1;
-fn aiur_fn_106(
-  inp: [G; IN_106],
+const INPUT_SIZE_104: usize = 6;
+const IN_104: usize = 6;
+const OUT_104: usize = 1;
+fn aiur_fn_104(
+  inp: [G; IN_104],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_106], ExecError> {
+) -> Result<[G; OUT_104], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9286,7 +8970,7 @@ fn aiur_fn_106(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -9468,68 +9152,68 @@ fn aiur_fn_106(
                                         let __v_162: G = __r_arr[30];
                                         let __v_163: G = __r_arr[31];
                                         let __v_164: G = { let __values: [G; 34] = [__v_25, __v_5, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                        let __ret: [G; OUT_106] = [__v_164];
-                                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_104] = [__v_164];
+                                        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_106] = [__v_5];
-                                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_104] = [__v_5];
+                                        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_106] = [__v_5];
-                                    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                    let __ret: [G; OUT_104] = [__v_5];
+                                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_106] = [__v_5];
-                                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                let __ret: [G; OUT_104] = [__v_5];
+                                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_106] = [__v_5];
-                            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_104] = [__v_5];
+                            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_106] = [__v_5];
-                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_104] = [__v_5];
+                        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_106] = [__v_5];
-                    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_104] = [__v_5];
+                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_106] = [__v_5];
-                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_104] = [__v_5];
+                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
           },
           _ => {
-            let __ret: [G; OUT_106] = [__v_5];
-            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_104] = [__v_5];
+            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
       _ => {
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = __r_arr[1];
         let __v_19: G = __r_arr[2];
@@ -9541,7 +9225,7 @@ fn aiur_fn_106(
         let __v_25: G = __r_arr[8];
         let __v_26: G = __r_arr[9];
         let __v_27: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         let __v_29: G = __r_arr[1];
         let __v_30: G = __r_arr[2];
@@ -9553,7 +9237,7 @@ fn aiur_fn_106(
         let __v_36: G = __r_arr[8];
         let __v_37: G = __r_arr[9];
         let __v_38: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = __r_arr[1];
         let __v_41: G = __r_arr[2];
@@ -9565,7 +9249,7 @@ fn aiur_fn_106(
         let __v_47: G = __r_arr[8];
         let __v_48: G = __r_arr[9];
         let __v_49: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_50: G = __r_arr[0];
         let __v_51: G = __r_arr[1];
         let __v_52: G = __r_arr[2];
@@ -9577,7 +9261,7 @@ fn aiur_fn_106(
         let __v_58: G = __r_arr[8];
         let __v_59: G = __r_arr[9];
         let __v_60: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_61: G = __r_arr[0];
         let __v_62: G = __r_arr[1];
         let __v_63: G = __r_arr[2];
@@ -9589,7 +9273,7 @@ fn aiur_fn_106(
         let __v_69: G = __r_arr[8];
         let __v_70: G = __r_arr[9];
         let __v_71: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_72: G = __r_arr[0];
         let __v_73: G = __r_arr[1];
         let __v_74: G = __r_arr[2];
@@ -9601,7 +9285,7 @@ fn aiur_fn_106(
         let __v_80: G = __r_arr[8];
         let __v_81: G = __r_arr[9];
         let __v_82: G = __r_arr[10];
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_83: G = __r_arr[0];
         let __v_84: G = __r_arr[1];
         let __v_85: G = __r_arr[2];
@@ -9761,8 +9445,8 @@ fn aiur_fn_106(
           1u64 => {
             let __v_209: G = G::from_u64(0);
             let __v_210: G = { let __values: [G; 34] = [__v_209, __v_5, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_106] = [__v_210];
-            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_104] = [__v_210];
+            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -9823,20 +9507,20 @@ fn aiur_fn_106(
                 let __v_259: G = { let __values: [G; 32] = [__v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218, __v_219, __v_220, __v_221, __v_222, __v_223, __v_224, __v_225, __v_226, __v_227, __v_228, __v_229, __v_230, __v_231, __v_232, __v_233, __v_234, __v_235, __v_236, __v_237, __v_238, __v_239, __v_240]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_260: G = G::from_u64(0);
                 let __v_261: G = { let __values: [G; 34] = [__v_260, __v_5, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_91, __v_92, __v_241, __v_258, __v_259, __v_261]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_91, __v_92, __v_241, __v_258, __v_259, __v_261]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                 let __v_262: G = __r_arr[0];
-                let __ret: [G; OUT_106] = [__v_262];
-                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_104] = [__v_262];
+                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_209: G = G::from_u64(1);
                 let __v_210: G = (__v_2 + __v_209);
                 let __v_211: G = { let __values: [G; 32] = [__v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_91, __v_92, __v_210, __v_3, __v_211, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_91, __v_92, __v_210, __v_3, __v_211, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                 let __v_212: G = __r_arr[0];
-                let __ret: [G; OUT_106] = [__v_212];
-                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_104] = [__v_212];
+                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -9847,15 +9531,15 @@ fn aiur_fn_106(
   })
 }
 
-const INPUT_SIZE_107: usize = 1;
-const IN_107: usize = 1;
-const OUT_107: usize = 32;
-fn aiur_fn_107(
-  inp: [G; IN_107],
+const INPUT_SIZE_105: usize = 1;
+const IN_105: usize = 1;
+const OUT_105: usize = 32;
+fn aiur_fn_105(
+  inp: [G; IN_105],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_107], ExecError> {
+) -> Result<[G; OUT_105], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(103);
@@ -9907,7 +9591,7 @@ fn aiur_fn_107(
     let __v_47: G = G::from_u64(1);
     let __v_48: G = G::from_u64(1);
     let __v_49: G = { let __values: [G; 34] = [__v_47, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_50.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_51: G = __loaded[0];
@@ -9977,28 +9661,28 @@ fn aiur_fn_107(
     let __v_114: G = __r_arr[29];
     let __v_115: G = __r_arr[30];
     let __v_116: G = __r_arr[31];
-    let __ret: [G; OUT_107] = [__v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116];
-    record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_105] = [__v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116];
+    record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_108: usize = 3;
-const IN_108: usize = 3;
-const OUT_108: usize = 32;
-fn aiur_fn_108(
-  inp: [G; IN_108],
+const INPUT_SIZE_106: usize = 3;
+const IN_106: usize = 3;
+const OUT_106: usize = 32;
+fn aiur_fn_106(
+  inp: [G; IN_106],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_108], ExecError> {
+) -> Result<[G; OUT_106], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
-    let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
     let __v_4: G = __r_arr[0];
     let __v_5: G = __r_arr[1];
     let __v_6: G = __r_arr[2];
@@ -10031,7 +9715,7 @@ fn aiur_fn_108(
     let __v_33: G = __r_arr[29];
     let __v_34: G = __r_arr[30];
     let __v_35: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
     let __v_37: G = __r_arr[1];
     let __v_38: G = __r_arr[2];
@@ -10064,21 +9748,21 @@ fn aiur_fn_108(
     let __v_65: G = __r_arr[29];
     let __v_66: G = __r_arr[30];
     let __v_67: G = __r_arr[31];
-    let __ret: [G; OUT_108] = [__v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67];
-    record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_106] = [__v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67];
+    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_109: usize = 35;
-const IN_109: usize = 35;
-const OUT_109: usize = 32;
-fn aiur_fn_109(
-  inp: [G; IN_109],
+const INPUT_SIZE_107: usize = 35;
+const IN_107: usize = 35;
+const OUT_107: usize = 32;
+fn aiur_fn_107(
+  inp: [G; IN_107],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_109], ExecError> {
+) -> Result<[G; OUT_107], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10115,16 +9799,16 @@ fn aiur_fn_109(
     let __v_32: G = inp[32];
     let __v_33: G = inp[33];
     let __v_34: G = inp[34];
-    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
     match __v_35.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_109] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34];
-        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_107] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34];
+        record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
         let __v_37: G = __r_arr[1];
         let __v_38: G = __r_arr[2];
@@ -10157,7 +9841,7 @@ fn aiur_fn_109(
         let __v_65: G = __r_arr[29];
         let __v_66: G = __r_arr[30];
         let __v_67: G = __r_arr[31];
-        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
         let __v_69: G = __r_arr[1];
         let __v_70: G = __r_arr[2];
@@ -10190,23 +9874,23 @@ fn aiur_fn_109(
         let __v_97: G = __r_arr[29];
         let __v_98: G = __r_arr[30];
         let __v_99: G = __r_arr[31];
-        let __ret: [G; OUT_109] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99];
-        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_107] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99];
+        record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_110: usize = 1;
-const IN_110: usize = 1;
-const OUT_110: usize = 1;
-fn aiur_fn_110(
-  inp: [G; IN_110],
+const INPUT_SIZE_108: usize = 1;
+const IN_108: usize = 1;
+const OUT_108: usize = 1;
+fn aiur_fn_108(
+  inp: [G; IN_108],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_110], ExecError> {
+) -> Result<[G; OUT_108], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -10216,18 +9900,18 @@ fn aiur_fn_110(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_110] = [__v_4];
-        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_108] = [__v_4];
+        record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(2);
-        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_4 * __v_5);
         let __v_7: G = (__v_2 + __v_6);
-        let __ret: [G; OUT_110] = [__v_7];
-        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_108] = [__v_7];
+        record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10237,15 +9921,15 @@ fn aiur_fn_110(
   })
 }
 
-const INPUT_SIZE_111: usize = 37;
-const IN_111: usize = 37;
-const OUT_111: usize = 33;
-fn aiur_fn_111(
-  inp: [G; IN_111],
+const INPUT_SIZE_109: usize = 37;
+const IN_109: usize = 37;
+const OUT_109: usize = 33;
+fn aiur_fn_109(
+  inp: [G; IN_109],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_111], ExecError> {
+) -> Result<[G; OUT_109], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10321,10 +10005,10 @@ fn aiur_fn_111(
     let __v_70: G = __loaded[33];
     match __v_37.as_canonical_u64() {
       1u64 => {
-        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
-        let __ret: [G; OUT_111] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_71];
-        record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_109] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_71];
+        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10334,7 +10018,7 @@ fn aiur_fn_111(
         let __v_73: G = __loaded[2];
         match __v_71.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_72, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_72, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
             let __v_74: G = __r_arr[0];
             let __v_75: G = __r_arr[1];
             let __v_76: G = __r_arr[2];
@@ -10367,7 +10051,7 @@ fn aiur_fn_111(
             let __v_103: G = __r_arr[29];
             let __v_104: G = __r_arr[30];
             let __v_105: G = __r_arr[31];
-            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_32, __v_33, __v_36, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_32, __v_33, __v_36, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
             let __v_106: G = __r_arr[0];
             let __v_107: G = __r_arr[1];
             let __v_108: G = __r_arr[2];
@@ -10402,7 +10086,7 @@ fn aiur_fn_111(
             let __v_137: G = __r_arr[31];
             let __v_138: G = G::from_u64(1);
             let __v_139: G = (__v_36 - __v_138);
-            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_32, __v_33, __v_70, __v_73, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_32, __v_33, __v_70, __v_73, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
             let __v_140: G = __r_arr[0];
             let __v_141: G = __r_arr[1];
             let __v_142: G = __r_arr[2];
@@ -10436,8 +10120,8 @@ fn aiur_fn_111(
             let __v_170: G = __r_arr[30];
             let __v_171: G = __r_arr[31];
             let __v_172: G = __r_arr[32];
-            let __ret: [G; OUT_111] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172];
-            record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_109] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172];
+            record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10452,22 +10136,22 @@ fn aiur_fn_111(
   })
 }
 
-const INPUT_SIZE_112: usize = 5;
-const IN_112: usize = 5;
-const OUT_112: usize = 33;
-fn aiur_fn_112(
-  inp: [G; IN_112],
+const INPUT_SIZE_110: usize = 5;
+const IN_110: usize = 5;
+const OUT_110: usize = 33;
+fn aiur_fn_110(
+  inp: [G; IN_110],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_112], ExecError> {
+) -> Result<[G; OUT_110], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_0, __v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
     let __v_7: G = __r_arr[2];
@@ -10502,7 +10186,7 @@ fn aiur_fn_112(
     let __v_36: G = __r_arr[31];
     let __v_37: G = G::from_u64(1);
     let __v_38: G = (__v_4 - __v_37);
-    let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_0, __v_1, __v_3, __v_2, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_0, __v_1, __v_3, __v_2, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10536,21 +10220,21 @@ fn aiur_fn_112(
     let __v_69: G = __r_arr[30];
     let __v_70: G = __r_arr[31];
     let __v_71: G = __r_arr[32];
-    let __ret: [G; OUT_112] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71];
-    record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_110] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71];
+    record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_113: usize = 6;
-const IN_113: usize = 6;
-const OUT_113: usize = 1;
-fn aiur_fn_113(
-  inp: [G; IN_113],
+const INPUT_SIZE_111: usize = 6;
+const IN_111: usize = 6;
+const OUT_111: usize = 1;
+fn aiur_fn_111(
+  inp: [G; IN_111],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_113], ExecError> {
+) -> Result<[G; OUT_111], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10558,7 +10242,7 @@ fn aiur_fn_113(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_1, __v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_1, __v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -10592,7 +10276,7 @@ fn aiur_fn_113(
     let __v_36: G = __r_arr[30];
     let __v_37: G = __r_arr[31];
     let __v_38: G = __r_arr[32];
-    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10625,23 +10309,23 @@ fn aiur_fn_113(
     let __v_68: G = __r_arr[29];
     let __v_69: G = __r_arr[30];
     let __v_70: G = __r_arr[31];
-    let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
     let __v_71: G = __r_arr[0];
-    let __ret: [G; OUT_113] = [__v_71];
-    record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_111] = [__v_71];
+    record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_114: usize = 2;
-const IN_114: usize = 2;
-const OUT_114: usize = 1;
-fn aiur_fn_114(
-  inp: [G; IN_114],
+const INPUT_SIZE_112: usize = 2;
+const IN_112: usize = 2;
+const OUT_112: usize = 1;
+fn aiur_fn_112(
+  inp: [G; IN_112],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_114], ExecError> {
+) -> Result<[G; OUT_112], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10651,17 +10335,17 @@ fn aiur_fn_114(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_114] = [__v_1];
-        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_112] = [__v_1];
+        record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_5: G = G::from_u64(0);
         let __v_6: G = { let __values: [G; 3] = [__v_5, __v_3, __v_1]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
-        let __ret: [G; OUT_114] = [__v_7];
-        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_112] = [__v_7];
+        record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10671,15 +10355,15 @@ fn aiur_fn_114(
   })
 }
 
-const INPUT_SIZE_115: usize = 2;
-const IN_115: usize = 2;
-const OUT_115: usize = 1;
-fn aiur_fn_115(
-  inp: [G; IN_115],
+const INPUT_SIZE_113: usize = 2;
+const IN_113: usize = 2;
+const OUT_113: usize = 1;
+fn aiur_fn_113(
+  inp: [G; IN_113],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_115], ExecError> {
+) -> Result<[G; OUT_113], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10690,26 +10374,26 @@ fn aiur_fn_115(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(1);
-        let __ret: [G; OUT_115] = [__v_5];
-        record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_113] = [__v_5];
+        record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_15] = { let __args: [G; IN_15] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[15].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_15] = unsafe { *(result.output.as_ptr() as *const [G; OUT_15]) }; __ret } else { aiur_fn_15(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         match __v_3.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_115] = [__v_6];
-            record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_113] = [__v_6];
+            record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
             let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
             let __v_7: G = __r_arr[0];
-            let __ret: [G; OUT_115] = [__v_7];
-            record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_113] = [__v_7];
+            record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -10721,15 +10405,15 @@ fn aiur_fn_115(
   })
 }
 
-const INPUT_SIZE_116: usize = 8;
-const IN_116: usize = 8;
-const OUT_116: usize = 2;
-fn aiur_fn_116(
-  inp: [G; IN_116],
+const INPUT_SIZE_114: usize = 8;
+const IN_114: usize = 8;
+const OUT_114: usize = 2;
+fn aiur_fn_114(
+  inp: [G; IN_114],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_116], ExecError> {
+) -> Result<[G; OUT_114], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10741,14 +10425,14 @@ fn aiur_fn_116(
     let __v_7: G = inp[7];
     let __v_8: G = G::from_u64(1);
     let __v_9: G = (__v_1 + __v_8);
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = G::from_u64(1);
     let __v_12: G = G::from_u64(1);
     let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __r_arr: [G; OUT_13] = { let __args: [G; IN_13] = [__v_15, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[13].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_13] = unsafe { *(result.output.as_ptr() as *const [G; OUT_13]) }; __ret } else { aiur_fn_13(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
@@ -10773,51 +10457,51 @@ fn aiur_fn_116(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_21, __v_22, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __v_31: G = __r_arr[1];
-    let __ret: [G; OUT_116] = [__v_30, __v_31];
-    record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_114] = [__v_30, __v_31];
+    record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_117: usize = 2;
-const IN_117: usize = 2;
-const OUT_117: usize = 1;
-fn aiur_fn_117(
-  inp: [G; IN_117],
+const INPUT_SIZE_115: usize = 2;
+const IN_115: usize = 2;
+const OUT_115: usize = 1;
+fn aiur_fn_115(
+  inp: [G; IN_115],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_117], ExecError> {
+) -> Result<[G; OUT_115], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_u64(7);
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = G::from_u64(1);
     let __v_5: G = G::from_u64(1);
     let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
     let __v_7: G = __r_arr[0];
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_2, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
     let __v_9: G = __r_arr[0];
-    let __ret: [G; OUT_117] = [__v_9];
-    record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_115] = [__v_9];
+    record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_118: usize = 1;
-const IN_118: usize = 1;
-const OUT_118: usize = 1;
-fn aiur_fn_118(
-  inp: [G; IN_118],
+const INPUT_SIZE_116: usize = 1;
+const IN_116: usize = 1;
+const OUT_116: usize = 1;
+fn aiur_fn_116(
+  inp: [G; IN_116],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_118], ExecError> {
+) -> Result<[G; OUT_116], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -10836,19 +10520,19 @@ fn aiur_fn_118(
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_118] = [__v_13];
-        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_116] = [__v_13];
+        record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_11: G = G::from_u64(0);
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 3] = [__v_11, __v_12, __v_13]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_118] = [__v_14];
-        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_116] = [__v_14];
+        record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10858,15 +10542,15 @@ fn aiur_fn_118(
   })
 }
 
-const INPUT_SIZE_119: usize = 10;
-const IN_119: usize = 10;
-const OUT_119: usize = 4;
-fn aiur_fn_119(
-  inp: [G; IN_119],
+const INPUT_SIZE_117: usize = 10;
+const IN_117: usize = 10;
+const OUT_117: usize = 4;
+fn aiur_fn_117(
+  inp: [G; IN_117],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_119], ExecError> {
+) -> Result<[G; OUT_117], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10884,8 +10568,8 @@ fn aiur_fn_119(
     let __v_12: G = __loaded[2];
     match __v_10.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_119] = [__v_6, __v_7, __v_8, __v_9];
-        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_117] = [__v_6, __v_7, __v_8, __v_9];
+        record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10912,13 +10596,13 @@ fn aiur_fn_119(
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
             let __v_26: G = __r_arr[0];
             let __v_27: G = __r_arr[1];
-            let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_12, __v_16, __v_2, __v_3, __v_4, __v_5, __v_24, __v_25, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_12, __v_16, __v_2, __v_3, __v_4, __v_5, __v_24, __v_25, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
             let __v_29: G = __r_arr[1];
             let __v_30: G = __r_arr[2];
             let __v_31: G = __r_arr[3];
-            let __ret: [G; OUT_119] = [__v_28, __v_29, __v_30, __v_31];
-            record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_117] = [__v_28, __v_29, __v_30, __v_31];
+            record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10933,15 +10617,15 @@ fn aiur_fn_119(
   })
 }
 
-const INPUT_SIZE_120: usize = 2;
-const IN_120: usize = 2;
-const OUT_120: usize = 1;
-fn aiur_fn_120(
-  inp: [G; IN_120],
+const INPUT_SIZE_118: usize = 2;
+const IN_118: usize = 2;
+const OUT_118: usize = 1;
+fn aiur_fn_118(
+  inp: [G; IN_118],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_120], ExecError> {
+) -> Result<[G; OUT_118], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10952,8 +10636,8 @@ fn aiur_fn_120(
     let __v_5: G = __loaded[3];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_120] = [__v_1];
-        record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_118] = [__v_1];
+        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10975,13 +10659,89 @@ fn aiur_fn_120(
         let __v_19: G = __r_arr[5];
         let __v_20: G = __r_arr[6];
         let __v_21: G = __r_arr[7];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
-        let __ret: [G; OUT_120] = [__v_24];
+        let __ret: [G; OUT_118] = [__v_24];
+        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_119: usize = 2;
+const IN_119: usize = 2;
+const OUT_119: usize = 1;
+fn aiur_fn_119(
+  inp: [G; IN_119],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_119], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_119] = [__v_1];
+        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_119] = [__v_6];
+        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_120: usize = 2;
+const IN_120: usize = 2;
+const OUT_120: usize = 1;
+fn aiur_fn_120(
+  inp: [G; IN_120],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_120], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_120] = [__v_1];
+        record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_120] = [__v_6];
         record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -10992,8 +10752,8 @@ fn aiur_fn_120(
   })
 }
 
-const INPUT_SIZE_121: usize = 2;
-const IN_121: usize = 2;
+const INPUT_SIZE_121: usize = 3;
+const IN_121: usize = 3;
 const OUT_121: usize = 1;
 fn aiur_fn_121(
   inp: [G; IN_121],
@@ -11004,27 +10764,22 @@ fn aiur_fn_121(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_121] = [__v_1];
+    let __v_2: G = inp[2];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_121] = [__v_2];
         record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      0u64 => {
-        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_121] = [__v_6];
+      1u64 => {
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __ret: [G; OUT_121] = [__v_3];
         record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
       },
     }
   })
@@ -11042,85 +10797,14 @@ fn aiur_fn_122(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_122] = [__v_1];
-        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_122] = [__v_6];
-        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_123: usize = 3;
-const IN_123: usize = 3;
-const OUT_123: usize = 1;
-fn aiur_fn_123(
-  inp: [G; IN_123],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_123], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_123] = [__v_2];
-        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __ret: [G; OUT_123] = [__v_3];
-        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_124: usize = 2;
-const IN_124: usize = 2;
-const OUT_124: usize = 1;
-fn aiur_fn_124(
-  inp: [G; IN_124],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_124], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_124] = [__v_0];
-        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_122] = [__v_0];
+        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11132,12 +10816,12 @@ fn aiur_fn_124(
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __ret: [G; OUT_124] = [__v_14];
-        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_122] = [__v_14];
+        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -11147,15 +10831,15 @@ fn aiur_fn_124(
   })
 }
 
-const INPUT_SIZE_125: usize = 10;
-const IN_125: usize = 10;
-const OUT_125: usize = 2;
-fn aiur_fn_125(
-  inp: [G; IN_125],
+const INPUT_SIZE_123: usize = 10;
+const IN_123: usize = 10;
+const OUT_123: usize = 2;
+fn aiur_fn_123(
+  inp: [G; IN_123],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_125], ExecError> {
+) -> Result<[G; OUT_123], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11172,43 +10856,43 @@ fn aiur_fn_125(
         let __v_10: G = G::from_u64(1);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = { let __values: [G; 3] = [__v_10, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_125] = [__v_0, __v_12];
-        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_123] = [__v_0, __v_12];
+        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
         let __v_15: G = __r_arr[1];
         let __v_16: G = __r_arr[2];
-        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_125] = [__v_15, __v_16];
-        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_123] = [__v_15, __v_16];
+        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_126: usize = 4;
-const IN_126: usize = 4;
-const OUT_126: usize = 2;
-fn aiur_fn_126(
-  inp: [G; IN_126],
+const INPUT_SIZE_124: usize = 4;
+const IN_124: usize = 4;
+const OUT_124: usize = 2;
+fn aiur_fn_124(
+  inp: [G; IN_124],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_126], ExecError> {
+) -> Result<[G; OUT_124], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11223,8 +10907,8 @@ fn aiur_fn_126(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_126] = [__v_9, __v_0];
-        record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_124] = [__v_9, __v_0];
+        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11241,12 +10925,12 @@ fn aiur_fn_126(
         let __v_16: G = __loaded[9];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
-            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
             let __v_19: G = __r_arr[1];
-            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
             let __v_21: G = __r_arr[1];
             let __v_22: G = __r_arr[2];
@@ -11265,7 +10949,7 @@ fn aiur_fn_126(
             let __v_35: G = __r_arr[15];
             let __v_36: G = __r_arr[16];
             let __v_37: G = __r_arr[17];
-            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = __r_arr[1];
             let __v_40: G = G::from_u64(0);
@@ -11274,8 +10958,8 @@ fn aiur_fn_126(
             let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
             let __v_42: G = __r_arr[0];
             let __v_43: G = { let __values: [G; 4] = [__v_40, __v_41, __v_42, __v_38]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_126] = [__v_43, __v_39];
-            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_124] = [__v_43, __v_39];
+            record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11290,15 +10974,15 @@ fn aiur_fn_126(
   })
 }
 
-const INPUT_SIZE_127: usize = 5;
-const IN_127: usize = 5;
-const OUT_127: usize = 1;
-fn aiur_fn_127(
-  inp: [G; IN_127],
+const INPUT_SIZE_125: usize = 5;
+const IN_125: usize = 5;
+const OUT_125: usize = 1;
+fn aiur_fn_125(
+  inp: [G; IN_125],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_127], ExecError> {
+) -> Result<[G; OUT_125], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11308,12 +10992,12 @@ fn aiur_fn_127(
     match __v_2.as_canonical_u64() {
       0u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_127] = [__v_5];
-        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_125] = [__v_5];
+        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_1 - __v_4);
         let __v_7: G = (__v_5 + __v_6);
@@ -11321,8 +11005,8 @@ fn aiur_fn_127(
         match __v_8.as_canonical_u64() {
           1u64 => {
             let __v_9: G = G::from_u64(1);
-            let __ret: [G; OUT_127] = [__v_9];
-            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_125] = [__v_9];
+            record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11330,10 +11014,10 @@ fn aiur_fn_127(
             let __v_10: G = (__v_2 - __v_9);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 + __v_11);
-            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
-            let __ret: [G; OUT_127] = [__v_13];
-            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_125] = [__v_13];
+            record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -11342,15 +11026,15 @@ fn aiur_fn_127(
   })
 }
 
-const INPUT_SIZE_128: usize = 4;
-const IN_128: usize = 4;
-const OUT_128: usize = 1;
-fn aiur_fn_128(
-  inp: [G; IN_128],
+const INPUT_SIZE_126: usize = 4;
+const IN_126: usize = 4;
+const OUT_126: usize = 1;
+fn aiur_fn_126(
+  inp: [G; IN_126],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_128], ExecError> {
+) -> Result<[G; OUT_126], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11361,22 +11045,22 @@ fn aiur_fn_128(
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 7] = [__v_4, __v_5, __v_5, __v_5, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_128] = [__v_6];
-        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_126] = [__v_6];
+        record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_3 - __v_6);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_128] = [__v_8];
-            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_126] = [__v_8];
+            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11387,11 +11071,11 @@ fn aiur_fn_128(
             let __v_10: G = G::from_u64(0);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 - __v_11);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = { let __values: [G; 7] = [__v_6, __v_3, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_128] = [__v_14];
-            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_126] = [__v_14];
+            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -11400,15 +11084,15 @@ fn aiur_fn_128(
   })
 }
 
-const INPUT_SIZE_129: usize = 8;
-const IN_129: usize = 8;
-const OUT_129: usize = 1;
-fn aiur_fn_129(
-  inp: [G; IN_129],
+const INPUT_SIZE_127: usize = 8;
+const IN_127: usize = 8;
+const OUT_127: usize = 1;
+fn aiur_fn_127(
+  inp: [G; IN_127],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_129], ExecError> {
+) -> Result<[G; OUT_127], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11431,8 +11115,8 @@ fn aiur_fn_129(
         let __v_15: G = G::from_u64(1);
         let __v_16: G = G::from_u64(1);
         let __v_17: G = { let __values: [G; 7] = [__v_15, __v_16, __v_16, __v_16, __v_16, __v_16, __v_16]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_129] = [__v_17];
-        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_127] = [__v_17];
+        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11442,24 +11126,24 @@ fn aiur_fn_129(
             let __v_16: G = G::from_bool((__v_15 == G::ZERO));
             match __v_16.as_canonical_u64() {
               1u64 => {
-                let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_12, __v_13, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_12, __v_13, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
                 let __v_17: G = __r_arr[0];
                 let __v_18: G = __r_arr[1];
                 let __v_19: G = __r_arr[2];
                 let __v_20: G = __r_arr[3];
                 let __v_21: G = G::from_u64(0);
                 let __v_22: G = { let __values: [G; 7] = [__v_21, __v_9, __v_19, __v_20, __v_17, __v_18, __v_14]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_129] = [__v_22];
-                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_127] = [__v_22];
+                record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_17: G = G::from_u64(0);
-                let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
                 let __v_18: G = __r_arr[0];
                 let __v_19: G = { let __values: [G; 7] = [__v_17, __v_9, __v_10, __v_11, __v_12, __v_13, __v_18]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_129] = [__v_19];
-                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_127] = [__v_19];
+                record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11473,15 +11157,15 @@ fn aiur_fn_129(
   })
 }
 
-const INPUT_SIZE_130: usize = 2;
-const IN_130: usize = 2;
-const OUT_130: usize = 1;
-fn aiur_fn_130(
-  inp: [G; IN_130],
+const INPUT_SIZE_128: usize = 2;
+const IN_128: usize = 2;
+const OUT_128: usize = 1;
+fn aiur_fn_128(
+  inp: [G; IN_128],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_130], ExecError> {
+) -> Result<[G; OUT_128], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11496,8 +11180,8 @@ fn aiur_fn_130(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_9: G = G::from_u64(1);
-        let __ret: [G; OUT_130] = [__v_9];
-        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_128] = [__v_9];
+        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11516,15 +11200,15 @@ fn aiur_fn_130(
                   return Err(ExecError::AssertEqMismatch { lhs: __v_13.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
                 }
                 let __v_15: G = G::from_u64(1);
-                let __ret: [G; OUT_130] = [__v_15];
-                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_128] = [__v_15];
+                record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_130] = [__v_11];
-                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_128] = [__v_11];
+                record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11538,8 +11222,90 @@ fn aiur_fn_130(
   })
 }
 
-const INPUT_SIZE_131: usize = 2;
-const IN_131: usize = 2;
+const INPUT_SIZE_129: usize = 2;
+const IN_129: usize = 2;
+const OUT_129: usize = 1;
+fn aiur_fn_129(
+  inp: [G; IN_129],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_129], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(0);
+        let __ret: [G; OUT_129] = [__v_2];
+        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __ret: [G; OUT_129] = [__v_2];
+        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_130: usize = 10;
+const IN_130: usize = 10;
+const OUT_130: usize = 1;
+fn aiur_fn_130(
+  inp: [G; IN_130],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_130], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = (__v_3 - __v_1);
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
+    let __v_16: G = __r_arr[0];
+    let __v_17: G = __r_arr[1];
+    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+    let __v_18: G = __r_arr[0];
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __v_20: G = (__v_18 - __v_19);
+    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+    let __v_22: G = G::from_u64(1);
+    if (__v_21 != __v_22) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+    }
+    let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __ret: [G; OUT_130] = [__v_23];
+    record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_131: usize = 11;
+const IN_131: usize = 11;
 const OUT_131: usize = 1;
 fn aiur_fn_131(
   inp: [G; IN_131],
@@ -11550,28 +11316,39 @@ fn aiur_fn_131(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(0);
-        let __ret: [G; OUT_131] = [__v_2];
-        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __ret: [G; OUT_131] = [__v_2];
-        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
-    }
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = G::from_u64(0);
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(1);
+    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+    let __v_15: G = __r_arr[0];
+    let __v_16: G = G::from_u64(0);
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_17: G = __r_arr[0];
+    let __v_18: G = __r_arr[1];
+    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __ret: [G; OUT_131] = [__v_20];
+    record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_132: usize = 10;
-const IN_132: usize = 10;
+const INPUT_SIZE_132: usize = 13;
+const IN_132: usize = 13;
 const OUT_132: usize = 1;
 fn aiur_fn_132(
   inp: [G; IN_132],
@@ -11590,38 +11367,43 @@ fn aiur_fn_132(
     let __v_7: G = inp[7];
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
-    let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __v_15: G = __r_arr[1];
-    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
-    let __v_16: G = __r_arr[0];
-    let __v_17: G = __r_arr[1];
-    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-    let __v_18: G = __r_arr[0];
-    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __v_20: G = (__v_18 - __v_19);
-    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-    let __v_22: G = G::from_u64(1);
-    if (__v_21 != __v_22) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    match __v_5.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_132] = [__v_0];
+        record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = G::from_u64(1);
+        let __v_20: G = (__v_4 + __v_19);
+        let __v_21: G = G::from_u64(1);
+        let __v_22: G = (__v_5 - __v_21);
+        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __ret: [G; OUT_132] = [__v_23];
+        record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
     }
-    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __ret: [G; OUT_132] = [__v_23];
-    record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_133: usize = 11;
-const IN_133: usize = 11;
+const INPUT_SIZE_133: usize = 13;
+const IN_133: usize = 13;
 const OUT_133: usize = 1;
 fn aiur_fn_133(
   inp: [G; IN_133],
@@ -11641,30 +11423,45 @@ fn aiur_fn_133(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
-    let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
-    let __v_15: G = __r_arr[0];
-    let __v_16: G = G::from_u64(0);
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_17: G = __r_arr[0];
-    let __v_18: G = __r_arr[1];
-    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __ret: [G; OUT_133] = [__v_20];
-    record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    match __v_5.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_133] = [__v_0];
+        record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __v_18: G = G::from_u64(0);
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
+        let __v_21: G = G::from_u64(1);
+        let __v_22: G = (__v_4 + __v_21);
+        let __v_23: G = G::from_u64(1);
+        let __v_24: G = (__v_5 - __v_23);
+        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __ret: [G; OUT_133] = [__v_25];
+        record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_134: usize = 13;
-const IN_134: usize = 13;
+const INPUT_SIZE_134: usize = 15;
+const IN_134: usize = 15;
 const OUT_134: usize = 1;
 fn aiur_fn_134(
   inp: [G; IN_134],
@@ -11686,6 +11483,8 @@ fn aiur_fn_134(
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
     match __v_5.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_134] = [__v_0];
@@ -11693,33 +11492,56 @@ fn aiur_fn_134(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = G::from_u64(1);
-        let __v_20: G = (__v_4 + __v_19);
-        let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_5 - __v_21);
-        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-        let __v_23: G = __r_arr[0];
-        let __ret: [G; OUT_134] = [__v_23];
-        record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __v_16: G = __r_arr[1];
+        match __v_15.as_canonical_u64() {
+          0u64 => {
+            let __v_17: G = G::from_u64(1);
+            let __v_18: G = (__v_4 + __v_17);
+            let __v_19: G = G::from_u64(1);
+            let __v_20: G = (__v_5 - __v_19);
+            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __ret: [G; OUT_134] = [__v_21];
+            record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_17: G = __r_arr[0];
+            let __v_18: G = (__v_17 + __v_3);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+            let __v_22: G = __r_arr[0];
+            let __v_23: G = G::from_u64(1);
+            let __v_24: G = (__v_4 + __v_23);
+            let __v_25: G = G::from_u64(1);
+            let __v_26: G = (__v_5 - __v_25);
+            let __v_27: G = G::from_u64(1);
+            let __v_28: G = (__v_6 + __v_27);
+            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_134] = [__v_29];
+            record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_135: usize = 13;
-const IN_135: usize = 13;
+const INPUT_SIZE_135: usize = 15;
+const IN_135: usize = 15;
 const OUT_135: usize = 1;
 fn aiur_fn_135(
   inp: [G; IN_135],
@@ -11741,43 +11563,59 @@ fn aiur_fn_135(
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
-    match __v_5.as_canonical_u64() {
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    match __v_3.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_135] = [__v_0];
         record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+      1u64 => {
+        let __v_15: G = G::from_u64(3);
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = G::from_u64(0);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_19: G = __r_arr[0];
-        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_4 + __v_21);
-        let __v_23: G = G::from_u64(1);
-        let __v_24: G = (__v_5 - __v_23);
-        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-        let __v_25: G = __r_arr[0];
-        let __ret: [G; OUT_135] = [__v_25];
-        record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __v_17: G = __r_arr[1];
+        match __v_16.as_canonical_u64() {
+          _ => {
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_18: G = __r_arr[0];
+            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __v_20: G = (__v_18 - __v_19);
+            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+            let __v_22: G = G::from_u64(1);
+            if (__v_21 != __v_22) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+            }
+            let __v_23: G = G::from_u64(0);
+            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+            let __v_24: G = __r_arr[0];
+            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+            let __v_25: G = __r_arr[0];
+            let __v_26: G = G::from_u64(1);
+            if (__v_25 != __v_26) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
+            }
+            let __v_27: G = G::from_u64(0);
+            let __v_28: G = G::from_u64(0);
+            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_135] = [__v_29];
+            record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_136: usize = 15;
-const IN_136: usize = 15;
+const INPUT_SIZE_136: usize = 4;
+const IN_136: usize = 4;
 const OUT_136: usize = 1;
 fn aiur_fn_136(
   inp: [G; IN_136],
@@ -11790,74 +11628,37 @@ fn aiur_fn_136(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    match __v_5.as_canonical_u64() {
+    match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_136] = [__v_0];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_136] = [__v_6];
         record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        match __v_15.as_canonical_u64() {
-          0u64 => {
-            let __v_17: G = G::from_u64(1);
-            let __v_18: G = (__v_4 + __v_17);
-            let __v_19: G = G::from_u64(1);
-            let __v_20: G = (__v_5 - __v_19);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __ret: [G; OUT_136] = [__v_21];
-            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-            let __v_17: G = __r_arr[0];
-            let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-            let __v_22: G = __r_arr[0];
-            let __v_23: G = G::from_u64(1);
-            let __v_24: G = (__v_4 + __v_23);
-            let __v_25: G = G::from_u64(1);
-            let __v_26: G = (__v_5 - __v_25);
-            let __v_27: G = G::from_u64(1);
-            let __v_28: G = (__v_6 + __v_27);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_136] = [__v_29];
-            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-          },
-        }
+        let __v_4: G = G::from_u64(0);
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_5 + __v_1);
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_2 - __v_7);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_3 + __v_9);
+        let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_136] = [__v_12];
+        record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_137: usize = 15;
-const IN_137: usize = 15;
+const INPUT_SIZE_137: usize = 5;
+const IN_137: usize = 5;
 const OUT_137: usize = 1;
 fn aiur_fn_137(
   inp: [G; IN_137],
@@ -11871,134 +11672,17 @@ fn aiur_fn_137(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_137] = [__v_0];
-        record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        match __v_16.as_canonical_u64() {
-          _ => {
-            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-            let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __v_20: G = (__v_18 - __v_19);
-            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-            let __v_22: G = G::from_u64(1);
-            if (__v_21 != __v_22) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-            }
-            let __v_23: G = G::from_u64(0);
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
-            let __v_24: G = __r_arr[0];
-            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __v_26: G = G::from_u64(1);
-            if (__v_25 != __v_26) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
-            }
-            let __v_27: G = G::from_u64(0);
-            let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_137] = [__v_29];
-            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_138: usize = 4;
-const IN_138: usize = 4;
-const OUT_138: usize = 1;
-fn aiur_fn_138(
-  inp: [G; IN_138],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_138], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_6];
-        record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_5 + __v_1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_2 - __v_7);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_3 + __v_9);
-        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_12];
-        record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_139: usize = 5;
-const IN_139: usize = 5;
-const OUT_139: usize = 1;
-fn aiur_fn_139(
-  inp: [G; IN_139],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_139], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
     match __v_3.as_canonical_u64() {
       0u64 => {
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_139] = [__v_7];
-        record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_137] = [__v_7];
+        record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         match __v_5.as_canonical_u64() {
@@ -12007,26 +11691,26 @@ fn aiur_fn_139(
             let __v_8: G = (__v_3 - __v_7);
             let __v_9: G = G::from_u64(1);
             let __v_10: G = (__v_4 + __v_9);
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
             let __v_11: G = __r_arr[0];
-            let __ret: [G; OUT_139] = [__v_11];
-            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_137] = [__v_11];
+            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
             let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = (__v_8 + __v_1);
             let __v_10: G = G::from_u64(1);
             let __v_11: G = (__v_3 - __v_10);
             let __v_12: G = G::from_u64(1);
             let __v_13: G = (__v_4 + __v_12);
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
             let __v_14: G = __r_arr[0];
             let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_139] = [__v_15];
-            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_137] = [__v_15];
+            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -12038,15 +11722,15 @@ fn aiur_fn_139(
   })
 }
 
-const INPUT_SIZE_140: usize = 5;
-const IN_140: usize = 5;
-const OUT_140: usize = 4;
-fn aiur_fn_140(
-  inp: [G; IN_140],
+const INPUT_SIZE_138: usize = 5;
+const IN_138: usize = 5;
+const OUT_138: usize = 4;
+fn aiur_fn_138(
+  inp: [G; IN_138],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_140], ExecError> {
+) -> Result<[G; OUT_138], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12055,28 +11739,28 @@ fn aiur_fn_140(
     let __v_4: G = inp[4];
     match __v_0.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_140] = [__v_1, __v_2, __v_3, __v_4];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_138] = [__v_1, __v_2, __v_3, __v_4];
+        record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __ret: [G; OUT_140] = [__v_3, __v_4, __v_1, __v_2];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_138] = [__v_3, __v_4, __v_1, __v_2];
+        record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_141: usize = 4;
-const IN_141: usize = 4;
-const OUT_141: usize = 1;
-fn aiur_fn_141(
-  inp: [G; IN_141],
+const INPUT_SIZE_139: usize = 4;
+const IN_139: usize = 4;
+const OUT_139: usize = 1;
+fn aiur_fn_139(
+  inp: [G; IN_139],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_141], ExecError> {
+) -> Result<[G; OUT_139], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12129,21 +11813,21 @@ fn aiur_fn_141(
     let __v_44: G = { let __values: [G; 10] = [__v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_43]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_45: G = { let __values: [G; 10] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_44]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_46: G = { let __values: [G; 10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_45]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_141] = [__v_46];
-    record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_139] = [__v_46];
+    record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_142: usize = 6;
-const IN_142: usize = 6;
-const OUT_142: usize = 3;
-fn aiur_fn_142(
-  inp: [G; IN_142],
+const INPUT_SIZE_140: usize = 6;
+const IN_140: usize = 6;
+const OUT_140: usize = 3;
+fn aiur_fn_140(
+  inp: [G; IN_140],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_142], ExecError> {
+) -> Result<[G; OUT_140], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12161,8 +11845,8 @@ fn aiur_fn_142(
     let __v_12: G = __loaded[6];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
-        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_140] = [__v_0, __v_1, __v_5];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12173,7 +11857,7 @@ fn aiur_fn_142(
             match __v_14.as_canonical_u64() {
               1u64 => {
                 let __v_15: G = G::from_u64(1);
-                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
                 let __v_16: G = __r_arr[0];
                 let __v_17: G = __r_arr[1];
                 let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_16, __v_17, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -12182,13 +11866,13 @@ fn aiur_fn_142(
                 let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 let __v_21: G = __r_arr[1];
-                let __ret: [G; OUT_142] = [__v_20, __v_21, __v_12];
-                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_140] = [__v_20, __v_21, __v_12];
+                record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
-                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_140] = [__v_0, __v_1, __v_5];
+                record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -12202,15 +11886,15 @@ fn aiur_fn_142(
   })
 }
 
-const INPUT_SIZE_143: usize = 9;
-const IN_143: usize = 9;
-const OUT_143: usize = 2;
-fn aiur_fn_143(
-  inp: [G; IN_143],
+const INPUT_SIZE_141: usize = 9;
+const IN_141: usize = 9;
+const OUT_141: usize = 2;
+fn aiur_fn_141(
+  inp: [G; IN_141],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_143], ExecError> {
+) -> Result<[G; OUT_141], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12235,14 +11919,14 @@ fn aiur_fn_143(
         if (__v_15 != __v_16) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_15.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_143] = [__v_0, __v_1];
-        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_141] = [__v_0, __v_1];
+        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12270,29 +11954,29 @@ fn aiur_fn_143(
                         let __v_24: G = G::from_u64(1);
                         let __v_25: G = (__v_6 - __v_24);
                         let __v_26: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
                         let __v_27: G = __r_arr[0];
                         let __v_28: G = __r_arr[1];
-                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
                         let __v_29: G = __r_arr[0];
                         let __v_30: G = __r_arr[1];
                         let __v_31: G = __r_arr[2];
                         let __v_32: G = __r_arr[3];
-                        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
                         let __v_33: G = __r_arr[0];
                         let __v_34: G = __r_arr[1];
-                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = __r_arr[1];
                         let __v_37: G = __r_arr[2];
-                        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
                         let __v_39: G = G::from_u64(1);
                         if (__v_38 != __v_39) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_38.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
                         }
                         let __v_40: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
                         let __v_41: G = __r_arr[0];
                         let __v_42: G = G::from_u64(1);
                         let __v_43: G = G::from_u64(1);
@@ -12303,17 +11987,17 @@ fn aiur_fn_143(
                         let __v_48: G = G::from_u64(1);
                         let __v_49: G = { let __values: [G; 3] = [__v_47, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                         let __v_50: G = { let __values: [G; 3] = [__v_46, __v_25, __v_49]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_19, __v_45, __v_50, __v_23, __v_12, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_19, __v_45, __v_50, __v_23, __v_12, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
                         let __v_51: G = __r_arr[0];
                         let __v_52: G = G::from_u64(1);
                         if (__v_51 != __v_52) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_51.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
                         }
-                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                         let __v_53: G = __r_arr[0];
                         let __v_54: G = __r_arr[1];
-                        let __ret: [G; OUT_143] = [__v_53, __v_54];
-                        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_141] = [__v_53, __v_54];
+                        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                       _ => {
@@ -12340,15 +12024,15 @@ fn aiur_fn_143(
   })
 }
 
-const INPUT_SIZE_144: usize = 25;
-const IN_144: usize = 25;
-const OUT_144: usize = 1;
-fn aiur_fn_144(
-  inp: [G; IN_144],
+const INPUT_SIZE_142: usize = 25;
+const IN_142: usize = 25;
+const OUT_142: usize = 1;
+fn aiur_fn_142(
+  inp: [G; IN_142],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_144], ExecError> {
+) -> Result<[G; OUT_142], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12377,38 +12061,38 @@ fn aiur_fn_144(
     let __v_24: G = inp[24];
     match __v_1.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
         let __v_25: G = __r_arr[0];
         let __v_26: G = G::from_u64(0);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         let __v_28: G = __r_arr[1];
         match __v_27.as_canonical_u64() {
           _ => {
             let __v_29: G = G::from_u64(0);
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
             let __v_30: G = __r_arr[0];
             let __v_31: G = G::from_u64(1);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
             let __v_32: G = __r_arr[0];
             let __v_33: G = __r_arr[1];
             match __v_32.as_canonical_u64() {
               _ => {
                 let __v_34: G = G::from_u64(0);
-                let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
                 let __v_35: G = __r_arr[0];
                 let __v_36: G = G::from_u64(2);
-                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 let __v_38: G = __r_arr[1];
                 match __v_37.as_canonical_u64() {
                   _ => {
                     let __v_39: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
                     let __v_40: G = __r_arr[0];
-                    let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
                     let __v_41: G = __r_arr[0];
-                    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
                     let __v_42: G = __r_arr[0];
                     let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
                     let __v_43: G = __loaded[0];
@@ -12422,10 +12106,10 @@ fn aiur_fn_144(
                       0u64 => {
                         match __v_44.as_canonical_u64() {
                           _ => {
-                            let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                             let __v_50: G = __r_arr[0];
                             let __v_51: G = __r_arr[1];
-                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
                             let __v_52: G = __r_arr[0];
                             let __v_53: G = (__v_52 - __v_24);
                             let __v_54: G = G::from_bool((__v_53 == G::ZERO));
@@ -12433,10 +12117,10 @@ fn aiur_fn_144(
                             if (__v_54 != __v_55) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                             let __v_56: G = __r_arr[0];
                             let __v_57: G = G::from_u64(3);
-                            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
                             let __v_58: G = __r_arr[0];
                             let __v_59: G = (__v_57 + __v_58);
                             let __v_60: G = (__v_56 - __v_59);
@@ -12445,7 +12129,7 @@ fn aiur_fn_144(
                             if (__v_61 != __v_62) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                             let __v_63: G = __r_arr[0];
                             let __v_64: G = (__v_63 - __v_18);
                             let __v_65: G = G::from_bool((__v_64 == G::ZERO));
@@ -12454,15 +12138,15 @@ fn aiur_fn_144(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
                             }
                             let __v_67: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
                             let __v_68: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
                             let __v_69: G = __r_arr[0];
                             let __v_70: G = G::from_u64(1);
                             if (__v_69 != __v_70) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                             let __v_71: G = __r_arr[0];
                             let __v_72: G = (__v_71 - __v_18);
                             let __v_73: G = G::from_bool((__v_72 == G::ZERO));
@@ -12471,15 +12155,15 @@ fn aiur_fn_144(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
                             }
                             let __v_75: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
                             let __v_76: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
                             let __v_77: G = __r_arr[0];
                             let __v_78: G = G::from_u64(1);
                             if (__v_77 != __v_78) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                             let __v_79: G = __r_arr[0];
                             let __v_80: G = (__v_79 - __v_18);
                             let __v_81: G = G::from_bool((__v_80 == G::ZERO));
@@ -12488,9 +12172,9 @@ fn aiur_fn_144(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
                             }
                             let __v_83: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
                             let __v_84: G = __r_arr[0];
-                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
                             let __v_85: G = __r_arr[0];
                             let __v_86: G = G::from_u64(1);
                             if (__v_85 != __v_86) {
@@ -12503,7 +12187,7 @@ fn aiur_fn_144(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
                             }
                             let __v_90: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
                             let __v_91: G = __r_arr[0];
                             let __v_92: G = __r_arr[1];
                             let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
@@ -12513,8 +12197,8 @@ fn aiur_fn_144(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
                             }
                             let __v_95: G = G::from_u64(1);
-                            let __ret: [G; OUT_144] = [__v_95];
-                            record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_142] = [__v_95];
+                            record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
@@ -12534,15 +12218,15 @@ fn aiur_fn_144(
   })
 }
 
-const INPUT_SIZE_145: usize = 25;
-const IN_145: usize = 25;
-const OUT_145: usize = 1;
-fn aiur_fn_145(
-  inp: [G; IN_145],
+const INPUT_SIZE_143: usize = 25;
+const IN_143: usize = 25;
+const OUT_143: usize = 1;
+fn aiur_fn_143(
+  inp: [G; IN_143],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_145], ExecError> {
+) -> Result<[G; OUT_143], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12577,21 +12261,21 @@ fn aiur_fn_145(
     match __v_25.as_canonical_u64() {
       1u64 => {
         let __v_29: G = G::from_u64(1);
-        let __ret: [G; OUT_145] = [__v_29];
-        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_143] = [__v_29];
+        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = __r_arr[1];
         let __v_31: G = __r_arr[2];
-        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
-        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
         let __v_33: G = __r_arr[0];
-        let __ret: [G; OUT_145] = [__v_33];
-        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_143] = [__v_33];
+        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12601,15 +12285,15 @@ fn aiur_fn_145(
   })
 }
 
-const INPUT_SIZE_146: usize = 31;
-const IN_146: usize = 31;
-const OUT_146: usize = 1;
-fn aiur_fn_146(
-  inp: [G; IN_146],
+const INPUT_SIZE_144: usize = 31;
+const IN_144: usize = 31;
+const OUT_144: usize = 1;
+fn aiur_fn_144(
+  inp: [G; IN_144],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_146], ExecError> {
+) -> Result<[G; OUT_144], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12644,25 +12328,25 @@ fn aiur_fn_146(
     let __v_30: G = inp[30];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_31: G = __r_arr[0];
         let __v_32: G = G::from_u64(1);
         let __v_33: G = G::from_u64(1);
         let __v_34: G = { let __values: [G; 3] = [__v_32, __v_33, __v_33]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_35: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = G::from_u64(1);
         let __v_41: G = G::from_u64(1);
         let __v_42: G = { let __values: [G; 3] = [__v_40, __v_41, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
         let __v_43: G = __r_arr[0];
         let __v_44: G = __r_arr[1];
         let __v_45: G = __r_arr[2];
@@ -12685,23 +12369,23 @@ fn aiur_fn_146(
         let __v_61: G = __r_arr[0];
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_62: G = __r_arr[0];
-        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
         let __v_63: G = __r_arr[0];
         let __v_64: G = __r_arr[1];
         let __v_65: G = G::from_u64(1);
         let __v_66: G = G::from_u64(1);
         let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
-        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
         let __v_72: G = __r_arr[1];
         let __v_73: G = (__v_31 + __v_27);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
         let __v_74: G = __r_arr[0];
         let __v_75: G = (__v_74 - __v_31);
         let __v_76: G = G::from_bool((__v_75 == G::ZERO));
@@ -12709,7 +12393,7 @@ fn aiur_fn_146(
         if (__v_76 != __v_77) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_78: G = __r_arr[0];
         let __v_79: G = (__v_78 - __v_28);
         let __v_80: G = G::from_bool((__v_79 == G::ZERO));
@@ -12717,52 +12401,52 @@ fn aiur_fn_146(
         if (__v_80 != __v_81) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_82: G = __r_arr[0];
         let __v_83: G = G::from_u64(1);
         if (__v_82 != __v_83) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_82.as_canonical_u64(), rhs: __v_83.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
         let __v_84: G = __r_arr[0];
-        let __ret: [G; OUT_146] = [__v_84];
-        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_144] = [__v_84];
+        record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_147: usize = 2;
-const IN_147: usize = 2;
-const OUT_147: usize = 1;
-fn aiur_fn_147(
-  inp: [G; IN_147],
+const INPUT_SIZE_145: usize = 2;
+const IN_145: usize = 2;
+const OUT_145: usize = 1;
+fn aiur_fn_145(
+  inp: [G; IN_145],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_147], ExecError> {
+) -> Result<[G; OUT_145], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_bool((__v_0 == G::ZERO));
     let __v_3: G = G::from_bool((__v_1 == G::ZERO));
     let __v_4: G = (__v_2 * __v_3);
-    let __ret: [G; OUT_147] = [__v_4];
-    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_145] = [__v_4];
+    record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_148: usize = 1;
-const IN_148: usize = 1;
-const OUT_148: usize = 1;
-fn aiur_fn_148(
-  inp: [G; IN_148],
+const INPUT_SIZE_146: usize = 1;
+const IN_146: usize = 1;
+const OUT_146: usize = 1;
+fn aiur_fn_146(
+  inp: [G; IN_146],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_148], ExecError> {
+) -> Result<[G; OUT_146], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -12773,8 +12457,8 @@ fn aiur_fn_148(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_148] = [__v_5];
-        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_146] = [__v_5];
+        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12785,17 +12469,17 @@ fn aiur_fn_148(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           1u64 => {
-            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_148] = [__v_9];
-            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_146] = [__v_9];
+            record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_148] = [__v_9];
-            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_146] = [__v_9];
+            record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -12807,15 +12491,15 @@ fn aiur_fn_148(
   })
 }
 
-const INPUT_SIZE_149: usize = 9;
-const IN_149: usize = 9;
-const OUT_149: usize = 1;
-fn aiur_fn_149(
-  inp: [G; IN_149],
+const INPUT_SIZE_147: usize = 9;
+const IN_147: usize = 9;
+const OUT_147: usize = 1;
+fn aiur_fn_147(
+  inp: [G; IN_147],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_149], ExecError> {
+) -> Result<[G; OUT_147], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12842,21 +12526,21 @@ fn aiur_fn_149(
     let __v_22: G = { let __values: [G; 3] = [__v_11, __v_2, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_23: G = { let __values: [G; 3] = [__v_10, __v_1, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_24: G = { let __values: [G; 3] = [__v_9, __v_0, __v_23]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_149] = [__v_24];
-    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_147] = [__v_24];
+    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_150: usize = 33;
-const IN_150: usize = 33;
-const OUT_150: usize = 1;
-fn aiur_fn_150(
-  inp: [G; IN_150],
+const INPUT_SIZE_148: usize = 33;
+const IN_148: usize = 33;
+const OUT_148: usize = 1;
+fn aiur_fn_148(
+  inp: [G; IN_148],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_150], ExecError> {
+) -> Result<[G; OUT_148], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12891,29 +12575,29 @@ fn aiur_fn_150(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __ret: [G; OUT_150] = [__v_36];
-    record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_148] = [__v_36];
+    record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_151: usize = 2;
-const IN_151: usize = 2;
-const OUT_151: usize = 1;
-fn aiur_fn_151(
-  inp: [G; IN_151],
+const INPUT_SIZE_149: usize = 2;
+const IN_149: usize = 2;
+const OUT_149: usize = 1;
+fn aiur_fn_149(
+  inp: [G; IN_149],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_151], ExecError> {
+) -> Result<[G; OUT_149], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12954,17 +12638,17 @@ fn aiur_fn_151(
     let __v_35: G = __loaded[33];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_151] = [__v_1];
-        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_149] = [__v_1];
+        record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __ret: [G; OUT_151] = [__v_37];
-        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_149] = [__v_37];
+        record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12974,15 +12658,15 @@ fn aiur_fn_151(
   })
 }
 
-const INPUT_SIZE_152: usize = 2;
-const IN_152: usize = 2;
-const OUT_152: usize = 1;
-fn aiur_fn_152(
-  inp: [G; IN_152],
+const INPUT_SIZE_150: usize = 2;
+const IN_150: usize = 2;
+const OUT_150: usize = 1;
+fn aiur_fn_150(
+  inp: [G; IN_150],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_152], ExecError> {
+) -> Result<[G; OUT_150], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12992,8 +12676,8 @@ fn aiur_fn_152(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_152] = [__v_1];
-        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_150] = [__v_1];
+        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -13004,12 +12688,12 @@ fn aiur_fn_152(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_152] = [__v_13];
-        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_150] = [__v_13];
+        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13019,15 +12703,15 @@ fn aiur_fn_152(
   })
 }
 
-const INPUT_SIZE_153: usize = 2;
-const IN_153: usize = 2;
-const OUT_153: usize = 3;
-fn aiur_fn_153(
-  inp: [G; IN_153],
+const INPUT_SIZE_151: usize = 2;
+const IN_151: usize = 2;
+const OUT_151: usize = 3;
+fn aiur_fn_151(
+  inp: [G; IN_151],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_153], ExecError> {
+) -> Result<[G; OUT_151], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13037,8 +12721,8 @@ fn aiur_fn_153(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_153] = [__v_3, __v_0, __v_4];
-        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_151] = [__v_3, __v_0, __v_4];
+        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -13078,12 +12762,12 @@ fn aiur_fn_153(
         let __v_37: G = G::from_u64(1);
         let __v_38: G = G::from_u64(1);
         let __v_39: G = { let __values: [G; 3] = [__v_37, __v_38, __v_38]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
         let __v_40: G = __r_arr[0];
         let __v_41: G = G::from_u64(1);
         let __v_42: G = G::from_u64(1);
         let __v_43: G = { let __values: [G; 3] = [__v_41, __v_42, __v_42]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
         let __v_44: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_44.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_45: G = __loaded[0];
@@ -13091,8 +12775,8 @@ fn aiur_fn_153(
         let __v_47: G = __loaded[2];
         match __v_45.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_153] = [__v_46, __v_40, __v_47];
-            record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_151] = [__v_46, __v_40, __v_47];
+            record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -13107,69 +12791,69 @@ fn aiur_fn_153(
   })
 }
 
-const INPUT_SIZE_154: usize = 2;
-const IN_154: usize = 2;
-const OUT_154: usize = 10;
-fn aiur_fn_154(
-  inp: [G; IN_154],
+const INPUT_SIZE_152: usize = 2;
+const IN_152: usize = 2;
+const OUT_152: usize = 10;
+fn aiur_fn_152(
+  inp: [G; IN_152],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_154], ExecError> {
+) -> Result<[G; OUT_152], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
     let __v_7: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
     let __v_10: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
     let __v_12: G = __r_arr[1];
     let __v_13: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
     let __v_15: G = __r_arr[1];
     let __v_16: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
     let __v_18: G = __r_arr[1];
     let __v_19: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = __r_arr[2];
-    let __ret: [G; OUT_154] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
-    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_152] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
+    record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_155: usize = 2;
-const IN_155: usize = 2;
-const OUT_155: usize = 10;
-fn aiur_fn_155(
-  inp: [G; IN_155],
+const INPUT_SIZE_153: usize = 2;
+const IN_153: usize = 2;
+const OUT_153: usize = 10;
+fn aiur_fn_153(
+  inp: [G; IN_153],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_155], ExecError> {
+) -> Result<[G; OUT_153], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13184,12 +12868,12 @@ fn aiur_fn_155(
     let __v_12: G = __r_arr[0];
     match __v_12.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_153] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = __r_arr[2];
@@ -13200,27 +12884,27 @@ fn aiur_fn_155(
         let __v_20: G = __r_arr[7];
         let __v_21: G = __r_arr[8];
         let __v_22: G = __r_arr[9];
-        let __ret: [G; OUT_155] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
-        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_153] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
+        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_156: usize = 2;
-const IN_156: usize = 2;
-const OUT_156: usize = 18;
-fn aiur_fn_156(
-  inp: [G; IN_156],
+const INPUT_SIZE_154: usize = 2;
+const IN_154: usize = 2;
+const OUT_154: usize = 18;
+fn aiur_fn_154(
+  inp: [G; IN_154],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_156], ExecError> {
+) -> Result<[G; OUT_154], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13231,7 +12915,7 @@ fn aiur_fn_156(
     let __v_9: G = __r_arr[7];
     let __v_10: G = __r_arr[8];
     let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = __r_arr[1];
     let __v_14: G = __r_arr[2];
@@ -13242,21 +12926,21 @@ fn aiur_fn_156(
     let __v_19: G = __r_arr[7];
     let __v_20: G = __r_arr[8];
     let __v_21: G = __r_arr[9];
-    let __ret: [G; OUT_156] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
-    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_154] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
+    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_157: usize = 8;
-const IN_157: usize = 8;
-const OUT_157: usize = 1;
-fn aiur_fn_157(
-  inp: [G; IN_157],
+const INPUT_SIZE_155: usize = 8;
+const IN_155: usize = 8;
+const OUT_155: usize = 1;
+fn aiur_fn_155(
+  inp: [G; IN_155],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_157], ExecError> {
+) -> Result<[G; OUT_155], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13341,37 +13025,37 @@ fn aiur_fn_157(
     let __v_72: G = G::from_u64(1);
     let __v_73: G = G::from_u64(1);
     let __v_74: G = { let __values: [G; 3] = [__v_72, __v_73, __v_73]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_76: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_77: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_78: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_80: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_82: G = __r_arr[0];
-    let __ret: [G; OUT_157] = [__v_82];
-    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_155] = [__v_82];
+    record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_158: usize = 2;
-const IN_158: usize = 2;
-const OUT_158: usize = 1;
-fn aiur_fn_158(
-  inp: [G; IN_158],
+const INPUT_SIZE_156: usize = 2;
+const IN_156: usize = 2;
+const OUT_156: usize = 1;
+fn aiur_fn_156(
+  inp: [G; IN_156],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_158], ExecError> {
+) -> Result<[G; OUT_156], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13380,8 +13064,8 @@ fn aiur_fn_158(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_158] = [__v_4];
-        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_156] = [__v_4];
+        record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13394,11 +13078,11 @@ fn aiur_fn_158(
             let __v_5: G = G::from_u64(0);
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_1 - __v_6);
-            let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_158] = [__v_9];
-            record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_156] = [__v_9];
+            record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -13410,20 +13094,20 @@ fn aiur_fn_158(
   })
 }
 
-const INPUT_SIZE_159: usize = 3;
-const IN_159: usize = 3;
-const OUT_159: usize = 3;
-fn aiur_fn_159(
-  inp: [G; IN_159],
+const INPUT_SIZE_157: usize = 3;
+const IN_157: usize = 3;
+const OUT_157: usize = 3;
+fn aiur_fn_157(
+  inp: [G; IN_157],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_159], ExecError> {
+) -> Result<[G; OUT_157], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __v_5: G = __r_arr[2];
@@ -13434,25 +13118,25 @@ fn aiur_fn_159(
     let __v_10: G = __r_arr[7];
     let __v_11: G = __r_arr[8];
     let __v_12: G = __r_arr[9];
-    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __ret: [G; OUT_159] = [__v_14, __v_11, __v_12];
-    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_157] = [__v_14, __v_11, __v_12];
+    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_160: usize = 9;
-const IN_160: usize = 9;
-const OUT_160: usize = 1;
-fn aiur_fn_160(
-  inp: [G; IN_160],
+const INPUT_SIZE_158: usize = 9;
+const IN_158: usize = 9;
+const OUT_158: usize = 1;
+fn aiur_fn_158(
+  inp: [G; IN_158],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_160], ExecError> {
+) -> Result<[G; OUT_158], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13466,50 +13150,50 @@ fn aiur_fn_160(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __ret: [G; OUT_160] = [__v_13];
-    record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_158] = [__v_13];
+    record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_161: usize = 2;
-const IN_161: usize = 2;
-const OUT_161: usize = 1;
-fn aiur_fn_161(
-  inp: [G; IN_161],
+const INPUT_SIZE_159: usize = 2;
+const IN_159: usize = 2;
+const OUT_159: usize = 1;
+fn aiur_fn_159(
+  inp: [G; IN_159],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_161], ExecError> {
+) -> Result<[G; OUT_159], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_u64(1);
     let __v_3: G = G::from_u64(1);
     let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
-    let __ret: [G; OUT_161] = [__v_6];
-    record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_159] = [__v_6];
+    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_162: usize = 2;
-const IN_162: usize = 2;
-const OUT_162: usize = 1;
-fn aiur_fn_162(
-  inp: [G; IN_162],
+const INPUT_SIZE_160: usize = 2;
+const IN_160: usize = 2;
+const OUT_160: usize = 1;
+fn aiur_fn_160(
+  inp: [G; IN_160],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_162], ExecError> {
+) -> Result<[G; OUT_160], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13526,17 +13210,17 @@ fn aiur_fn_162(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_162] = [__v_1];
-        record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_160] = [__v_1];
+        record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_162] = [__v_13];
-        record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_160] = [__v_13];
+        record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13546,15 +13230,15 @@ fn aiur_fn_162(
   })
 }
 
-const INPUT_SIZE_163: usize = 2;
-const IN_163: usize = 2;
-const OUT_163: usize = 1;
-fn aiur_fn_163(
-  inp: [G; IN_163],
+const INPUT_SIZE_161: usize = 2;
+const IN_161: usize = 2;
+const OUT_161: usize = 1;
+fn aiur_fn_161(
+  inp: [G; IN_161],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_163], ExecError> {
+) -> Result<[G; OUT_161], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13564,12 +13248,12 @@ fn aiur_fn_163(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_163] = [__v_1];
-        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_161] = [__v_1];
+        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = __r_arr[2];
@@ -13578,14 +13262,14 @@ fn aiur_fn_163(
         let __v_10: G = __r_arr[5];
         let __v_11: G = __r_arr[6];
         let __v_12: G = __r_arr[7];
-        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __ret: [G; OUT_163] = [__v_15];
-        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_161] = [__v_15];
+        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13595,19 +13279,19 @@ fn aiur_fn_163(
   })
 }
 
-const INPUT_SIZE_164: usize = 2;
-const IN_164: usize = 2;
-const OUT_164: usize = 1;
-fn aiur_fn_164(
-  inp: [G; IN_164],
+const INPUT_SIZE_162: usize = 2;
+const IN_162: usize = 2;
+const OUT_162: usize = 1;
+fn aiur_fn_162(
+  inp: [G; IN_162],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_164], ExecError> {
+) -> Result<[G; OUT_162], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13616,25 +13300,25 @@ fn aiur_fn_164(
     let __v_7: G = __r_arr[5];
     let __v_8: G = __r_arr[6];
     let __v_9: G = __r_arr[7];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
-    let __ret: [G; OUT_164] = [__v_11];
-    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_162] = [__v_11];
+    record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_165: usize = 1;
-const IN_165: usize = 1;
-const OUT_165: usize = 1;
-fn aiur_fn_165(
-  inp: [G; IN_165],
+const INPUT_SIZE_163: usize = 1;
+const IN_163: usize = 1;
+const OUT_163: usize = 1;
+fn aiur_fn_163(
+  inp: [G; IN_163],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_165], ExecError> {
+) -> Result<[G; OUT_163], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(0);
@@ -13679,21 +13363,21 @@ fn aiur_fn_165(
     let __v_40: G = { let __values: [G; 3] = [__v_5, __v_6, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_41: G = { let __values: [G; 3] = [__v_3, __v_4, __v_40]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_42: G = { let __values: [G; 3] = [__v_1, __v_2, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_165] = [__v_42];
-    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_163] = [__v_42];
+    record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_166: usize = 2;
-const IN_166: usize = 2;
-const OUT_166: usize = 1;
-fn aiur_fn_166(
-  inp: [G; IN_166],
+const INPUT_SIZE_164: usize = 2;
+const IN_164: usize = 2;
+const OUT_164: usize = 1;
+fn aiur_fn_164(
+  inp: [G; IN_164],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_166], ExecError> {
+) -> Result<[G; OUT_164], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13702,13 +13386,13 @@ fn aiur_fn_166(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 34] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_166] = [__v_4];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_164] = [__v_4];
+        record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __ret: [G; OUT_166] = [__v_1];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_164] = [__v_1];
+        record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13718,15 +13402,15 @@ fn aiur_fn_166(
   })
 }
 
-const INPUT_SIZE_167: usize = 9;
-const IN_167: usize = 9;
-const OUT_167: usize = 9;
-fn aiur_fn_167(
-  inp: [G; IN_167],
+const INPUT_SIZE_165: usize = 9;
+const IN_165: usize = 9;
+const OUT_165: usize = 9;
+fn aiur_fn_165(
+  inp: [G; IN_165],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_167], ExecError> {
+) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13740,24 +13424,24 @@ fn aiur_fn_167(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
-    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
-    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
     let __v_19: G = G::from_u64(1);
     let __v_20: G = G::from_u64(1);
     let __v_21: G = { let __values: [G; 3] = [__v_19, __v_20, __v_20]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
     let __v_24: G = __r_arr[2];
@@ -13776,14 +13460,14 @@ fn aiur_fn_167(
     let __v_37: G = __r_arr[15];
     let __v_38: G = __r_arr[16];
     let __v_39: G = __r_arr[17];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = G::from_u64(1);
     let __v_43: G = G::from_u64(1);
     let __v_44: G = { let __values: [G; 3] = [__v_42, __v_43, __v_43]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
     let __v_46: G = __r_arr[1];
     let __v_47: G = __r_arr[2];
@@ -13802,23 +13486,23 @@ fn aiur_fn_167(
     let __v_60: G = __r_arr[15];
     let __v_61: G = __r_arr[16];
     let __v_62: G = __r_arr[17];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_63: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_64: G = __r_arr[0];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_65: G = __r_arr[0];
     let __v_66: G = G::from_u64(1);
     let __v_67: G = G::from_u64(1);
     let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_70: G = __r_arr[0];
     let __v_71: G = G::from_u64(1);
     let __v_72: G = G::from_u64(1);
     let __v_73: G = { let __values: [G; 3] = [__v_71, __v_72, __v_72]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_74: G = __r_arr[0];
     let __v_75: G = __r_arr[1];
     let __v_76: G = __r_arr[2];
@@ -13837,12 +13521,12 @@ fn aiur_fn_167(
     let __v_89: G = __r_arr[15];
     let __v_90: G = __r_arr[16];
     let __v_91: G = __r_arr[17];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_92: G = __r_arr[0];
     let __v_93: G = G::from_u64(1);
     let __v_94: G = G::from_u64(1);
     let __v_95: G = { let __values: [G; 3] = [__v_93, __v_94, __v_94]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -13877,9 +13561,259 @@ fn aiur_fn_167(
     let __v_120: G = __r_arr[0];
     let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
     let __v_121: G = __r_arr[0];
-    let __ret: [G; OUT_167] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
-    record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_165] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
+    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_166: usize = 3;
+const IN_166: usize = 3;
+const OUT_166: usize = 2;
+fn aiur_fn_166(
+  inp: [G; IN_166],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_166], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    match __v_2.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_166] = [__v_0, __v_1];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_2 - __v_5);
+        let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = __r_arr[1];
+        let __ret: [G; OUT_166] = [__v_7, __v_8];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_167: usize = 1;
+const IN_167: usize = 1;
+const OUT_167: usize = 1;
+fn aiur_fn_167(
+  inp: [G; IN_167],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_167], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(18446744069414584320);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(281474976710656);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(18446744069397807105);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(17293822564807737345);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(70368744161280);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(549755813888);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(17870292113338400769);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(13797081185216407910);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(1803076106186727246);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(11353340290879379826);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(455906449640507599);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(17492915097719143606);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(1532612707718625687);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16207902636198568418);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(17776499369601055404);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(6115771955107415310);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(12380578893860276750);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      18u64 => {
+        let __v_1: G = G::from_u64(9306717745644682924);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      19u64 => {
+        let __v_1: G = G::from_u64(18146160046829613826);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      20u64 => {
+        let __v_1: G = G::from_u64(3511170319078647661);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      21u64 => {
+        let __v_1: G = G::from_u64(17654865857378133588);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      22u64 => {
+        let __v_1: G = G::from_u64(5416168637041100469);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      23u64 => {
+        let __v_1: G = G::from_u64(16905767614792059275);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      24u64 => {
+        let __v_1: G = G::from_u64(9713644485405565297);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      25u64 => {
+        let __v_1: G = G::from_u64(5456943929260765144);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      26u64 => {
+        let __v_1: G = G::from_u64(17096174751763063430);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      27u64 => {
+        let __v_1: G = G::from_u64(1213594585890690845);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      28u64 => {
+        let __v_1: G = G::from_u64(6414415596519834757);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      29u64 => {
+        let __v_1: G = G::from_u64(16116352524544190054);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      30u64 => {
+        let __v_1: G = G::from_u64(9123114210336311365);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      31u64 => {
+        let __v_1: G = G::from_u64(4614640910117430873);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(1753635133440165772);
+        let __ret: [G; OUT_167] = [__v_1];
+        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
@@ -13896,32 +13830,23 @@ fn aiur_fn_168(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_168] = [__v_0, __v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __v_4: G = __r_arr[1];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_2 - __v_5);
-        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __ret: [G; OUT_168] = [__v_7, __v_8];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __v_8: G = __r_arr[1];
+    let __ret: [G; OUT_168] = [__v_7, __v_8];
+    record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_169: usize = 1;
-const IN_169: usize = 1;
-const OUT_169: usize = 1;
+const INPUT_SIZE_169: usize = 3;
+const IN_169: usize = 3;
+const OUT_169: usize = 8;
 fn aiur_fn_169(
   inp: [G; IN_169],
   record: &mut QueryRecord,
@@ -13930,253 +13855,12 @@ fn aiur_fn_169(
 ) -> Result<[G; OUT_169], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(18446744069414584320);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(281474976710656);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(18446744069397807105);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(17293822564807737345);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(70368744161280);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(549755813888);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(17870292113338400769);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(13797081185216407910);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(1803076106186727246);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(11353340290879379826);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(455906449640507599);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(17492915097719143606);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(1532612707718625687);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16207902636198568418);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(17776499369601055404);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(6115771955107415310);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(12380578893860276750);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      18u64 => {
-        let __v_1: G = G::from_u64(9306717745644682924);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      19u64 => {
-        let __v_1: G = G::from_u64(18146160046829613826);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      20u64 => {
-        let __v_1: G = G::from_u64(3511170319078647661);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      21u64 => {
-        let __v_1: G = G::from_u64(17654865857378133588);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      22u64 => {
-        let __v_1: G = G::from_u64(5416168637041100469);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      23u64 => {
-        let __v_1: G = G::from_u64(16905767614792059275);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      24u64 => {
-        let __v_1: G = G::from_u64(9713644485405565297);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      25u64 => {
-        let __v_1: G = G::from_u64(5456943929260765144);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      26u64 => {
-        let __v_1: G = G::from_u64(17096174751763063430);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      27u64 => {
-        let __v_1: G = G::from_u64(1213594585890690845);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      28u64 => {
-        let __v_1: G = G::from_u64(6414415596519834757);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      29u64 => {
-        let __v_1: G = G::from_u64(16116352524544190054);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      30u64 => {
-        let __v_1: G = G::from_u64(9123114210336311365);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      31u64 => {
-        let __v_1: G = G::from_u64(4614640910117430873);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(1753635133440165772);
-        let __ret: [G; OUT_169] = [__v_1];
-        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_170: usize = 3;
-const IN_170: usize = 3;
-const OUT_170: usize = 2;
-fn aiur_fn_170(
-  inp: [G; IN_170],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_170], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __ret: [G; OUT_170] = [__v_7, __v_8];
-    record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_171: usize = 3;
-const IN_171: usize = 3;
-const OUT_171: usize = 8;
-fn aiur_fn_171(
-  inp: [G; IN_171],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_171], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __r_arr: [G; OUT_16] = { let __args: [G; IN_16] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[16].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_16] = unsafe { *(result.output.as_ptr() as *const [G; OUT_16]) }; __ret } else { aiur_fn_16(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
@@ -14202,21 +13886,21 @@ fn aiur_fn_171(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_21: G = __r_arr[0];
     let __v_22: G = __r_arr[1];
-    let __ret: [G; OUT_171] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
-    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_169] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
+    record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_172: usize = 23;
-const IN_172: usize = 23;
-const OUT_172: usize = 1;
-fn aiur_fn_172(
-  inp: [G; IN_172],
+const INPUT_SIZE_170: usize = 23;
+const IN_170: usize = 23;
+const OUT_170: usize = 1;
+fn aiur_fn_170(
+  inp: [G; IN_170],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_172], ExecError> {
+) -> Result<[G; OUT_170], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14243,52 +13927,52 @@ fn aiur_fn_172(
     let __v_22: G = inp[22];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = G::from_bool((__v_23 == G::ZERO));
         let __v_25: G = G::from_u64(0);
         if (__v_24 != __v_25) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         if (__v_26 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         if (__v_28 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = G::from_u64(1);
         if (__v_29 != __v_30) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
         }
         let __v_31: G = G::from_u64(1);
-        let __ret: [G; OUT_172] = [__v_31];
-        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_170] = [__v_31];
+        record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_173: usize = 6;
-const IN_173: usize = 6;
-const OUT_173: usize = 2;
-fn aiur_fn_173(
-  inp: [G; IN_173],
+const INPUT_SIZE_171: usize = 6;
+const IN_171: usize = 6;
+const OUT_171: usize = 2;
+fn aiur_fn_171(
+  inp: [G; IN_171],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_173], ExecError> {
+) -> Result<[G; OUT_171], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14302,21 +13986,21 @@ fn aiur_fn_173(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_173] = [__v_8, __v_9];
-    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_171] = [__v_8, __v_9];
+    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_174: usize = 4;
-const IN_174: usize = 4;
-const OUT_174: usize = 2;
-fn aiur_fn_174(
-  inp: [G; IN_174],
+const INPUT_SIZE_172: usize = 4;
+const IN_172: usize = 4;
+const OUT_172: usize = 2;
+fn aiur_fn_172(
+  inp: [G; IN_172],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_174], ExecError> {
+) -> Result<[G; OUT_172], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14330,21 +14014,21 @@ fn aiur_fn_174(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_174] = [__v_8, __v_9];
-    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_172] = [__v_8, __v_9];
+    record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_175: usize = 1;
-const IN_175: usize = 1;
-const OUT_175: usize = 1;
-fn aiur_fn_175(
-  inp: [G; IN_175],
+const INPUT_SIZE_173: usize = 1;
+const IN_173: usize = 1;
+const OUT_173: usize = 1;
+fn aiur_fn_173(
+  inp: [G; IN_173],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_175], ExecError> {
+) -> Result<[G; OUT_173], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14357,8 +14041,8 @@ fn aiur_fn_175(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_175] = [__v_7];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_173] = [__v_7];
+        record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14370,14 +14054,14 @@ fn aiur_fn_175(
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_9: G = G::from_u64(0);
-            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
             let __v_10: G = __r_arr[0];
             let __v_11: G = __r_arr[1];
-            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_175] = [__v_13];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_173] = [__v_13];
+            record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14392,9 +14076,202 @@ fn aiur_fn_175(
   })
 }
 
-const INPUT_SIZE_176: usize = 6;
-const IN_176: usize = 6;
-const OUT_176: usize = 2;
+const INPUT_SIZE_174: usize = 2;
+const IN_174: usize = 2;
+const OUT_174: usize = 2;
+fn aiur_fn_174(
+  inp: [G; IN_174],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_174], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __v_3: G = __r_arr[1];
+    let __ret: [G; OUT_174] = [__v_2, __v_3];
+    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_175: usize = 18;
+const IN_175: usize = 18;
+const OUT_175: usize = 2;
+fn aiur_fn_175(
+  inp: [G; IN_175],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_175], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_18: G = G::from_u64(0);
+        let __ret: [G; OUT_175] = [__v_1, __v_18];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_18: G = (__v_1 + __v_2);
+        let __v_19: G = (__v_1 + __v_18);
+        match __v_19.as_canonical_u64() {
+          0u64 => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_7, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __v_21: G = __r_arr[1];
+            let __ret: [G; OUT_175] = [__v_20, __v_21];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __v_21: G = __r_arr[1];
+            let __ret: [G; OUT_175] = [__v_20, __v_21];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          2u64 => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_5, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __v_21: G = __r_arr[1];
+            let __ret: [G; OUT_175] = [__v_20, __v_21];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          3u64 => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __v_21: G = __r_arr[1];
+            let __ret: [G; OUT_175] = [__v_20, __v_21];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          4u64 => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __v_21: G = __r_arr[1];
+            let __ret: [G; OUT_175] = [__v_20, __v_21];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_10, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __v_21: G = __r_arr[1];
+            let __ret: [G; OUT_175] = [__v_20, __v_21];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+        }
+      },
+      2u64 => {
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = __r_arr[1];
+        let __ret: [G; OUT_175] = [__v_18, __v_19];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __ret: [G; OUT_175] = [__v_12, __v_13];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __ret: [G; OUT_175] = [__v_14, __v_15];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __ret: [G; OUT_175] = [__v_16, __v_17];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = __r_arr[1];
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
+        let __v_21: G = __r_arr[1];
+        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+        let __v_22: G = __r_arr[0];
+        let __v_23: G = __r_arr[1];
+        let __ret: [G; OUT_175] = [__v_22, __v_23];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = __r_arr[1];
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
+        let __v_21: G = __r_arr[1];
+        let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+        let __v_22: G = __r_arr[0];
+        let __v_23: G = __r_arr[1];
+        let __ret: [G; OUT_175] = [__v_22, __v_23];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = __r_arr[1];
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
+        let __v_21: G = __r_arr[1];
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_22: G = __r_arr[0];
+        let __v_23: G = __r_arr[1];
+        let __ret: [G; OUT_175] = [__v_22, __v_23];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = __r_arr[1];
+        let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
+        let __v_21: G = __r_arr[1];
+        let __ret: [G; OUT_175] = [__v_20, __v_21];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_176: usize = 15;
+const IN_176: usize = 15;
+const OUT_176: usize = 1;
 fn aiur_fn_176(
   inp: [G; IN_176],
   record: &mut QueryRecord,
@@ -14408,182 +14285,54 @@ fn aiur_fn_176(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        match __v_1.as_canonical_u64() {
-          1u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_6: G = __r_arr[0];
-            let __v_7: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_6, __v_7];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          0u64 => {
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_6: G = __r_arr[0];
-            let __v_7: G = __r_arr[1];
-            let __ret: [G; OUT_176] = [__v_6, __v_7];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          2u64 => {
-            let __v_6: G = G::from_u64(0);
-            let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_176] = [__v_6, __v_7];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          3u64 => {
-            let __v_6: G = G::from_u64(0);
-            let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_176] = [__v_6, __v_7];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          4u64 => {
-            let __v_6: G = G::from_u64(0);
-            let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_176] = [__v_6, __v_7];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          5u64 => {
-            let __v_6: G = G::from_u64(0);
-            let __v_7: G = G::from_u64(0);
-            let __ret: [G; OUT_176] = [__v_6, __v_7];
-            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-          },
-        }
-      },
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+    let __v_15: G = __loaded[0];
+    let __v_16: G = __loaded[1];
+    let __v_17: G = __loaded[2];
+    let __v_18: G = __loaded[3];
+    let __v_19: G = __loaded[4];
+    let __v_20: G = __loaded[5];
+    match __v_15.as_canonical_u64() {
       1u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_176] = [__v_6, __v_7];
+        let __ret: [G; OUT_176] = [__v_1];
         record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      2u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_176] = [__v_6, __v_7];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_176] = [__v_6, __v_7];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_176] = [__v_1, __v_6];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_6: G = __loaded[0];
-        let __v_7: G = __loaded[1];
-        let __v_8: G = __loaded[2];
-        let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_10: G = __r_arr[0];
-        let __v_11: G = __r_arr[1];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_12: G = __loaded[0];
-        let __v_13: G = __loaded[1];
-        let __v_14: G = __loaded[2];
-        let __v_15: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_10, __v_11, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_18, __v_19];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_6: G = __loaded[0];
-        let __v_7: G = __loaded[1];
-        let __v_8: G = __loaded[2];
-        let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_10: G = __r_arr[0];
-        let __v_11: G = __r_arr[1];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_12: G = __loaded[0];
-        let __v_13: G = __loaded[1];
-        let __v_14: G = __loaded[2];
-        let __v_15: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_10, __v_11, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_18, __v_19];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_6: G = __loaded[0];
-        let __v_7: G = __loaded[1];
-        let __v_8: G = __loaded[2];
-        let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_10: G = __r_arr[0];
-        let __v_11: G = __r_arr[1];
-        let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __v_13: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_12, __v_13];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_6: G = __loaded[0];
-        let __v_7: G = __loaded[1];
-        let __v_8: G = __loaded[2];
-        let __v_9: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_10: G = __r_arr[0];
-        let __v_11: G = __r_arr[1];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_12: G = __loaded[0];
-        let __v_13: G = __loaded[1];
-        let __v_14: G = __loaded[2];
-        let __v_15: G = __loaded[3];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_12, __v_13, __v_14, __v_15, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_18, __v_19];
+      0u64 => {
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_16, __v_17, __v_18, __v_19, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __v_21: G = __r_arr[0];
+        let __v_22: G = __r_arr[1];
+        let __v_23: G = G::from_u64(0);
+        let __v_24: G = G::from_u64(1);
+        let __v_25: G = G::from_u64(1);
+        let __v_26: G = { let __values: [G; 4] = [__v_24, __v_25, __v_25, __v_25]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __v_27: G = { let __values: [G; 4] = [__v_23, __v_21, __v_22, __v_26]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_28: G = __r_arr[0];
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_20, __v_28, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __v_29: G = __r_arr[0];
+        let __ret: [G; OUT_176] = [__v_29];
         record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_177: usize = 5;
-const IN_177: usize = 5;
+const INPUT_SIZE_177: usize = 6;
+const IN_177: usize = 6;
 const OUT_177: usize = 2;
 fn aiur_fn_177(
   inp: [G; IN_177],
@@ -14597,47 +14346,40 @@ fn aiur_fn_177(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-    let __v_5: G = __loaded[0];
-    let __v_6: G = __loaded[1];
-    let __v_7: G = __loaded[2];
-    let __v_8: G = __loaded[3];
-    let __v_9: G = __loaded[4];
-    let __v_10: G = __loaded[5];
-    match __v_5.as_canonical_u64() {
+    let __v_5: G = inp[5];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_6: G = __loaded[0];
+    let __v_7: G = __loaded[1];
+    let __v_8: G = __loaded[2];
+    match __v_6.as_canonical_u64() {
       1u64 => {
-        let __v_11: G = G::from_u64(0);
-        let __v_12: G = G::from_u64(0);
-        let __ret: [G; OUT_177] = [__v_11, __v_12];
+        let __ret: [G; OUT_177] = [__v_0, __v_1];
         record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_6, __v_7, __v_8, __v_9, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_5, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __v_9: G = __r_arr[0];
+        let __v_10: G = __r_arr[1];
+        let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_0, __v_1, __v_2, __v_3, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_0, __v_1, __v_10, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_11, __v_12, __v_2, __v_3, __v_8, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_11, __v_12, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = __r_arr[1];
-        let __ret: [G; OUT_177] = [__v_17, __v_18];
+        let __ret: [G; OUT_177] = [__v_13, __v_14];
         record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_6.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_178: usize = 6;
-const IN_178: usize = 6;
+const INPUT_SIZE_178: usize = 17;
+const IN_178: usize = 17;
 const OUT_178: usize = 2;
 fn aiur_fn_178(
   inp: [G; IN_178],
@@ -14652,46 +14394,36 @@ fn aiur_fn_178(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-    let __v_6: G = __loaded[0];
-    let __v_7: G = __loaded[1];
-    let __v_8: G = __loaded[2];
-    let __v_9: G = __loaded[3];
-    let __v_10: G = __loaded[4];
-    let __v_11: G = __loaded[5];
-    match __v_6.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_178] = [__v_0, __v_1];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_12: G = G::from_u64(1);
-        let __v_13: G = G::from_u64(1);
-        let __v_14: G = { let __values: [G; 4] = [__v_12, __v_13, __v_13, __v_13]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_7, __v_8, __v_9, __v_10, __v_5, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = __r_arr[1];
-        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_17, __v_18, __v_2, __v_3, __v_11, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
-        let __v_19: G = __r_arr[0];
-        let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_178] = [__v_19, __v_20];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_6.as_canonical_u64()));
-      },
-    }
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = G::from_u64(1);
+    let __v_18: G = G::from_u64(1);
+    let __v_19: G = { let __values: [G; 4] = [__v_17, __v_18, __v_18, __v_18]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_19, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __v_21: G = G::from_u64(0);
+    let __v_22: G = G::from_u64(0);
+    let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_21, __v_22, __v_15, __v_16, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __v_24: G = __r_arr[1];
+    let __ret: [G; OUT_178] = [__v_23, __v_24];
+    record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_179: usize = 7;
-const IN_179: usize = 7;
-const OUT_179: usize = 2;
+const INPUT_SIZE_179: usize = 8;
+const IN_179: usize = 8;
+const OUT_179: usize = 1;
 fn aiur_fn_179(
   inp: [G; IN_179],
   record: &mut QueryRecord,
@@ -14706,383 +14438,49 @@ fn aiur_fn_179(
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
     let __v_6: G = inp[6];
-    match __v_6.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_179] = [__v_0, __v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = G::from_u64(0);
-        let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_7, __v_8, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = __r_arr[1];
-        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        let __v_17: G = G::from_u64(1);
-        let __v_18: G = (__v_5 + __v_17);
-        let __v_19: G = G::from_u64(1);
-        let __v_20: G = (__v_6 - __v_19);
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_15, __v_16, __v_2, __v_3, __v_4, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
-        let __v_21: G = __r_arr[0];
-        let __v_22: G = __r_arr[1];
-        let __ret: [G; OUT_179] = [__v_21, __v_22];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __v_7: G = inp[7];
+    let __v_8: G = G::from_u64(0);
+    let __v_9: G = G::from_u64(0);
+    let __v_10: G = G::from_u64(0);
+    let __v_11: G = G::from_u64(0);
+    let __v_12: G = G::from_u64(0);
+    let __v_13: G = G::from_u64(0);
+    let __v_14: G = G::from_u64(0);
+    let __v_15: G = G::from_u64(0);
+    let __v_16: G = G::from_u64(0);
+    let __v_17: G = G::from_u64(0);
+    let __v_18: G = G::from_u64(0);
+    let __v_19: G = G::from_u64(0);
+    let __v_20: G = G::from_u64(0);
+    let __v_21: G = G::from_u64(0);
+    let __v_22: G = G::from_u64(0);
+    let __v_23: G = G::from_u64(0);
+    let __v_24: G = G::from_u64(1);
+    let __v_25: G = G::from_u64(1);
+    let __v_26: G = { let __values: [G; 4] = [__v_24, __v_25, __v_25, __v_25]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_27: G = { let __values: [G; 4] = [__v_22, __v_7, __v_23, __v_26]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_28: G = { let __values: [G; 4] = [__v_20, __v_6, __v_21, __v_27]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_29: G = { let __values: [G; 4] = [__v_18, __v_5, __v_19, __v_28]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_30: G = { let __values: [G; 4] = [__v_16, __v_4, __v_17, __v_29]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_31: G = { let __values: [G; 4] = [__v_14, __v_3, __v_15, __v_30]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_32: G = { let __values: [G; 4] = [__v_12, __v_2, __v_13, __v_31]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_33: G = { let __values: [G; 4] = [__v_10, __v_1, __v_11, __v_32]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __v_34: G = { let __values: [G; 4] = [__v_8, __v_0, __v_9, __v_33]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __ret: [G; OUT_179] = [__v_34];
+    record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_180: usize = 15;
-const IN_180: usize = 15;
-const OUT_180: usize = 4;
+const INPUT_SIZE_180: usize = 5;
+const IN_180: usize = 5;
+const OUT_180: usize = 2;
 fn aiur_fn_180(
   inp: [G; IN_180],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_180], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-    let __v_15: G = __loaded[0];
-    let __v_16: G = __loaded[1];
-    let __v_17: G = __loaded[2];
-    let __v_18: G = __loaded[3];
-    let __v_19: G = __loaded[4];
-    let __v_20: G = __loaded[5];
-    let __v_21: G = __loaded[6];
-    match __v_15.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_180] = [__v_0, __v_1, __v_13, __v_14];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        match __v_16.as_canonical_u64() {
-          _ => {
-            let __v_22: G = G::from_u64(1);
-            let __v_23: G = (__v_5 + __v_22);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_24: G = __r_arr[0];
-            let __v_25: G = __r_arr[1];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_16, __v_17, __v_18, __v_19, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-            let __v_26: G = __r_arr[0];
-            let __v_27: G = __r_arr[1];
-            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_11, __v_12, __v_20, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
-            let __v_28: G = __r_arr[0];
-            let __v_29: G = __r_arr[1];
-            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-            let __v_30: G = __r_arr[0];
-            let __v_31: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_30, __v_31, __v_24, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_32: G = __r_arr[0];
-            let __v_33: G = __r_arr[1];
-            let __v_34: G = G::from_u64(1);
-            let __v_35: G = G::from_u64(0);
-            let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-            let __v_36: G = __r_arr[0];
-            let __v_37: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-            let __v_38: G = __r_arr[0];
-            let __v_39: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_26, __v_27, __v_24, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_40: G = __r_arr[0];
-            let __v_41: G = __r_arr[1];
-            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_40, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-            let __v_42: G = __r_arr[0];
-            let __v_43: G = __r_arr[1];
-            let __v_44: G = G::from_u64(1);
-            let __v_45: G = (__v_5 + __v_44);
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_38, __v_39, __v_2, __v_3, __v_21, __v_45, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
-            let __v_46: G = __r_arr[0];
-            let __v_47: G = __r_arr[1];
-            let __v_48: G = __r_arr[2];
-            let __v_49: G = __r_arr[3];
-            let __ret: [G; OUT_180] = [__v_46, __v_47, __v_48, __v_49];
-            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_181: usize = 27;
-const IN_181: usize = 27;
-const OUT_181: usize = 2;
-fn aiur_fn_181(
-  inp: [G; IN_181],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = inp[17];
-    let __v_18: G = inp[18];
-    let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
-    let __v_21: G = inp[21];
-    let __v_22: G = inp[22];
-    let __v_23: G = inp[23];
-    let __v_24: G = inp[24];
-    let __v_25: G = inp[25];
-    let __v_26: G = inp[26];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        match __v_1.as_canonical_u64() {
-          _ => {
-            let __v_27: G = G::from_u64(0);
-            let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_27, __v_28, __v_25, __v_26, __v_1, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __v_30: G = __r_arr[1];
-            let __v_31: G = (__v_3 - __v_2);
-            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_29, __v_30, __v_25, __v_26, __v_6, __v_2, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
-            let __v_32: G = __r_arr[0];
-            let __v_33: G = __r_arr[1];
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_32, __v_33, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
-            let __v_34: G = __r_arr[0];
-            let __v_35: G = __r_arr[1];
-            let __ret: [G; OUT_181] = [__v_34, __v_35];
-            record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-      1u64 => {
-        match __v_1.as_canonical_u64() {
-          _ => {
-            let __v_27: G = G::from_u64(1);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_28: G = __r_arr[0];
-            let __v_29: G = __r_arr[1];
-            let __v_30: G = G::from_u64(2);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_31: G = __r_arr[0];
-            let __v_32: G = __r_arr[1];
-            let __v_33: G = G::from_u64(1);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_34: G = __r_arr[0];
-            let __v_35: G = __r_arr[1];
-            let __v_36: G = G::from_u64(2);
-            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-            let __v_37: G = __r_arr[0];
-            let __v_38: G = __r_arr[1];
-            let __v_39: G = G::from_u64(0);
-            let __v_40: G = G::from_u64(0);
-            let __v_41: G = G::from_u64(1);
-            let __v_42: G = G::from_u64(0);
-            let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_28, __v_29, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-            let __v_43: G = __r_arr[0];
-            let __v_44: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_28, __v_29, __v_43, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_45: G = __r_arr[0];
-            let __v_46: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_39, __v_40, __v_25, __v_26, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-            let __v_47: G = __r_arr[0];
-            let __v_48: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_34, __v_35, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_49: G = __r_arr[0];
-            let __v_50: G = __r_arr[1];
-            let __v_51: G = G::from_u64(1);
-            let __v_52: G = G::from_u64(0);
-            let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_28, __v_29, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-            let __v_53: G = __r_arr[0];
-            let __v_54: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_49, __v_50, __v_53, __v_54]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_55: G = __r_arr[0];
-            let __v_56: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_47, __v_48, __v_25, __v_26, __v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-            let __v_57: G = __r_arr[0];
-            let __v_58: G = __r_arr[1];
-            let __v_59: G = G::from_u64(1);
-            let __v_60: G = G::from_u64(0);
-            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_31, __v_32, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
-            let __v_61: G = __r_arr[0];
-            let __v_62: G = __r_arr[1];
-            let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_37, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-            let __v_63: G = __r_arr[0];
-            let __v_64: G = __r_arr[1];
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_49, __v_50, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_65: G = __r_arr[0];
-            let __v_66: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_57, __v_58, __v_25, __v_26, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-            let __v_67: G = __r_arr[0];
-            let __v_68: G = __r_arr[1];
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_67, __v_68, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
-            let __v_69: G = __r_arr[0];
-            let __v_70: G = __r_arr[1];
-            let __ret: [G; OUT_181] = [__v_69, __v_70];
-            record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
-      2u64 => {
-        let __v_27: G = G::from_u64(0);
-        let __v_28: G = G::from_u64(0);
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_27, __v_28, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
-        let __v_29: G = __r_arr[0];
-        let __v_30: G = __r_arr[1];
-        let __ret: [G; OUT_181] = [__v_29, __v_30];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_27: G = G::from_u64(0);
-        let __v_28: G = G::from_u64(0);
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_27, __v_28, __v_5, __v_6, __v_10, __v_8, __v_9, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
-        let __v_29: G = __r_arr[0];
-        let __v_30: G = __r_arr[1];
-        let __ret: [G; OUT_181] = [__v_29, __v_30];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_182: usize = 23;
-const IN_182: usize = 23;
-const OUT_182: usize = 2;
-fn aiur_fn_182(
-  inp: [G; IN_182],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = inp[17];
-    let __v_18: G = inp[18];
-    let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
-    let __v_21: G = inp[21];
-    let __v_22: G = inp[22];
-    let __v_23: G = G::from_u64(0);
-    let __v_24: G = G::from_u64(0);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-    let __v_25: G = __r_arr[0];
-    let __v_26: G = __r_arr[1];
-    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_0, __v_1, __v_21, __v_22, __v_2, __v_23, __v_3, __v_4, __v_5, __v_13, __v_14, __v_15, __v_16, __v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
-    let __v_27: G = __r_arr[0];
-    let __v_28: G = __r_arr[1];
-    let __v_29: G = __r_arr[2];
-    let __v_30: G = __r_arr[3];
-    let __v_31: G = G::from_u64(0);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-    let __v_32: G = __r_arr[0];
-    let __v_33: G = __r_arr[1];
-    let __v_34: G = G::from_u64(0);
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-    let __v_35: G = __r_arr[0];
-    let __v_36: G = __r_arr[1];
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_32, __v_33, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_37: G = __r_arr[0];
-    let __v_38: G = __r_arr[1];
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_7, __v_8, __v_37, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_39: G = __r_arr[0];
-    let __v_40: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_27, __v_28, __v_21, __v_22, __v_39, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-    let __v_41: G = __r_arr[0];
-    let __v_42: G = __r_arr[1];
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_29, __v_30, __v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_43: G = __r_arr[0];
-    let __v_44: G = __r_arr[1];
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_11, __v_12, __v_43, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_45: G = __r_arr[0];
-    let __v_46: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_41, __v_42, __v_21, __v_22, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-    let __v_47: G = __r_arr[0];
-    let __v_48: G = __r_arr[1];
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_29, __v_30, __v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_49: G = __r_arr[0];
-    let __v_50: G = __r_arr[1];
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_9, __v_10, __v_49, __v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_51: G = __r_arr[0];
-    let __v_52: G = __r_arr[1];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_47, __v_48, __v_21, __v_22, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-    let __v_53: G = __r_arr[0];
-    let __v_54: G = __r_arr[1];
-    let __ret: [G; OUT_182] = [__v_53, __v_54];
-    record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_183: usize = 5;
-const IN_183: usize = 5;
-const OUT_183: usize = 2;
-fn aiur_fn_183(
-  inp: [G; IN_183],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15098,8 +14496,8 @@ fn aiur_fn_183(
       1u64 => {
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_183] = [__v_9, __v_10];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_180] = [__v_9, __v_10];
+        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15109,14 +14507,14 @@ fn aiur_fn_183(
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
-        let __ret: [G; OUT_183] = [__v_15, __v_16];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_180] = [__v_15, __v_16];
+        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15126,145 +14524,145 @@ fn aiur_fn_183(
   })
 }
 
-const INPUT_SIZE_184: usize = 1;
-const IN_184: usize = 1;
-const OUT_184: usize = 1;
-fn aiur_fn_184(
-  inp: [G; IN_184],
+const INPUT_SIZE_181: usize = 1;
+const IN_181: usize = 1;
+const OUT_181: usize = 1;
+fn aiur_fn_181(
+  inp: [G; IN_181],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_184], ExecError> {
+) -> Result<[G; OUT_181], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     match __v_0.as_canonical_u64() {
       0u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       10u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       11u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       12u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       13u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       14u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       15u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       16u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       17u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_184] = [__v_1];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_181] = [__v_1];
+        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_185: usize = 4;
-const IN_185: usize = 4;
-const OUT_185: usize = 1;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_182: usize = 4;
+const IN_182: usize = 4;
+const OUT_182: usize = 2;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15275,8 +14673,11 @@ fn aiur_fn_185(
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 4] = [__v_4, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_185] = [__v_6];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_182] = [__v_6, __v_9];
+        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -15285,18 +14686,24 @@ fn aiur_fn_185(
             let __v_4: G = G::from_u64(1);
             let __v_5: G = G::from_u64(1);
             let __v_6: G = { let __values: [G; 4] = [__v_4, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_185] = [__v_6];
-            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __v_7: G = G::from_u64(1);
+            let __v_8: G = G::from_u64(1);
+            let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_182] = [__v_6, __v_9];
+            record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
-            let __ret: [G; OUT_185] = [__v_6];
-            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __v_7: G = G::from_u64(1);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __ret: [G; OUT_182] = [__v_6, __v_8];
+            record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -15311,15 +14718,15 @@ fn aiur_fn_185(
   })
 }
 
-const INPUT_SIZE_186: usize = 20;
-const IN_186: usize = 20;
-const OUT_186: usize = 1;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_183: usize = 20;
+const IN_183: usize = 20;
+const OUT_183: usize = 1;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15341,118 +14748,105 @@ fn aiur_fn_186(
     let __v_17: G = inp[17];
     let __v_18: G = inp[18];
     let __v_19: G = inp[19];
-    let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_20: G = __loaded[0];
     let __v_21: G = __loaded[1];
     let __v_22: G = __loaded[2];
     let __v_23: G = __loaded[3];
     let __v_24: G = __loaded[4];
     let __v_25: G = __loaded[5];
-    let __v_26: G = __loaded[6];
-    let __v_27: G = __loaded[7];
-    let __v_28: G = __loaded[8];
-    let __v_29: G = __loaded[9];
-    let __v_30: G = __loaded[10];
-    let __v_31: G = __loaded[11];
-    let __v_32: G = __loaded[12];
-    let __v_33: G = __loaded[13];
     match __v_20.as_canonical_u64() {
       1u64 => {
-        let __v_34: G = G::from_u64(1);
-        let __ret: [G; OUT_186] = [__v_34];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_26: G = G::from_u64(1);
+        let __ret: [G; OUT_183] = [__v_26];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         match __v_21.as_canonical_u64() {
           _ => {
-            match __v_21.as_canonical_u64() {
-              _ => {
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_34: G = __r_arr[0];
-                let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
-                let __v_35: G = __r_arr[0];
-                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-                let __v_36: G = __r_arr[0];
-                let __v_37: G = __r_arr[1];
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_38: G = __r_arr[0];
-                let __v_39: G = G::from_u64(0);
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_38, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_40: G = __r_arr[0];
-                let __v_41: G = G::from_u64(1);
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_38, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_42: G = __r_arr[0];
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_43: G = __r_arr[0];
-                let __v_44: G = G::from_u64(0);
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_43, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_45: G = __r_arr[0];
-                let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
-                let __v_46: G = __r_arr[0];
-                let __v_47: G = G::from_u64(1);
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_43, __v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_48: G = __r_arr[0];
-                let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
-                let __v_49: G = __r_arr[0];
-                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-                let __v_50: G = __r_arr[0];
-                let __v_51: G = __r_arr[1];
-                let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_6, __v_7, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
-                let __v_52: G = __r_arr[0];
-                let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_18, __v_19, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
-                let __v_53: G = __r_arr[0];
-                let __v_54: G = __r_arr[1];
-                let __v_55: G = __r_arr[2];
-                let __v_56: G = __r_arr[3];
-                let __v_57: G = __r_arr[4];
-                let __v_58: G = __r_arr[5];
-                let __v_59: G = __r_arr[6];
-                let __v_60: G = __r_arr[7];
-                let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_40, __v_42, __v_46, __v_49, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_36, __v_37, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
-                let __v_61: G = __r_arr[0];
-                let __v_62: G = __r_arr[1];
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_63: G = __r_arr[0];
-                let __v_64: G = G::from_u64(0);
-                let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                let __v_65: G = __r_arr[0];
-                let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_65]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
-                let __v_66: G = __r_arr[0];
-                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_18, __v_19, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
-                let __v_67: G = __r_arr[0];
-                let __v_68: G = __r_arr[1];
-                let __v_69: G = G::from_u64(1);
-                let __v_70: G = G::from_u64(0);
-                let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_66, __v_67, __v_68, __v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
-                let __v_71: G = __r_arr[0];
-                let __v_72: G = __r_arr[1];
-                let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-                let __v_73: G = __r_arr[0];
-                let __v_74: G = (__v_73 - __v_35);
-                let __v_75: G = G::from_bool((__v_74 == G::ZERO));
-                let __v_76: G = G::from_u64(1);
-                if (__v_75 != __v_76) {
-                  return Err(ExecError::AssertEqMismatch { lhs: __v_75.as_canonical_u64(), rhs: __v_76.as_canonical_u64() });
-                }
-                let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_61, __v_62, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-                let __v_77: G = __r_arr[0];
-                let __v_78: G = __r_arr[1];
-                let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_77, __v_78, __v_71, __v_72]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
-                let __v_79: G = __r_arr[0];
-                let __v_80: G = G::from_u64(1);
-                if (__v_79 != __v_80) {
-                  return Err(ExecError::AssertEqMismatch { lhs: __v_79.as_canonical_u64(), rhs: __v_80.as_canonical_u64() });
-                }
-                let __v_81: G = G::from_u64(1);
-                let __v_82: G = (__v_9 + __v_81);
-                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_33, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_82, __v_36, __v_37, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
-                let __v_83: G = __r_arr[0];
-                let __ret: [G; OUT_186] = [__v_83];
-                record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                return Ok(__ret);
-              },
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_26: G = __r_arr[0];
+            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __v_27: G = __r_arr[0];
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_28: G = __r_arr[0];
+            let __v_29: G = __r_arr[1];
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_30: G = __r_arr[0];
+            let __v_31: G = G::from_u64(0);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_32: G = __r_arr[0];
+            let __v_33: G = G::from_u64(1);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_30, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_34: G = __r_arr[0];
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_35: G = __r_arr[0];
+            let __v_36: G = G::from_u64(0);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_37: G = __r_arr[0];
+            let __v_38: G = G::from_u64(1);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_35, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_39: G = __r_arr[0];
+            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_40: G = __r_arr[0];
+            let __v_41: G = __r_arr[1];
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_6, __v_7, __v_40, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+            let __v_42: G = __r_arr[0];
+            let __v_43: G = __r_arr[1];
+            let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_18, __v_19, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+            let __v_44: G = __r_arr[0];
+            let __v_45: G = __r_arr[1];
+            let __v_46: G = __r_arr[2];
+            let __v_47: G = __r_arr[3];
+            let __v_48: G = __r_arr[4];
+            let __v_49: G = __r_arr[5];
+            let __v_50: G = __r_arr[6];
+            let __v_51: G = __r_arr[7];
+            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __v_52: G = __r_arr[0];
+            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_21, __v_23, __v_32, __v_34, __v_42, __v_43, __v_37, __v_39, __v_52, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+            let __v_53: G = __r_arr[0];
+            let __v_54: G = __r_arr[1];
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_55: G = __r_arr[0];
+            let __v_56: G = G::from_u64(0);
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __v_57: G = __r_arr[0];
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __v_58: G = __r_arr[0];
+            let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_18, __v_19, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+            let __v_59: G = __r_arr[0];
+            let __v_60: G = __r_arr[1];
+            let __v_61: G = G::from_u64(1);
+            let __v_62: G = G::from_u64(0);
+            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_58, __v_59, __v_60, __v_61, __v_62]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __v_63: G = __r_arr[0];
+            let __v_64: G = __r_arr[1];
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_65: G = __r_arr[0];
+            let __v_66: G = (__v_65 - __v_27);
+            let __v_67: G = G::from_bool((__v_66 == G::ZERO));
+            let __v_68: G = G::from_u64(1);
+            if (__v_67 != __v_68) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_67.as_canonical_u64(), rhs: __v_68.as_canonical_u64() });
             }
+            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_53, __v_54, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+            let __v_69: G = __r_arr[0];
+            let __v_70: G = __r_arr[1];
+            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_69, __v_70, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
+            let __v_71: G = __r_arr[0];
+            let __v_72: G = G::from_u64(1);
+            if (__v_71 != __v_72) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_71.as_canonical_u64(), rhs: __v_72.as_canonical_u64() });
+            }
+            let __v_73: G = G::from_u64(1);
+            let __v_74: G = (__v_9 + __v_73);
+            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_25, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_74, __v_28, __v_29, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __v_75: G = __r_arr[0];
+            let __ret: [G; OUT_183] = [__v_75];
+            record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
           },
         }
       },
@@ -15463,15 +14857,15 @@ fn aiur_fn_186(
   })
 }
 
-const INPUT_SIZE_187: usize = 3;
-const IN_187: usize = 3;
-const OUT_187: usize = 2;
-fn aiur_fn_187(
-  inp: [G; IN_187],
+const INPUT_SIZE_184: usize = 3;
+const IN_184: usize = 3;
+const OUT_184: usize = 2;
+fn aiur_fn_184(
+  inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
+) -> Result<[G; OUT_184], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15491,15 +14885,15 @@ fn aiur_fn_187(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_187] = [__v_13, __v_14];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_13, __v_14];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = G::from_u64(0);
-        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -15508,8 +14902,8 @@ fn aiur_fn_187(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_187] = [__v_19, __v_20];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_19, __v_20];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15519,15 +14913,15 @@ fn aiur_fn_187(
   })
 }
 
-const INPUT_SIZE_188: usize = 7;
-const IN_188: usize = 7;
-const OUT_188: usize = 2;
-fn aiur_fn_188(
-  inp: [G; IN_188],
+const INPUT_SIZE_185: usize = 7;
+const IN_185: usize = 7;
+const OUT_185: usize = 2;
+fn aiur_fn_185(
+  inp: [G; IN_185],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15542,12 +14936,12 @@ fn aiur_fn_188(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_188] = [__v_0, __v_1];
-        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_0, __v_1];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_3, __v_4, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -15559,11 +14953,11 @@ fn aiur_fn_188(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_188] = [__v_18, __v_19];
-        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_18, __v_19];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15573,15 +14967,15 @@ fn aiur_fn_188(
   })
 }
 
-const INPUT_SIZE_189: usize = 36;
-const IN_189: usize = 36;
-const OUT_189: usize = 1;
-fn aiur_fn_189(
-  inp: [G; IN_189],
+const INPUT_SIZE_186: usize = 36;
+const IN_186: usize = 36;
+const OUT_186: usize = 1;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15625,15 +15019,15 @@ fn aiur_fn_189(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
-                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
                     let __v_38: G = __r_arr[0];
-                    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_39: G = __r_arr[0];
                     let __v_40: G = __r_arr[1];
                     let __v_41: G = __r_arr[2];
@@ -15645,21 +15039,21 @@ fn aiur_fn_189(
                     let __v_47: G = __r_arr[8];
                     let __v_48: G = G::from_u64(0);
                     let __v_49: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
                     let __v_51: G = __r_arr[1];
                     let __v_52: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
                     let __v_53: G = __r_arr[0];
-                    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                     let __v_54: G = __r_arr[0];
                     let __v_55: G = G::from_u64(1);
                     if (__v_54 != __v_55) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                     let __v_56: G = __r_arr[0];
-                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_57: G = __r_arr[0];
                     let __v_58: G = (__v_56 - __v_57);
                     let __v_59: G = G::from_bool((__v_58 == G::ZERO));
@@ -15667,9 +15061,9 @@ fn aiur_fn_189(
                     if (__v_59 != __v_60) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_59.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_61: G = __r_arr[0];
-                    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
                     let __v_62: G = __r_arr[0];
                     let __v_63: G = (__v_61 - __v_62);
                     let __v_64: G = G::from_bool((__v_63 == G::ZERO));
@@ -15677,12 +15071,12 @@ fn aiur_fn_189(
                     if (__v_64 != __v_65) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_66: G = __r_arr[0];
-                    let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
                     let __v_67: G = __r_arr[0];
-                    let __ret: [G; OUT_189] = [__v_67];
-                    record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_186] = [__v_67];
+                    record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -15695,15 +15089,15 @@ fn aiur_fn_189(
   })
 }
 
-const INPUT_SIZE_190: usize = 1;
-const IN_190: usize = 1;
-const OUT_190: usize = 1;
-fn aiur_fn_190(
-  inp: [G; IN_190],
+const INPUT_SIZE_187: usize = 1;
+const IN_187: usize = 1;
+const OUT_187: usize = 1;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_190], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15713,8 +15107,8 @@ fn aiur_fn_190(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_4];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_4];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15725,10 +15119,10 @@ fn aiur_fn_190(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_190] = [__v_8];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_8];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15738,70 +15132,62 @@ fn aiur_fn_190(
   })
 }
 
-const INPUT_SIZE_191: usize = 2;
-const IN_191: usize = 2;
-const OUT_191: usize = 1;
-fn aiur_fn_191(
-  inp: [G; IN_191],
+const INPUT_SIZE_188: usize = 2;
+const IN_188: usize = 2;
+const OUT_188: usize = 1;
+fn aiur_fn_188(
+  inp: [G; IN_188],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_191], ExecError> {
+) -> Result<[G; OUT_188], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     let __v_5: G = __loaded[3];
     let __v_6: G = __loaded[4];
     let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    let __v_9: G = __loaded[7];
-    let __v_10: G = __loaded[8];
-    let __v_11: G = __loaded[9];
-    let __v_12: G = __loaded[10];
-    let __v_13: G = __loaded[11];
-    let __v_14: G = __loaded[12];
-    let __v_15: G = __loaded[13];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __v_16: G = G::from_u64(1);
-        let __v_17: G = G::from_u64(1);
-        let __v_18: G = { let __values: [G; 14] = [__v_16, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17, __v_17]; let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_18];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = { let __values: [G; 6] = [__v_8, __v_9, __v_9, __v_9, __v_9, __v_9]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_188] = [__v_10];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_16: G = __loaded[0];
-        let __v_17: G = __loaded[1];
-        let __v_18: G = __loaded[2];
-        match __v_16.as_canonical_u64() {
+        let __v_8: G = __loaded[0];
+        let __v_9: G = __loaded[1];
+        let __v_10: G = __loaded[2];
+        match __v_8.as_canonical_u64() {
           0u64 => {
-            match __v_17.as_canonical_u64() {
+            match __v_9.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_15, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
-                let __v_19: G = __r_arr[0];
-                let __ret: [G; OUT_191] = [__v_19];
-                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                let __v_11: G = __r_arr[0];
+                let __ret: [G; OUT_188] = [__v_11];
+                record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __v_19: G = G::from_u64(0);
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_15, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
-                let __v_20: G = __r_arr[0];
-                let __v_21: G = { let __values: [G; 14] = [__v_19, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_20]; let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_191] = [__v_21];
-                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __v_11: G = G::from_u64(0);
+                let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+                let __v_12: G = __r_arr[0];
+                let __v_13: G = { let __values: [G; 6] = [__v_11, __v_3, __v_4, __v_5, __v_6, __v_12]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                let __ret: [G; OUT_188] = [__v_13];
+                record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
           },
           _ => {
-            return Err(ExecError::MatchNoCase(__v_16.as_canonical_u64()));
+            return Err(ExecError::MatchNoCase(__v_8.as_canonical_u64()));
           },
         }
       },
@@ -15812,15 +15198,15 @@ fn aiur_fn_191(
   })
 }
 
-const INPUT_SIZE_192: usize = 2;
-const IN_192: usize = 2;
-const OUT_192: usize = 1;
-fn aiur_fn_192(
-  inp: [G; IN_192],
+const INPUT_SIZE_189: usize = 2;
+const IN_189: usize = 2;
+const OUT_189: usize = 1;
+fn aiur_fn_189(
+  inp: [G; IN_189],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
+) -> Result<[G; OUT_189], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15834,8 +15220,8 @@ fn aiur_fn_192(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_192] = [__v_8];
-        record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_189] = [__v_8];
+        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15847,19 +15233,19 @@ fn aiur_fn_192(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_192] = [__v_9];
-                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_189] = [__v_9];
+                record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_192] = [__v_11];
-                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_189] = [__v_11];
+                record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15876,8 +15262,94 @@ fn aiur_fn_192(
   })
 }
 
-const INPUT_SIZE_193: usize = 1;
-const IN_193: usize = 1;
+const INPUT_SIZE_190: usize = 1;
+const IN_190: usize = 1;
+const OUT_190: usize = 2;
+fn aiur_fn_190(
+  inp: [G; IN_190],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_190], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_190] = [__v_3, __v_4];
+    record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_191: usize = 2;
+const IN_191: usize = 2;
+const OUT_191: usize = 2;
+fn aiur_fn_191(
+  inp: [G; IN_191],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_191], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_191] = [__v_4, __v_0];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = (__v_1 - __v_4);
+        let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = __r_arr[1];
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_191] = [__v_9, __v_7];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_192: usize = 1;
+const IN_192: usize = 1;
+const OUT_192: usize = 2;
+fn aiur_fn_192(
+  inp: [G; IN_192],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_192], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_192] = [__v_3, __v_4];
+    record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_193: usize = 2;
+const IN_193: usize = 2;
 const OUT_193: usize = 2;
 fn aiur_fn_193(
   inp: [G; IN_193],
@@ -15887,100 +15359,14 @@ fn aiur_fn_193(
 ) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_193] = [__v_3, __v_4];
-    record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_194: usize = 2;
-const IN_194: usize = 2;
-const OUT_194: usize = 2;
-fn aiur_fn_194(
-  inp: [G; IN_194],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_194], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_194] = [__v_4, __v_0];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
-        let __v_2: G = __r_arr[0];
-        let __v_3: G = __r_arr[1];
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_194] = [__v_9, __v_7];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_195: usize = 1;
-const IN_195: usize = 1;
-const OUT_195: usize = 2;
-fn aiur_fn_195(
-  inp: [G; IN_195],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_195], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_195] = [__v_3, __v_4];
-    record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_196: usize = 2;
-const IN_196: usize = 2;
-const OUT_196: usize = 2;
-fn aiur_fn_196(
-  inp: [G; IN_196],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_196] = [__v_4, __v_0];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_193] = [__v_4, __v_0];
+        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15996,28 +15382,28 @@ fn aiur_fn_196(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_196] = [__v_16, __v_14];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_193] = [__v_16, __v_14];
+        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_197: usize = 64;
-const IN_197: usize = 64;
-const OUT_197: usize = 0;
-fn aiur_fn_197(
-  inp: [G; IN_197],
+const INPUT_SIZE_194: usize = 64;
+const IN_194: usize = 64;
+const OUT_194: usize = 0;
+fn aiur_fn_194(
+  inp: [G; IN_194],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
+) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16118,7 +15504,7 @@ fn aiur_fn_197(
     let __io_pair: (G, G) = { let __key: [G; 1] = [__v_93]; let __info = io_buffer.get_info(__v_92, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
     let __v_94: G = __io_pair.0;
     let __v_95: G = __io_pair.1;
-    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -16140,7 +15526,7 @@ fn aiur_fn_197(
     let __v_113: G = G::from_u64(2);
     let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = __r_arr[1];
     let __v_117: G = (__v_66 + __v_67);
@@ -16148,7 +15534,7 @@ fn aiur_fn_197(
       return Err(ExecError::AssertEqMismatch { lhs: __v_91.as_canonical_u64(), rhs: __v_117.as_canonical_u64() });
     }
     let __v_118: G = G::from_u64(1);
-    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
     let __v_119: G = __r_arr[0];
     let __v_120: G = __r_arr[1];
     let __v_121: G = __r_arr[2];
@@ -16181,7 +15567,7 @@ fn aiur_fn_197(
     let __v_148: G = __r_arr[29];
     let __v_149: G = __r_arr[30];
     let __v_150: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_151: G = __r_arr[0];
     let __v_152: G = __r_arr[1];
     let __v_153: G = __r_arr[2];
@@ -16347,7 +15733,7 @@ fn aiur_fn_197(
     let __v_213: G = __r_arr[29];
     let __v_214: G = __r_arr[30];
     let __v_215: G = __r_arr[31];
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_216: G = __r_arr[0];
     let __v_217: G = __r_arr[1];
     let __v_218: G = __r_arr[2];
@@ -16491,33 +15877,33 @@ fn aiur_fn_197(
     if (__v_250 != __v_252) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
     let __v_253: G = __r_arr[0];
     let __v_254: G = G::from_u64(1);
     if (__v_253 != __v_254) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
     let __v_255: G = __r_arr[0];
     let __v_256: G = G::from_u64(1);
     if (__v_255 != __v_256) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
-    let __ret: [G; OUT_197] = [];
-    record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_194] = [];
+    record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_198: usize = 1;
-const IN_198: usize = 1;
-const OUT_198: usize = 1;
-fn aiur_fn_198(
-  inp: [G; IN_198],
+const INPUT_SIZE_195: usize = 1;
+const IN_195: usize = 1;
+const OUT_195: usize = 1;
+fn aiur_fn_195(
+  inp: [G; IN_195],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_198], ExecError> {
+) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16527,17 +15913,17 @@ fn aiur_fn_198(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_198] = [__v_4];
-        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_195] = [__v_4];
+        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = G::from_u64(1);
         let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_198] = [__v_6];
-        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_195] = [__v_6];
+        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16547,15 +15933,15 @@ fn aiur_fn_198(
   })
 }
 
-const INPUT_SIZE_199: usize = 1;
-const IN_199: usize = 1;
-const OUT_199: usize = 1;
-fn aiur_fn_199(
-  inp: [G; IN_199],
+const INPUT_SIZE_196: usize = 1;
+const IN_196: usize = 1;
+const OUT_196: usize = 1;
+fn aiur_fn_196(
+  inp: [G; IN_196],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_199], ExecError> {
+) -> Result<[G; OUT_196], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16565,14 +15951,14 @@ fn aiur_fn_199(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_199] = [__v_4];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_4];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_199] = [__v_4];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_4];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16582,19 +15968,19 @@ fn aiur_fn_199(
   })
 }
 
-const INPUT_SIZE_200: usize = 2;
-const IN_200: usize = 2;
-const OUT_200: usize = 2;
-fn aiur_fn_200(
-  inp: [G; IN_200],
+const INPUT_SIZE_197: usize = 2;
+const IN_197: usize = 2;
+const OUT_197: usize = 2;
+fn aiur_fn_197(
+  inp: [G; IN_197],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_200], ExecError> {
+) -> Result<[G; OUT_197], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16603,8 +15989,8 @@ fn aiur_fn_200(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_200] = [__v_4, __v_5];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_197] = [__v_4, __v_5];
+        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16614,15 +16000,15 @@ fn aiur_fn_200(
   })
 }
 
-const INPUT_SIZE_201: usize = 1;
-const IN_201: usize = 1;
-const OUT_201: usize = 8;
-fn aiur_fn_201(
-  inp: [G; IN_201],
+const INPUT_SIZE_198: usize = 1;
+const IN_198: usize = 1;
+const OUT_198: usize = 8;
+fn aiur_fn_198(
+  inp: [G; IN_198],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_201], ExecError> {
+) -> Result<[G; OUT_198], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -16646,12 +16032,12 @@ fn aiur_fn_201(
         let __v_16: G = G::from_u64(0);
         let __v_17: G = G::from_u64(0);
         let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_201] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_198] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
         let __v_13: G = __r_arr[2];
@@ -16669,8 +16055,8 @@ fn aiur_fn_201(
         let __v_24: G = __r_arr[5];
         let __v_25: G = __r_arr[6];
         let __v_26: G = __r_arr[7];
-        let __ret: [G; OUT_201] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_198] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16680,19 +16066,19 @@ fn aiur_fn_201(
   })
 }
 
-const INPUT_SIZE_202: usize = 2;
-const IN_202: usize = 2;
-const OUT_202: usize = 1;
-fn aiur_fn_202(
-  inp: [G; IN_202],
+const INPUT_SIZE_199: usize = 2;
+const IN_199: usize = 2;
+const OUT_199: usize = 1;
+fn aiur_fn_199(
+  inp: [G; IN_199],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_202], ExecError> {
+) -> Result<[G; OUT_199], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16700,8 +16086,8 @@ fn aiur_fn_202(
     let __v_5: G = __loaded[2];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_202] = [__v_4];
-        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16711,15 +16097,54 @@ fn aiur_fn_202(
   })
 }
 
-const INPUT_SIZE_203: usize = 1;
-const IN_203: usize = 1;
-const OUT_203: usize = 1;
-fn aiur_fn_203(
-  inp: [G; IN_203],
+const INPUT_SIZE_200: usize = 2;
+const IN_200: usize = 2;
+const OUT_200: usize = 1;
+fn aiur_fn_200(
+  inp: [G; IN_200],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_203], ExecError> {
+) -> Result<[G; OUT_200], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_200] = [__v_1];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_6: G = G::from_u64(0);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = { let __values: [G; 4] = [__v_6, __v_3, __v_4, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_200] = [__v_8];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_201: usize = 1;
+const IN_201: usize = 1;
+const OUT_201: usize = 1;
+fn aiur_fn_201(
+  inp: [G; IN_201],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_201], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
@@ -16731,17 +16156,17 @@ fn aiur_fn_203(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_203] = [__v_6];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_6];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = G::from_u64(1);
         let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_203] = [__v_8];
-        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_8];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16751,15 +16176,15 @@ fn aiur_fn_203(
   })
 }
 
-const INPUT_SIZE_204: usize = 1;
-const IN_204: usize = 1;
-const OUT_204: usize = 1;
-fn aiur_fn_204(
-  inp: [G; IN_204],
+const INPUT_SIZE_202: usize = 1;
+const IN_202: usize = 1;
+const OUT_202: usize = 1;
+fn aiur_fn_202(
+  inp: [G; IN_202],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_204], ExecError> {
+) -> Result<[G; OUT_202], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -16770,16 +16195,120 @@ fn aiur_fn_204(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_204] = [__v_5];
+        let __ret: [G; OUT_202] = [__v_5];
+        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = (__v_5 + __v_6);
+        let __ret: [G; OUT_202] = [__v_7];
+        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_203: usize = 2;
+const IN_203: usize = 2;
+const OUT_203: usize = 1;
+fn aiur_fn_203(
+  inp: [G; IN_203],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_203], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    let __v_9: G = __loaded[7];
+    let __v_10: G = __loaded[8];
+    let __v_11: G = __loaded[9];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_203] = [__v_1];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_12: G = G::from_u64(0);
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_203] = [__v_14];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_204: usize = 1;
+const IN_204: usize = 1;
+const OUT_204: usize = 8;
+fn aiur_fn_204(
+  inp: [G; IN_204],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_204], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_4: G = G::from_u64(0);
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(0);
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = G::from_u64(0);
+        let __v_11: G = G::from_u64(0);
+        let __ret: [G; OUT_204] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
         record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_204] = [__v_7];
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = __r_arr[1];
+        let __v_6: G = __r_arr[2];
+        let __v_7: G = __r_arr[3];
+        let __v_8: G = __r_arr[4];
+        let __v_9: G = __r_arr[5];
+        let __v_10: G = __r_arr[6];
+        let __v_11: G = __r_arr[7];
+        let __r_arr: [G; OUT_8] = { let __args: [G; IN_8] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[8].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_8] = unsafe { *(result.output.as_ptr() as *const [G; OUT_8]) }; __ret } else { aiur_fn_8(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __v_13: G = __r_arr[1];
+        let __v_14: G = __r_arr[2];
+        let __v_15: G = __r_arr[3];
+        let __v_16: G = __r_arr[4];
+        let __v_17: G = __r_arr[5];
+        let __v_18: G = __r_arr[6];
+        let __v_19: G = __r_arr[7];
+        let __ret: [G; OUT_204] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
         record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16802,17 +16331,10 @@ fn aiur_fn_205(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    let __v_9: G = __loaded[7];
-    let __v_10: G = __loaded[8];
-    let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __ret: [G; OUT_205] = [__v_1];
@@ -16820,11 +16342,11 @@ fn aiur_fn_205(
         return Ok(__ret);
       },
       0u64 => {
-        let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_205] = [__v_14];
+        let __v_5: G = G::from_u64(0);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_205] = [__v_7];
         record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16835,9 +16357,9 @@ fn aiur_fn_205(
   })
 }
 
-const INPUT_SIZE_206: usize = 1;
-const IN_206: usize = 1;
-const OUT_206: usize = 8;
+const INPUT_SIZE_206: usize = 2;
+const IN_206: usize = 2;
+const OUT_206: usize = 1;
 fn aiur_fn_206(
   inp: [G; IN_206],
   record: &mut QueryRecord,
@@ -16846,56 +16368,39 @@ fn aiur_fn_206(
 ) -> Result<[G; OUT_206], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
+    let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_4: G = G::from_u64(0);
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(0);
-        let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
       0u64 => {
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = __r_arr[1];
-        let __v_6: G = __r_arr[2];
-        let __v_7: G = __r_arr[3];
-        let __v_8: G = __r_arr[4];
-        let __v_9: G = __r_arr[5];
-        let __v_10: G = __r_arr[6];
-        let __v_11: G = __r_arr[7];
-        let __r_arr: [G; OUT_8] = { let __args: [G; IN_8] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[8].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_8] = unsafe { *(result.output.as_ptr() as *const [G; OUT_8]) }; __ret } else { aiur_fn_8(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __v_13: G = __r_arr[1];
-        let __v_14: G = __r_arr[2];
-        let __v_15: G = __r_arr[3];
-        let __v_16: G = __r_arr[4];
-        let __v_17: G = __r_arr[5];
-        let __v_18: G = __r_arr[6];
-        let __v_19: G = __r_arr[7];
-        let __ret: [G; OUT_206] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        let __ret: [G; OUT_206] = [__v_0];
         record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_206] = [__v_7];
+            record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_207: usize = 2;
-const IN_207: usize = 2;
+const INPUT_SIZE_207: usize = 1;
+const IN_207: usize = 1;
 const OUT_207: usize = 1;
 fn aiur_fn_207(
   inp: [G; IN_207],
@@ -16905,35 +16410,39 @@ fn aiur_fn_207(
 ) -> Result<[G; OUT_207], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    let __v_6: G = __loaded[5];
+    let __v_7: G = __loaded[6];
+    match __v_1.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_207] = [__v_1];
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_207] = [__v_8];
         record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_207] = [__v_7];
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __v_8: G = __r_arr[0];
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_8 + __v_9);
+        let __ret: [G; OUT_207] = [__v_10];
         record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_208: usize = 2;
-const IN_208: usize = 2;
+const INPUT_SIZE_208: usize = 1;
+const IN_208: usize = 1;
 const OUT_208: usize = 1;
 fn aiur_fn_208(
   inp: [G; IN_208],
@@ -16943,32 +16452,35 @@ fn aiur_fn_208(
 ) -> Result<[G; OUT_208], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
+    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    let __v_6: G = __loaded[5];
+    let __v_7: G = __loaded[6];
+    let __v_8: G = __loaded[7];
+    let __v_9: G = __loaded[8];
+    let __v_10: G = __loaded[9];
     match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_11: G = G::from_u64(0);
+        let __ret: [G; OUT_208] = [__v_11];
+        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
       0u64 => {
-        let __ret: [G; OUT_208] = [__v_0];
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = G::from_u64(1);
+        let __v_13: G = (__v_11 + __v_12);
+        let __ret: [G; OUT_208] = [__v_13];
         record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_208] = [__v_7];
-            record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -16985,27 +16497,26 @@ fn aiur_fn_209(
 ) -> Result<[G; OUT_209], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
     let __v_3: G = __loaded[2];
     let __v_4: G = __loaded[3];
     let __v_5: G = __loaded[4];
     let __v_6: G = __loaded[5];
-    let __v_7: G = __loaded[6];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_209] = [__v_8];
+        let __v_7: G = G::from_u64(0);
+        let __ret: [G; OUT_209] = [__v_7];
         record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
-        let __v_8: G = __r_arr[0];
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_209] = [__v_10];
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = (__v_7 + __v_8);
+        let __ret: [G; OUT_209] = [__v_9];
         record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -17016,9 +16527,9 @@ fn aiur_fn_209(
   })
 }
 
-const INPUT_SIZE_210: usize = 1;
-const IN_210: usize = 1;
-const OUT_210: usize = 1;
+const INPUT_SIZE_210: usize = 2;
+const IN_210: usize = 2;
+const OUT_210: usize = 32;
 fn aiur_fn_210(
   inp: [G; IN_210],
   record: &mut QueryRecord,
@@ -17027,102 +16538,8 @@ fn aiur_fn_210(
 ) -> Result<[G; OUT_210], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    let __v_6: G = __loaded[5];
-    let __v_7: G = __loaded[6];
-    let __v_8: G = __loaded[7];
-    let __v_9: G = __loaded[8];
-    let __v_10: G = __loaded[9];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_210] = [__v_11];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = G::from_u64(1);
-        let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_210] = [__v_13];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_211: usize = 1;
-const IN_211: usize = 1;
-const OUT_211: usize = 1;
-fn aiur_fn_211(
-  inp: [G; IN_211],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_211], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 14] = { let __mq = record.memory_queries.get_mut(&14).ok_or(ExecError::InvalidMemorySize(14))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 14 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 14] = __args[..14].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    let __v_6: G = __loaded[5];
-    let __v_7: G = __loaded[6];
-    let __v_8: G = __loaded[7];
-    let __v_9: G = __loaded[8];
-    let __v_10: G = __loaded[9];
-    let __v_11: G = __loaded[10];
-    let __v_12: G = __loaded[11];
-    let __v_13: G = __loaded[12];
-    let __v_14: G = __loaded[13];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_15: G = G::from_u64(0);
-        let __ret: [G; OUT_211] = [__v_15];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __v_16: G = G::from_u64(1);
-        let __v_17: G = (__v_15 + __v_16);
-        let __ret: [G; OUT_211] = [__v_17];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_212: usize = 2;
-const IN_212: usize = 2;
-const OUT_212: usize = 32;
-fn aiur_fn_212(
-  inp: [G; IN_212],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_212], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -17161,8 +16578,8 @@ fn aiur_fn_212(
     let __v_36: G = __loaded[33];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_212] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
-        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -17172,28 +16589,28 @@ fn aiur_fn_212(
   })
 }
 
-const INPUT_SIZE_213: usize = 2;
-const IN_213: usize = 2;
-const OUT_213: usize = 1;
-fn aiur_fn_213(
-  inp: [G; IN_213],
+const INPUT_SIZE_211: usize = 2;
+const IN_211: usize = 2;
+const OUT_211: usize = 1;
+fn aiur_fn_211(
+  inp: [G; IN_211],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_213], ExecError> {
+) -> Result<[G; OUT_211], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_213] = [__v_0];
-        record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_211] = [__v_0];
+        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17202,8 +16619,8 @@ fn aiur_fn_213(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_213] = [__v_8];
-            record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_211] = [__v_8];
+            record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -17215,28 +16632,28 @@ fn aiur_fn_213(
   })
 }
 
-const INPUT_SIZE_214: usize = 2;
-const IN_214: usize = 2;
-const OUT_214: usize = 1;
-fn aiur_fn_214(
-  inp: [G; IN_214],
+const INPUT_SIZE_212: usize = 2;
+const IN_212: usize = 2;
+const OUT_212: usize = 1;
+fn aiur_fn_212(
+  inp: [G; IN_212],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_214], ExecError> {
+) -> Result<[G; OUT_212], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_214] = [__v_0];
-        record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_212] = [__v_0];
+        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17275,8 +16692,8 @@ fn aiur_fn_214(
         let __v_38: G = __loaded[33];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_214] = [__v_38];
-            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_212] = [__v_38];
+            record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -18358,16 +17775,6 @@ pub(crate) fn execute_generated(
     212u64 => {
       let __inp: [G; IN_212] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_212(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    213u64 => {
-      let __inp: [G; IN_213] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_213(__inp, record, io_buffer, false)?;
-      return Ok(__out.to_vec());
-    },
-    214u64 => {
-      let __inp: [G; IN_214] = args.try_into().expect("input size mismatch");
-      let __out = aiur_fn_214(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -6543,7 +6543,7 @@ fn aiur_fn_82(
     let __v_2: G = __r_arr[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __r_arr: [G; OUT_79] = { let __args: [G; IN_79] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[79].get_mut(&__args[..]) { let __ret: [G; OUT_79] = unsafe { *(result.output.as_ptr() as *const [G; OUT_79]) }; __ret } else { aiur_fn_79(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(0);
@@ -6553,22 +6553,17 @@ fn aiur_fn_82(
         return Ok(__ret);
       },
       1u64 => {
-        let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_79] = { let __args: [G; IN_79] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[79].get_mut(&__args[..]) { let __ret: [G; OUT_79] = unsafe { *(result.output.as_ptr() as *const [G; OUT_79]) }; __ret } else { aiur_fn_79(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
-        let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_6]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __v_9: G = G::from_u64(1);
-        let __ret: [G; OUT_82] = [__v_9, __v_3, __v_5, __v_7, __v_8];
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(2);
@@ -6599,10 +6594,10 @@ fn aiur_fn_82(
         return Ok(__ret);
       },
       6u64 => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(6);
@@ -6612,10 +6607,10 @@ fn aiur_fn_82(
         return Ok(__ret);
       },
       7u64 => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(7);
@@ -6625,10 +6620,10 @@ fn aiur_fn_82(
         return Ok(__ret);
       },
       8u64 => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_4]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(8);
@@ -6637,13 +6632,79 @@ fn aiur_fn_82(
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+      9u64 => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_3: G = __r_arr[0];
         let __v_4: G = __r_arr[1];
         let __v_5: G = G::from_u64(9);
         let __v_6: G = G::from_u64(0);
         let __ret: [G; OUT_82] = [__v_5, __v_3, __v_6, __v_6, __v_4];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(1);
+        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = G::from_u64(1);
+        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(2);
+        let __v_7: G = G::from_u64(0);
+        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
+        record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(2);
+        let __v_7: G = G::from_u64(1);
+        let __ret: [G; OUT_82] = [__v_5, __v_6, __v_7, __v_3, __v_4];
         record.function_queries[82].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -6716,7 +6777,7 @@ fn aiur_fn_84(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
@@ -6745,10 +6806,10 @@ fn aiur_fn_85(
 ) -> Result<[G; OUT_85], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_74] = { let __args: [G; IN_74] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[74].get_mut(&__args[..]) { let __ret: [G; OUT_74] = unsafe { *(result.output.as_ptr() as *const [G; OUT_74]) }; __ret } else { aiur_fn_74(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4341,7 +4341,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4499,10 +4499,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -6736,13 +6736,80 @@ fn aiur_fn_84(
 
 const INPUT_SIZE_85: usize = 1;
 const IN_85: usize = 1;
-const OUT_85: usize = 53;
+const OUT_85: usize = 3;
 fn aiur_fn_85(
   inp: [G; IN_85],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_85], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_2]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __v_6: G = __r_arr[1];
+    let __ret: [G; OUT_85] = [__v_1, __v_5, __v_6];
+    record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_86: usize = 2;
+const IN_86: usize = 2;
+const OUT_86: usize = 2;
+fn aiur_fn_86(
+  inp: [G; IN_86],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_86], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 4] = [__v_2, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_86] = [__v_4, __v_0];
+        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = __r_arr[2];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_1 - __v_5);
+        let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = __r_arr[1];
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = { let __values: [G; 4] = [__v_9, __v_2, __v_3, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_86] = [__v_10, __v_8];
+        record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_87: usize = 1;
+const IN_87: usize = 1;
+const OUT_87: usize = 54;
+fn aiur_fn_87(
+  inp: [G; IN_87],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_87], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
@@ -6781,70 +6848,81 @@ fn aiur_fn_85(
     let __v_30: G = __r_arr[7];
     let __v_31: G = __r_arr[8];
     let __v_32: G = __r_arr[9];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_32]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_32]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
     let __v_34: G = __r_arr[1];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_34]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_35: G = __r_arr[0];
-    let __v_36: G = __r_arr[1];
-    let __v_37: G = __r_arr[2];
-    let __v_38: G = __r_arr[3];
-    let __v_39: G = __r_arr[4];
-    let __v_40: G = __r_arr[5];
-    let __v_41: G = __r_arr[6];
-    let __v_42: G = __r_arr[7];
-    let __v_43: G = __r_arr[8];
-    let __v_44: G = __r_arr[9];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_44]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_45: G = __r_arr[0];
-    let __v_46: G = __r_arr[1];
-    let __v_47: G = __r_arr[2];
-    let __v_48: G = __r_arr[3];
-    let __v_49: G = __r_arr[4];
-    let __v_50: G = __r_arr[5];
-    let __v_51: G = __r_arr[6];
-    let __v_52: G = __r_arr[7];
-    let __v_53: G = __r_arr[8];
-    let __v_54: G = __r_arr[9];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_54]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_55: G = __r_arr[0];
-    let __v_56: G = __r_arr[1];
-    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_56]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
-    let __v_57: G = __r_arr[0];
-    let __v_58: G = __r_arr[1];
-    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_58, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
-    let __v_59: G = __r_arr[0];
-    let __v_60: G = __r_arr[1];
-    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_60]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
-    let __v_61: G = __r_arr[0];
-    let __v_62: G = __r_arr[1];
-    let __v_63: G = __r_arr[2];
-    let __v_64: G = __r_arr[3];
-    let __v_65: G = __r_arr[4];
-    let __v_66: G = __r_arr[5];
-    let __v_67: G = __r_arr[6];
-    let __v_68: G = __r_arr[7];
-    let __v_69: G = __r_arr[8];
-    let __v_70: G = __r_arr[9];
-    let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_70, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
+    let __v_35: G = __r_arr[2];
+    let __v_36: G = __r_arr[3];
+    let __v_37: G = __r_arr[4];
+    let __v_38: G = __r_arr[5];
+    let __v_39: G = __r_arr[6];
+    let __v_40: G = __r_arr[7];
+    let __v_41: G = __r_arr[8];
+    let __v_42: G = __r_arr[9];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_42]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_43: G = __r_arr[0];
+    let __v_44: G = __r_arr[1];
+    let __v_45: G = __r_arr[2];
+    let __v_46: G = __r_arr[3];
+    let __v_47: G = __r_arr[4];
+    let __v_48: G = __r_arr[5];
+    let __v_49: G = __r_arr[6];
+    let __v_50: G = __r_arr[7];
+    let __v_51: G = __r_arr[8];
+    let __v_52: G = __r_arr[9];
+    let __r_arr: [G; OUT_77] = { let __args: [G; IN_77] = [__v_52]; let __cu = true; if let Some(result) = record.function_queries[77].get_mut(&__args[..]) { let __ret: [G; OUT_77] = unsafe { *(result.output.as_ptr() as *const [G; OUT_77]) }; __ret } else { aiur_fn_77(__args, record, io_buffer, __cu)? } };
+    let __v_53: G = __r_arr[0];
+    let __v_54: G = __r_arr[1];
+    let __v_55: G = __r_arr[2];
+    let __v_56: G = __r_arr[3];
+    let __v_57: G = __r_arr[4];
+    let __v_58: G = __r_arr[5];
+    let __v_59: G = __r_arr[6];
+    let __v_60: G = __r_arr[7];
+    let __v_61: G = __r_arr[8];
+    let __v_62: G = __r_arr[9];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_62]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_63: G = __r_arr[0];
+    let __v_64: G = __r_arr[1];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_64]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_65: G = __r_arr[0];
+    let __v_66: G = __r_arr[1];
+    let __r_arr: [G; OUT_83] = { let __args: [G; IN_83] = [__v_66, __v_65]; let __cu = unconstrained; if let Some(result) = record.function_queries[83].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_83] = unsafe { *(result.output.as_ptr() as *const [G; OUT_83]) }; __ret } else { aiur_fn_83(__args, record, io_buffer, __cu)? } };
+    let __v_67: G = __r_arr[0];
+    let __v_68: G = __r_arr[1];
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_68]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_69: G = __r_arr[0];
+    let __v_70: G = __r_arr[1];
+    let __r_arr: [G; OUT_84] = { let __args: [G; IN_84] = [__v_70, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[84].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_84] = unsafe { *(result.output.as_ptr() as *const [G; OUT_84]) }; __ret } else { aiur_fn_84(__args, record, io_buffer, __cu)? } };
     let __v_71: G = __r_arr[0];
     let __v_72: G = __r_arr[1];
-    let __v_73: G = (__v_2 + __v_1);
-    let __ret: [G; OUT_85] = [__v_59, __v_57, __v_71, __v_45, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_73];
-    record.function_queries[85].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __r_arr: [G; OUT_76] = { let __args: [G; IN_76] = [__v_72]; let __cu = true; if let Some(result) = record.function_queries[76].get_mut(&__args[..]) { let __ret: [G; OUT_76] = unsafe { *(result.output.as_ptr() as *const [G; OUT_76]) }; __ret } else { aiur_fn_76(__args, record, io_buffer, __cu)? } };
+    let __v_73: G = __r_arr[0];
+    let __v_74: G = __r_arr[1];
+    let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_74, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
+    let __v_75: G = __r_arr[0];
+    let __v_76: G = __r_arr[1];
+    let __v_77: G = (__v_2 + __v_1);
+    let __v_78: G = (__v_77 - __v_76);
+    let __v_79: G = G::from_u64(0);
+    if (__v_78 != __v_79) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_78.as_canonical_u64(), rhs: __v_79.as_canonical_u64() });
+    }
+    let __ret: [G; OUT_87] = [__v_67, __v_65, __v_71, __v_53, __v_75, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_77];
+    record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_86: usize = 49;
-const IN_86: usize = 49;
-const OUT_86: usize = 1;
-fn aiur_fn_86(
-  inp: [G; IN_86],
+const INPUT_SIZE_88: usize = 49;
+const IN_88: usize = 49;
+const OUT_88: usize = 1;
+fn aiur_fn_88(
+  inp: [G; IN_88],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_86], ExecError> {
+) -> Result<[G; OUT_88], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -6907,21 +6985,21 @@ fn aiur_fn_86(
     let __v_58: G = { let __values: [G; 10] = [__v_51, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_57]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_59: G = { let __values: [G; 10] = [__v_50, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_58]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_60: G = { let __values: [G; 10] = [__v_49, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_59]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_86] = [__v_60];
-    record.function_queries[86].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_88] = [__v_60];
+    record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_87: usize = 2;
-const IN_87: usize = 2;
-const OUT_87: usize = 3;
-fn aiur_fn_87(
-  inp: [G; IN_87],
+const INPUT_SIZE_89: usize = 2;
+const IN_89: usize = 2;
+const OUT_89: usize = 3;
+fn aiur_fn_89(
+  inp: [G; IN_89],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_87], ExecError> {
+) -> Result<[G; OUT_89], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -6929,16 +7007,16 @@ fn aiur_fn_87(
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 6] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __v_4: G = { let __values: [G; 7] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 10] = [__v_5, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_87] = [__v_4, __v_7, __v_0];
-        record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_89] = [__v_4, __v_7, __v_0];
+        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_85] = { let __args: [G; IN_85] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[85].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_85] = unsafe { *(result.output.as_ptr() as *const [G; OUT_85]) }; __ret } else { aiur_fn_85(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = __r_arr[2];
@@ -6992,33 +7070,34 @@ fn aiur_fn_87(
         let __v_52: G = __r_arr[50];
         let __v_53: G = __r_arr[51];
         let __v_54: G = __r_arr[52];
-        let __v_55: G = G::from_u64(1);
-        let __v_56: G = (__v_1 - __v_55);
-        let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_54, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
-        let __v_57: G = __r_arr[0];
-        let __v_58: G = __r_arr[1];
-        let __v_59: G = __r_arr[2];
-        let __v_60: G = G::from_u64(0);
-        let __v_61: G = { let __values: [G; 6] = [__v_60, __v_2, __v_3, __v_4, __v_5, __v_57]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_86] = { let __args: [G; IN_86] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[86].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_86] = unsafe { *(result.output.as_ptr() as *const [G; OUT_86]) }; __ret } else { aiur_fn_86(__args, record, io_buffer, __cu)? } };
-        let __v_62: G = __r_arr[0];
-        let __ret: [G; OUT_87] = [__v_61, __v_62, __v_59];
-        record.function_queries[87].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_55: G = __r_arr[53];
+        let __v_56: G = G::from_u64(1);
+        let __v_57: G = (__v_1 - __v_56);
+        let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_55, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
+        let __v_58: G = __r_arr[0];
+        let __v_59: G = __r_arr[1];
+        let __v_60: G = __r_arr[2];
+        let __v_61: G = G::from_u64(0);
+        let __v_62: G = { let __values: [G; 7] = [__v_61, __v_2, __v_3, __v_4, __v_5, __v_6, __v_58]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
+        let __v_63: G = __r_arr[0];
+        let __ret: [G; OUT_89] = [__v_62, __v_63, __v_60];
+        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_88: usize = 1;
-const IN_88: usize = 1;
-const OUT_88: usize = 3;
-fn aiur_fn_88(
-  inp: [G; IN_88],
+const INPUT_SIZE_90: usize = 1;
+const IN_90: usize = 1;
+const OUT_90: usize = 3;
+fn aiur_fn_90(
+  inp: [G; IN_90],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_88], ExecError> {
+) -> Result<[G; OUT_90], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_73] = { let __args: [G; IN_73] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[73].get_mut(&__args[..]) { let __ret: [G; OUT_73] = unsafe { *(result.output.as_ptr() as *const [G; OUT_73]) }; __ret } else { aiur_fn_73(__args, record, io_buffer, __cu)? } };
@@ -7028,8 +7107,8 @@ fn aiur_fn_88(
       0u64 => {
         let __v_3: G = G::from_u64(0);
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_88] = [__v_3, __v_4, __v_2];
-        record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_90] = [__v_3, __v_4, __v_2];
+        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7040,23 +7119,23 @@ fn aiur_fn_88(
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = G::from_u64(1);
-        let __ret: [G; OUT_88] = [__v_7, __v_5, __v_6];
-        record.function_queries[88].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_90] = [__v_7, __v_5, __v_6];
+        record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_89: usize = 2;
-const IN_89: usize = 2;
-const OUT_89: usize = 2;
-fn aiur_fn_89(
-  inp: [G; IN_89],
+const INPUT_SIZE_91: usize = 2;
+const IN_91: usize = 2;
+const OUT_91: usize = 2;
+fn aiur_fn_91(
+  inp: [G; IN_91],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_89], ExecError> {
+) -> Result<[G; OUT_91], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7065,8 +7144,8 @@ fn aiur_fn_89(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 4] = [__v_2, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_89] = [__v_4, __v_0];
-        record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_91] = [__v_4, __v_0];
+        record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7075,7 +7154,7 @@ fn aiur_fn_89(
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
         let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = __r_arr[1];
         match __v_2.as_canonical_u64() {
@@ -7084,16 +7163,16 @@ fn aiur_fn_89(
             let __v_9: G = G::from_u64(0);
             let __v_10: G = G::from_u64(0);
             let __v_11: G = { let __values: [G; 4] = [__v_8, __v_9, __v_10, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_89] = [__v_11, __v_7];
-            record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_91] = [__v_11, __v_7];
+            record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
             let __v_8: G = G::from_u64(0);
             let __v_9: G = G::from_u64(1);
             let __v_10: G = { let __values: [G; 4] = [__v_8, __v_9, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_89] = [__v_10, __v_7];
-            record.function_queries[89].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_91] = [__v_10, __v_7];
+            record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -7102,15 +7181,15 @@ fn aiur_fn_89(
   })
 }
 
-const INPUT_SIZE_90: usize = 1;
-const IN_90: usize = 1;
-const OUT_90: usize = 9;
-fn aiur_fn_90(
-  inp: [G; IN_90],
+const INPUT_SIZE_92: usize = 1;
+const IN_92: usize = 1;
+const OUT_92: usize = 9;
+fn aiur_fn_92(
+  inp: [G; IN_92],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_90], ExecError> {
+) -> Result<[G; OUT_92], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_75] = { let __args: [G; IN_75] = [__v_0]; let __cu = true; if let Some(result) = record.function_queries[75].get_mut(&__args[..]) { let __ret: [G; OUT_75] = unsafe { *(result.output.as_ptr() as *const [G; OUT_75]) }; __ret } else { aiur_fn_75(__args, record, io_buffer, __cu)? } };
@@ -7207,24 +7286,24 @@ fn aiur_fn_90(
     let __v_85: G = { let __values: [G; 10] = [__v_73, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_84]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_86: G = { let __values: [G; 10] = [__v_72, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_85]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_87: G = { let __values: [G; 10] = [__v_71, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_86]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_90] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_87, __v_70];
-    record.function_queries[90].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_92] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_87, __v_70];
+    record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_91: usize = 1;
-const IN_91: usize = 1;
-const OUT_91: usize = 13;
-fn aiur_fn_91(
-  inp: [G; IN_91],
+const INPUT_SIZE_93: usize = 1;
+const IN_93: usize = 1;
+const OUT_93: usize = 13;
+fn aiur_fn_93(
+  inp: [G; IN_93],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_91], ExecError> {
+) -> Result<[G; OUT_93], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
     let __v_3: G = __r_arr[2];
@@ -7245,36 +7324,36 @@ fn aiur_fn_91(
     let __v_17: G = __r_arr[7];
     let __v_18: G = __r_arr[8];
     let __v_19: G = __r_arr[9];
-    let __r_arr: [G; OUT_87] = { let __args: [G; IN_87] = [__v_19, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[87].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_87] = unsafe { *(result.output.as_ptr() as *const [G; OUT_87]) }; __ret } else { aiur_fn_87(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_19, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_88] = { let __args: [G; IN_88] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[88].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_88] = unsafe { *(result.output.as_ptr() as *const [G; OUT_88]) }; __ret } else { aiur_fn_88(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_90] = { let __args: [G; IN_90] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[90].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_90] = unsafe { *(result.output.as_ptr() as *const [G; OUT_90]) }; __ret } else { aiur_fn_90(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = __r_arr[2];
-    let __r_arr: [G; OUT_89] = { let __args: [G; IN_89] = [__v_25, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[89].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_89] = unsafe { *(result.output.as_ptr() as *const [G; OUT_89]) }; __ret } else { aiur_fn_89(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_25, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
     let __v_26: G = __r_arr[0];
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = { let __values: [G; 10] = [__v_28, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_21]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
-    let __ret: [G; OUT_91] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
-    record.function_queries[91].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_93] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
+    record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_92: usize = 5;
-const IN_92: usize = 5;
-const OUT_92: usize = 1;
-fn aiur_fn_92(
-  inp: [G; IN_92],
+const INPUT_SIZE_94: usize = 5;
+const IN_94: usize = 5;
+const OUT_94: usize = 1;
+fn aiur_fn_94(
+  inp: [G; IN_94],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_92], ExecError> {
+) -> Result<[G; OUT_94], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7289,21 +7368,21 @@ fn aiur_fn_92(
     let __v_10: G = { let __values: [G; 3] = [__v_7, __v_2, __v_9]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_11: G = { let __values: [G; 3] = [__v_6, __v_1, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_12: G = { let __values: [G; 3] = [__v_5, __v_0, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_92] = [__v_12];
-    record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_94] = [__v_12];
+    record.function_queries[94].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_93: usize = 33;
-const IN_93: usize = 33;
-const OUT_93: usize = 1;
-fn aiur_fn_93(
-  inp: [G; IN_93],
+const INPUT_SIZE_95: usize = 33;
+const IN_95: usize = 33;
+const OUT_95: usize = 1;
+fn aiur_fn_95(
+  inp: [G; IN_95],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_93], ExecError> {
+) -> Result<[G; OUT_95], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7338,37 +7417,37 @@ fn aiur_fn_93(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_24, __v_25, __v_26, __v_27, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_24, __v_25, __v_26, __v_27, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_20, __v_21, __v_22, __v_23, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_20, __v_21, __v_22, __v_23, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_16, __v_17, __v_18, __v_19, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_16, __v_17, __v_18, __v_19, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_12, __v_13, __v_14, __v_15, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_12, __v_13, __v_14, __v_15, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_37: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_8, __v_9, __v_10, __v_11, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_8, __v_9, __v_10, __v_11, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_38: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_4, __v_5, __v_6, __v_7, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_4, __v_5, __v_6, __v_7, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
-    let __r_arr: [G; OUT_92] = { let __args: [G; IN_92] = [__v_0, __v_1, __v_2, __v_3, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[92].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_92] = unsafe { *(result.output.as_ptr() as *const [G; OUT_92]) }; __ret } else { aiur_fn_92(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_0, __v_1, __v_2, __v_3, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __ret: [G; OUT_93] = [__v_40];
-    record.function_queries[93].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_95] = [__v_40];
+    record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_94: usize = 32;
-const IN_94: usize = 32;
-const OUT_94: usize = 32;
-fn aiur_fn_94(
-  inp: [G; IN_94],
+const INPUT_SIZE_96: usize = 32;
+const IN_96: usize = 32;
+const OUT_96: usize = 32;
+fn aiur_fn_96(
+  inp: [G; IN_96],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_94], ExecError> {
+) -> Result<[G; OUT_96], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7402,21 +7481,21 @@ fn aiur_fn_94(
     let __v_29: G = inp[29];
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
-    let __ret: [G; OUT_94] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31];
-    record.function_queries[94].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_96] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31];
+    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_95: usize = 4;
-const IN_95: usize = 4;
-const OUT_95: usize = 1;
-fn aiur_fn_95(
-  inp: [G; IN_95],
+const INPUT_SIZE_97: usize = 4;
+const IN_97: usize = 4;
+const OUT_97: usize = 1;
+fn aiur_fn_97(
+  inp: [G; IN_97],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_95], ExecError> {
+) -> Result<[G; OUT_97], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7424,8 +7503,8 @@ fn aiur_fn_95(
     let __v_3: G = inp[3];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_95] = [__v_3];
-        record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_97] = [__v_3];
+        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -7437,25 +7516,25 @@ fn aiur_fn_95(
         let __v_8: G = (__v_2 - __v_7);
         let __v_9: G = G::from_u64(0);
         let __v_10: G = { let __values: [G; 3] = [__v_9, __v_4, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_0, __v_6, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_6, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
-        let __ret: [G; OUT_95] = [__v_11];
-        record.function_queries[95].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_97] = [__v_11];
+        record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_96: usize = 7;
-const IN_96: usize = 7;
-const OUT_96: usize = 1;
-fn aiur_fn_96(
-  inp: [G; IN_96],
+const INPUT_SIZE_98: usize = 7;
+const IN_98: usize = 7;
+const OUT_98: usize = 1;
+fn aiur_fn_98(
+  inp: [G; IN_98],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_96], ExecError> {
+) -> Result<[G; OUT_98], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -7641,8 +7720,8 @@ fn aiur_fn_96(
           1u64 => {
             let __v_172: G = G::from_u64(0);
             let __v_173: G = { let __values: [G; 34] = [__v_172, __v_6, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_96] = [__v_173];
-            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_98] = [__v_173];
+            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -7707,10 +7786,10 @@ fn aiur_fn_96(
                 let __v_226: G = { let __values: [G; 32] = [__v_172, __v_173, __v_174, __v_175, __v_176, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_227: G = G::from_u64(0);
                 let __v_228: G = { let __values: [G; 34] = [__v_227, __v_6, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_205, __v_207, __v_208, __v_225, __v_226, __v_228]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_205, __v_207, __v_208, __v_225, __v_226, __v_228]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
                 let __v_229: G = __r_arr[0];
-                let __ret: [G; OUT_96] = [__v_229];
-                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_98] = [__v_229];
+                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
@@ -7721,10 +7800,10 @@ fn aiur_fn_96(
                 let __v_176: G = G::from_u64(1);
                 let __v_177: G = (__v_3 + __v_176);
                 let __v_178: G = { let __values: [G; 32] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_173, __v_175, __v_177, __v_4, __v_178, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_173, __v_175, __v_177, __v_4, __v_178, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
                 let __v_179: G = __r_arr[0];
-                let __ret: [G; OUT_96] = [__v_179];
-                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_98] = [__v_179];
+                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -7902,62 +7981,62 @@ fn aiur_fn_96(
                                             let __v_154: G = __r_arr[30];
                                             let __v_155: G = __r_arr[31];
                                             let __v_156: G = { let __values: [G; 34] = [__v_17, __v_6, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                            let __ret: [G; OUT_96] = [__v_156];
-                                            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                            let __ret: [G; OUT_98] = [__v_156];
+                                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                             return Ok(__ret);
                                           },
                                           _ => {
-                                            let __ret: [G; OUT_96] = [__v_6];
-                                            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                            let __ret: [G; OUT_98] = [__v_6];
+                                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                             return Ok(__ret);
                                           },
                                         }
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_96] = [__v_6];
-                                        record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_98] = [__v_6];
+                                        record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_96] = [__v_6];
-                                    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                    let __ret: [G; OUT_98] = [__v_6];
+                                    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_96] = [__v_6];
-                                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                let __ret: [G; OUT_98] = [__v_6];
+                                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_96] = [__v_6];
-                            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_98] = [__v_6];
+                            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_96] = [__v_6];
-                        record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_98] = [__v_6];
+                        record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_96] = [__v_6];
-                    record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_98] = [__v_6];
+                    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_96] = [__v_6];
-                record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_98] = [__v_6];
+                record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -7966,7 +8045,7 @@ fn aiur_fn_96(
             let __v_9: G = G::from_u64(1);
             let __v_10: G = G::from_u64(1);
             let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_0, __v_1, __v_2, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_0, __v_1, __v_2, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = G::from_u64(64);
             let __v_14: G = (__v_13 - __v_2);
@@ -8131,8 +8210,8 @@ fn aiur_fn_96(
             let __v_166: G = __r_arr[30];
             let __v_167: G = __r_arr[31];
             let __v_168: G = { let __values: [G; 34] = [__v_95, __v_6, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_96] = [__v_168];
-            record.function_queries[96].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_98] = [__v_168];
+            record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -8141,15 +8220,15 @@ fn aiur_fn_96(
   })
 }
 
-const INPUT_SIZE_97: usize = 3;
-const IN_97: usize = 3;
-const OUT_97: usize = 32;
-fn aiur_fn_97(
-  inp: [G; IN_97],
+const INPUT_SIZE_99: usize = 3;
+const IN_99: usize = 3;
+const OUT_99: usize = 32;
+fn aiur_fn_99(
+  inp: [G; IN_99],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_97], ExecError> {
+) -> Result<[G; OUT_99], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8200,7 +8279,7 @@ fn aiur_fn_97(
     let __v_46: G = G::from_u64(1);
     let __v_47: G = G::from_u64(1);
     let __v_48: G = { let __values: [G; 34] = [__v_46, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47, __v_47]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_0, __v_1, __v_2, __v_35, __v_44, __v_45, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_0, __v_1, __v_2, __v_35, __v_44, __v_45, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
     let __v_49: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_49.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_50: G = __loaded[0];
@@ -8270,21 +8349,21 @@ fn aiur_fn_97(
     let __v_113: G = __r_arr[29];
     let __v_114: G = __r_arr[30];
     let __v_115: G = __r_arr[31];
-    let __ret: [G; OUT_97] = [__v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115];
-    record.function_queries[97].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_99] = [__v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115];
+    record.function_queries[99].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_98: usize = 64;
-const IN_98: usize = 64;
-const OUT_98: usize = 32;
-fn aiur_fn_98(
-  inp: [G; IN_98],
+const INPUT_SIZE_100: usize = 64;
+const IN_100: usize = 64;
+const OUT_100: usize = 32;
+fn aiur_fn_100(
+  inp: [G; IN_100],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_98], ExecError> {
+) -> Result<[G; OUT_100], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8425,7 +8504,7 @@ fn aiur_fn_98(
     let __v_135: G = __r_arr[29];
     let __v_136: G = __r_arr[30];
     let __v_137: G = __r_arr[31];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
     let __v_138: G = __r_arr[0];
     let __v_139: G = __r_arr[1];
     let __v_140: G = __r_arr[2];
@@ -8458,21 +8537,21 @@ fn aiur_fn_98(
     let __v_167: G = __r_arr[29];
     let __v_168: G = __r_arr[30];
     let __v_169: G = __r_arr[31];
-    let __ret: [G; OUT_98] = [__v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169];
-    record.function_queries[98].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_100] = [__v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169];
+    record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_99: usize = 64;
-const IN_99: usize = 64;
-const OUT_99: usize = 1;
-fn aiur_fn_99(
-  inp: [G; IN_99],
+const INPUT_SIZE_101: usize = 64;
+const IN_101: usize = 64;
+const OUT_101: usize = 1;
+fn aiur_fn_101(
+  inp: [G; IN_101],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_99], ExecError> {
+) -> Result<[G; OUT_101], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8565,21 +8644,21 @@ fn aiur_fn_99(
     let __v_80: G = (__v_75 * __v_79);
     let __v_81: G = (__v_71 * __v_80);
     let __v_82: G = (__v_67 * __v_81);
-    let __ret: [G; OUT_99] = [__v_82];
-    record.function_queries[99].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_101] = [__v_82];
+    record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_100: usize = 65;
-const IN_100: usize = 65;
-const OUT_100: usize = 32;
-fn aiur_fn_100(
-  inp: [G; IN_100],
+const INPUT_SIZE_102: usize = 65;
+const IN_102: usize = 65;
+const OUT_102: usize = 32;
+fn aiur_fn_102(
+  inp: [G; IN_102],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_100], ExecError> {
+) -> Result<[G; OUT_102], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8648,7 +8727,7 @@ fn aiur_fn_100(
     let __v_64: G = inp[64];
     match __v_0.as_canonical_u64() {
       0u64 => {
-        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
         let __v_65: G = __r_arr[0];
         let __v_66: G = __r_arr[1];
         let __v_67: G = __r_arr[2];
@@ -8681,12 +8760,12 @@ fn aiur_fn_100(
         let __v_94: G = __r_arr[29];
         let __v_95: G = __r_arr[30];
         let __v_96: G = __r_arr[31];
-        let __ret: [G; OUT_100] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
-        record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_102] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
+        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
         let __v_65: G = __r_arr[0];
         let __v_66: G = __r_arr[1];
         let __v_67: G = __r_arr[2];
@@ -8719,23 +8798,23 @@ fn aiur_fn_100(
         let __v_94: G = __r_arr[29];
         let __v_95: G = __r_arr[30];
         let __v_96: G = __r_arr[31];
-        let __ret: [G; OUT_100] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
-        record.function_queries[100].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_102] = [__v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96];
+        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_101: usize = 2;
-const IN_101: usize = 2;
-const OUT_101: usize = 1;
-fn aiur_fn_101(
-  inp: [G; IN_101],
+const INPUT_SIZE_103: usize = 2;
+const IN_103: usize = 2;
+const OUT_103: usize = 1;
+fn aiur_fn_103(
+  inp: [G; IN_103],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_101], ExecError> {
+) -> Result<[G; OUT_103], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8746,8 +8825,8 @@ fn aiur_fn_101(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_101] = [__v_5];
-        record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_103] = [__v_5];
+        record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -8756,15 +8835,15 @@ fn aiur_fn_101(
         match __v_6.as_canonical_u64() {
           1u64 => {
             let __v_7: G = G::from_u64(1);
-            let __ret: [G; OUT_101] = [__v_7];
-            record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_103] = [__v_7];
+            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
             let __v_7: G = __r_arr[0];
-            let __ret: [G; OUT_101] = [__v_7];
-            record.function_queries[101].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_103] = [__v_7];
+            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -8776,15 +8855,15 @@ fn aiur_fn_101(
   })
 }
 
-const INPUT_SIZE_102: usize = 3;
-const IN_102: usize = 3;
-const OUT_102: usize = 1;
-fn aiur_fn_102(
-  inp: [G; IN_102],
+const INPUT_SIZE_104: usize = 3;
+const IN_104: usize = 3;
+const OUT_104: usize = 1;
+fn aiur_fn_104(
+  inp: [G; IN_104],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_102], ExecError> {
+) -> Result<[G; OUT_104], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8798,8 +8877,8 @@ fn aiur_fn_102(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 3] = [__v_6, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_102] = [__v_8];
-        record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_104] = [__v_8];
+        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -8813,10 +8892,10 @@ fn aiur_fn_102(
             let __v_10: G = G::from_bool((__v_9 == G::ZERO));
             match __v_10.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_102] = [__v_11];
-                record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_104] = [__v_11];
+                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
@@ -8833,19 +8912,19 @@ fn aiur_fn_102(
                 let __v_20: G = __loaded[9];
                 match __v_11.as_canonical_u64() {
                   1u64 => {
-                    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                     let __v_21: G = __r_arr[0];
-                    let __ret: [G; OUT_102] = [__v_21];
-                    record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_104] = [__v_21];
+                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                   _ => {
                     let __v_21: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                     let __v_22: G = __r_arr[0];
                     let __v_23: G = { let __values: [G; 3] = [__v_21, __v_4, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __ret: [G; OUT_102] = [__v_23];
-                    record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_104] = [__v_23];
+                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -8864,15 +8943,15 @@ fn aiur_fn_102(
   })
 }
 
-const INPUT_SIZE_103: usize = 2;
-const IN_103: usize = 2;
-const OUT_103: usize = 11;
-fn aiur_fn_103(
-  inp: [G; IN_103],
+const INPUT_SIZE_105: usize = 2;
+const IN_105: usize = 2;
+const OUT_105: usize = 11;
+fn aiur_fn_105(
+  inp: [G; IN_105],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_103], ExecError> {
+) -> Result<[G; OUT_105], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8901,8 +8980,8 @@ fn aiur_fn_103(
         let __v_19: G = __r_arr[6];
         let __v_20: G = __r_arr[7];
         let __v_21: G = G::from_u64(1);
-        let __ret: [G; OUT_103] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_11, __v_1, __v_21];
-        record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_105] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_11, __v_1, __v_21];
+        record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -8921,12 +9000,12 @@ fn aiur_fn_103(
             let __v_21: G = G::from_u64(0);
             let __v_22: G = G::from_u64(0);
             let __v_23: G = G::from_u64(0);
-            let __ret: [G; OUT_103] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
-            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_105] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
+            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
             let __v_15: G = __r_arr[0];
             let __v_16: G = __r_arr[1];
             let __v_17: G = __r_arr[2];
@@ -8938,8 +9017,8 @@ fn aiur_fn_103(
             let __v_23: G = __r_arr[8];
             let __v_24: G = __r_arr[9];
             let __v_25: G = __r_arr[10];
-            let __ret: [G; OUT_103] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
-            record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_105] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
+            record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -8954,15 +9033,15 @@ fn aiur_fn_103(
   })
 }
 
-const INPUT_SIZE_104: usize = 6;
-const IN_104: usize = 6;
-const OUT_104: usize = 1;
-fn aiur_fn_104(
-  inp: [G; IN_104],
+const INPUT_SIZE_106: usize = 6;
+const IN_106: usize = 6;
+const OUT_106: usize = 1;
+fn aiur_fn_106(
+  inp: [G; IN_106],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_104], ExecError> {
+) -> Result<[G; OUT_106], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -8970,7 +9049,7 @@ fn aiur_fn_104(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -9152,68 +9231,68 @@ fn aiur_fn_104(
                                         let __v_162: G = __r_arr[30];
                                         let __v_163: G = __r_arr[31];
                                         let __v_164: G = { let __values: [G; 34] = [__v_25, __v_5, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                        let __ret: [G; OUT_104] = [__v_164];
-                                        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_106] = [__v_164];
+                                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_104] = [__v_5];
-                                        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                        let __ret: [G; OUT_106] = [__v_5];
+                                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_104] = [__v_5];
-                                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                    let __ret: [G; OUT_106] = [__v_5];
+                                    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_104] = [__v_5];
-                                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                                let __ret: [G; OUT_106] = [__v_5];
+                                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_104] = [__v_5];
-                            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_106] = [__v_5];
+                            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_104] = [__v_5];
-                        record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_106] = [__v_5];
+                        record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_104] = [__v_5];
-                    record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_106] = [__v_5];
+                    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_104] = [__v_5];
-                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_106] = [__v_5];
+                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
           },
           _ => {
-            let __ret: [G; OUT_104] = [__v_5];
-            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_106] = [__v_5];
+            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
       _ => {
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = __r_arr[1];
         let __v_19: G = __r_arr[2];
@@ -9225,7 +9304,7 @@ fn aiur_fn_104(
         let __v_25: G = __r_arr[8];
         let __v_26: G = __r_arr[9];
         let __v_27: G = __r_arr[10];
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         let __v_29: G = __r_arr[1];
         let __v_30: G = __r_arr[2];
@@ -9237,7 +9316,7 @@ fn aiur_fn_104(
         let __v_36: G = __r_arr[8];
         let __v_37: G = __r_arr[9];
         let __v_38: G = __r_arr[10];
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = __r_arr[1];
         let __v_41: G = __r_arr[2];
@@ -9249,7 +9328,7 @@ fn aiur_fn_104(
         let __v_47: G = __r_arr[8];
         let __v_48: G = __r_arr[9];
         let __v_49: G = __r_arr[10];
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_50: G = __r_arr[0];
         let __v_51: G = __r_arr[1];
         let __v_52: G = __r_arr[2];
@@ -9261,7 +9340,7 @@ fn aiur_fn_104(
         let __v_58: G = __r_arr[8];
         let __v_59: G = __r_arr[9];
         let __v_60: G = __r_arr[10];
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_61: G = __r_arr[0];
         let __v_62: G = __r_arr[1];
         let __v_63: G = __r_arr[2];
@@ -9273,7 +9352,7 @@ fn aiur_fn_104(
         let __v_69: G = __r_arr[8];
         let __v_70: G = __r_arr[9];
         let __v_71: G = __r_arr[10];
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_72: G = __r_arr[0];
         let __v_73: G = __r_arr[1];
         let __v_74: G = __r_arr[2];
@@ -9285,7 +9364,7 @@ fn aiur_fn_104(
         let __v_80: G = __r_arr[8];
         let __v_81: G = __r_arr[9];
         let __v_82: G = __r_arr[10];
-        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
         let __v_83: G = __r_arr[0];
         let __v_84: G = __r_arr[1];
         let __v_85: G = __r_arr[2];
@@ -9445,8 +9524,8 @@ fn aiur_fn_104(
           1u64 => {
             let __v_209: G = G::from_u64(0);
             let __v_210: G = { let __values: [G; 34] = [__v_209, __v_5, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_104] = [__v_210];
-            record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_106] = [__v_210];
+            record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -9507,20 +9586,20 @@ fn aiur_fn_104(
                 let __v_259: G = { let __values: [G; 32] = [__v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218, __v_219, __v_220, __v_221, __v_222, __v_223, __v_224, __v_225, __v_226, __v_227, __v_228, __v_229, __v_230, __v_231, __v_232, __v_233, __v_234, __v_235, __v_236, __v_237, __v_238, __v_239, __v_240]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_260: G = G::from_u64(0);
                 let __v_261: G = { let __values: [G; 34] = [__v_260, __v_5, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_91, __v_92, __v_241, __v_258, __v_259, __v_261]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_91, __v_92, __v_241, __v_258, __v_259, __v_261]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
                 let __v_262: G = __r_arr[0];
-                let __ret: [G; OUT_104] = [__v_262];
-                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_106] = [__v_262];
+                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_209: G = G::from_u64(1);
                 let __v_210: G = (__v_2 + __v_209);
                 let __v_211: G = { let __values: [G; 32] = [__v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_91, __v_92, __v_210, __v_3, __v_211, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_91, __v_92, __v_210, __v_3, __v_211, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
                 let __v_212: G = __r_arr[0];
-                let __ret: [G; OUT_104] = [__v_212];
-                record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_106] = [__v_212];
+                record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -9531,15 +9610,15 @@ fn aiur_fn_104(
   })
 }
 
-const INPUT_SIZE_105: usize = 1;
-const IN_105: usize = 1;
-const OUT_105: usize = 32;
-fn aiur_fn_105(
-  inp: [G; IN_105],
+const INPUT_SIZE_107: usize = 1;
+const IN_107: usize = 1;
+const OUT_107: usize = 32;
+fn aiur_fn_107(
+  inp: [G; IN_107],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_105], ExecError> {
+) -> Result<[G; OUT_107], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(103);
@@ -9591,7 +9670,7 @@ fn aiur_fn_105(
     let __v_47: G = G::from_u64(1);
     let __v_48: G = G::from_u64(1);
     let __v_49: G = { let __values: [G; 34] = [__v_47, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_50.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_51: G = __loaded[0];
@@ -9661,28 +9740,28 @@ fn aiur_fn_105(
     let __v_114: G = __r_arr[29];
     let __v_115: G = __r_arr[30];
     let __v_116: G = __r_arr[31];
-    let __ret: [G; OUT_105] = [__v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116];
-    record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_107] = [__v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116];
+    record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_106: usize = 3;
-const IN_106: usize = 3;
-const OUT_106: usize = 32;
-fn aiur_fn_106(
-  inp: [G; IN_106],
+const INPUT_SIZE_108: usize = 3;
+const IN_108: usize = 3;
+const OUT_108: usize = 32;
+fn aiur_fn_108(
+  inp: [G; IN_108],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_106], ExecError> {
+) -> Result<[G; OUT_108], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
-    let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
     let __v_4: G = __r_arr[0];
     let __v_5: G = __r_arr[1];
     let __v_6: G = __r_arr[2];
@@ -9715,7 +9794,7 @@ fn aiur_fn_106(
     let __v_33: G = __r_arr[29];
     let __v_34: G = __r_arr[30];
     let __v_35: G = __r_arr[31];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
     let __v_37: G = __r_arr[1];
     let __v_38: G = __r_arr[2];
@@ -9748,21 +9827,21 @@ fn aiur_fn_106(
     let __v_65: G = __r_arr[29];
     let __v_66: G = __r_arr[30];
     let __v_67: G = __r_arr[31];
-    let __ret: [G; OUT_106] = [__v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67];
-    record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_108] = [__v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67];
+    record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_107: usize = 35;
-const IN_107: usize = 35;
-const OUT_107: usize = 32;
-fn aiur_fn_107(
-  inp: [G; IN_107],
+const INPUT_SIZE_109: usize = 35;
+const IN_109: usize = 35;
+const OUT_109: usize = 32;
+fn aiur_fn_109(
+  inp: [G; IN_109],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_107], ExecError> {
+) -> Result<[G; OUT_109], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9799,16 +9878,16 @@ fn aiur_fn_107(
     let __v_32: G = inp[32];
     let __v_33: G = inp[33];
     let __v_34: G = inp[34];
-    let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
     match __v_35.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_107] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34];
-        record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_109] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34];
+        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
         let __v_37: G = __r_arr[1];
         let __v_38: G = __r_arr[2];
@@ -9841,7 +9920,7 @@ fn aiur_fn_107(
         let __v_65: G = __r_arr[29];
         let __v_66: G = __r_arr[30];
         let __v_67: G = __r_arr[31];
-        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
         let __v_69: G = __r_arr[1];
         let __v_70: G = __r_arr[2];
@@ -9874,23 +9953,23 @@ fn aiur_fn_107(
         let __v_97: G = __r_arr[29];
         let __v_98: G = __r_arr[30];
         let __v_99: G = __r_arr[31];
-        let __ret: [G; OUT_107] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99];
-        record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_109] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99];
+        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_108: usize = 1;
-const IN_108: usize = 1;
-const OUT_108: usize = 1;
-fn aiur_fn_108(
-  inp: [G; IN_108],
+const INPUT_SIZE_110: usize = 1;
+const IN_110: usize = 1;
+const OUT_110: usize = 1;
+fn aiur_fn_110(
+  inp: [G; IN_110],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_108], ExecError> {
+) -> Result<[G; OUT_110], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -9900,18 +9979,18 @@ fn aiur_fn_108(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_108] = [__v_4];
-        record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_110] = [__v_4];
+        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(2);
-        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_4 * __v_5);
         let __v_7: G = (__v_2 + __v_6);
-        let __ret: [G; OUT_108] = [__v_7];
-        record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_110] = [__v_7];
+        record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -9921,15 +10000,15 @@ fn aiur_fn_108(
   })
 }
 
-const INPUT_SIZE_109: usize = 37;
-const IN_109: usize = 37;
-const OUT_109: usize = 33;
-fn aiur_fn_109(
-  inp: [G; IN_109],
+const INPUT_SIZE_111: usize = 37;
+const IN_111: usize = 37;
+const OUT_111: usize = 33;
+fn aiur_fn_111(
+  inp: [G; IN_111],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_109], ExecError> {
+) -> Result<[G; OUT_111], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10005,10 +10084,10 @@ fn aiur_fn_109(
     let __v_70: G = __loaded[33];
     match __v_37.as_canonical_u64() {
       1u64 => {
-        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
-        let __ret: [G; OUT_109] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_71];
-        record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_111] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_71];
+        record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10018,7 +10097,7 @@ fn aiur_fn_109(
         let __v_73: G = __loaded[2];
         match __v_71.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_72, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_72, __v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
             let __v_74: G = __r_arr[0];
             let __v_75: G = __r_arr[1];
             let __v_76: G = __r_arr[2];
@@ -10051,7 +10130,7 @@ fn aiur_fn_109(
             let __v_103: G = __r_arr[29];
             let __v_104: G = __r_arr[30];
             let __v_105: G = __r_arr[31];
-            let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_32, __v_33, __v_36, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_32, __v_33, __v_36, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
             let __v_106: G = __r_arr[0];
             let __v_107: G = __r_arr[1];
             let __v_108: G = __r_arr[2];
@@ -10086,7 +10165,7 @@ fn aiur_fn_109(
             let __v_137: G = __r_arr[31];
             let __v_138: G = G::from_u64(1);
             let __v_139: G = (__v_36 - __v_138);
-            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_32, __v_33, __v_70, __v_73, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_106, __v_107, __v_108, __v_109, __v_110, __v_111, __v_112, __v_113, __v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_32, __v_33, __v_70, __v_73, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
             let __v_140: G = __r_arr[0];
             let __v_141: G = __r_arr[1];
             let __v_142: G = __r_arr[2];
@@ -10120,8 +10199,8 @@ fn aiur_fn_109(
             let __v_170: G = __r_arr[30];
             let __v_171: G = __r_arr[31];
             let __v_172: G = __r_arr[32];
-            let __ret: [G; OUT_109] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172];
-            record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_111] = [__v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150, __v_151, __v_152, __v_153, __v_154, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172];
+            record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10136,22 +10215,22 @@ fn aiur_fn_109(
   })
 }
 
-const INPUT_SIZE_110: usize = 5;
-const IN_110: usize = 5;
-const OUT_110: usize = 33;
-fn aiur_fn_110(
-  inp: [G; IN_110],
+const INPUT_SIZE_112: usize = 5;
+const IN_112: usize = 5;
+const OUT_112: usize = 33;
+fn aiur_fn_112(
+  inp: [G; IN_112],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_110], ExecError> {
+) -> Result<[G; OUT_112], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_0, __v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
     let __v_7: G = __r_arr[2];
@@ -10186,7 +10265,7 @@ fn aiur_fn_110(
     let __v_36: G = __r_arr[31];
     let __v_37: G = G::from_u64(1);
     let __v_38: G = (__v_4 - __v_37);
-    let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_0, __v_1, __v_3, __v_2, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_0, __v_1, __v_3, __v_2, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10220,21 +10299,21 @@ fn aiur_fn_110(
     let __v_69: G = __r_arr[30];
     let __v_70: G = __r_arr[31];
     let __v_71: G = __r_arr[32];
-    let __ret: [G; OUT_110] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71];
-    record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_112] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71];
+    record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_111: usize = 6;
-const IN_111: usize = 6;
-const OUT_111: usize = 1;
-fn aiur_fn_111(
-  inp: [G; IN_111],
+const INPUT_SIZE_113: usize = 6;
+const IN_113: usize = 6;
+const OUT_113: usize = 1;
+fn aiur_fn_113(
+  inp: [G; IN_113],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_111], ExecError> {
+) -> Result<[G; OUT_113], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10242,7 +10321,7 @@ fn aiur_fn_111(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_1, __v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_1, __v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -10276,7 +10355,7 @@ fn aiur_fn_111(
     let __v_36: G = __r_arr[30];
     let __v_37: G = __r_arr[31];
     let __v_38: G = __r_arr[32];
-    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10309,23 +10388,23 @@ fn aiur_fn_111(
     let __v_68: G = __r_arr[29];
     let __v_69: G = __r_arr[30];
     let __v_70: G = __r_arr[31];
-    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_101] = { let __args: [G; IN_101] = [__v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[101].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_101] = unsafe { *(result.output.as_ptr() as *const [G; OUT_101]) }; __ret } else { aiur_fn_101(__args, record, io_buffer, __cu)? } };
     let __v_71: G = __r_arr[0];
-    let __ret: [G; OUT_111] = [__v_71];
-    record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_113] = [__v_71];
+    record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_112: usize = 2;
-const IN_112: usize = 2;
-const OUT_112: usize = 1;
-fn aiur_fn_112(
-  inp: [G; IN_112],
+const INPUT_SIZE_114: usize = 2;
+const IN_114: usize = 2;
+const OUT_114: usize = 1;
+fn aiur_fn_114(
+  inp: [G; IN_114],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_112], ExecError> {
+) -> Result<[G; OUT_114], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10335,17 +10414,17 @@ fn aiur_fn_112(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_112] = [__v_1];
-        record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_114] = [__v_1];
+        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_5: G = G::from_u64(0);
         let __v_6: G = { let __values: [G; 3] = [__v_5, __v_3, __v_1]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
-        let __ret: [G; OUT_112] = [__v_7];
-        record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_114] = [__v_7];
+        record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10355,15 +10434,15 @@ fn aiur_fn_112(
   })
 }
 
-const INPUT_SIZE_113: usize = 2;
-const IN_113: usize = 2;
-const OUT_113: usize = 1;
-fn aiur_fn_113(
-  inp: [G; IN_113],
+const INPUT_SIZE_115: usize = 2;
+const IN_115: usize = 2;
+const OUT_115: usize = 1;
+fn aiur_fn_115(
+  inp: [G; IN_115],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_113], ExecError> {
+) -> Result<[G; OUT_115], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10374,26 +10453,26 @@ fn aiur_fn_113(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(1);
-        let __ret: [G; OUT_113] = [__v_5];
-        record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_115] = [__v_5];
+        record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_15] = { let __args: [G; IN_15] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[15].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_15] = unsafe { *(result.output.as_ptr() as *const [G; OUT_15]) }; __ret } else { aiur_fn_15(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         match __v_3.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_113] = [__v_6];
-            record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_115] = [__v_6];
+            record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
             let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
             let __v_7: G = __r_arr[0];
-            let __ret: [G; OUT_113] = [__v_7];
-            record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_115] = [__v_7];
+            record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -10405,15 +10484,15 @@ fn aiur_fn_113(
   })
 }
 
-const INPUT_SIZE_114: usize = 8;
-const IN_114: usize = 8;
-const OUT_114: usize = 2;
-fn aiur_fn_114(
-  inp: [G; IN_114],
+const INPUT_SIZE_116: usize = 8;
+const IN_116: usize = 8;
+const OUT_116: usize = 2;
+fn aiur_fn_116(
+  inp: [G; IN_116],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_114], ExecError> {
+) -> Result<[G; OUT_116], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10425,14 +10504,14 @@ fn aiur_fn_114(
     let __v_7: G = inp[7];
     let __v_8: G = G::from_u64(1);
     let __v_9: G = (__v_1 + __v_8);
-    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = G::from_u64(1);
     let __v_12: G = G::from_u64(1);
     let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __r_arr: [G; OUT_13] = { let __args: [G; IN_13] = [__v_15, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[13].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_13] = unsafe { *(result.output.as_ptr() as *const [G; OUT_13]) }; __ret } else { aiur_fn_13(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
@@ -10457,51 +10536,51 @@ fn aiur_fn_114(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_21, __v_22, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __v_31: G = __r_arr[1];
-    let __ret: [G; OUT_114] = [__v_30, __v_31];
-    record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_116] = [__v_30, __v_31];
+    record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_115: usize = 2;
-const IN_115: usize = 2;
-const OUT_115: usize = 1;
-fn aiur_fn_115(
-  inp: [G; IN_115],
+const INPUT_SIZE_117: usize = 2;
+const IN_117: usize = 2;
+const OUT_117: usize = 1;
+fn aiur_fn_117(
+  inp: [G; IN_117],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_115], ExecError> {
+) -> Result<[G; OUT_117], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_u64(7);
-    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = G::from_u64(1);
     let __v_5: G = G::from_u64(1);
     let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
     let __v_7: G = __r_arr[0];
-    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __r_arr: [G; OUT_14] = { let __args: [G; IN_14] = [__v_2, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[14].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_14] = unsafe { *(result.output.as_ptr() as *const [G; OUT_14]) }; __ret } else { aiur_fn_14(__args, record, io_buffer, __cu)? } };
     let __v_9: G = __r_arr[0];
-    let __ret: [G; OUT_115] = [__v_9];
-    record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_117] = [__v_9];
+    record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_116: usize = 1;
-const IN_116: usize = 1;
-const OUT_116: usize = 1;
-fn aiur_fn_116(
-  inp: [G; IN_116],
+const INPUT_SIZE_118: usize = 1;
+const IN_118: usize = 1;
+const OUT_118: usize = 1;
+fn aiur_fn_118(
+  inp: [G; IN_118],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_116], ExecError> {
+) -> Result<[G; OUT_118], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -10520,19 +10599,19 @@ fn aiur_fn_116(
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_116] = [__v_13];
-        record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_118] = [__v_13];
+        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_11: G = G::from_u64(0);
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 3] = [__v_11, __v_12, __v_13]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_116] = [__v_14];
-        record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_118] = [__v_14];
+        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10542,15 +10621,15 @@ fn aiur_fn_116(
   })
 }
 
-const INPUT_SIZE_117: usize = 10;
-const IN_117: usize = 10;
-const OUT_117: usize = 4;
-fn aiur_fn_117(
-  inp: [G; IN_117],
+const INPUT_SIZE_119: usize = 10;
+const IN_119: usize = 10;
+const OUT_119: usize = 4;
+fn aiur_fn_119(
+  inp: [G; IN_119],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_117], ExecError> {
+) -> Result<[G; OUT_119], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10568,8 +10647,8 @@ fn aiur_fn_117(
     let __v_12: G = __loaded[2];
     match __v_10.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_117] = [__v_6, __v_7, __v_8, __v_9];
-        record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_119] = [__v_6, __v_7, __v_8, __v_9];
+        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10596,13 +10675,13 @@ fn aiur_fn_117(
             let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_8, __v_9, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
             let __v_26: G = __r_arr[0];
             let __v_27: G = __r_arr[1];
-            let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_12, __v_16, __v_2, __v_3, __v_4, __v_5, __v_24, __v_25, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_12, __v_16, __v_2, __v_3, __v_4, __v_5, __v_24, __v_25, __v_26, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
             let __v_29: G = __r_arr[1];
             let __v_30: G = __r_arr[2];
             let __v_31: G = __r_arr[3];
-            let __ret: [G; OUT_117] = [__v_28, __v_29, __v_30, __v_31];
-            record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_119] = [__v_28, __v_29, __v_30, __v_31];
+            record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10617,15 +10696,15 @@ fn aiur_fn_117(
   })
 }
 
-const INPUT_SIZE_118: usize = 2;
-const IN_118: usize = 2;
-const OUT_118: usize = 1;
-fn aiur_fn_118(
-  inp: [G; IN_118],
+const INPUT_SIZE_120: usize = 2;
+const IN_120: usize = 2;
+const OUT_120: usize = 1;
+fn aiur_fn_120(
+  inp: [G; IN_120],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_118], ExecError> {
+) -> Result<[G; OUT_120], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10636,8 +10715,8 @@ fn aiur_fn_118(
     let __v_5: G = __loaded[3];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_118] = [__v_1];
-        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_120] = [__v_1];
+        record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10659,89 +10738,13 @@ fn aiur_fn_118(
         let __v_19: G = __r_arr[5];
         let __v_20: G = __r_arr[6];
         let __v_21: G = __r_arr[7];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
-        let __ret: [G; OUT_118] = [__v_24];
-        record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_119: usize = 2;
-const IN_119: usize = 2;
-const OUT_119: usize = 1;
-fn aiur_fn_119(
-  inp: [G; IN_119],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_119], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_119] = [__v_1];
-        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_119] = [__v_6];
-        record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_120: usize = 2;
-const IN_120: usize = 2;
-const OUT_120: usize = 1;
-fn aiur_fn_120(
-  inp: [G; IN_120],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_120], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_120] = [__v_1];
-        record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_120] = [__v_6];
+        let __ret: [G; OUT_120] = [__v_24];
         record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -10752,8 +10755,8 @@ fn aiur_fn_120(
   })
 }
 
-const INPUT_SIZE_121: usize = 3;
-const IN_121: usize = 3;
+const INPUT_SIZE_121: usize = 2;
+const IN_121: usize = 2;
 const OUT_121: usize = 1;
 fn aiur_fn_121(
   inp: [G; IN_121],
@@ -10764,22 +10767,27 @@ fn aiur_fn_121(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_121] = [__v_2];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_121] = [__v_1];
         record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      1u64 => {
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __ret: [G; OUT_121] = [__v_3];
+      0u64 => {
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_121] = [__v_6];
         record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -10797,14 +10805,85 @@ fn aiur_fn_122(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_122] = [__v_1];
+        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_122] = [__v_6];
+        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_123: usize = 3;
+const IN_123: usize = 3;
+const OUT_123: usize = 1;
+fn aiur_fn_123(
+  inp: [G; IN_123],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_123], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_123] = [__v_2];
+        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __ret: [G; OUT_123] = [__v_3];
+        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_124: usize = 2;
+const IN_124: usize = 2;
+const OUT_124: usize = 1;
+fn aiur_fn_124(
+  inp: [G; IN_124],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_124], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_122] = [__v_0];
-        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_124] = [__v_0];
+        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10816,12 +10895,12 @@ fn aiur_fn_122(
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __ret: [G; OUT_122] = [__v_14];
-        record.function_queries[122].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_124] = [__v_14];
+        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -10831,15 +10910,15 @@ fn aiur_fn_122(
   })
 }
 
-const INPUT_SIZE_123: usize = 10;
-const IN_123: usize = 10;
-const OUT_123: usize = 2;
-fn aiur_fn_123(
-  inp: [G; IN_123],
+const INPUT_SIZE_125: usize = 10;
+const IN_125: usize = 10;
+const OUT_125: usize = 2;
+fn aiur_fn_125(
+  inp: [G; IN_125],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_123], ExecError> {
+) -> Result<[G; OUT_125], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10856,43 +10935,43 @@ fn aiur_fn_123(
         let __v_10: G = G::from_u64(1);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = { let __values: [G; 3] = [__v_10, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_123] = [__v_0, __v_12];
-        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_125] = [__v_0, __v_12];
+        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
         let __v_15: G = __r_arr[1];
         let __v_16: G = __r_arr[2];
-        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_123] = [__v_15, __v_16];
-        record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_125] = [__v_15, __v_16];
+        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_124: usize = 4;
-const IN_124: usize = 4;
-const OUT_124: usize = 2;
-fn aiur_fn_124(
-  inp: [G; IN_124],
+const INPUT_SIZE_126: usize = 4;
+const IN_126: usize = 4;
+const OUT_126: usize = 2;
+fn aiur_fn_126(
+  inp: [G; IN_126],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_124], ExecError> {
+) -> Result<[G; OUT_126], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10907,8 +10986,8 @@ fn aiur_fn_124(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_124] = [__v_9, __v_0];
-        record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_126] = [__v_9, __v_0];
+        record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -10925,12 +11004,12 @@ fn aiur_fn_124(
         let __v_16: G = __loaded[9];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
-            let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
             let __v_19: G = __r_arr[1];
-            let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
             let __v_21: G = __r_arr[1];
             let __v_22: G = __r_arr[2];
@@ -10949,7 +11028,7 @@ fn aiur_fn_124(
             let __v_35: G = __r_arr[15];
             let __v_36: G = __r_arr[16];
             let __v_37: G = __r_arr[17];
-            let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = __r_arr[1];
             let __v_40: G = G::from_u64(0);
@@ -10958,8 +11037,8 @@ fn aiur_fn_124(
             let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
             let __v_42: G = __r_arr[0];
             let __v_43: G = { let __values: [G; 4] = [__v_40, __v_41, __v_42, __v_38]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_124] = [__v_43, __v_39];
-            record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_126] = [__v_43, __v_39];
+            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -10974,15 +11053,15 @@ fn aiur_fn_124(
   })
 }
 
-const INPUT_SIZE_125: usize = 5;
-const IN_125: usize = 5;
-const OUT_125: usize = 1;
-fn aiur_fn_125(
-  inp: [G; IN_125],
+const INPUT_SIZE_127: usize = 5;
+const IN_127: usize = 5;
+const OUT_127: usize = 1;
+fn aiur_fn_127(
+  inp: [G; IN_127],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_125], ExecError> {
+) -> Result<[G; OUT_127], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10992,12 +11071,12 @@ fn aiur_fn_125(
     match __v_2.as_canonical_u64() {
       0u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_125] = [__v_5];
-        record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_127] = [__v_5];
+        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_1 - __v_4);
         let __v_7: G = (__v_5 + __v_6);
@@ -11005,8 +11084,8 @@ fn aiur_fn_125(
         match __v_8.as_canonical_u64() {
           1u64 => {
             let __v_9: G = G::from_u64(1);
-            let __ret: [G; OUT_125] = [__v_9];
-            record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_127] = [__v_9];
+            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11014,10 +11093,10 @@ fn aiur_fn_125(
             let __v_10: G = (__v_2 - __v_9);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 + __v_11);
-            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
-            let __ret: [G; OUT_125] = [__v_13];
-            record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_127] = [__v_13];
+            record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -11026,15 +11105,15 @@ fn aiur_fn_125(
   })
 }
 
-const INPUT_SIZE_126: usize = 4;
-const IN_126: usize = 4;
-const OUT_126: usize = 1;
-fn aiur_fn_126(
-  inp: [G; IN_126],
+const INPUT_SIZE_128: usize = 4;
+const IN_128: usize = 4;
+const OUT_128: usize = 1;
+fn aiur_fn_128(
+  inp: [G; IN_128],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_126], ExecError> {
+) -> Result<[G; OUT_128], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11045,22 +11124,22 @@ fn aiur_fn_126(
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 7] = [__v_4, __v_5, __v_5, __v_5, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_126] = [__v_6];
-        record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_128] = [__v_6];
+        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_3 - __v_6);
-            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_126] = [__v_8];
-            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_128] = [__v_8];
+            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -11071,11 +11150,11 @@ fn aiur_fn_126(
             let __v_10: G = G::from_u64(0);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 - __v_11);
-            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = { let __values: [G; 7] = [__v_6, __v_3, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_126] = [__v_14];
-            record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_128] = [__v_14];
+            record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -11084,15 +11163,15 @@ fn aiur_fn_126(
   })
 }
 
-const INPUT_SIZE_127: usize = 8;
-const IN_127: usize = 8;
-const OUT_127: usize = 1;
-fn aiur_fn_127(
-  inp: [G; IN_127],
+const INPUT_SIZE_129: usize = 8;
+const IN_129: usize = 8;
+const OUT_129: usize = 1;
+fn aiur_fn_129(
+  inp: [G; IN_129],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_127], ExecError> {
+) -> Result<[G; OUT_129], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11115,8 +11194,8 @@ fn aiur_fn_127(
         let __v_15: G = G::from_u64(1);
         let __v_16: G = G::from_u64(1);
         let __v_17: G = { let __values: [G; 7] = [__v_15, __v_16, __v_16, __v_16, __v_16, __v_16, __v_16]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_127] = [__v_17];
-        record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_129] = [__v_17];
+        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11126,24 +11205,24 @@ fn aiur_fn_127(
             let __v_16: G = G::from_bool((__v_15 == G::ZERO));
             match __v_16.as_canonical_u64() {
               1u64 => {
-                let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_12, __v_13, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_12, __v_13, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
                 let __v_17: G = __r_arr[0];
                 let __v_18: G = __r_arr[1];
                 let __v_19: G = __r_arr[2];
                 let __v_20: G = __r_arr[3];
                 let __v_21: G = G::from_u64(0);
                 let __v_22: G = { let __values: [G; 7] = [__v_21, __v_9, __v_19, __v_20, __v_17, __v_18, __v_14]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_127] = [__v_22];
-                record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_129] = [__v_22];
+                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_17: G = G::from_u64(0);
-                let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
                 let __v_18: G = __r_arr[0];
                 let __v_19: G = { let __values: [G; 7] = [__v_17, __v_9, __v_10, __v_11, __v_12, __v_13, __v_18]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_127] = [__v_19];
-                record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_129] = [__v_19];
+                record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11157,15 +11236,15 @@ fn aiur_fn_127(
   })
 }
 
-const INPUT_SIZE_128: usize = 2;
-const IN_128: usize = 2;
-const OUT_128: usize = 1;
-fn aiur_fn_128(
-  inp: [G; IN_128],
+const INPUT_SIZE_130: usize = 2;
+const IN_130: usize = 2;
+const OUT_130: usize = 1;
+fn aiur_fn_130(
+  inp: [G; IN_130],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_128], ExecError> {
+) -> Result<[G; OUT_130], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11180,8 +11259,8 @@ fn aiur_fn_128(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_9: G = G::from_u64(1);
-        let __ret: [G; OUT_128] = [__v_9];
-        record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_130] = [__v_9];
+        record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11200,15 +11279,15 @@ fn aiur_fn_128(
                   return Err(ExecError::AssertEqMismatch { lhs: __v_13.as_canonical_u64(), rhs: __v_14.as_canonical_u64() });
                 }
                 let __v_15: G = G::from_u64(1);
-                let __ret: [G; OUT_128] = [__v_15];
-                record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_130] = [__v_15];
+                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_128] = [__v_11];
-                record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_130] = [__v_11];
+                record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11222,90 +11301,8 @@ fn aiur_fn_128(
   })
 }
 
-const INPUT_SIZE_129: usize = 2;
-const IN_129: usize = 2;
-const OUT_129: usize = 1;
-fn aiur_fn_129(
-  inp: [G; IN_129],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_129], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(0);
-        let __ret: [G; OUT_129] = [__v_2];
-        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __ret: [G; OUT_129] = [__v_2];
-        record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_130: usize = 10;
-const IN_130: usize = 10;
-const OUT_130: usize = 1;
-fn aiur_fn_130(
-  inp: [G; IN_130],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_130], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __v_15: G = __r_arr[1];
-    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
-    let __v_16: G = __r_arr[0];
-    let __v_17: G = __r_arr[1];
-    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-    let __v_18: G = __r_arr[0];
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __v_20: G = (__v_18 - __v_19);
-    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-    let __v_22: G = G::from_u64(1);
-    if (__v_21 != __v_22) {
-      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-    }
-    let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __ret: [G; OUT_130] = [__v_23];
-    record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_131: usize = 11;
-const IN_131: usize = 11;
+const INPUT_SIZE_131: usize = 2;
+const IN_131: usize = 2;
 const OUT_131: usize = 1;
 fn aiur_fn_131(
   inp: [G; IN_131],
@@ -11316,39 +11313,28 @@ fn aiur_fn_131(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
-    let __v_15: G = __r_arr[0];
-    let __v_16: G = G::from_u64(0);
-    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-    let __v_17: G = __r_arr[0];
-    let __v_18: G = __r_arr[1];
-    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __ret: [G; OUT_131] = [__v_20];
-    record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(0);
+        let __ret: [G; OUT_131] = [__v_2];
+        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __ret: [G; OUT_131] = [__v_2];
+        record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
   })
 }
 
-const INPUT_SIZE_132: usize = 13;
-const IN_132: usize = 13;
+const INPUT_SIZE_132: usize = 10;
+const IN_132: usize = 10;
 const OUT_132: usize = 1;
 fn aiur_fn_132(
   inp: [G; IN_132],
@@ -11367,43 +11353,38 @@ fn aiur_fn_132(
     let __v_7: G = inp[7];
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    match __v_5.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_132] = [__v_0];
-        record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __v_19: G = G::from_u64(1);
-        let __v_20: G = (__v_4 + __v_19);
-        let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_5 - __v_21);
-        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-        let __v_23: G = __r_arr[0];
-        let __ret: [G; OUT_132] = [__v_23];
-        record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
+    let __v_10: G = (__v_3 - __v_1);
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_4, __v_5, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
+    let __v_16: G = __r_arr[0];
+    let __v_17: G = __r_arr[1];
+    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+    let __v_18: G = __r_arr[0];
+    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __v_20: G = (__v_18 - __v_19);
+    let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+    let __v_22: G = G::from_u64(1);
+    if (__v_21 != __v_22) {
+      return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
     }
+    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_6, __v_7, __v_16, __v_17, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __ret: [G; OUT_132] = [__v_23];
+    record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_133: usize = 13;
-const IN_133: usize = 13;
+const INPUT_SIZE_133: usize = 11;
+const IN_133: usize = 11;
 const OUT_133: usize = 1;
 fn aiur_fn_133(
   inp: [G; IN_133],
@@ -11423,45 +11404,30 @@ fn aiur_fn_133(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    match __v_5.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_133] = [__v_0];
-        record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = G::from_u64(0);
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_19: G = __r_arr[0];
-        let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-        let __v_20: G = __r_arr[0];
-        let __v_21: G = G::from_u64(1);
-        let __v_22: G = (__v_4 + __v_21);
-        let __v_23: G = G::from_u64(1);
-        let __v_24: G = (__v_5 - __v_23);
-        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-        let __v_25: G = __r_arr[0];
-        let __ret: [G; OUT_133] = [__v_25];
-        record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __v_11: G = G::from_u64(0);
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(1);
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __v_15: G = __r_arr[0];
+    let __v_16: G = G::from_u64(0);
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_17: G = __r_arr[0];
+    let __v_18: G = __r_arr[1];
+    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+    let __v_19: G = __r_arr[0];
+    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_19, __v_3, __v_1, __v_2, __v_17, __v_18, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __ret: [G; OUT_133] = [__v_20];
+    record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_134: usize = 15;
-const IN_134: usize = 15;
+const INPUT_SIZE_134: usize = 13;
+const IN_134: usize = 13;
 const OUT_134: usize = 1;
 fn aiur_fn_134(
   inp: [G; IN_134],
@@ -11483,8 +11449,6 @@ fn aiur_fn_134(
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
     match __v_5.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_134] = [__v_0];
@@ -11492,56 +11456,33 @@ fn aiur_fn_134(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        match __v_15.as_canonical_u64() {
-          0u64 => {
-            let __v_17: G = G::from_u64(1);
-            let __v_18: G = (__v_4 + __v_17);
-            let __v_19: G = G::from_u64(1);
-            let __v_20: G = (__v_5 - __v_19);
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __ret: [G; OUT_134] = [__v_21];
-            record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_17: G = __r_arr[0];
-            let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
-            let __v_22: G = __r_arr[0];
-            let __v_23: G = G::from_u64(1);
-            let __v_24: G = (__v_4 + __v_23);
-            let __v_25: G = G::from_u64(1);
-            let __v_26: G = (__v_5 - __v_25);
-            let __v_27: G = G::from_u64(1);
-            let __v_28: G = (__v_6 + __v_27);
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_134] = [__v_29];
-            record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-          },
-        }
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __v_19: G = G::from_u64(1);
+        let __v_20: G = (__v_4 + __v_19);
+        let __v_21: G = G::from_u64(1);
+        let __v_22: G = (__v_5 - __v_21);
+        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_18, __v_1, __v_2, __v_3, __v_20, __v_22, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+        let __v_23: G = __r_arr[0];
+        let __ret: [G; OUT_134] = [__v_23];
+        record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_135: usize = 15;
-const IN_135: usize = 15;
+const INPUT_SIZE_135: usize = 13;
+const IN_135: usize = 13;
 const OUT_135: usize = 1;
 fn aiur_fn_135(
   inp: [G; IN_135],
@@ -11563,59 +11504,43 @@ fn aiur_fn_135(
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    match __v_3.as_canonical_u64() {
+    match __v_5.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_135] = [__v_0];
         record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      1u64 => {
-        let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __v_17: G = __r_arr[1];
-        match __v_16.as_canonical_u64() {
-          _ => {
-            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-            let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __v_20: G = (__v_18 - __v_19);
-            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-            let __v_22: G = G::from_u64(1);
-            if (__v_21 != __v_22) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
-            }
-            let __v_23: G = G::from_u64(0);
-            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-            let __v_24: G = __r_arr[0];
-            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __v_26: G = G::from_u64(1);
-            if (__v_25 != __v_26) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
-            }
-            let __v_27: G = G::from_u64(0);
-            let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_135] = [__v_29];
-            record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-        }
-      },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __v_18: G = G::from_u64(0);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+        let __v_20: G = __r_arr[0];
+        let __v_21: G = G::from_u64(1);
+        let __v_22: G = (__v_4 + __v_21);
+        let __v_23: G = G::from_u64(1);
+        let __v_24: G = (__v_5 - __v_23);
+        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_20, __v_1, __v_2, __v_3, __v_22, __v_24, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __ret: [G; OUT_135] = [__v_25];
+        record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_136: usize = 4;
-const IN_136: usize = 4;
+const INPUT_SIZE_136: usize = 15;
+const IN_136: usize = 15;
 const OUT_136: usize = 1;
 fn aiur_fn_136(
   inp: [G; IN_136],
@@ -11628,37 +11553,74 @@ fn aiur_fn_136(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    match __v_2.as_canonical_u64() {
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    match __v_5.as_canonical_u64() {
       0u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_136] = [__v_6];
+        let __ret: [G; OUT_136] = [__v_0];
         record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_5 + __v_1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_2 - __v_7);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_3 + __v_9);
-        let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_136] = [__v_12];
-        record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __v_16: G = __r_arr[1];
+        match __v_15.as_canonical_u64() {
+          0u64 => {
+            let __v_17: G = G::from_u64(1);
+            let __v_18: G = (__v_4 + __v_17);
+            let __v_19: G = G::from_u64(1);
+            let __v_20: G = (__v_5 - __v_19);
+            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __ret: [G; OUT_136] = [__v_21];
+            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_17: G = __r_arr[0];
+            let __v_18: G = (__v_17 + __v_3);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+            let __v_22: G = __r_arr[0];
+            let __v_23: G = G::from_u64(1);
+            let __v_24: G = (__v_4 + __v_23);
+            let __v_25: G = G::from_u64(1);
+            let __v_26: G = (__v_5 - __v_25);
+            let __v_27: G = G::from_u64(1);
+            let __v_28: G = (__v_6 + __v_27);
+            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_22, __v_1, __v_2, __v_3, __v_24, __v_26, __v_28, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_136] = [__v_29];
+            record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_137: usize = 5;
-const IN_137: usize = 5;
+const INPUT_SIZE_137: usize = 15;
+const IN_137: usize = 15;
 const OUT_137: usize = 1;
 fn aiur_fn_137(
   inp: [G; IN_137],
@@ -11672,59 +11634,68 @@ fn aiur_fn_137(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_137] = [__v_7];
+        let __ret: [G; OUT_137] = [__v_0];
         record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __v_7: G = G::from_u64(1);
-            let __v_8: G = (__v_3 - __v_7);
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_4 + __v_9);
-            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-            let __v_11: G = __r_arr[0];
-            let __ret: [G; OUT_137] = [__v_11];
-            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_8: G = __r_arr[0];
-            let __v_9: G = (__v_8 + __v_1);
-            let __v_10: G = G::from_u64(1);
-            let __v_11: G = (__v_3 - __v_10);
-            let __v_12: G = G::from_u64(1);
-            let __v_13: G = (__v_4 + __v_12);
-            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-            let __v_14: G = __r_arr[0];
-            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_137] = [__v_15];
-            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
+      1u64 => {
+        let __v_15: G = G::from_u64(3);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __v_17: G = __r_arr[1];
+        match __v_16.as_canonical_u64() {
           _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __v_18: G = __r_arr[0];
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __v_20: G = (__v_18 - __v_19);
+            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
+            let __v_22: G = G::from_u64(1);
+            if (__v_21 != __v_22) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+            }
+            let __v_23: G = G::from_u64(0);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __v_24: G = __r_arr[0];
+            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+            let __v_25: G = __r_arr[0];
+            let __v_26: G = G::from_u64(1);
+            if (__v_25 != __v_26) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
+            }
+            let __v_27: G = G::from_u64(0);
+            let __v_28: G = G::from_u64(0);
+            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __ret: [G; OUT_137] = [__v_29];
+            record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
           },
         }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_138: usize = 5;
-const IN_138: usize = 5;
-const OUT_138: usize = 4;
+const INPUT_SIZE_138: usize = 4;
+const IN_138: usize = 4;
+const OUT_138: usize = 1;
 fn aiur_fn_138(
   inp: [G; IN_138],
   record: &mut QueryRecord,
@@ -11736,15 +11707,28 @@ fn aiur_fn_138(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_0.as_canonical_u64() {
+    match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_138] = [__v_1, __v_2, __v_3, __v_4];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_138] = [__v_6];
         record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __ret: [G; OUT_138] = [__v_3, __v_4, __v_1, __v_2];
+        let __v_4: G = G::from_u64(0);
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_5 + __v_1);
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_2 - __v_7);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_3 + __v_9);
+        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_138] = [__v_12];
         record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -11752,8 +11736,8 @@ fn aiur_fn_138(
   })
 }
 
-const INPUT_SIZE_139: usize = 4;
-const IN_139: usize = 4;
+const INPUT_SIZE_139: usize = 5;
+const IN_139: usize = 5;
 const OUT_139: usize = 1;
 fn aiur_fn_139(
   inp: [G; IN_139],
@@ -11761,6 +11745,101 @@ fn aiur_fn_139(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_139], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_139] = [__v_7];
+        record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __v_7: G = G::from_u64(1);
+            let __v_8: G = (__v_3 - __v_7);
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_4 + __v_9);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __v_11: G = __r_arr[0];
+            let __ret: [G; OUT_139] = [__v_11];
+            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __v_7: G = G::from_u64(0);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __v_9: G = (__v_8 + __v_1);
+            let __v_10: G = G::from_u64(1);
+            let __v_11: G = (__v_3 - __v_10);
+            let __v_12: G = G::from_u64(1);
+            let __v_13: G = (__v_4 + __v_12);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __v_14: G = __r_arr[0];
+            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_139] = [__v_15];
+            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_140: usize = 5;
+const IN_140: usize = 5;
+const OUT_140: usize = 4;
+fn aiur_fn_140(
+  inp: [G; IN_140],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_140], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_140] = [__v_1, __v_2, __v_3, __v_4];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __ret: [G; OUT_140] = [__v_3, __v_4, __v_1, __v_2];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_141: usize = 4;
+const IN_141: usize = 4;
+const OUT_141: usize = 1;
+fn aiur_fn_141(
+  inp: [G; IN_141],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_141], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11813,21 +11892,21 @@ fn aiur_fn_139(
     let __v_44: G = { let __values: [G; 10] = [__v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_43]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_45: G = { let __values: [G; 10] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_44]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_46: G = { let __values: [G; 10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_45]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_139] = [__v_46];
-    record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_141] = [__v_46];
+    record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_140: usize = 6;
-const IN_140: usize = 6;
-const OUT_140: usize = 3;
-fn aiur_fn_140(
-  inp: [G; IN_140],
+const INPUT_SIZE_142: usize = 6;
+const IN_142: usize = 6;
+const OUT_142: usize = 3;
+fn aiur_fn_142(
+  inp: [G; IN_142],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_140], ExecError> {
+) -> Result<[G; OUT_142], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11845,8 +11924,8 @@ fn aiur_fn_140(
     let __v_12: G = __loaded[6];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_140] = [__v_0, __v_1, __v_5];
-        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
+        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11857,7 +11936,7 @@ fn aiur_fn_140(
             match __v_14.as_canonical_u64() {
               1u64 => {
                 let __v_15: G = G::from_u64(1);
-                let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
                 let __v_16: G = __r_arr[0];
                 let __v_17: G = __r_arr[1];
                 let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_16, __v_17, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -11866,13 +11945,13 @@ fn aiur_fn_140(
                 let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 let __v_21: G = __r_arr[1];
-                let __ret: [G; OUT_140] = [__v_20, __v_21, __v_12];
-                record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_142] = [__v_20, __v_21, __v_12];
+                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __ret: [G; OUT_140] = [__v_0, __v_1, __v_5];
-                record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
+                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11886,15 +11965,15 @@ fn aiur_fn_140(
   })
 }
 
-const INPUT_SIZE_141: usize = 9;
-const IN_141: usize = 9;
-const OUT_141: usize = 2;
-fn aiur_fn_141(
-  inp: [G; IN_141],
+const INPUT_SIZE_143: usize = 9;
+const IN_143: usize = 9;
+const OUT_143: usize = 2;
+fn aiur_fn_143(
+  inp: [G; IN_143],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_141], ExecError> {
+) -> Result<[G; OUT_143], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11919,14 +11998,14 @@ fn aiur_fn_141(
         if (__v_15 != __v_16) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_15.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_141] = [__v_0, __v_1];
-        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_143] = [__v_0, __v_1];
+        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11954,29 +12033,29 @@ fn aiur_fn_141(
                         let __v_24: G = G::from_u64(1);
                         let __v_25: G = (__v_6 - __v_24);
                         let __v_26: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                         let __v_27: G = __r_arr[0];
                         let __v_28: G = __r_arr[1];
-                        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
                         let __v_29: G = __r_arr[0];
                         let __v_30: G = __r_arr[1];
                         let __v_31: G = __r_arr[2];
                         let __v_32: G = __r_arr[3];
-                        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
                         let __v_33: G = __r_arr[0];
                         let __v_34: G = __r_arr[1];
-                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = __r_arr[1];
                         let __v_37: G = __r_arr[2];
-                        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
                         let __v_39: G = G::from_u64(1);
                         if (__v_38 != __v_39) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_38.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
                         }
                         let __v_40: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                         let __v_41: G = __r_arr[0];
                         let __v_42: G = G::from_u64(1);
                         let __v_43: G = G::from_u64(1);
@@ -11987,17 +12066,17 @@ fn aiur_fn_141(
                         let __v_48: G = G::from_u64(1);
                         let __v_49: G = { let __values: [G; 3] = [__v_47, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                         let __v_50: G = { let __values: [G; 3] = [__v_46, __v_25, __v_49]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_19, __v_45, __v_50, __v_23, __v_12, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_19, __v_45, __v_50, __v_23, __v_12, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
                         let __v_51: G = __r_arr[0];
                         let __v_52: G = G::from_u64(1);
                         if (__v_51 != __v_52) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_51.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
                         }
-                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
                         let __v_53: G = __r_arr[0];
                         let __v_54: G = __r_arr[1];
-                        let __ret: [G; OUT_141] = [__v_53, __v_54];
-                        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_143] = [__v_53, __v_54];
+                        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                       _ => {
@@ -12024,15 +12103,15 @@ fn aiur_fn_141(
   })
 }
 
-const INPUT_SIZE_142: usize = 25;
-const IN_142: usize = 25;
-const OUT_142: usize = 1;
-fn aiur_fn_142(
-  inp: [G; IN_142],
+const INPUT_SIZE_144: usize = 25;
+const IN_144: usize = 25;
+const OUT_144: usize = 1;
+fn aiur_fn_144(
+  inp: [G; IN_144],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_142], ExecError> {
+) -> Result<[G; OUT_144], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12061,38 +12140,38 @@ fn aiur_fn_142(
     let __v_24: G = inp[24];
     match __v_1.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
         let __v_25: G = __r_arr[0];
         let __v_26: G = G::from_u64(0);
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         let __v_28: G = __r_arr[1];
         match __v_27.as_canonical_u64() {
           _ => {
             let __v_29: G = G::from_u64(0);
-            let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
             let __v_30: G = __r_arr[0];
             let __v_31: G = G::from_u64(1);
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_32: G = __r_arr[0];
             let __v_33: G = __r_arr[1];
             match __v_32.as_canonical_u64() {
               _ => {
                 let __v_34: G = G::from_u64(0);
-                let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
                 let __v_35: G = __r_arr[0];
                 let __v_36: G = G::from_u64(2);
-                let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 let __v_38: G = __r_arr[1];
                 match __v_37.as_canonical_u64() {
                   _ => {
                     let __v_39: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
                     let __v_40: G = __r_arr[0];
-                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
                     let __v_41: G = __r_arr[0];
-                    let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
                     let __v_42: G = __r_arr[0];
                     let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
                     let __v_43: G = __loaded[0];
@@ -12106,10 +12185,10 @@ fn aiur_fn_142(
                       0u64 => {
                         match __v_44.as_canonical_u64() {
                           _ => {
-                            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
                             let __v_50: G = __r_arr[0];
                             let __v_51: G = __r_arr[1];
-                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
                             let __v_52: G = __r_arr[0];
                             let __v_53: G = (__v_52 - __v_24);
                             let __v_54: G = G::from_bool((__v_53 == G::ZERO));
@@ -12117,10 +12196,10 @@ fn aiur_fn_142(
                             if (__v_54 != __v_55) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                             let __v_56: G = __r_arr[0];
                             let __v_57: G = G::from_u64(3);
-                            let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
                             let __v_58: G = __r_arr[0];
                             let __v_59: G = (__v_57 + __v_58);
                             let __v_60: G = (__v_56 - __v_59);
@@ -12129,7 +12208,7 @@ fn aiur_fn_142(
                             if (__v_61 != __v_62) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                             let __v_63: G = __r_arr[0];
                             let __v_64: G = (__v_63 - __v_18);
                             let __v_65: G = G::from_bool((__v_64 == G::ZERO));
@@ -12138,15 +12217,15 @@ fn aiur_fn_142(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
                             }
                             let __v_67: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
                             let __v_68: G = __r_arr[0];
-                            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
                             let __v_69: G = __r_arr[0];
                             let __v_70: G = G::from_u64(1);
                             if (__v_69 != __v_70) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                             let __v_71: G = __r_arr[0];
                             let __v_72: G = (__v_71 - __v_18);
                             let __v_73: G = G::from_bool((__v_72 == G::ZERO));
@@ -12155,15 +12234,15 @@ fn aiur_fn_142(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
                             }
                             let __v_75: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
                             let __v_76: G = __r_arr[0];
-                            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
                             let __v_77: G = __r_arr[0];
                             let __v_78: G = G::from_u64(1);
                             if (__v_77 != __v_78) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
                             }
-                            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                             let __v_79: G = __r_arr[0];
                             let __v_80: G = (__v_79 - __v_18);
                             let __v_81: G = G::from_bool((__v_80 == G::ZERO));
@@ -12172,9 +12251,9 @@ fn aiur_fn_142(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
                             }
                             let __v_83: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
                             let __v_84: G = __r_arr[0];
-                            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
                             let __v_85: G = __r_arr[0];
                             let __v_86: G = G::from_u64(1);
                             if (__v_85 != __v_86) {
@@ -12187,7 +12266,7 @@ fn aiur_fn_142(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
                             }
                             let __v_90: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                             let __v_91: G = __r_arr[0];
                             let __v_92: G = __r_arr[1];
                             let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
@@ -12197,8 +12276,8 @@ fn aiur_fn_142(
                               return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
                             }
                             let __v_95: G = G::from_u64(1);
-                            let __ret: [G; OUT_142] = [__v_95];
-                            record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            let __ret: [G; OUT_144] = [__v_95];
+                            record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                             return Ok(__ret);
                           },
                         }
@@ -12218,15 +12297,15 @@ fn aiur_fn_142(
   })
 }
 
-const INPUT_SIZE_143: usize = 25;
-const IN_143: usize = 25;
-const OUT_143: usize = 1;
-fn aiur_fn_143(
-  inp: [G; IN_143],
+const INPUT_SIZE_145: usize = 25;
+const IN_145: usize = 25;
+const OUT_145: usize = 1;
+fn aiur_fn_145(
+  inp: [G; IN_145],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_143], ExecError> {
+) -> Result<[G; OUT_145], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12261,21 +12340,21 @@ fn aiur_fn_143(
     match __v_25.as_canonical_u64() {
       1u64 => {
         let __v_29: G = G::from_u64(1);
-        let __ret: [G; OUT_143] = [__v_29];
-        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_145] = [__v_29];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = __r_arr[1];
         let __v_31: G = __r_arr[2];
-        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
-        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
         let __v_33: G = __r_arr[0];
-        let __ret: [G; OUT_143] = [__v_33];
-        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_145] = [__v_33];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12285,15 +12364,15 @@ fn aiur_fn_143(
   })
 }
 
-const INPUT_SIZE_144: usize = 31;
-const IN_144: usize = 31;
-const OUT_144: usize = 1;
-fn aiur_fn_144(
-  inp: [G; IN_144],
+const INPUT_SIZE_146: usize = 31;
+const IN_146: usize = 31;
+const OUT_146: usize = 1;
+fn aiur_fn_146(
+  inp: [G; IN_146],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_144], ExecError> {
+) -> Result<[G; OUT_146], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12328,25 +12407,25 @@ fn aiur_fn_144(
     let __v_30: G = inp[30];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_31: G = __r_arr[0];
         let __v_32: G = G::from_u64(1);
         let __v_33: G = G::from_u64(1);
         let __v_34: G = { let __values: [G; 3] = [__v_32, __v_33, __v_33]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_5, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_35: G = __r_arr[0];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = G::from_u64(1);
         let __v_41: G = G::from_u64(1);
         let __v_42: G = { let __values: [G; 3] = [__v_40, __v_41, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
         let __v_43: G = __r_arr[0];
         let __v_44: G = __r_arr[1];
         let __v_45: G = __r_arr[2];
@@ -12369,23 +12448,23 @@ fn aiur_fn_144(
         let __v_61: G = __r_arr[0];
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_62: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_59, __v_6, __v_7, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
         let __v_63: G = __r_arr[0];
         let __v_64: G = __r_arr[1];
         let __v_65: G = G::from_u64(1);
         let __v_66: G = G::from_u64(1);
         let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
-        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_70, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_71: G = __r_arr[0];
         let __v_72: G = __r_arr[1];
         let __v_73: G = (__v_31 + __v_27);
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
         let __v_74: G = __r_arr[0];
         let __v_75: G = (__v_74 - __v_31);
         let __v_76: G = G::from_bool((__v_75 == G::ZERO));
@@ -12393,7 +12472,7 @@ fn aiur_fn_144(
         if (__v_76 != __v_77) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_78: G = __r_arr[0];
         let __v_79: G = (__v_78 - __v_28);
         let __v_80: G = G::from_bool((__v_79 == G::ZERO));
@@ -12401,52 +12480,52 @@ fn aiur_fn_144(
         if (__v_80 != __v_81) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_82: G = __r_arr[0];
         let __v_83: G = G::from_u64(1);
         if (__v_82 != __v_83) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_82.as_canonical_u64(), rhs: __v_83.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
         let __v_84: G = __r_arr[0];
-        let __ret: [G; OUT_144] = [__v_84];
-        record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_146] = [__v_84];
+        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_145: usize = 2;
-const IN_145: usize = 2;
-const OUT_145: usize = 1;
-fn aiur_fn_145(
-  inp: [G; IN_145],
+const INPUT_SIZE_147: usize = 2;
+const IN_147: usize = 2;
+const OUT_147: usize = 1;
+fn aiur_fn_147(
+  inp: [G; IN_147],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_145], ExecError> {
+) -> Result<[G; OUT_147], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_bool((__v_0 == G::ZERO));
     let __v_3: G = G::from_bool((__v_1 == G::ZERO));
     let __v_4: G = (__v_2 * __v_3);
-    let __ret: [G; OUT_145] = [__v_4];
-    record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_147] = [__v_4];
+    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_146: usize = 1;
-const IN_146: usize = 1;
-const OUT_146: usize = 1;
-fn aiur_fn_146(
-  inp: [G; IN_146],
+const INPUT_SIZE_148: usize = 1;
+const IN_148: usize = 1;
+const OUT_148: usize = 1;
+fn aiur_fn_148(
+  inp: [G; IN_148],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_146], ExecError> {
+) -> Result<[G; OUT_148], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -12457,8 +12536,8 @@ fn aiur_fn_146(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_146] = [__v_5];
-        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_148] = [__v_5];
+        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12469,17 +12548,17 @@ fn aiur_fn_146(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           1u64 => {
-            let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_146] = [__v_9];
-            record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_148] = [__v_9];
+            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_146] = [__v_9];
-            record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_148] = [__v_9];
+            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -12491,15 +12570,15 @@ fn aiur_fn_146(
   })
 }
 
-const INPUT_SIZE_147: usize = 9;
-const IN_147: usize = 9;
-const OUT_147: usize = 1;
-fn aiur_fn_147(
-  inp: [G; IN_147],
+const INPUT_SIZE_149: usize = 9;
+const IN_149: usize = 9;
+const OUT_149: usize = 1;
+fn aiur_fn_149(
+  inp: [G; IN_149],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_147], ExecError> {
+) -> Result<[G; OUT_149], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12526,21 +12605,21 @@ fn aiur_fn_147(
     let __v_22: G = { let __values: [G; 3] = [__v_11, __v_2, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_23: G = { let __values: [G; 3] = [__v_10, __v_1, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_24: G = { let __values: [G; 3] = [__v_9, __v_0, __v_23]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_147] = [__v_24];
-    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_149] = [__v_24];
+    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_148: usize = 33;
-const IN_148: usize = 33;
-const OUT_148: usize = 1;
-fn aiur_fn_148(
-  inp: [G; IN_148],
+const INPUT_SIZE_150: usize = 33;
+const IN_150: usize = 33;
+const OUT_150: usize = 1;
+fn aiur_fn_150(
+  inp: [G; IN_150],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_148], ExecError> {
+) -> Result<[G; OUT_150], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12575,29 +12654,29 @@ fn aiur_fn_148(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __ret: [G; OUT_148] = [__v_36];
-    record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_150] = [__v_36];
+    record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_149: usize = 2;
-const IN_149: usize = 2;
-const OUT_149: usize = 1;
-fn aiur_fn_149(
-  inp: [G; IN_149],
+const INPUT_SIZE_151: usize = 2;
+const IN_151: usize = 2;
+const OUT_151: usize = 1;
+fn aiur_fn_151(
+  inp: [G; IN_151],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_149], ExecError> {
+) -> Result<[G; OUT_151], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12638,17 +12717,17 @@ fn aiur_fn_149(
     let __v_35: G = __loaded[33];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_149] = [__v_1];
-        record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_151] = [__v_1];
+        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
         let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __ret: [G; OUT_149] = [__v_37];
-        record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_151] = [__v_37];
+        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12658,15 +12737,15 @@ fn aiur_fn_149(
   })
 }
 
-const INPUT_SIZE_150: usize = 2;
-const IN_150: usize = 2;
-const OUT_150: usize = 1;
-fn aiur_fn_150(
-  inp: [G; IN_150],
+const INPUT_SIZE_152: usize = 2;
+const IN_152: usize = 2;
+const OUT_152: usize = 1;
+fn aiur_fn_152(
+  inp: [G; IN_152],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_150], ExecError> {
+) -> Result<[G; OUT_152], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12676,8 +12755,8 @@ fn aiur_fn_150(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_150] = [__v_1];
-        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_152] = [__v_1];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12688,12 +12767,12 @@ fn aiur_fn_150(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_150] = [__v_13];
-        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_152] = [__v_13];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12703,15 +12782,15 @@ fn aiur_fn_150(
   })
 }
 
-const INPUT_SIZE_151: usize = 2;
-const IN_151: usize = 2;
-const OUT_151: usize = 3;
-fn aiur_fn_151(
-  inp: [G; IN_151],
+const INPUT_SIZE_153: usize = 2;
+const IN_153: usize = 2;
+const OUT_153: usize = 3;
+fn aiur_fn_153(
+  inp: [G; IN_153],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_151], ExecError> {
+) -> Result<[G; OUT_153], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12721,8 +12800,8 @@ fn aiur_fn_151(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_151] = [__v_3, __v_0, __v_4];
-        record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_153] = [__v_3, __v_0, __v_4];
+        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -12762,12 +12841,12 @@ fn aiur_fn_151(
         let __v_37: G = G::from_u64(1);
         let __v_38: G = G::from_u64(1);
         let __v_39: G = { let __values: [G; 3] = [__v_37, __v_38, __v_38]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_95] = { let __args: [G; IN_95] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[95].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_95] = unsafe { *(result.output.as_ptr() as *const [G; OUT_95]) }; __ret } else { aiur_fn_95(__args, record, io_buffer, __cu)? } };
         let __v_40: G = __r_arr[0];
         let __v_41: G = G::from_u64(1);
         let __v_42: G = G::from_u64(1);
         let __v_43: G = { let __values: [G; 3] = [__v_41, __v_42, __v_42]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
         let __v_44: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_44.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_45: G = __loaded[0];
@@ -12775,8 +12854,8 @@ fn aiur_fn_151(
         let __v_47: G = __loaded[2];
         match __v_45.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_151] = [__v_46, __v_40, __v_47];
-            record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_153] = [__v_46, __v_40, __v_47];
+            record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -12791,69 +12870,69 @@ fn aiur_fn_151(
   })
 }
 
-const INPUT_SIZE_152: usize = 2;
-const IN_152: usize = 2;
-const OUT_152: usize = 10;
-fn aiur_fn_152(
-  inp: [G; IN_152],
+const INPUT_SIZE_154: usize = 2;
+const IN_154: usize = 2;
+const OUT_154: usize = 10;
+fn aiur_fn_154(
+  inp: [G; IN_154],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_152], ExecError> {
+) -> Result<[G; OUT_154], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __v_6: G = __r_arr[1];
     let __v_7: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
     let __v_10: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
     let __v_12: G = __r_arr[1];
     let __v_13: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
     let __v_15: G = __r_arr[1];
     let __v_16: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
     let __v_18: G = __r_arr[1];
     let __v_19: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = __r_arr[2];
-    let __ret: [G; OUT_152] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
-    record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_154] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
+    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_153: usize = 2;
-const IN_153: usize = 2;
-const OUT_153: usize = 10;
-fn aiur_fn_153(
-  inp: [G; IN_153],
+const INPUT_SIZE_155: usize = 2;
+const IN_155: usize = 2;
+const OUT_155: usize = 10;
+fn aiur_fn_155(
+  inp: [G; IN_155],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_153], ExecError> {
+) -> Result<[G; OUT_155], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -12868,12 +12947,12 @@ fn aiur_fn_153(
     let __v_12: G = __r_arr[0];
     match __v_12.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_153] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = __r_arr[2];
@@ -12884,27 +12963,27 @@ fn aiur_fn_153(
         let __v_20: G = __r_arr[7];
         let __v_21: G = __r_arr[8];
         let __v_22: G = __r_arr[9];
-        let __ret: [G; OUT_153] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
-        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_155] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
+        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_154: usize = 2;
-const IN_154: usize = 2;
-const OUT_154: usize = 18;
-fn aiur_fn_154(
-  inp: [G; IN_154],
+const INPUT_SIZE_156: usize = 2;
+const IN_156: usize = 2;
+const OUT_156: usize = 18;
+fn aiur_fn_156(
+  inp: [G; IN_156],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_154], ExecError> {
+) -> Result<[G; OUT_156], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -12915,7 +12994,7 @@ fn aiur_fn_154(
     let __v_9: G = __r_arr[7];
     let __v_10: G = __r_arr[8];
     let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = __r_arr[1];
     let __v_14: G = __r_arr[2];
@@ -12926,21 +13005,21 @@ fn aiur_fn_154(
     let __v_19: G = __r_arr[7];
     let __v_20: G = __r_arr[8];
     let __v_21: G = __r_arr[9];
-    let __ret: [G; OUT_154] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
-    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_156] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
+    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_155: usize = 8;
-const IN_155: usize = 8;
-const OUT_155: usize = 1;
-fn aiur_fn_155(
-  inp: [G; IN_155],
+const INPUT_SIZE_157: usize = 8;
+const IN_157: usize = 8;
+const OUT_157: usize = 1;
+fn aiur_fn_157(
+  inp: [G; IN_157],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_155], ExecError> {
+) -> Result<[G; OUT_157], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13025,37 +13104,37 @@ fn aiur_fn_155(
     let __v_72: G = G::from_u64(1);
     let __v_73: G = G::from_u64(1);
     let __v_74: G = { let __values: [G; 3] = [__v_72, __v_73, __v_73]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_76: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_77: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_78: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_80: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_82: G = __r_arr[0];
-    let __ret: [G; OUT_155] = [__v_82];
-    record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_157] = [__v_82];
+    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_156: usize = 2;
-const IN_156: usize = 2;
-const OUT_156: usize = 1;
-fn aiur_fn_156(
-  inp: [G; IN_156],
+const INPUT_SIZE_158: usize = 2;
+const IN_158: usize = 2;
+const OUT_158: usize = 1;
+fn aiur_fn_158(
+  inp: [G; IN_158],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_156], ExecError> {
+) -> Result<[G; OUT_158], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13064,8 +13143,8 @@ fn aiur_fn_156(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_156] = [__v_4];
-        record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_158] = [__v_4];
+        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13078,11 +13157,11 @@ fn aiur_fn_156(
             let __v_5: G = G::from_u64(0);
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_1 - __v_6);
-            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_156] = [__v_9];
-            record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_158] = [__v_9];
+            record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -13094,20 +13173,20 @@ fn aiur_fn_156(
   })
 }
 
-const INPUT_SIZE_157: usize = 3;
-const IN_157: usize = 3;
-const OUT_157: usize = 3;
-fn aiur_fn_157(
-  inp: [G; IN_157],
+const INPUT_SIZE_159: usize = 3;
+const IN_159: usize = 3;
+const OUT_159: usize = 3;
+fn aiur_fn_159(
+  inp: [G; IN_159],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_157], ExecError> {
+) -> Result<[G; OUT_159], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __v_5: G = __r_arr[2];
@@ -13118,25 +13197,25 @@ fn aiur_fn_157(
     let __v_10: G = __r_arr[7];
     let __v_11: G = __r_arr[8];
     let __v_12: G = __r_arr[9];
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __ret: [G; OUT_157] = [__v_14, __v_11, __v_12];
-    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_159] = [__v_14, __v_11, __v_12];
+    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_158: usize = 9;
-const IN_158: usize = 9;
-const OUT_158: usize = 1;
-fn aiur_fn_158(
-  inp: [G; IN_158],
+const INPUT_SIZE_160: usize = 9;
+const IN_160: usize = 9;
+const OUT_160: usize = 1;
+fn aiur_fn_160(
+  inp: [G; IN_160],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_158], ExecError> {
+) -> Result<[G; OUT_160], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13150,50 +13229,50 @@ fn aiur_fn_158(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __ret: [G; OUT_158] = [__v_13];
-    record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_160] = [__v_13];
+    record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_159: usize = 2;
-const IN_159: usize = 2;
-const OUT_159: usize = 1;
-fn aiur_fn_159(
-  inp: [G; IN_159],
+const INPUT_SIZE_161: usize = 2;
+const IN_161: usize = 2;
+const OUT_161: usize = 1;
+fn aiur_fn_161(
+  inp: [G; IN_161],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_159], ExecError> {
+) -> Result<[G; OUT_161], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_u64(1);
     let __v_3: G = G::from_u64(1);
     let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
-    let __ret: [G; OUT_159] = [__v_6];
-    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_161] = [__v_6];
+    record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_160: usize = 2;
-const IN_160: usize = 2;
-const OUT_160: usize = 1;
-fn aiur_fn_160(
-  inp: [G; IN_160],
+const INPUT_SIZE_162: usize = 2;
+const IN_162: usize = 2;
+const OUT_162: usize = 1;
+fn aiur_fn_162(
+  inp: [G; IN_162],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_160], ExecError> {
+) -> Result<[G; OUT_162], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13210,17 +13289,17 @@ fn aiur_fn_160(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_160] = [__v_1];
-        record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_162] = [__v_1];
+        record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_160] = [__v_13];
-        record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_162] = [__v_13];
+        record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13230,15 +13309,15 @@ fn aiur_fn_160(
   })
 }
 
-const INPUT_SIZE_161: usize = 2;
-const IN_161: usize = 2;
-const OUT_161: usize = 1;
-fn aiur_fn_161(
-  inp: [G; IN_161],
+const INPUT_SIZE_163: usize = 2;
+const IN_163: usize = 2;
+const OUT_163: usize = 1;
+fn aiur_fn_163(
+  inp: [G; IN_163],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_161], ExecError> {
+) -> Result<[G; OUT_163], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13248,12 +13327,12 @@ fn aiur_fn_161(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_161] = [__v_1];
-        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_163] = [__v_1];
+        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = __r_arr[1];
         let __v_7: G = __r_arr[2];
@@ -13262,14 +13341,14 @@ fn aiur_fn_161(
         let __v_10: G = __r_arr[5];
         let __v_11: G = __r_arr[6];
         let __v_12: G = __r_arr[7];
-        let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __ret: [G; OUT_161] = [__v_15];
-        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_163] = [__v_15];
+        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13279,19 +13358,19 @@ fn aiur_fn_161(
   })
 }
 
-const INPUT_SIZE_162: usize = 2;
-const IN_162: usize = 2;
-const OUT_162: usize = 1;
-fn aiur_fn_162(
-  inp: [G; IN_162],
+const INPUT_SIZE_164: usize = 2;
+const IN_164: usize = 2;
+const OUT_164: usize = 1;
+fn aiur_fn_164(
+  inp: [G; IN_164],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_162], ExecError> {
+) -> Result<[G; OUT_164], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13300,25 +13379,25 @@ fn aiur_fn_162(
     let __v_7: G = __r_arr[5];
     let __v_8: G = __r_arr[6];
     let __v_9: G = __r_arr[7];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
-    let __ret: [G; OUT_162] = [__v_11];
-    record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_164] = [__v_11];
+    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_163: usize = 1;
-const IN_163: usize = 1;
-const OUT_163: usize = 1;
-fn aiur_fn_163(
-  inp: [G; IN_163],
+const INPUT_SIZE_165: usize = 1;
+const IN_165: usize = 1;
+const OUT_165: usize = 1;
+fn aiur_fn_165(
+  inp: [G; IN_165],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_163], ExecError> {
+) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(0);
@@ -13363,21 +13442,21 @@ fn aiur_fn_163(
     let __v_40: G = { let __values: [G; 3] = [__v_5, __v_6, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_41: G = { let __values: [G; 3] = [__v_3, __v_4, __v_40]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_42: G = { let __values: [G; 3] = [__v_1, __v_2, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_163] = [__v_42];
-    record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_165] = [__v_42];
+    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_164: usize = 2;
-const IN_164: usize = 2;
-const OUT_164: usize = 1;
-fn aiur_fn_164(
-  inp: [G; IN_164],
+const INPUT_SIZE_166: usize = 2;
+const IN_166: usize = 2;
+const OUT_166: usize = 1;
+fn aiur_fn_166(
+  inp: [G; IN_166],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_164], ExecError> {
+) -> Result<[G; OUT_166], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13386,13 +13465,13 @@ fn aiur_fn_164(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 34] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_164] = [__v_4];
-        record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_166] = [__v_4];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __ret: [G; OUT_164] = [__v_1];
-        record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_166] = [__v_1];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13402,15 +13481,15 @@ fn aiur_fn_164(
   })
 }
 
-const INPUT_SIZE_165: usize = 9;
-const IN_165: usize = 9;
-const OUT_165: usize = 9;
-fn aiur_fn_165(
-  inp: [G; IN_165],
+const INPUT_SIZE_167: usize = 9;
+const IN_167: usize = 9;
+const OUT_167: usize = 9;
+fn aiur_fn_167(
+  inp: [G; IN_167],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_165], ExecError> {
+) -> Result<[G; OUT_167], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13424,24 +13503,24 @@ fn aiur_fn_165(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
-    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
     let __v_19: G = G::from_u64(1);
     let __v_20: G = G::from_u64(1);
     let __v_21: G = { let __values: [G; 3] = [__v_19, __v_20, __v_20]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
     let __v_24: G = __r_arr[2];
@@ -13460,14 +13539,14 @@ fn aiur_fn_165(
     let __v_37: G = __r_arr[15];
     let __v_38: G = __r_arr[16];
     let __v_39: G = __r_arr[17];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = G::from_u64(1);
     let __v_43: G = G::from_u64(1);
     let __v_44: G = { let __values: [G; 3] = [__v_42, __v_43, __v_43]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
     let __v_46: G = __r_arr[1];
     let __v_47: G = __r_arr[2];
@@ -13486,23 +13565,23 @@ fn aiur_fn_165(
     let __v_60: G = __r_arr[15];
     let __v_61: G = __r_arr[16];
     let __v_62: G = __r_arr[17];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_63: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_64: G = __r_arr[0];
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_65: G = __r_arr[0];
     let __v_66: G = G::from_u64(1);
     let __v_67: G = G::from_u64(1);
     let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_70: G = __r_arr[0];
     let __v_71: G = G::from_u64(1);
     let __v_72: G = G::from_u64(1);
     let __v_73: G = { let __values: [G; 3] = [__v_71, __v_72, __v_72]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_74: G = __r_arr[0];
     let __v_75: G = __r_arr[1];
     let __v_76: G = __r_arr[2];
@@ -13521,12 +13600,12 @@ fn aiur_fn_165(
     let __v_89: G = __r_arr[15];
     let __v_90: G = __r_arr[16];
     let __v_91: G = __r_arr[17];
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_92: G = __r_arr[0];
     let __v_93: G = G::from_u64(1);
     let __v_94: G = G::from_u64(1);
     let __v_95: G = { let __values: [G; 3] = [__v_93, __v_94, __v_94]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -13561,259 +13640,9 @@ fn aiur_fn_165(
     let __v_120: G = __r_arr[0];
     let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
     let __v_121: G = __r_arr[0];
-    let __ret: [G; OUT_165] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
-    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_167] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
+    record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_166: usize = 3;
-const IN_166: usize = 3;
-const OUT_166: usize = 2;
-fn aiur_fn_166(
-  inp: [G; IN_166],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_166], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_166] = [__v_0, __v_1];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __v_4: G = __r_arr[1];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_2 - __v_5);
-        let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __ret: [G; OUT_166] = [__v_7, __v_8];
-        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_167: usize = 1;
-const IN_167: usize = 1;
-const OUT_167: usize = 1;
-fn aiur_fn_167(
-  inp: [G; IN_167],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_167], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(18446744069414584320);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(281474976710656);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(18446744069397807105);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(17293822564807737345);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(70368744161280);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(549755813888);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(17870292113338400769);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(13797081185216407910);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(1803076106186727246);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(11353340290879379826);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(455906449640507599);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(17492915097719143606);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(1532612707718625687);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16207902636198568418);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(17776499369601055404);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(6115771955107415310);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(12380578893860276750);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      18u64 => {
-        let __v_1: G = G::from_u64(9306717745644682924);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      19u64 => {
-        let __v_1: G = G::from_u64(18146160046829613826);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      20u64 => {
-        let __v_1: G = G::from_u64(3511170319078647661);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      21u64 => {
-        let __v_1: G = G::from_u64(17654865857378133588);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      22u64 => {
-        let __v_1: G = G::from_u64(5416168637041100469);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      23u64 => {
-        let __v_1: G = G::from_u64(16905767614792059275);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      24u64 => {
-        let __v_1: G = G::from_u64(9713644485405565297);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      25u64 => {
-        let __v_1: G = G::from_u64(5456943929260765144);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      26u64 => {
-        let __v_1: G = G::from_u64(17096174751763063430);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      27u64 => {
-        let __v_1: G = G::from_u64(1213594585890690845);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      28u64 => {
-        let __v_1: G = G::from_u64(6414415596519834757);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      29u64 => {
-        let __v_1: G = G::from_u64(16116352524544190054);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      30u64 => {
-        let __v_1: G = G::from_u64(9123114210336311365);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      31u64 => {
-        let __v_1: G = G::from_u64(4614640910117430873);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(1753635133440165772);
-        let __ret: [G; OUT_167] = [__v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
   })
 }
 
@@ -13830,23 +13659,32 @@ fn aiur_fn_168(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __ret: [G; OUT_168] = [__v_7, __v_8];
-    record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    match __v_2.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_168] = [__v_0, __v_1];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_2 - __v_5);
+        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = __r_arr[1];
+        let __ret: [G; OUT_168] = [__v_7, __v_8];
+        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_169: usize = 3;
-const IN_169: usize = 3;
-const OUT_169: usize = 8;
+const INPUT_SIZE_169: usize = 1;
+const IN_169: usize = 1;
+const OUT_169: usize = 1;
 fn aiur_fn_169(
   inp: [G; IN_169],
   record: &mut QueryRecord,
@@ -13855,12 +13693,253 @@ fn aiur_fn_169(
 ) -> Result<[G; OUT_169], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(18446744069414584320);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(281474976710656);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(18446744069397807105);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(17293822564807737345);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(70368744161280);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(549755813888);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(17870292113338400769);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(13797081185216407910);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(1803076106186727246);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(11353340290879379826);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(455906449640507599);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(17492915097719143606);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(1532612707718625687);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16207902636198568418);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(17776499369601055404);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(6115771955107415310);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(12380578893860276750);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      18u64 => {
+        let __v_1: G = G::from_u64(9306717745644682924);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      19u64 => {
+        let __v_1: G = G::from_u64(18146160046829613826);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      20u64 => {
+        let __v_1: G = G::from_u64(3511170319078647661);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      21u64 => {
+        let __v_1: G = G::from_u64(17654865857378133588);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      22u64 => {
+        let __v_1: G = G::from_u64(5416168637041100469);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      23u64 => {
+        let __v_1: G = G::from_u64(16905767614792059275);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      24u64 => {
+        let __v_1: G = G::from_u64(9713644485405565297);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      25u64 => {
+        let __v_1: G = G::from_u64(5456943929260765144);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      26u64 => {
+        let __v_1: G = G::from_u64(17096174751763063430);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      27u64 => {
+        let __v_1: G = G::from_u64(1213594585890690845);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      28u64 => {
+        let __v_1: G = G::from_u64(6414415596519834757);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      29u64 => {
+        let __v_1: G = G::from_u64(16116352524544190054);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      30u64 => {
+        let __v_1: G = G::from_u64(9123114210336311365);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      31u64 => {
+        let __v_1: G = G::from_u64(4614640910117430873);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(1753635133440165772);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_170: usize = 3;
+const IN_170: usize = 3;
+const OUT_170: usize = 2;
+fn aiur_fn_170(
+  inp: [G; IN_170],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_170], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __v_8: G = __r_arr[1];
+    let __ret: [G; OUT_170] = [__v_7, __v_8];
+    record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_171: usize = 3;
+const IN_171: usize = 3;
+const OUT_171: usize = 8;
+fn aiur_fn_171(
+  inp: [G; IN_171],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_171], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __r_arr: [G; OUT_16] = { let __args: [G; IN_16] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[16].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_16] = unsafe { *(result.output.as_ptr() as *const [G; OUT_16]) }; __ret } else { aiur_fn_16(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
@@ -13886,21 +13965,21 @@ fn aiur_fn_169(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_21: G = __r_arr[0];
     let __v_22: G = __r_arr[1];
-    let __ret: [G; OUT_169] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
-    record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_171] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
+    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_170: usize = 23;
-const IN_170: usize = 23;
-const OUT_170: usize = 1;
-fn aiur_fn_170(
-  inp: [G; IN_170],
+const INPUT_SIZE_172: usize = 23;
+const IN_172: usize = 23;
+const OUT_172: usize = 1;
+fn aiur_fn_172(
+  inp: [G; IN_172],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_170], ExecError> {
+) -> Result<[G; OUT_172], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13927,52 +14006,52 @@ fn aiur_fn_170(
     let __v_22: G = inp[22];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = G::from_bool((__v_23 == G::ZERO));
         let __v_25: G = G::from_u64(0);
         if (__v_24 != __v_25) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         if (__v_26 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         if (__v_28 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = G::from_u64(1);
         if (__v_29 != __v_30) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
         }
         let __v_31: G = G::from_u64(1);
-        let __ret: [G; OUT_170] = [__v_31];
-        record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_172] = [__v_31];
+        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_171: usize = 6;
-const IN_171: usize = 6;
-const OUT_171: usize = 2;
-fn aiur_fn_171(
-  inp: [G; IN_171],
+const INPUT_SIZE_173: usize = 6;
+const IN_173: usize = 6;
+const OUT_173: usize = 2;
+fn aiur_fn_173(
+  inp: [G; IN_173],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_171], ExecError> {
+) -> Result<[G; OUT_173], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13986,21 +14065,21 @@ fn aiur_fn_171(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_171] = [__v_8, __v_9];
-    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_173] = [__v_8, __v_9];
+    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_172: usize = 4;
-const IN_172: usize = 4;
-const OUT_172: usize = 2;
-fn aiur_fn_172(
-  inp: [G; IN_172],
+const INPUT_SIZE_174: usize = 4;
+const IN_174: usize = 4;
+const OUT_174: usize = 2;
+fn aiur_fn_174(
+  inp: [G; IN_174],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_172], ExecError> {
+) -> Result<[G; OUT_174], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14014,21 +14093,21 @@ fn aiur_fn_172(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_172] = [__v_8, __v_9];
-    record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_174] = [__v_8, __v_9];
+    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_173: usize = 1;
-const IN_173: usize = 1;
-const OUT_173: usize = 1;
-fn aiur_fn_173(
-  inp: [G; IN_173],
+const INPUT_SIZE_175: usize = 1;
+const IN_175: usize = 1;
+const OUT_175: usize = 1;
+fn aiur_fn_175(
+  inp: [G; IN_175],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_173], ExecError> {
+) -> Result<[G; OUT_175], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14041,8 +14120,8 @@ fn aiur_fn_173(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_173] = [__v_7];
-        record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_7];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14054,14 +14133,14 @@ fn aiur_fn_173(
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_9: G = G::from_u64(0);
-            let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
             let __v_10: G = __r_arr[0];
             let __v_11: G = __r_arr[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_173] = [__v_13];
-            record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_13];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14076,15 +14155,15 @@ fn aiur_fn_173(
   })
 }
 
-const INPUT_SIZE_174: usize = 15;
-const IN_174: usize = 15;
-const OUT_174: usize = 2;
-fn aiur_fn_174(
-  inp: [G; IN_174],
+const INPUT_SIZE_176: usize = 15;
+const IN_176: usize = 15;
+const OUT_176: usize = 2;
+fn aiur_fn_176(
+  inp: [G; IN_176],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_174], ExecError> {
+) -> Result<[G; OUT_176], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14101,7 +14180,7 @@ fn aiur_fn_174(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __v_16: G = __r_arr[1];
     let __v_17: G = __r_arr[2];
@@ -14109,8 +14188,8 @@ fn aiur_fn_174(
     match __v_15.as_canonical_u64() {
       0u64 => {
         let __v_19: G = G::from_u64(0);
-        let __ret: [G; OUT_174] = [__v_16, __v_19];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_16, __v_19];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -14118,129 +14197,129 @@ fn aiur_fn_174(
         let __v_20: G = (__v_16 + __v_19);
         match __v_20.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_174] = [__v_21, __v_22];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_174] = [__v_21, __v_22];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           2u64 => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_174] = [__v_21, __v_22];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           3u64 => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_174] = [__v_21, __v_22];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           4u64 => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_174] = [__v_21, __v_22];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_174] = [__v_21, __v_22];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
       2u64 => {
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_174] = [__v_19, __v_20];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_19, __v_20];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
-        let __ret: [G; OUT_174] = [__v_9, __v_10];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_9, __v_10];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
-        let __ret: [G; OUT_174] = [__v_11, __v_12];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_11, __v_12];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
-        let __ret: [G; OUT_174] = [__v_13, __v_14];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_13, __v_14];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_174] = [__v_23, __v_24];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_23, __v_24];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_174] = [__v_23, __v_24];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_23, __v_24];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_174] = [__v_23, __v_24];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_23, __v_24];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
         let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
-        let __ret: [G; OUT_174] = [__v_21, __v_22];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_21, __v_22];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14250,15 +14329,15 @@ fn aiur_fn_174(
   })
 }
 
-const INPUT_SIZE_175: usize = 19;
-const IN_175: usize = 19;
-const OUT_175: usize = 2;
-fn aiur_fn_175(
-  inp: [G; IN_175],
+const INPUT_SIZE_177: usize = 19;
+const IN_177: usize = 19;
+const OUT_177: usize = 2;
+fn aiur_fn_177(
+  inp: [G; IN_177],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_175], ExecError> {
+) -> Result<[G; OUT_177], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14285,22 +14364,22 @@ fn aiur_fn_175(
     let __v_21: G = __loaded[2];
     match __v_19.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_175] = [__v_0, __v_1];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_177] = [__v_0, __v_1];
+        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
-        let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __v_25: G = __r_arr[1];
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_26, __v_27];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_177] = [__v_26, __v_27];
+        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14310,15 +14389,62 @@ fn aiur_fn_175(
   })
 }
 
-const INPUT_SIZE_176: usize = 17;
-const IN_176: usize = 17;
-const OUT_176: usize = 2;
-fn aiur_fn_176(
-  inp: [G; IN_176],
+const INPUT_SIZE_178: usize = 8;
+const IN_178: usize = 8;
+const OUT_178: usize = 4;
+fn aiur_fn_178(
+  inp: [G; IN_178],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_176], ExecError> {
+) -> Result<[G; OUT_178], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __v_9: G = __r_arr[1];
+    let __v_10: G = G::from_u64(7);
+    let __v_11: G = G::from_u64(0);
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_8, __v_9, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+    let __v_16: G = __r_arr[0];
+    let __v_17: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_18: G = __r_arr[0];
+    let __v_19: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_2, __v_3, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __v_21: G = __r_arr[1];
+    let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+    let __v_22: G = __r_arr[0];
+    let __v_23: G = __r_arr[1];
+    let __ret: [G; OUT_178] = [__v_16, __v_17, __v_22, __v_23];
+    record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_179: usize = 19;
+const IN_179: usize = 19;
+const OUT_179: usize = 4;
+fn aiur_fn_179(
+  inp: [G; IN_179],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14337,26 +14463,340 @@ fn aiur_fn_176(
     let __v_14: G = inp[14];
     let __v_15: G = inp[15];
     let __v_16: G = inp[16];
-    let __v_17: G = G::from_u64(0);
+    let __v_17: G = inp[17];
+    let __v_18: G = inp[18];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_19: G = __loaded[0];
+    let __v_20: G = __loaded[1];
+    let __v_21: G = __loaded[2];
+    match __v_19.as_canonical_u64() {
+      1u64 => {
+        let __v_22: G = G::from_u64(0);
+        let __v_23: G = G::from_u64(0);
+        let __v_24: G = G::from_u64(0);
+        let __v_25: G = G::from_u64(0);
+        let __ret: [G; OUT_179] = [__v_22, __v_23, __v_24, __v_25];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __v_22: G = __r_arr[0];
+        let __v_23: G = __r_arr[1];
+        let __v_24: G = __r_arr[2];
+        let __v_25: G = __r_arr[3];
+        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+        let __v_26: G = __r_arr[0];
+        let __v_27: G = __r_arr[1];
+        let __v_28: G = __r_arr[2];
+        let __v_29: G = __r_arr[3];
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __v_30: G = __r_arr[0];
+        let __v_31: G = __r_arr[1];
+        let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_26, __v_27, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+        let __v_32: G = __r_arr[0];
+        let __v_33: G = __r_arr[1];
+        let __ret: [G; OUT_179] = [__v_32, __v_33, __v_28, __v_29];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_19.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_180: usize = 32;
+const IN_180: usize = 32;
+const OUT_180: usize = 6;
+fn aiur_fn_180(
+  inp: [G; IN_180],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_180], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
+    let __v_18: G = inp[18];
+    let __v_19: G = inp[19];
+    let __v_20: G = inp[20];
+    let __v_21: G = inp[21];
+    let __v_22: G = inp[22];
+    let __v_23: G = inp[23];
+    let __v_24: G = inp[24];
+    let __v_25: G = inp[25];
+    let __v_26: G = inp[26];
+    let __v_27: G = inp[27];
+    let __v_28: G = inp[28];
+    let __v_29: G = inp[29];
+    let __v_30: G = inp[30];
+    let __v_31: G = inp[31];
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_32: G = __loaded[0];
+    let __v_33: G = __loaded[1];
+    let __v_34: G = __loaded[2];
+    let __v_35: G = __loaded[3];
+    match __v_32.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_180] = [__v_0, __v_1, __v_6, __v_7, __v_8, __v_9];
+        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        match __v_33.as_canonical_u64() {
+          _ => {
+            let __v_36: G = G::from_u64(2);
+            let __v_37: G = (__v_5 + __v_5);
+            let __v_38: G = (__v_36 + __v_37);
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __v_39: G = __r_arr[0];
+            let __v_40: G = __r_arr[1];
+            let __v_41: G = G::from_u64(3);
+            let __v_42: G = (__v_5 + __v_5);
+            let __v_43: G = (__v_41 + __v_42);
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __v_44: G = __r_arr[0];
+            let __v_45: G = __r_arr[1];
+            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_34, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __v_46: G = __r_arr[0];
+            let __v_47: G = __r_arr[1];
+            let __v_48: G = __r_arr[2];
+            let __v_49: G = __r_arr[3];
+            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_46, __v_47, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+            let __v_50: G = __r_arr[0];
+            let __v_51: G = __r_arr[1];
+            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_48, __v_49, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+            let __v_52: G = __r_arr[0];
+            let __v_53: G = __r_arr[1];
+            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_50, __v_51, __v_52, __v_53, __v_39, __v_40, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+            let __v_54: G = __r_arr[0];
+            let __v_55: G = __r_arr[1];
+            let __v_56: G = __r_arr[2];
+            let __v_57: G = __r_arr[3];
+            let __v_58: G = G::from_u64(1);
+            let __v_59: G = G::from_u64(0);
+            let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_54, __v_55, __v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+            let __v_60: G = __r_arr[0];
+            let __v_61: G = __r_arr[1];
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_60, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __v_62: G = __r_arr[0];
+            let __v_63: G = __r_arr[1];
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_62, __v_63, __v_2, __v_3, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __v_64: G = __r_arr[0];
+            let __v_65: G = __r_arr[1];
+            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_18, __v_33, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __v_66: G = __r_arr[0];
+            let __v_67: G = __r_arr[1];
+            let __v_68: G = G::from_u64(1);
+            let __v_69: G = (__v_5 + __v_68);
+            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_66, __v_67, __v_39, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+            let __v_70: G = __r_arr[0];
+            let __v_71: G = __r_arr[1];
+            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_70, __v_71]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+            let __v_72: G = __r_arr[0];
+            let __v_73: G = __r_arr[1];
+            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_66, __v_67, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+            let __v_74: G = __r_arr[0];
+            let __v_75: G = __r_arr[1];
+            let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_8, __v_9, __v_74, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
+            let __v_76: G = __r_arr[0];
+            let __v_77: G = __r_arr[1];
+            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_64, __v_65, __v_2, __v_3, __v_35, __v_69, __v_72, __v_73, __v_76, __v_77, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __v_78: G = __r_arr[0];
+            let __v_79: G = __r_arr[1];
+            let __v_80: G = __r_arr[2];
+            let __v_81: G = __r_arr[3];
+            let __v_82: G = __r_arr[4];
+            let __v_83: G = __r_arr[5];
+            let __ret: [G; OUT_180] = [__v_78, __v_79, __v_80, __v_81, __v_82, __v_83];
+            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_32.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_181: usize = 18;
+const IN_181: usize = 18;
+const OUT_181: usize = 2;
+fn aiur_fn_181(
+  inp: [G; IN_181],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_181], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
     let __v_18: G = G::from_u64(0);
-    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_17, __v_18, __v_15, __v_16, __v_1, __v_0, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
-    let __v_19: G = __r_arr[0];
-    let __v_20: G = __r_arr[1];
-    let __ret: [G; OUT_176] = [__v_19, __v_20];
-    record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __v_19: G = G::from_u64(0);
+    let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_18, __v_19, __v_16, __v_17, __v_1, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __v_21: G = __r_arr[1];
+    let __v_22: G = G::from_u64(0);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __v_24: G = __r_arr[1];
+    let __v_25: G = G::from_u64(1);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_26: G = __r_arr[0];
+    let __v_27: G = __r_arr[1];
+    let __v_28: G = G::from_u64(2);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_29: G = __r_arr[0];
+    let __v_30: G = __r_arr[1];
+    let __v_31: G = G::from_u64(3);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_32: G = __r_arr[0];
+    let __v_33: G = __r_arr[1];
+    let __v_34: G = G::from_u64(4);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_35: G = __r_arr[0];
+    let __v_36: G = __r_arr[1];
+    let __v_37: G = G::from_u64(5);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_38: G = __r_arr[0];
+    let __v_39: G = __r_arr[1];
+    let __v_40: G = G::from_u64(6);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_41: G = __r_arr[0];
+    let __v_42: G = __r_arr[1];
+    let __v_43: G = G::from_u64(7);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_44: G = __r_arr[0];
+    let __v_45: G = __r_arr[1];
+    let __v_46: G = G::from_u64(0);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_47: G = __r_arr[0];
+    let __v_48: G = __r_arr[1];
+    let __v_49: G = G::from_u64(1);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_50: G = __r_arr[0];
+    let __v_51: G = __r_arr[1];
+    let __v_52: G = G::from_u64(0);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_53: G = __r_arr[0];
+    let __v_54: G = __r_arr[1];
+    let __v_55: G = G::from_u64(1);
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __v_56: G = __r_arr[0];
+    let __v_57: G = __r_arr[1];
+    let __v_58: G = G::from_u64(0);
+    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_20, __v_21, __v_16, __v_17, __v_2, __v_58, __v_47, __v_48, __v_50, __v_51, __v_23, __v_24, __v_26, __v_27, __v_29, __v_30, __v_32, __v_33, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+    let __v_59: G = __r_arr[0];
+    let __v_60: G = __r_arr[1];
+    let __v_61: G = __r_arr[2];
+    let __v_62: G = __r_arr[3];
+    let __v_63: G = __r_arr[4];
+    let __v_64: G = __r_arr[5];
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_47, __v_48, __v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_65: G = __r_arr[0];
+    let __v_66: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_67: G = __r_arr[0];
+    let __v_68: G = __r_arr[1];
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_59, __v_60, __v_16, __v_17, __v_67, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __v_69: G = __r_arr[0];
+    let __v_70: G = __r_arr[1];
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_50, __v_51, __v_38, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_71: G = __r_arr[0];
+    let __v_72: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_71, __v_72]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_73: G = __r_arr[0];
+    let __v_74: G = __r_arr[1];
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_69, __v_70, __v_16, __v_17, __v_73, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __v_75: G = __r_arr[0];
+    let __v_76: G = __r_arr[1];
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_53, __v_54]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_77: G = __r_arr[0];
+    let __v_78: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_14, __v_15, __v_77, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_79: G = __r_arr[0];
+    let __v_80: G = __r_arr[1];
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_75, __v_76, __v_16, __v_17, __v_79, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __v_81: G = __r_arr[0];
+    let __v_82: G = __r_arr[1];
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_63, __v_64, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_83: G = __r_arr[0];
+    let __v_84: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_14, __v_15, __v_83, __v_84]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_85: G = __r_arr[0];
+    let __v_86: G = __r_arr[1];
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_81, __v_82, __v_16, __v_17, __v_85, __v_86]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __v_87: G = __r_arr[0];
+    let __v_88: G = __r_arr[1];
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_89: G = __r_arr[0];
+    let __v_90: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_12, __v_13, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_91: G = __r_arr[0];
+    let __v_92: G = __r_arr[1];
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_87, __v_88, __v_16, __v_17, __v_91, __v_92]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __v_93: G = __r_arr[0];
+    let __v_94: G = __r_arr[1];
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_63, __v_64, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_95: G = __r_arr[0];
+    let __v_96: G = __r_arr[1];
+    let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_12, __v_13, __v_95, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+    let __v_97: G = __r_arr[0];
+    let __v_98: G = __r_arr[1];
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_93, __v_94, __v_16, __v_17, __v_97, __v_98]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __v_99: G = __r_arr[0];
+    let __v_100: G = __r_arr[1];
+    let __ret: [G; OUT_181] = [__v_99, __v_100];
+    record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_177: usize = 8;
-const IN_177: usize = 8;
-const OUT_177: usize = 1;
-fn aiur_fn_177(
-  inp: [G; IN_177],
+const INPUT_SIZE_182: usize = 8;
+const IN_182: usize = 8;
+const OUT_182: usize = 1;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_177], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14393,21 +14833,21 @@ fn aiur_fn_177(
     let __v_32: G = { let __values: [G; 4] = [__v_12, __v_2, __v_13, __v_31]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_33: G = { let __values: [G; 4] = [__v_10, __v_1, __v_11, __v_32]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_34: G = { let __values: [G; 4] = [__v_8, __v_0, __v_9, __v_33]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_177] = [__v_34];
-    record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_182] = [__v_34];
+    record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_178: usize = 5;
-const IN_178: usize = 5;
-const OUT_178: usize = 2;
-fn aiur_fn_178(
-  inp: [G; IN_178],
+const INPUT_SIZE_183: usize = 5;
+const IN_183: usize = 5;
+const OUT_183: usize = 2;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_178], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14423,8 +14863,8 @@ fn aiur_fn_178(
       1u64 => {
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_178] = [__v_9, __v_10];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_9, __v_10];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14434,14 +14874,14 @@ fn aiur_fn_178(
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
-        let __ret: [G; OUT_178] = [__v_15, __v_16];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_15, __v_16];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14451,145 +14891,145 @@ fn aiur_fn_178(
   })
 }
 
-const INPUT_SIZE_179: usize = 1;
-const IN_179: usize = 1;
-const OUT_179: usize = 1;
-fn aiur_fn_179(
-  inp: [G; IN_179],
+const INPUT_SIZE_184: usize = 1;
+const IN_184: usize = 1;
+const OUT_184: usize = 1;
+fn aiur_fn_184(
+  inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_179], ExecError> {
+) -> Result<[G; OUT_184], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     match __v_0.as_canonical_u64() {
       0u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       2u64 => {
         let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
         let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
         let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
         let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       10u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       11u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       12u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       13u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       14u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       15u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       16u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       17u64 => {
         let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_179] = [__v_1];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_180: usize = 4;
-const IN_180: usize = 4;
-const OUT_180: usize = 2;
-fn aiur_fn_180(
-  inp: [G; IN_180],
+const INPUT_SIZE_185: usize = 4;
+const IN_185: usize = 4;
+const OUT_185: usize = 2;
+fn aiur_fn_185(
+  inp: [G; IN_185],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_180], ExecError> {
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14603,8 +15043,8 @@ fn aiur_fn_180(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_180] = [__v_6, __v_9];
-        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_6, __v_9];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -14616,21 +15056,21 @@ fn aiur_fn_180(
             let __v_7: G = G::from_u64(1);
             let __v_8: G = G::from_u64(1);
             let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_180] = [__v_6, __v_9];
-            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_6, __v_9];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = G::from_u64(1);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_180] = [__v_6, __v_8];
-            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_6, __v_8];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14645,15 +15085,15 @@ fn aiur_fn_180(
   })
 }
 
-const INPUT_SIZE_181: usize = 20;
-const IN_181: usize = 20;
-const OUT_181: usize = 1;
-fn aiur_fn_181(
-  inp: [G; IN_181],
+const INPUT_SIZE_186: usize = 20;
+const IN_186: usize = 20;
+const OUT_186: usize = 1;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14675,104 +15115,105 @@ fn aiur_fn_181(
     let __v_17: G = inp[17];
     let __v_18: G = inp[18];
     let __v_19: G = inp[19];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
     let __v_20: G = __loaded[0];
     let __v_21: G = __loaded[1];
     let __v_22: G = __loaded[2];
     let __v_23: G = __loaded[3];
     let __v_24: G = __loaded[4];
     let __v_25: G = __loaded[5];
+    let __v_26: G = __loaded[6];
     match __v_20.as_canonical_u64() {
       1u64 => {
-        let __v_26: G = G::from_u64(1);
-        let __ret: [G; OUT_181] = [__v_26];
-        record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_27: G = G::from_u64(1);
+        let __ret: [G; OUT_186] = [__v_27];
+        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         match __v_21.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_26: G = __r_arr[0];
-            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_27: G = __r_arr[0];
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
-            let __v_29: G = __r_arr[1];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_30: G = __r_arr[0];
-            let __v_31: G = G::from_u64(0);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_32: G = __r_arr[0];
-            let __v_33: G = G::from_u64(1);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_30, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_34: G = __r_arr[0];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __v_29: G = __r_arr[0];
+            let __v_30: G = __r_arr[1];
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_31: G = __r_arr[0];
+            let __v_32: G = G::from_u64(0);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_33: G = __r_arr[0];
+            let __v_34: G = G::from_u64(1);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_31, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_35: G = __r_arr[0];
-            let __v_36: G = G::from_u64(0);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_35, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_37: G = __r_arr[0];
-            let __v_38: G = G::from_u64(1);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_35, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_39: G = __r_arr[0];
-            let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_36: G = __r_arr[0];
+            let __v_37: G = G::from_u64(0);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_38: G = __r_arr[0];
+            let __v_39: G = G::from_u64(1);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_40: G = __r_arr[0];
-            let __v_41: G = __r_arr[1];
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_6, __v_7, __v_40, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
-            let __v_42: G = __r_arr[0];
-            let __v_43: G = __r_arr[1];
-            let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_18, __v_19, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
-            let __v_44: G = __r_arr[0];
-            let __v_45: G = __r_arr[1];
-            let __v_46: G = __r_arr[2];
-            let __v_47: G = __r_arr[3];
-            let __v_48: G = __r_arr[4];
-            let __v_49: G = __r_arr[5];
-            let __v_50: G = __r_arr[6];
-            let __v_51: G = __r_arr[7];
-            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
-            let __v_52: G = __r_arr[0];
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_21, __v_23, __v_32, __v_34, __v_42, __v_43, __v_37, __v_39, __v_52, __v_44, __v_45, __v_46, __v_47, __v_48, __v_49, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __v_41: G = __r_arr[0];
+            let __v_42: G = __r_arr[1];
+            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_6, __v_7, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+            let __v_43: G = __r_arr[0];
+            let __v_44: G = __r_arr[1];
+            let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+            let __v_45: G = __r_arr[0];
+            let __v_46: G = __r_arr[1];
+            let __v_47: G = __r_arr[2];
+            let __v_48: G = __r_arr[3];
+            let __v_49: G = __r_arr[4];
+            let __v_50: G = __r_arr[5];
+            let __v_51: G = __r_arr[6];
+            let __v_52: G = __r_arr[7];
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_29, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_53: G = __r_arr[0];
-            let __v_54: G = __r_arr[1];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_55: G = __r_arr[0];
-            let __v_56: G = G::from_u64(0);
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_55, __v_56]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_57: G = __r_arr[0];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_21, __v_23, __v_25, __v_33, __v_35, __v_43, __v_44, __v_38, __v_40, __v_53, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __v_54: G = __r_arr[0];
+            let __v_55: G = __r_arr[1];
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_56: G = __r_arr[0];
+            let __v_57: G = G::from_u64(0);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_58: G = __r_arr[0];
-            let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_18, __v_19, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_59: G = __r_arr[0];
-            let __v_60: G = __r_arr[1];
-            let __v_61: G = G::from_u64(1);
-            let __v_62: G = G::from_u64(0);
-            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_58, __v_59, __v_60, __v_61, __v_62]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
-            let __v_63: G = __r_arr[0];
-            let __v_64: G = __r_arr[1];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-            let __v_65: G = __r_arr[0];
-            let __v_66: G = (__v_65 - __v_27);
-            let __v_67: G = G::from_bool((__v_66 == G::ZERO));
-            let __v_68: G = G::from_u64(1);
-            if (__v_67 != __v_68) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_67.as_canonical_u64(), rhs: __v_68.as_canonical_u64() });
+            let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+            let __v_60: G = __r_arr[0];
+            let __v_61: G = __r_arr[1];
+            let __v_62: G = G::from_u64(1);
+            let __v_63: G = G::from_u64(0);
+            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_59, __v_60, __v_61, __v_62, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __v_64: G = __r_arr[0];
+            let __v_65: G = __r_arr[1];
+            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __v_66: G = __r_arr[0];
+            let __v_67: G = (__v_66 - __v_28);
+            let __v_68: G = G::from_bool((__v_67 == G::ZERO));
+            let __v_69: G = G::from_u64(1);
+            if (__v_68 != __v_69) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_68.as_canonical_u64(), rhs: __v_69.as_canonical_u64() });
             }
-            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_53, __v_54, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-            let __v_69: G = __r_arr[0];
-            let __v_70: G = __r_arr[1];
-            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_69, __v_70, __v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
-            let __v_71: G = __r_arr[0];
-            let __v_72: G = G::from_u64(1);
-            if (__v_71 != __v_72) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_71.as_canonical_u64(), rhs: __v_72.as_canonical_u64() });
-            }
+            let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_54, __v_55, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+            let __v_70: G = __r_arr[0];
+            let __v_71: G = __r_arr[1];
+            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_70, __v_71, __v_64, __v_65]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
+            let __v_72: G = __r_arr[0];
             let __v_73: G = G::from_u64(1);
-            let __v_74: G = (__v_9 + __v_73);
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_25, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_74, __v_28, __v_29, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
-            let __v_75: G = __r_arr[0];
-            let __ret: [G; OUT_181] = [__v_75];
-            record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            if (__v_72 != __v_73) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_72.as_canonical_u64(), rhs: __v_73.as_canonical_u64() });
+            }
+            let __v_74: G = G::from_u64(1);
+            let __v_75: G = (__v_9 + __v_74);
+            let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_26, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_75, __v_29, __v_30, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+            let __v_76: G = __r_arr[0];
+            let __ret: [G; OUT_186] = [__v_76];
+            record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -14784,15 +15225,15 @@ fn aiur_fn_181(
   })
 }
 
-const INPUT_SIZE_182: usize = 3;
-const IN_182: usize = 3;
-const OUT_182: usize = 2;
-fn aiur_fn_182(
-  inp: [G; IN_182],
+const INPUT_SIZE_187: usize = 3;
+const IN_187: usize = 3;
+const OUT_187: usize = 2;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14812,15 +15253,15 @@ fn aiur_fn_182(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_182] = [__v_13, __v_14];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_13, __v_14];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = G::from_u64(0);
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -14829,8 +15270,8 @@ fn aiur_fn_182(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_182] = [__v_19, __v_20];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_19, __v_20];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14840,15 +15281,15 @@ fn aiur_fn_182(
   })
 }
 
-const INPUT_SIZE_183: usize = 7;
-const IN_183: usize = 7;
-const OUT_183: usize = 2;
-fn aiur_fn_183(
-  inp: [G; IN_183],
+const INPUT_SIZE_188: usize = 7;
+const IN_188: usize = 7;
+const OUT_188: usize = 2;
+fn aiur_fn_188(
+  inp: [G; IN_188],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
+) -> Result<[G; OUT_188], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14863,12 +15304,12 @@ fn aiur_fn_183(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_183] = [__v_0, __v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_188] = [__v_0, __v_1];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_3, __v_4, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -14880,11 +15321,11 @@ fn aiur_fn_183(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_183] = [__v_18, __v_19];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_188] = [__v_18, __v_19];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14894,15 +15335,15 @@ fn aiur_fn_183(
   })
 }
 
-const INPUT_SIZE_184: usize = 36;
-const IN_184: usize = 36;
-const OUT_184: usize = 1;
-fn aiur_fn_184(
-  inp: [G; IN_184],
+const INPUT_SIZE_189: usize = 36;
+const IN_189: usize = 36;
+const OUT_189: usize = 1;
+fn aiur_fn_189(
+  inp: [G; IN_189],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_184], ExecError> {
+) -> Result<[G; OUT_189], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14946,15 +15387,15 @@ fn aiur_fn_184(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
-                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
                     let __v_38: G = __r_arr[0];
-                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
                     let __v_39: G = __r_arr[0];
                     let __v_40: G = __r_arr[1];
                     let __v_41: G = __r_arr[2];
@@ -14966,21 +15407,21 @@ fn aiur_fn_184(
                     let __v_47: G = __r_arr[8];
                     let __v_48: G = G::from_u64(0);
                     let __v_49: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
                     let __v_51: G = __r_arr[1];
                     let __v_52: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
                     let __v_53: G = __r_arr[0];
-                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
                     let __v_54: G = __r_arr[0];
                     let __v_55: G = G::from_u64(1);
                     if (__v_54 != __v_55) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                     let __v_56: G = __r_arr[0];
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_57: G = __r_arr[0];
                     let __v_58: G = (__v_56 - __v_57);
                     let __v_59: G = G::from_bool((__v_58 == G::ZERO));
@@ -14988,9 +15429,9 @@ fn aiur_fn_184(
                     if (__v_59 != __v_60) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_59.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_61: G = __r_arr[0];
-                    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                     let __v_62: G = __r_arr[0];
                     let __v_63: G = (__v_61 - __v_62);
                     let __v_64: G = G::from_bool((__v_63 == G::ZERO));
@@ -14998,12 +15439,12 @@ fn aiur_fn_184(
                     if (__v_64 != __v_65) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_66: G = __r_arr[0];
-                    let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
                     let __v_67: G = __r_arr[0];
-                    let __ret: [G; OUT_184] = [__v_67];
-                    record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_189] = [__v_67];
+                    record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -15016,15 +15457,15 @@ fn aiur_fn_184(
   })
 }
 
-const INPUT_SIZE_185: usize = 1;
-const IN_185: usize = 1;
-const OUT_185: usize = 1;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_190: usize = 1;
+const IN_190: usize = 1;
+const OUT_190: usize = 1;
+fn aiur_fn_190(
+  inp: [G; IN_190],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_190], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15034,8 +15475,8 @@ fn aiur_fn_185(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_185] = [__v_4];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_190] = [__v_4];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15046,10 +15487,10 @@ fn aiur_fn_185(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_185] = [__v_8];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_190] = [__v_8];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15059,62 +15500,63 @@ fn aiur_fn_185(
   })
 }
 
-const INPUT_SIZE_186: usize = 2;
-const IN_186: usize = 2;
-const OUT_186: usize = 1;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_191: usize = 2;
+const IN_191: usize = 2;
+const OUT_191: usize = 1;
+fn aiur_fn_191(
+  inp: [G; IN_191],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
+) -> Result<[G; OUT_191], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     let __v_5: G = __loaded[3];
     let __v_6: G = __loaded[4];
     let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __v_8: G = G::from_u64(1);
         let __v_9: G = G::from_u64(1);
-        let __v_10: G = { let __values: [G; 6] = [__v_8, __v_9, __v_9, __v_9, __v_9, __v_9]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_186] = [__v_10];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __v_10: G = G::from_u64(1);
+        let __v_11: G = { let __values: [G; 7] = [__v_9, __v_10, __v_10, __v_10, __v_10, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_191] = [__v_11];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_8: G = __loaded[0];
-        let __v_9: G = __loaded[1];
-        let __v_10: G = __loaded[2];
-        match __v_8.as_canonical_u64() {
+        let __v_9: G = __loaded[0];
+        let __v_10: G = __loaded[1];
+        let __v_11: G = __loaded[2];
+        match __v_9.as_canonical_u64() {
           0u64 => {
-            match __v_9.as_canonical_u64() {
+            match __v_10.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
-                let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_186] = [__v_11];
-                record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __v_12: G = __r_arr[0];
+                let __ret: [G; OUT_191] = [__v_12];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __v_11: G = G::from_u64(0);
-                let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_7, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
-                let __v_12: G = __r_arr[0];
-                let __v_13: G = { let __values: [G; 6] = [__v_11, __v_3, __v_4, __v_5, __v_6, __v_12]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_186] = [__v_13];
-                record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __v_12: G = G::from_u64(0);
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __v_13: G = __r_arr[0];
+                let __v_14: G = { let __values: [G; 7] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                let __ret: [G; OUT_191] = [__v_14];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
           },
           _ => {
-            return Err(ExecError::MatchNoCase(__v_8.as_canonical_u64()));
+            return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
           },
         }
       },
@@ -15125,15 +15567,15 @@ fn aiur_fn_186(
   })
 }
 
-const INPUT_SIZE_187: usize = 2;
-const IN_187: usize = 2;
-const OUT_187: usize = 1;
-fn aiur_fn_187(
-  inp: [G; IN_187],
+const INPUT_SIZE_192: usize = 2;
+const IN_192: usize = 2;
+const OUT_192: usize = 1;
+fn aiur_fn_192(
+  inp: [G; IN_192],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
+) -> Result<[G; OUT_192], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15147,8 +15589,8 @@ fn aiur_fn_187(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_187] = [__v_8];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_192] = [__v_8];
+        record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15160,19 +15602,19 @@ fn aiur_fn_187(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_187] = [__v_9];
-                record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_192] = [__v_9];
+                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_187] = [__v_11];
-                record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_192] = [__v_11];
+                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15189,38 +15631,38 @@ fn aiur_fn_187(
   })
 }
 
-const INPUT_SIZE_188: usize = 1;
-const IN_188: usize = 1;
-const OUT_188: usize = 2;
-fn aiur_fn_188(
-  inp: [G; IN_188],
+const INPUT_SIZE_193: usize = 1;
+const IN_193: usize = 1;
+const OUT_193: usize = 2;
+fn aiur_fn_193(
+  inp: [G; IN_193],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_188] = [__v_3, __v_4];
-    record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_193] = [__v_3, __v_4];
+    record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_189: usize = 2;
-const IN_189: usize = 2;
-const OUT_189: usize = 2;
-fn aiur_fn_189(
-  inp: [G; IN_189],
+const INPUT_SIZE_194: usize = 2;
+const IN_194: usize = 2;
+const OUT_194: usize = 2;
+fn aiur_fn_194(
+  inp: [G; IN_194],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
+) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15229,61 +15671,61 @@ fn aiur_fn_189(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_189] = [__v_4, __v_0];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_194] = [__v_4, __v_0];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_2: G = __r_arr[0];
         let __v_3: G = __r_arr[1];
         let __v_4: G = G::from_u64(1);
         let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = __r_arr[1];
         let __v_8: G = G::from_u64(0);
         let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_189] = [__v_9, __v_7];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_194] = [__v_9, __v_7];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_190: usize = 1;
-const IN_190: usize = 1;
-const OUT_190: usize = 2;
-fn aiur_fn_190(
-  inp: [G; IN_190],
+const INPUT_SIZE_195: usize = 1;
+const IN_195: usize = 1;
+const OUT_195: usize = 2;
+fn aiur_fn_195(
+  inp: [G; IN_195],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_190], ExecError> {
+) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
     let __v_1: G = __r_arr[0];
     let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_190] = [__v_3, __v_4];
-    record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_195] = [__v_3, __v_4];
+    record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_191: usize = 2;
-const IN_191: usize = 2;
-const OUT_191: usize = 2;
-fn aiur_fn_191(
-  inp: [G; IN_191],
+const INPUT_SIZE_196: usize = 2;
+const IN_196: usize = 2;
+const OUT_196: usize = 2;
+fn aiur_fn_196(
+  inp: [G; IN_196],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_191], ExecError> {
+) -> Result<[G; OUT_196], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15292,8 +15734,8 @@ fn aiur_fn_191(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_4, __v_0];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_4, __v_0];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15309,28 +15751,28 @@ fn aiur_fn_191(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_16, __v_14];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_16, __v_14];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_192: usize = 64;
-const IN_192: usize = 64;
-const OUT_192: usize = 0;
-fn aiur_fn_192(
-  inp: [G; IN_192],
+const INPUT_SIZE_197: usize = 64;
+const IN_197: usize = 64;
+const OUT_197: usize = 0;
+fn aiur_fn_197(
+  inp: [G; IN_197],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
+) -> Result<[G; OUT_197], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15431,7 +15873,7 @@ fn aiur_fn_192(
     let __io_pair: (G, G) = { let __key: [G; 1] = [__v_93]; let __info = io_buffer.get_info(__v_92, &__key[..])?; (G::from_usize(__info.idx), G::from_usize(__info.len)) };
     let __v_94: G = __io_pair.0;
     let __v_95: G = __io_pair.1;
-    let __r_arr: [G; OUT_91] = { let __args: [G; IN_91] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[91].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_91] = unsafe { *(result.output.as_ptr() as *const [G; OUT_91]) }; __ret } else { aiur_fn_91(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_93] = { let __args: [G; IN_93] = [__v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[93].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_93] = unsafe { *(result.output.as_ptr() as *const [G; OUT_93]) }; __ret } else { aiur_fn_93(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -15453,7 +15895,7 @@ fn aiur_fn_192(
     let __v_113: G = G::from_u64(2);
     let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = __r_arr[1];
     let __v_117: G = (__v_66 + __v_67);
@@ -15461,7 +15903,7 @@ fn aiur_fn_192(
       return Err(ExecError::AssertEqMismatch { lhs: __v_91.as_canonical_u64(), rhs: __v_117.as_canonical_u64() });
     }
     let __v_118: G = G::from_u64(1);
-    let __r_arr: [G; OUT_97] = { let __args: [G; IN_97] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[97].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_97] = unsafe { *(result.output.as_ptr() as *const [G; OUT_97]) }; __ret } else { aiur_fn_97(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_118, __v_94, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
     let __v_119: G = __r_arr[0];
     let __v_120: G = __r_arr[1];
     let __v_121: G = __r_arr[2];
@@ -15494,7 +15936,7 @@ fn aiur_fn_192(
     let __v_148: G = __r_arr[29];
     let __v_149: G = __r_arr[30];
     let __v_150: G = __r_arr[31];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_137, __v_138, __v_139, __v_140, __v_141, __v_142, __v_143, __v_144, __v_145, __v_146, __v_147, __v_148, __v_149, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
     let __v_151: G = __r_arr[0];
     let __v_152: G = __r_arr[1];
     let __v_153: G = __r_arr[2];
@@ -15660,7 +16102,7 @@ fn aiur_fn_192(
     let __v_213: G = __r_arr[29];
     let __v_214: G = __r_arr[30];
     let __v_215: G = __r_arr[31];
-    let __r_arr: [G; OUT_94] = { let __args: [G; IN_94] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[94].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_94] = unsafe { *(result.output.as_ptr() as *const [G; OUT_94]) }; __ret } else { aiur_fn_94(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_96] = { let __args: [G; IN_96] = [__v_184, __v_185, __v_186, __v_187, __v_188, __v_189, __v_190, __v_191, __v_192, __v_193, __v_194, __v_195, __v_196, __v_197, __v_198, __v_199, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215]; let __cu = unconstrained; if let Some(result) = record.function_queries[96].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_96] = unsafe { *(result.output.as_ptr() as *const [G; OUT_96]) }; __ret } else { aiur_fn_96(__args, record, io_buffer, __cu)? } };
     let __v_216: G = __r_arr[0];
     let __v_217: G = __r_arr[1];
     let __v_218: G = __r_arr[2];
@@ -15804,33 +16246,33 @@ fn aiur_fn_192(
     if (__v_250 != __v_252) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_253: G = __r_arr[0];
     let __v_254: G = G::from_u64(1);
     if (__v_253 != __v_254) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
     let __v_255: G = __r_arr[0];
     let __v_256: G = G::from_u64(1);
     if (__v_255 != __v_256) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
-    let __ret: [G; OUT_192] = [];
-    record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_197] = [];
+    record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_193: usize = 1;
-const IN_193: usize = 1;
-const OUT_193: usize = 1;
-fn aiur_fn_193(
-  inp: [G; IN_193],
+const INPUT_SIZE_198: usize = 1;
+const IN_198: usize = 1;
+const OUT_198: usize = 1;
+fn aiur_fn_198(
+  inp: [G; IN_198],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_193], ExecError> {
+) -> Result<[G; OUT_198], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15840,17 +16282,17 @@ fn aiur_fn_193(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_193] = [__v_4];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_198] = [__v_4];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = G::from_u64(1);
         let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_193] = [__v_6];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_198] = [__v_6];
+        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15860,15 +16302,15 @@ fn aiur_fn_193(
   })
 }
 
-const INPUT_SIZE_194: usize = 1;
-const IN_194: usize = 1;
-const OUT_194: usize = 1;
-fn aiur_fn_194(
-  inp: [G; IN_194],
+const INPUT_SIZE_199: usize = 1;
+const IN_199: usize = 1;
+const OUT_199: usize = 1;
+fn aiur_fn_199(
+  inp: [G; IN_199],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_194], ExecError> {
+) -> Result<[G; OUT_199], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15878,14 +16320,14 @@ fn aiur_fn_194(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_194] = [__v_4];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_194] = [__v_4];
-        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15895,19 +16337,19 @@ fn aiur_fn_194(
   })
 }
 
-const INPUT_SIZE_195: usize = 2;
-const IN_195: usize = 2;
-const OUT_195: usize = 2;
-fn aiur_fn_195(
-  inp: [G; IN_195],
+const INPUT_SIZE_200: usize = 2;
+const IN_200: usize = 2;
+const OUT_200: usize = 2;
+fn aiur_fn_200(
+  inp: [G; IN_200],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_195], ExecError> {
+) -> Result<[G; OUT_200], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -15916,8 +16358,8 @@ fn aiur_fn_195(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_195] = [__v_4, __v_5];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_4, __v_5];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15927,15 +16369,15 @@ fn aiur_fn_195(
   })
 }
 
-const INPUT_SIZE_196: usize = 1;
-const IN_196: usize = 1;
-const OUT_196: usize = 8;
-fn aiur_fn_196(
-  inp: [G; IN_196],
+const INPUT_SIZE_201: usize = 1;
+const IN_201: usize = 1;
+const OUT_201: usize = 8;
+fn aiur_fn_201(
+  inp: [G; IN_201],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
+) -> Result<[G; OUT_201], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -15959,12 +16401,12 @@ fn aiur_fn_196(
         let __v_16: G = G::from_u64(0);
         let __v_17: G = G::from_u64(0);
         let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_196] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
         let __v_13: G = __r_arr[2];
@@ -15982,221 +16424,7 @@ fn aiur_fn_196(
         let __v_24: G = __r_arr[5];
         let __v_25: G = __r_arr[6];
         let __v_26: G = __r_arr[7];
-        let __ret: [G; OUT_196] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
-        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_197: usize = 2;
-const IN_197: usize = 2;
-const OUT_197: usize = 1;
-fn aiur_fn_197(
-  inp: [G; IN_197],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_197] = [__v_4];
-        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_198: usize = 1;
-const IN_198: usize = 1;
-const OUT_198: usize = 1;
-fn aiur_fn_198(
-  inp: [G; IN_198],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_198], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_198] = [__v_6];
-        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_198] = [__v_8];
-        record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_199: usize = 1;
-const IN_199: usize = 1;
-const OUT_199: usize = 1;
-fn aiur_fn_199(
-  inp: [G; IN_199],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_199], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_199] = [__v_5];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_199] = [__v_7];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_200: usize = 2;
-const IN_200: usize = 2;
-const OUT_200: usize = 1;
-fn aiur_fn_200(
-  inp: [G; IN_200],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_200], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    let __v_9: G = __loaded[7];
-    let __v_10: G = __loaded[8];
-    let __v_11: G = __loaded[9];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_200] = [__v_1];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_200] = [__v_14];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_201: usize = 1;
-const IN_201: usize = 1;
-const OUT_201: usize = 8;
-fn aiur_fn_201(
-  inp: [G; IN_201],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_201], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_4: G = G::from_u64(0);
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(0);
-        let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_201] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = __r_arr[1];
-        let __v_6: G = __r_arr[2];
-        let __v_7: G = __r_arr[3];
-        let __v_8: G = __r_arr[4];
-        let __v_9: G = __r_arr[5];
-        let __v_10: G = __r_arr[6];
-        let __v_11: G = __r_arr[7];
-        let __r_arr: [G; OUT_8] = { let __args: [G; IN_8] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[8].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_8] = unsafe { *(result.output.as_ptr() as *const [G; OUT_8]) }; __ret } else { aiur_fn_8(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __v_13: G = __r_arr[1];
-        let __v_14: G = __r_arr[2];
-        let __v_15: G = __r_arr[3];
-        let __v_16: G = __r_arr[4];
-        let __v_17: G = __r_arr[5];
-        let __v_18: G = __r_arr[6];
-        let __v_19: G = __r_arr[7];
-        let __ret: [G; OUT_201] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        let __ret: [G; OUT_201] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
         record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16219,34 +16447,27 @@ fn aiur_fn_202(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_202] = [__v_1];
-        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    match __v_3.as_canonical_u64() {
       0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_202] = [__v_7];
+        let __ret: [G; OUT_202] = [__v_4];
         record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_203: usize = 2;
-const IN_203: usize = 2;
+const INPUT_SIZE_203: usize = 1;
+const IN_203: usize = 1;
 const OUT_203: usize = 1;
 fn aiur_fn_203(
   inp: [G; IN_203],
@@ -16256,32 +16477,30 @@ fn aiur_fn_203(
 ) -> Result<[G; OUT_203], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
+    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
     match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_203] = [__v_6];
+        record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
       0u64 => {
-        let __ret: [G; OUT_203] = [__v_0];
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_6 + __v_7);
+        let __ret: [G; OUT_203] = [__v_8];
         record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_203] = [__v_7];
-            record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -16298,6 +16517,229 @@ fn aiur_fn_204(
 ) -> Result<[G; OUT_204], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_204] = [__v_5];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = (__v_5 + __v_6);
+        let __ret: [G; OUT_204] = [__v_7];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_205: usize = 2;
+const IN_205: usize = 2;
+const OUT_205: usize = 1;
+fn aiur_fn_205(
+  inp: [G; IN_205],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_205], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    let __v_9: G = __loaded[7];
+    let __v_10: G = __loaded[8];
+    let __v_11: G = __loaded[9];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_205] = [__v_1];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_12: G = G::from_u64(0);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_205] = [__v_14];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_206: usize = 1;
+const IN_206: usize = 1;
+const OUT_206: usize = 8;
+fn aiur_fn_206(
+  inp: [G; IN_206],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_206], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_4: G = G::from_u64(0);
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(0);
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = G::from_u64(0);
+        let __v_11: G = G::from_u64(0);
+        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = __r_arr[1];
+        let __v_6: G = __r_arr[2];
+        let __v_7: G = __r_arr[3];
+        let __v_8: G = __r_arr[4];
+        let __v_9: G = __r_arr[5];
+        let __v_10: G = __r_arr[6];
+        let __v_11: G = __r_arr[7];
+        let __r_arr: [G; OUT_8] = { let __args: [G; IN_8] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[8].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_8] = unsafe { *(result.output.as_ptr() as *const [G; OUT_8]) }; __ret } else { aiur_fn_8(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __v_13: G = __r_arr[1];
+        let __v_14: G = __r_arr[2];
+        let __v_15: G = __r_arr[3];
+        let __v_16: G = __r_arr[4];
+        let __v_17: G = __r_arr[5];
+        let __v_18: G = __r_arr[6];
+        let __v_19: G = __r_arr[7];
+        let __ret: [G; OUT_206] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_207: usize = 2;
+const IN_207: usize = 2;
+const OUT_207: usize = 1;
+fn aiur_fn_207(
+  inp: [G; IN_207],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_207], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_207] = [__v_1];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_207] = [__v_7];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_208: usize = 2;
+const IN_208: usize = 2;
+const OUT_208: usize = 1;
+fn aiur_fn_208(
+  inp: [G; IN_208],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_208], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_208] = [__v_0];
+        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_208] = [__v_7];
+            record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_209: usize = 1;
+const IN_209: usize = 1;
+const OUT_209: usize = 1;
+fn aiur_fn_209(
+  inp: [G; IN_209],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_209], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -16309,17 +16751,17 @@ fn aiur_fn_204(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_204] = [__v_8];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_209] = [__v_8];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
         let __v_9: G = G::from_u64(1);
         let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_204] = [__v_10];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_209] = [__v_10];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16329,15 +16771,15 @@ fn aiur_fn_204(
   })
 }
 
-const INPUT_SIZE_205: usize = 1;
-const IN_205: usize = 1;
-const OUT_205: usize = 1;
-fn aiur_fn_205(
-  inp: [G; IN_205],
+const INPUT_SIZE_210: usize = 1;
+const IN_210: usize = 1;
+const OUT_210: usize = 1;
+fn aiur_fn_210(
+  inp: [G; IN_210],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_205], ExecError> {
+) -> Result<[G; OUT_210], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -16354,17 +16796,17 @@ fn aiur_fn_205(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_205] = [__v_11];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_11];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_u64(1);
         let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_205] = [__v_13];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_13];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16374,19 +16816,19 @@ fn aiur_fn_205(
   })
 }
 
-const INPUT_SIZE_206: usize = 2;
-const IN_206: usize = 2;
-const OUT_206: usize = 4;
-fn aiur_fn_206(
-  inp: [G; IN_206],
+const INPUT_SIZE_211: usize = 2;
+const IN_211: usize = 2;
+const OUT_211: usize = 4;
+fn aiur_fn_211(
+  inp: [G; IN_211],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_206], ExecError> {
+) -> Result<[G; OUT_211], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16397,8 +16839,8 @@ fn aiur_fn_206(
     let __v_8: G = __loaded[5];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_211] = [__v_4, __v_5, __v_6, __v_7];
+        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16408,60 +16850,19 @@ fn aiur_fn_206(
   })
 }
 
-const INPUT_SIZE_207: usize = 1;
-const IN_207: usize = 1;
-const OUT_207: usize = 1;
-fn aiur_fn_207(
-  inp: [G; IN_207],
+const INPUT_SIZE_212: usize = 2;
+const IN_212: usize = 2;
+const OUT_212: usize = 32;
+fn aiur_fn_212(
+  inp: [G; IN_212],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_207], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    let __v_6: G = __loaded[5];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_207] = [__v_7];
-        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = G::from_u64(1);
-        let __v_9: G = (__v_7 + __v_8);
-        let __ret: [G; OUT_207] = [__v_9];
-        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_208: usize = 2;
-const IN_208: usize = 2;
-const OUT_208: usize = 32;
-fn aiur_fn_208(
-  inp: [G; IN_208],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_208], ExecError> {
+) -> Result<[G; OUT_212], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16500,8 +16901,8 @@ fn aiur_fn_208(
     let __v_36: G = __loaded[33];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_208] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
-        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_212] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
+        record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16511,28 +16912,28 @@ fn aiur_fn_208(
   })
 }
 
-const INPUT_SIZE_209: usize = 2;
-const IN_209: usize = 2;
-const OUT_209: usize = 1;
-fn aiur_fn_209(
-  inp: [G; IN_209],
+const INPUT_SIZE_213: usize = 2;
+const IN_213: usize = 2;
+const OUT_213: usize = 1;
+fn aiur_fn_213(
+  inp: [G; IN_213],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_209], ExecError> {
+) -> Result<[G; OUT_213], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_209] = [__v_0];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_213] = [__v_0];
+        record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -16541,8 +16942,8 @@ fn aiur_fn_209(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_209] = [__v_8];
-            record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_213] = [__v_8];
+            record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -16554,28 +16955,28 @@ fn aiur_fn_209(
   })
 }
 
-const INPUT_SIZE_210: usize = 2;
-const IN_210: usize = 2;
-const OUT_210: usize = 1;
-fn aiur_fn_210(
-  inp: [G; IN_210],
+const INPUT_SIZE_214: usize = 2;
+const IN_214: usize = 2;
+const OUT_214: usize = 1;
+fn aiur_fn_214(
+  inp: [G; IN_214],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_210], ExecError> {
+) -> Result<[G; OUT_214], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_210] = [__v_0];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_214] = [__v_0];
+        record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -16586,8 +16987,8 @@ fn aiur_fn_210(
         let __v_10: G = __loaded[5];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_210] = [__v_10];
-            record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_214] = [__v_10];
+            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -16599,28 +17000,28 @@ fn aiur_fn_210(
   })
 }
 
-const INPUT_SIZE_211: usize = 2;
-const IN_211: usize = 2;
-const OUT_211: usize = 1;
-fn aiur_fn_211(
-  inp: [G; IN_211],
+const INPUT_SIZE_215: usize = 2;
+const IN_215: usize = 2;
+const OUT_215: usize = 1;
+fn aiur_fn_215(
+  inp: [G; IN_215],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_211], ExecError> {
+) -> Result<[G; OUT_215], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_211] = [__v_0];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_215] = [__v_0];
+        record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -16659,8 +17060,8 @@ fn aiur_fn_211(
         let __v_38: G = __loaded[33];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_211] = [__v_38];
-            record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_215] = [__v_38];
+            record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -17737,6 +18138,26 @@ pub(crate) fn execute_generated(
     211u64 => {
       let __inp: [G; IN_211] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_211(__inp, record, io_buffer, false)?;
+      return Ok(__out.to_vec());
+    },
+    212u64 => {
+      let __inp: [G; IN_212] = args.try_into().expect("input size mismatch");
+      let __out = aiur_fn_212(__inp, record, io_buffer, false)?;
+      return Ok(__out.to_vec());
+    },
+    213u64 => {
+      let __inp: [G; IN_213] = args.try_into().expect("input size mismatch");
+      let __out = aiur_fn_213(__inp, record, io_buffer, false)?;
+      return Ok(__out.to_vec());
+    },
+    214u64 => {
+      let __inp: [G; IN_214] = args.try_into().expect("input size mismatch");
+      let __out = aiur_fn_214(__inp, record, io_buffer, false)?;
+      return Ok(__out.to_vec());
+    },
+    215u64 => {
+      let __inp: [G; IN_215] = args.try_into().expect("input size mismatch");
+      let __out = aiur_fn_215(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {


### PR DESCRIPTION
 # Aiur on constraint-IR multi-stark + in-circuit verifier port

  Adopts the multi-stark constraint restructure
  ([argumentcomputer/multi-stark#`multi-stark-overhaul`](https://github.com/argumentcomputer/multi-stark/tree/multi-stark-overhaul),
  rev `1c6ef62`), where circuits are **data** instead of `Air` trait impls:
  frontend `Expr` trees compile to a flat, hash-consed node graph
  (`graph::ConstraintGraph`) that the prover, verifier, and witness
  generator evaluate with a dense forward sweep. Three commits, each
  building and passing tests on its own:

  ## 1. `aiur: migrate to constraint-IR multi-stark`
  
  Aiur no longer defines AIRs — it builds `CircuitInputs` (Expr
  constraints + lookups) directly.

  - **constraints.rs**: `SymbolicExpression` → `multi_stark::expr::Expr`;
    the `Constraints` `Air`/`BaseAir` impls are deleted; the per-selector
    boolean constraints formerly emitted in `eval` are materialized into
    the constraint vector; degree-tracking auxiliary-column allocation is
    kept.
  - **synthesis.rs**: `System<SC, AiurCircuit>` → `System<SC>`; the
    `AiurCircuit` AIR enum is gone; each circuit becomes a
    `CircuitInputs`. Prove/verify logic unchanged.
  - **memory.rs / gadgets**: lookups over `Expr` (pull = negated
    multiplicity); memory transition rules re-expressed as explicit
    constraints via `IsTransition` / next-row columns.
  - **vk_codec.rs**: vk wire format v3 — serializes the compiled node
    graph (tagged node stream, constraint roots, layout widths) instead
    of the symbolic AIR. Node degrees are derived on decode, not stored.
  - Adds a Rust end-to-end prove/verify test exercising an auxiliary
    column and the function-channel lookup: honest proof verifies,
    tampered claim rejected.

  ## 2. `aiur: broaden e2e prove/verify test to call + memory`

  Extends the e2e test to cover function calls and store/load, so the
  function and memory lookup channels are exercised through real proofs.
  
  ## 3. `MultiStark: port in-circuit recursive verifier to constraint-IR`

  The Aiur-DSL recursive STARK verifier now consumes vk v3.

  - **SystemDeserialize.lean**: parses the per-circuit header + tagged
    node stream + constraint roots. The symbolic reader
    (`SymExpr`/`SysAir`/`SysLookupAir`) is deleted — lookup constraints
    arrive pre-compiled into the roots.
  - **Verifier.lean**: the symbolic-tree interpreter + `LookupAir` replay
    is replaced by a forward node sweep mirroring the Rust evaluator:
    one value buffer slot per node, leaves read from the opened rows /
    lookup publics / Lagrange selector evals, roots Horner-folded with α.
    Stage-2 openings are consumed as base columns directly (no
    `from_ext_basis` except for the quotient). Quotient recombination
    unchanged.
  - `crates/ixvm-codegen/src/aiur_multi_stark.rs` regenerated
    (`lake exe ix codegen`).

  ## Testing

  - `cargo test -p aiur --release`: 5/5 e2e prove/verify programs;
    workspace `check`/`clippy`/`fmt` clean.
  - `lake test -- --ignored multi-stark`: non-native Goldilocks /
    ExtGoldilocks arithmetic + reduced-opening fold vs reference, 12/12.
  - `lake test -- --ignored recursive-verifier`: honest proof accepted
    (vk digest + OOD + FRI), codegen'd verifier matches the interpreter,
    tampered proof advice and tampered claim both rejected, 6/6.
  - `lake test -- --ignored aiur`: execute/interpret/claim/prove/verify
    across the test programs.
