### PR TITLE
multi-stark: reduce the query index per batch for the preprocessed MMCS

### DIFF
--- a/Benchmarks/RecursionDebug.lean
+++ b/Benchmarks/RecursionDebug.lean
@@ -1,0 +1,207 @@
+import Ix.IxVM
+import Ix.IxVM.ClaimHarness
+import Ix.Aiur.Protocol
+import Ix.Aiur.Compiler
+import Ix.Aiur.Interpret
+import Ix.Aiur.Statistics
+import Ix.MultiStark
+import Ix.Cli.NameResolve
+
+/-!
+# Recursive-verifier debugging harness
+
+Proves the IxVM typecheck of a single constant (same recipe as
+`bench-typecheck --recursive`'s inner prove), SAVES the proof/vk/claims blobs
+to disk, and re-runs the in-circuit recursive verifier
+(`verify_multi_stark_proof`) from the saved blobs — so an expensive prove
+(e.g. `Array.extract_append`) runs once and the recursive-verification step
+can be replayed cheaply under different execution backends:
+
+```
+lake exe bench-recursion-debug --ixe init.ixe --const Nat.add_comm
+lake exe bench-recursion-debug --ixe init.ixe --const Array.extract_append --mode interp
+
+  --ixe <path>     serialized `Ixon.Env` (default: init.ixe)
+  --const <name>   fully-qualified constant to typecheck-prove (required)
+  --dir <path>     blob directory (default: recursion-debug); blobs are
+                   `<dir>/<const>.{proof,vk,claims}.bin` — if all three exist
+                   the prove is skipped and blobs are loaded instead
+  --reprove        force a fresh prove even when blobs exist
+  --skip-deps      subject-only check (`verify_const`) instead of the
+                   full-closure `verify_claim` default
+  --queries N      FRI numQueries (default 100 — matches bench-typecheck
+                   --recursive); must match between prove and replay!
+  --mode M         how to run the recursive verifier over the saved proof:
+                     native    codegen'd Rust verifier (default; the
+                               production path bench-typecheck uses)
+                     bytecode  generic Rust Aiur bytecode interpreter
+                     interp    Lean debug interpreter — call-stack trace +
+                               pretty-printed values on failure (slow)
+  --depth N        interp: pointer-deref depth in the pp (default 2)
+  --stack N        interp: max call-stack frames shown (default 40)
+```
+-/
+
+open Lean (Name)
+
+def argNat (args : List String) (flag : String) (dflt : Nat) : Nat :=
+  match args.dropWhile (· != flag) with
+  | _ :: v :: _ => v.toNat?.getD dflt
+  | _ => dflt
+
+def argStr (args : List String) (flag : String) : Option String :=
+  match args.dropWhile (· != flag) with
+  | _ :: v :: _ => some v
+  | _ => none
+
+def commitParams : Aiur.CommitmentParameters := { logBlowup := 2, capHeight := 0 }
+
+def friParams (numQueries : Nat) : Aiur.FriParameters :=
+  { logFinalPolyLen := 0, maxLogArity := 1, numQueries,
+    commitProofOfWorkBits := 0, queryProofOfWorkBits := 20 }
+
+def secs (t0 t1 : Nat) : Float := (Float.ofNat (t1 - t0)) / 1e9
+
+/-- Prove `constName`'s typecheck and return `(proofBytes, vkBytes, claimBytes)`. -/
+def proveConst (ixePath constName : String) (skipDeps : Bool)
+    (fri : Aiur.FriParameters) : IO (Option (ByteArray × ByteArray × ByteArray)) := do
+  let .ok toplevel := IxVM.ixVM
+    | IO.eprintln "IxVM toplevel merge failed"; return none
+  let .ok compiled := toplevel.compile
+    | IO.eprintln "IxVM compile failed"; return none
+  let entrypoint := if skipDeps then `verify_const else `verify_claim
+  let some funIdx := compiled.getFuncIdx entrypoint
+    | IO.eprintln s!"{entrypoint} entrypoint missing"; return none
+  let aiurSystem := Aiur.AiurSystem.build compiled.bytecode commitParams fri
+  let ixonEnv ← match Ixon.deEnvAnon (← IO.FS.readBinFile ixePath) with
+    | .error e => IO.eprintln s!"deserialize {ixePath} failed: {e}"; return none
+    | .ok env => pure env
+  let some addr := Ix.Cli.NameResolve.resolveIxeAddr ixonEnv constName
+    | IO.eprintln s!"{constName} not found in {ixePath}"; return none
+  IO.println s!"proving {constName} ({if skipDeps then "subject-only" else "full closure"}, \
+    numQueries={fri.numQueries}) …"
+  (← IO.getStdout).flush
+  let t0 ← IO.monoNanosNow
+  let (claim, proof) ←
+    if skipDeps then
+      let witness := IxVM.ClaimHarness.buildVerifyConst ixonEnv addr
+      let (claim, proof, _) := aiurSystem.proveIxVM funIdx witness.input witness.inputIOBuffer
+      pure (claim, proof)
+    else do
+      let envHandle ← match Aiur.EnvHandle.fromIxe ixePath with
+        | .error e => IO.eprintln s!"EnvHandle.fromIxe: {e}"; return none
+        | .ok h => pure h
+      match aiurSystem.proveAddrWithEnv funIdx envHandle addr.hash with
+      | .error e => IO.eprintln s!"proveAddrWithEnv failed: {e}"; return none
+      | .ok (claimBytes, proof, _) =>
+        -- `verify_claim`'s public input is the 32-G blake3 digest of the
+        -- serialized `Ix.Claim` (same recipe as `ix verify` / bench-typecheck).
+        let digest := Address.blake3 claimBytes
+        pure (Aiur.buildClaim funIdx (digest.hash.data.map .ofUInt8) #[], proof)
+  let t1 ← IO.monoNanosNow
+  let proofBytes := proof.toBytes
+  IO.println s!"inner prove: {secs t0 t1} s, proof {proofBytes.size} bytes"
+  -- Sanity: the inner proof must verify out-of-circuit before we chase the
+  -- recursive verifier.
+  match aiurSystem.verify claim proof with
+  | .ok () => IO.println "inner proof verifies out-of-circuit: ok"
+  | .error e => IO.eprintln s!"⚠ inner proof FAILS out-of-circuit verify: {e}"
+  return some (proofBytes, aiurSystem.vkBytes, MultiStark.serializeClaims #[claim])
+
+def main (args : List String) : IO UInt32 := do
+  let ixePath := (argStr args "--ixe").getD "init.ixe"
+  let some constName := argStr args "--const"
+    | IO.eprintln "usage: bench-recursion-debug --const <name> [--ixe <path>] \
+        [--dir <path>] [--mode native|bytecode|interp] [--skip-deps] [--reprove]"
+      return 1
+  let dir := (argStr args "--dir").getD "recursion-debug"
+  let mode := (argStr args "--mode").getD "native"
+  let skipDeps := args.contains "--skip-deps"
+  let fri := friParams (argNat args "--queries" 100)
+  let depth := argNat args "--depth" 2
+  let stackLimit := argNat args "--stack" 40
+  IO.FS.createDirAll dir
+  let tag := if skipDeps then s!"{constName}.skipdeps" else constName
+  let tag := s!"{tag}.q{fri.numQueries}"
+  let proofPath : System.FilePath := s!"{dir}/{tag}.proof.bin"
+  let vkPath : System.FilePath := s!"{dir}/{tag}.vk.bin"
+  let claimsPath : System.FilePath := s!"{dir}/{tag}.claims.bin"
+  let allSaved := (← proofPath.pathExists) && (← vkPath.pathExists)
+    && (← claimsPath.pathExists)
+  let (proofBytes, vkBytes, claimBytes) ←
+    if allSaved && !args.contains "--reprove" then do
+      IO.println s!"loading saved blobs {dir}/{tag}.*.bin"
+      pure (← IO.FS.readBinFile proofPath, ← IO.FS.readBinFile vkPath,
+            ← IO.FS.readBinFile claimsPath)
+    else do
+      let some blobs ← proveConst ixePath constName skipDeps fri | return 1
+      let (p, v, c) := blobs
+      IO.FS.writeBinFile proofPath p
+      IO.FS.writeBinFile vkPath v
+      IO.FS.writeBinFile claimsPath c
+      IO.println s!"saved blobs to {dir}/{tag}.*.bin"
+      pure (p, v, c)
+  IO.println s!"proof {proofBytes.size} bytes, vk {vkBytes.size} bytes, \
+    claims {claimBytes.size} bytes"
+
+  -- ── the recursive verifier over the saved blobs ───────────────────────────
+  let .ok vTop := MultiStark.multiStark
+    | IO.eprintln "multi-stark verifier toplevel merge failed"; return 1
+  -- `--list-funcs`: dump the compiled verifier's funIdx → name table (for
+  -- decoding fun_idx stacks printed by the Rust bytecode interpreter).
+  if args.contains "--list-funcs" then
+    let .ok vCompiled := vTop.compile
+      | IO.eprintln "multi-stark verifier compile failed"; return 1
+    let entries := vCompiled.nameMap.toArray.qsort (·.2 < ·.2)
+    for (g, i) in entries do
+      IO.println s!"{i} {g}"
+    return 0
+  let pubInput := MultiStark.verifierPubInput vkBytes claimBytes
+  if mode == "interp" then
+    -- Lean debug interpreter: call-stack + pretty-printed values on failure.
+    let decls ← match vTop.mkDecls with
+      | .error e => IO.eprintln s!"mkDecls failed: {e}"; return 1
+      | .ok d => pure d
+    let gName := Aiur.Global.mk `verify_multi_stark_proof
+    let inputTypes ← match decls.getByKey gName with
+      | some (.function f) => pure (f.inputs.map (·.2))
+      | _ => IO.eprintln "verify_multi_stark_proof not in decls"; return 1
+    let inputs := Aiur.unflattenInputs decls pubInput inputTypes
+    let toGs := fun (b : ByteArray) => b.data.map Aiur.G.ofUInt8
+    let io := (((default : Aiur.IOBuffer).extend 0 #[Aiur.G.ofNat 0] (toGs proofBytes)).extend
+        1 #[Aiur.G.ofNat 0] (toGs vkBytes)).extend
+        2 #[Aiur.G.ofNat 0] (toGs claimBytes)
+    IO.println "running verify_multi_stark_proof under the Lean debug interpreter …"
+    (← IO.getStdout).flush
+    let t0 ← IO.monoNanosNow
+    match Aiur.runFunction decls gName inputs io with
+    | (.error e, s) =>
+      let t1 ← IO.monoNanosNow
+      IO.eprintln s!"REJECTED after {secs t0 t1} s:\n{e.ppDeref s.store depth stackLimit}"
+      return 1
+    | (.ok v, s) =>
+      let t1 ← IO.monoNanosNow
+      IO.println s!"ACCEPTED in {secs t0 t1} s: {Aiur.Value.ppDeref s.store depth v}"
+      return 0
+  else
+    let .ok vCompiled := vTop.compile
+      | IO.eprintln "multi-stark verifier compile failed"; return 1
+    let some vIdx := vCompiled.getFuncIdx `verify_multi_stark_proof
+      | IO.eprintln "verify_multi_stark_proof entrypoint missing"; return 1
+    let useBytecode := mode == "bytecode"
+    IO.println s!"executing verify_multi_stark_proof \
+      ({if useBytecode then "Rust bytecode interpreter" else "codegen'd native"}) …"
+    (← IO.getStdout).flush
+    let t0 ← IO.monoNanosNow
+    match vCompiled.bytecode.executeMultiStark vIdx pubInput proofBytes vkBytes
+        claimBytes useBytecode with
+    | .error e =>
+      let t1 ← IO.monoNanosNow
+      IO.eprintln s!"REJECTED after {secs t0 t1} s: {e}"
+      return 1
+    | .ok (out, qc) =>
+      let t1 ← IO.monoNanosNow
+      let stats := Aiur.computeStats vCompiled qc
+      IO.println s!"ACCEPTED in {secs t0 t1} s, output {out}, \
+        fft-cost {stats.totalFftCost}"
+      return 0

--- a/Ix/MultiStark/Pcs.lean
+++ b/Ix/MultiStark/Pcs.lean
@@ -820,8 +820,15 @@ def pcs := ⟦
         let BatchOpening.Mk(rows_p, proof_p) = list_lookup(input_proof, 3);
         -- one opened base row per preprocessed matrix (BatchOpenedValuesCountMismatch)
         assert_eq!(eq_zero(list_length(rows_p) - list_length(prep_round)), 1);
-        assert_eq!(mmcs_verify(prep_commit, rows_p,
-          heights_prep(log_degrees, log_blowup, prep_indices, num_circuits, 0), idxbits, proof_p, log_gmax), 1);
+        -- The preprocessed tree's max height is over the PREP circuits only, so
+        -- it can be SHORTER than the global max when the tallest circuits carry
+        -- no preprocessed matrix. Mirror Plonky3's per-batch index reduction
+        -- (`index >> (log_global_max - log_batch_max)` — dropping the low bits
+        -- of the LSB-first bit list) and verify against the batch's own height.
+        let prep_heights = heights_prep(log_degrees, log_blowup, prep_indices, num_circuits, 0);
+        let log_pmax = heights_max(prep_heights);
+        assert_eq!(mmcs_verify(prep_commit, rows_p, prep_heights,
+          list_drop(idxbits, log_gmax - log_pmax), proof_p, log_pmax), 1);
         open_prep(buckets, idxbits, log_gmax, log_blowup, 0, num_circuits, 0, log_degrees,
                   prep_indices, zeta, rows_p, prep_round, alpha),
     }
@@ -833,6 +840,19 @@ def pcs := ⟦
       0 => store(ListNode.Nil),
       _ => store(ListNode.Cons(to_field(list_lookup(log_degrees, i)) + log_blowup,
                                heights_all(log_degrees, log_blowup, rem - 1, i + 1))),
+    }
+  }
+  -- Max of a height list (0 when empty): Plonky3's
+  -- `batch_heights.iter().max().unwrap_or(0)` for the per-batch index reduction.
+  fn heights_max(hs: List‹G›) -> G {
+    match load(hs) {
+      ListNode.Nil => 0,
+      ListNode.Cons(h, rest) =>
+        let m = heights_max(rest);
+        match u32_less_than(m, h) {
+          0 => m,
+          _ => h,
+        },
     }
   }
   fn heights_prep(log_degrees: List‹U8›, log_blowup: G, prep_indices: List‹OptIdx›, rem: G, i: G) -> List‹G› {

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4341,7 +4341,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4499,10 +4499,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -7357,7 +7357,7 @@ fn aiur_fn_92(
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = { let __values: [G; 10] = [__v_28, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_21]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __ret: [G; OUT_92] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_30, __v_20, __v_23, __v_24, __v_26, __v_27];
     record.function_queries[92].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -10375,7 +10375,7 @@ fn aiur_fn_112(
     let __v_36: G = __r_arr[30];
     let __v_37: G = __r_arr[31];
     let __v_38: G = __r_arr[32];
-    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
     let __v_39: G = __r_arr[0];
     let __v_40: G = __r_arr[1];
     let __v_41: G = __r_arr[2];
@@ -10524,7 +10524,7 @@ fn aiur_fn_115(
     let __v_7: G = inp[7];
     let __v_8: G = G::from_u64(1);
     let __v_9: G = (__v_1 + __v_8);
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = G::from_u64(1);
     let __v_12: G = G::from_u64(1);
@@ -10575,7 +10575,7 @@ fn aiur_fn_116(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = G::from_u64(7);
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = G::from_u64(1);
     let __v_5: G = G::from_u64(1);
@@ -10760,9 +10760,9 @@ fn aiur_fn_119(
         let __v_21: G = __r_arr[7];
         let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __ret: [G; OUT_119] = [__v_24];
         record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
@@ -10915,7 +10915,7 @@ fn aiur_fn_123(
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
@@ -10960,12 +10960,12 @@ fn aiur_fn_124(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
         let __v_15: G = __r_arr[1];
         let __v_16: G = __r_arr[2];
@@ -11024,12 +11024,12 @@ fn aiur_fn_125(
         let __v_16: G = __loaded[9];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
             let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
             let __v_19: G = __r_arr[1];
-            let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
             let __v_21: G = __r_arr[1];
             let __v_22: G = __r_arr[2];
@@ -11096,7 +11096,7 @@ fn aiur_fn_126(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_1 - __v_4);
         let __v_7: G = (__v_5 + __v_6);
@@ -11374,7 +11374,7 @@ fn aiur_fn_131(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
     let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
@@ -11385,9 +11385,9 @@ fn aiur_fn_131(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
     let __v_17: G = __r_arr[1];
-    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
-    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
     let __v_19: G = __r_arr[0];
     let __v_20: G = (__v_18 - __v_19);
     let __v_21: G = G::from_bool((__v_20 == G::ZERO));
@@ -11425,12 +11425,12 @@ fn aiur_fn_132(
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
     let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __v_16: G = G::from_u64(0);
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_5, __v_6, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -11476,14 +11476,14 @@ fn aiur_fn_133(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_16, __v_17, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
@@ -11531,17 +11531,17 @@ fn aiur_fn_134(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_16, __v_19, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
         let __v_20: G = __r_arr[0];
@@ -11591,7 +11591,7 @@ fn aiur_fn_135(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         match __v_15.as_canonical_u64() {
@@ -11607,14 +11607,14 @@ fn aiur_fn_135(
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
             let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_19: G = __r_arr[0];
             let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_20, __v_21, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
             let __v_22: G = __r_arr[0];
@@ -11672,35 +11672,40 @@ fn aiur_fn_136(
       },
       1u64 => {
         let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
         match __v_16.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-            let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __v_18: G = G::from_u64(0);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_6, __v_10, __v_5, __v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
             let __v_19: G = __r_arr[0];
-            let __v_20: G = (__v_18 - __v_19);
-            let __v_21: G = G::from_bool((__v_20 == G::ZERO));
-            let __v_22: G = G::from_u64(1);
-            if (__v_21 != __v_22) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64() });
+            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __v_22: G = __r_arr[0];
+            let __v_23: G = (__v_21 - __v_22);
+            let __v_24: G = G::from_bool((__v_23 == G::ZERO));
+            let __v_25: G = G::from_u64(1);
+            if (__v_24 != __v_25) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
             }
-            let __v_23: G = G::from_u64(0);
-            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_6, __v_10, __v_5, __v_7, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-            let __v_24: G = __r_arr[0];
-            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_2, __v_16, __v_24, __v_8, __v_17, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
-            let __v_25: G = __r_arr[0];
-            let __v_26: G = G::from_u64(1);
-            if (__v_25 != __v_26) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64() });
+            let __v_26: G = (__v_9 - __v_20);
+            let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_8, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+            let __v_27: G = __r_arr[0];
+            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_2, __v_16, __v_19, __v_27, __v_17, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+            let __v_28: G = __r_arr[0];
+            let __v_29: G = G::from_u64(1);
+            if (__v_28 != __v_29) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_29.as_canonical_u64() });
             }
-            let __v_27: G = G::from_u64(0);
-            let __v_28: G = G::from_u64(0);
-            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_0, __v_8, __v_9, __v_10, __v_27, __v_7, __v_28, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-            let __v_29: G = __r_arr[0];
-            let __ret: [G; OUT_136] = [__v_29];
+            let __v_30: G = G::from_u64(0);
+            let __v_31: G = G::from_u64(0);
+            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_0, __v_8, __v_9, __v_10, __v_30, __v_7, __v_31, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+            let __v_32: G = __r_arr[0];
+            let __ret: [G; OUT_136] = [__v_32];
             record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
@@ -11738,7 +11743,7 @@ fn aiur_fn_137(
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_5 + __v_1);
         let __v_7: G = G::from_u64(1);
@@ -11756,8 +11761,8 @@ fn aiur_fn_137(
   })
 }
 
-const INPUT_SIZE_138: usize = 5;
-const IN_138: usize = 5;
+const INPUT_SIZE_138: usize = 1;
+const IN_138: usize = 1;
 const OUT_138: usize = 1;
 fn aiur_fn_138(
   inp: [G; IN_138],
@@ -11767,55 +11772,36 @@ fn aiur_fn_138(
 ) -> Result<[G; OUT_138], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_7];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_4: G = G::from_u64(0);
+        let __ret: [G; OUT_138] = [__v_4];
         record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
-      _ => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
+      0u64 => {
+        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = { let __a_val = __v_4.as_canonical_u64(); let __b_val = __v_2.as_canonical_u64(); let __a_u32 = u32::try_from(__a_val).ok().ok_or(ExecError::U32OutOfRange(__a_val))?; let __b_u32 = u32::try_from(__b_val).ok().ok_or(ExecError::U32OutOfRange(__b_val))?; let __result = G::from_bool(__a_u32 < __b_u32); if !unconstrained { let __x_bytes = __a_u32.to_le_bytes(); let __z_bytes = __b_u32.to_le_bytes(); let __c_u32 = __b_u32.wrapping_sub(__a_u32).wrapping_sub(1); let __y_bytes = __c_u32.to_le_bytes(); record.bytes2_queries.bump_range_check(&G::from_u8(__x_bytes[0]), &G::from_u8(__x_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__x_bytes[2]), &G::from_u8(__x_bytes[3])); record.bytes2_queries.bump_range_check(&G::from_u8(__y_bytes[0]), &G::from_u8(__y_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__y_bytes[2]), &G::from_u8(__y_bytes[3])); record.bytes2_queries.bump_range_check(&G::from_u8(__z_bytes[0]), &G::from_u8(__z_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__z_bytes[2]), &G::from_u8(__z_bytes[3])); } __result };
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __v_7: G = G::from_u64(1);
-            let __v_8: G = (__v_3 - __v_7);
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_4 + __v_9);
-            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-            let __v_11: G = __r_arr[0];
-            let __ret: [G; OUT_138] = [__v_11];
-            record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
-            let __v_8: G = __r_arr[0];
-            let __v_9: G = (__v_8 + __v_1);
-            let __v_10: G = G::from_u64(1);
-            let __v_11: G = (__v_3 - __v_10);
-            let __v_12: G = G::from_u64(1);
-            let __v_13: G = (__v_4 + __v_12);
-            let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-            let __v_14: G = __r_arr[0];
-            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_138] = [__v_15];
+            let __ret: [G; OUT_138] = [__v_4];
             record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+            let __ret: [G; OUT_138] = [__v_2];
+            record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
           },
         }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -11823,7 +11809,7 @@ fn aiur_fn_138(
 
 const INPUT_SIZE_139: usize = 5;
 const IN_139: usize = 5;
-const OUT_139: usize = 4;
+const OUT_139: usize = 1;
 fn aiur_fn_139(
   inp: [G; IN_139],
   record: &mut QueryRecord,
@@ -11836,30 +11822,95 @@ fn aiur_fn_139(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    match __v_0.as_canonical_u64() {
+    match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_139] = [__v_1, __v_2, __v_3, __v_4];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_139] = [__v_7];
         record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __ret: [G; OUT_139] = [__v_3, __v_4, __v_1, __v_2];
-        record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __v_7: G = G::from_u64(1);
+            let __v_8: G = (__v_3 - __v_7);
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_4 + __v_9);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __v_11: G = __r_arr[0];
+            let __ret: [G; OUT_139] = [__v_11];
+            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __v_7: G = G::from_u64(0);
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __v_9: G = (__v_8 + __v_1);
+            let __v_10: G = G::from_u64(1);
+            let __v_11: G = (__v_3 - __v_10);
+            let __v_12: G = G::from_u64(1);
+            let __v_13: G = (__v_4 + __v_12);
+            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+            let __v_14: G = __r_arr[0];
+            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_139] = [__v_15];
+            record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_140: usize = 4;
-const IN_140: usize = 4;
-const OUT_140: usize = 1;
+const INPUT_SIZE_140: usize = 5;
+const IN_140: usize = 5;
+const OUT_140: usize = 4;
 fn aiur_fn_140(
   inp: [G; IN_140],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_140], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_140] = [__v_1, __v_2, __v_3, __v_4];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __ret: [G; OUT_140] = [__v_3, __v_4, __v_1, __v_2];
+        record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_141: usize = 4;
+const IN_141: usize = 4;
+const OUT_141: usize = 1;
+fn aiur_fn_141(
+  inp: [G; IN_141],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_141], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11912,21 +11963,21 @@ fn aiur_fn_140(
     let __v_44: G = { let __values: [G; 10] = [__v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_43]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_45: G = { let __values: [G; 10] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_44]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_46: G = { let __values: [G; 10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_45]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_140] = [__v_46];
-    record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_141] = [__v_46];
+    record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_141: usize = 6;
-const IN_141: usize = 6;
-const OUT_141: usize = 3;
-fn aiur_fn_141(
-  inp: [G; IN_141],
+const INPUT_SIZE_142: usize = 6;
+const IN_142: usize = 6;
+const OUT_142: usize = 3;
+fn aiur_fn_142(
+  inp: [G; IN_142],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_141], ExecError> {
+) -> Result<[G; OUT_142], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11944,8 +11995,8 @@ fn aiur_fn_141(
     let __v_12: G = __loaded[6];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_141] = [__v_0, __v_1, __v_5];
-        record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
+        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -11956,7 +12007,7 @@ fn aiur_fn_141(
             match __v_14.as_canonical_u64() {
               1u64 => {
                 let __v_15: G = G::from_u64(1);
-                let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
                 let __v_16: G = __r_arr[0];
                 let __v_17: G = __r_arr[1];
                 let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_16, __v_17, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -11965,13 +12016,13 @@ fn aiur_fn_141(
                 let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 let __v_21: G = __r_arr[1];
-                let __ret: [G; OUT_141] = [__v_20, __v_21, __v_12];
-                record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_142] = [__v_20, __v_21, __v_12];
+                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
-                let __ret: [G; OUT_141] = [__v_0, __v_1, __v_5];
-                record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_142] = [__v_0, __v_1, __v_5];
+                record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -11985,15 +12036,15 @@ fn aiur_fn_141(
   })
 }
 
-const INPUT_SIZE_142: usize = 9;
-const IN_142: usize = 9;
-const OUT_142: usize = 2;
-fn aiur_fn_142(
-  inp: [G; IN_142],
+const INPUT_SIZE_143: usize = 9;
+const IN_143: usize = 9;
+const OUT_143: usize = 2;
+fn aiur_fn_143(
+  inp: [G; IN_143],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_142], ExecError> {
+) -> Result<[G; OUT_143], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12018,14 +12069,14 @@ fn aiur_fn_142(
         if (__v_15 != __v_16) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_15.as_canonical_u64(), rhs: __v_16.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64() });
         }
-        let __ret: [G; OUT_142] = [__v_0, __v_1];
-        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_143] = [__v_0, __v_1];
+        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12053,10 +12104,10 @@ fn aiur_fn_142(
                         let __v_24: G = G::from_u64(1);
                         let __v_25: G = (__v_6 - __v_24);
                         let __v_26: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_11, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
                         let __v_27: G = __r_arr[0];
                         let __v_28: G = __r_arr[1];
-                        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_22, __v_0, __v_1, __v_27, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
                         let __v_29: G = __r_arr[0];
                         let __v_30: G = __r_arr[1];
                         let __v_31: G = __r_arr[2];
@@ -12064,18 +12115,18 @@ fn aiur_fn_142(
                         let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_23, __v_25, __v_15, __v_16, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                         let __v_33: G = __r_arr[0];
                         let __v_34: G = __r_arr[1];
-                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_33, __v_34, __v_25, __v_15, __v_16, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = __r_arr[1];
                         let __v_37: G = __r_arr[2];
-                        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
                         let __v_39: G = G::from_u64(1);
                         if (__v_38 != __v_39) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_38.as_canonical_u64(), rhs: __v_39.as_canonical_u64() });
                         }
                         let __v_40: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                         let __v_41: G = __r_arr[0];
                         let __v_42: G = G::from_u64(1);
                         let __v_43: G = G::from_u64(1);
@@ -12092,11 +12143,11 @@ fn aiur_fn_142(
                         if (__v_51 != __v_52) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_51.as_canonical_u64(), rhs: __v_52.as_canonical_u64() });
                         }
-                        let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_35, __v_36, __v_17, __v_20, __v_13, __v_23, __v_25, __v_37, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
                         let __v_53: G = __r_arr[0];
                         let __v_54: G = __r_arr[1];
-                        let __ret: [G; OUT_142] = [__v_53, __v_54];
-                        record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                        let __ret: [G; OUT_143] = [__v_53, __v_54];
+                        record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                         return Ok(__ret);
                       },
                       _ => {
@@ -12118,200 +12169,6 @@ fn aiur_fn_142(
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_143: usize = 25;
-const IN_143: usize = 25;
-const OUT_143: usize = 1;
-fn aiur_fn_143(
-  inp: [G; IN_143],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_143], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = inp[17];
-    let __v_18: G = inp[18];
-    let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
-    let __v_21: G = inp[21];
-    let __v_22: G = inp[22];
-    let __v_23: G = inp[23];
-    let __v_24: G = inp[24];
-    match __v_1.as_canonical_u64() {
-      _ => {
-        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
-        let __v_25: G = __r_arr[0];
-        let __v_26: G = G::from_u64(0);
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-        let __v_27: G = __r_arr[0];
-        let __v_28: G = __r_arr[1];
-        match __v_27.as_canonical_u64() {
-          _ => {
-            let __v_29: G = G::from_u64(0);
-            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-            let __v_30: G = __r_arr[0];
-            let __v_31: G = G::from_u64(1);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-            let __v_32: G = __r_arr[0];
-            let __v_33: G = __r_arr[1];
-            match __v_32.as_canonical_u64() {
-              _ => {
-                let __v_34: G = G::from_u64(0);
-                let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-                let __v_35: G = __r_arr[0];
-                let __v_36: G = G::from_u64(2);
-                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-                let __v_37: G = __r_arr[0];
-                let __v_38: G = __r_arr[1];
-                match __v_37.as_canonical_u64() {
-                  _ => {
-                    let __v_39: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-                    let __v_40: G = __r_arr[0];
-                    let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-                    let __v_41: G = __r_arr[0];
-                    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
-                    let __v_42: G = __r_arr[0];
-                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-                    let __v_43: G = __loaded[0];
-                    let __v_44: G = __loaded[1];
-                    let __v_45: G = __loaded[2];
-                    let __v_46: G = __loaded[3];
-                    let __v_47: G = __loaded[4];
-                    let __v_48: G = __loaded[5];
-                    let __v_49: G = __loaded[6];
-                    match __v_43.as_canonical_u64() {
-                      0u64 => {
-                        match __v_44.as_canonical_u64() {
-                          _ => {
-                            let __r_arr: [G; OUT_142] = { let __args: [G; IN_142] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[142].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_142] = unsafe { *(result.output.as_ptr() as *const [G; OUT_142]) }; __ret } else { aiur_fn_142(__args, record, io_buffer, __cu)? } };
-                            let __v_50: G = __r_arr[0];
-                            let __v_51: G = __r_arr[1];
-                            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-                            let __v_52: G = __r_arr[0];
-                            let __v_53: G = (__v_52 - __v_24);
-                            let __v_54: G = G::from_bool((__v_53 == G::ZERO));
-                            let __v_55: G = G::from_u64(1);
-                            if (__v_54 != __v_55) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-                            let __v_56: G = __r_arr[0];
-                            let __v_57: G = G::from_u64(3);
-                            let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-                            let __v_58: G = __r_arr[0];
-                            let __v_59: G = (__v_57 + __v_58);
-                            let __v_60: G = (__v_56 - __v_59);
-                            let __v_61: G = G::from_bool((__v_60 == G::ZERO));
-                            let __v_62: G = G::from_u64(1);
-                            if (__v_61 != __v_62) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                            let __v_63: G = __r_arr[0];
-                            let __v_64: G = (__v_63 - __v_18);
-                            let __v_65: G = G::from_bool((__v_64 == G::ZERO));
-                            let __v_66: G = G::from_u64(1);
-                            if (__v_65 != __v_66) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
-                            }
-                            let __v_67: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-                            let __v_68: G = __r_arr[0];
-                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
-                            let __v_69: G = __r_arr[0];
-                            let __v_70: G = G::from_u64(1);
-                            if (__v_69 != __v_70) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                            let __v_71: G = __r_arr[0];
-                            let __v_72: G = (__v_71 - __v_18);
-                            let __v_73: G = G::from_bool((__v_72 == G::ZERO));
-                            let __v_74: G = G::from_u64(1);
-                            if (__v_73 != __v_74) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
-                            }
-                            let __v_75: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-                            let __v_76: G = __r_arr[0];
-                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
-                            let __v_77: G = __r_arr[0];
-                            let __v_78: G = G::from_u64(1);
-                            if (__v_77 != __v_78) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
-                            }
-                            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                            let __v_79: G = __r_arr[0];
-                            let __v_80: G = (__v_79 - __v_18);
-                            let __v_81: G = G::from_bool((__v_80 == G::ZERO));
-                            let __v_82: G = G::from_u64(1);
-                            if (__v_81 != __v_82) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
-                            }
-                            let __v_83: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-                            let __v_84: G = __r_arr[0];
-                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
-                            let __v_85: G = __r_arr[0];
-                            let __v_86: G = G::from_u64(1);
-                            if (__v_85 != __v_86) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64() });
-                            }
-                            let __v_87: G = (__v_44 - __v_20);
-                            let __v_88: G = G::from_bool((__v_87 == G::ZERO));
-                            let __v_89: G = G::from_u64(1);
-                            if (__v_88 != __v_89) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
-                            }
-                            let __v_90: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
-                            let __v_91: G = __r_arr[0];
-                            let __v_92: G = __r_arr[1];
-                            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
-                            let __v_93: G = __r_arr[0];
-                            let __v_94: G = G::from_u64(1);
-                            if (__v_93 != __v_94) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
-                            }
-                            let __v_95: G = G::from_u64(1);
-                            let __ret: [G; OUT_143] = [__v_95];
-                            record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                            return Ok(__ret);
-                          },
-                        }
-                      },
-                      _ => {
-                        return Err(ExecError::MatchNoCase(__v_43.as_canonical_u64()));
-                      },
-                    }
-                  },
-                }
-              },
-            }
-          },
-        }
       },
     }
   })
@@ -12352,6 +12209,200 @@ fn aiur_fn_144(
     let __v_22: G = inp[22];
     let __v_23: G = inp[23];
     let __v_24: G = inp[24];
+    match __v_1.as_canonical_u64() {
+      _ => {
+        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __v_26: G = G::from_u64(0);
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __v_27: G = __r_arr[0];
+        let __v_28: G = __r_arr[1];
+        match __v_27.as_canonical_u64() {
+          _ => {
+            let __v_29: G = G::from_u64(0);
+            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_25, __v_0, __v_20, __v_19, __v_29, __v_18, __v_15, __v_16, __v_17, __v_27, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+            let __v_30: G = __r_arr[0];
+            let __v_31: G = G::from_u64(1);
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+            let __v_32: G = __r_arr[0];
+            let __v_33: G = __r_arr[1];
+            match __v_32.as_canonical_u64() {
+              _ => {
+                let __v_34: G = G::from_u64(0);
+                let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_30, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_32, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+                let __v_35: G = __r_arr[0];
+                let __v_36: G = G::from_u64(2);
+                let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                let __v_37: G = __r_arr[0];
+                let __v_38: G = __r_arr[1];
+                match __v_37.as_canonical_u64() {
+                  _ => {
+                    let __v_39: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_35, __v_0, __v_20, __v_19, __v_39, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+                    let __v_40: G = __r_arr[0];
+                    let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_40, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+                    let __v_41: G = __r_arr[0];
+                    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_41, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+                    let __v_42: G = __r_arr[0];
+                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_41.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+                    let __v_43: G = __loaded[0];
+                    let __v_44: G = __loaded[1];
+                    let __v_45: G = __loaded[2];
+                    let __v_46: G = __loaded[3];
+                    let __v_47: G = __loaded[4];
+                    let __v_48: G = __loaded[5];
+                    let __v_49: G = __loaded[6];
+                    match __v_43.as_canonical_u64() {
+                      0u64 => {
+                        match __v_44.as_canonical_u64() {
+                          _ => {
+                            let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_47, __v_48, __v_21, __v_22, __v_2, __v_0, __v_20, __v_49, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                            let __v_50: G = __r_arr[0];
+                            let __v_51: G = __r_arr[1];
+                            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+                            let __v_52: G = __r_arr[0];
+                            let __v_53: G = (__v_52 - __v_24);
+                            let __v_54: G = G::from_bool((__v_53 == G::ZERO));
+                            let __v_55: G = G::from_u64(1);
+                            if (__v_54 != __v_55) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+                            let __v_56: G = __r_arr[0];
+                            let __v_57: G = G::from_u64(3);
+                            let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                            let __v_58: G = __r_arr[0];
+                            let __v_59: G = (__v_57 + __v_58);
+                            let __v_60: G = (__v_56 - __v_59);
+                            let __v_61: G = G::from_bool((__v_60 == G::ZERO));
+                            let __v_62: G = G::from_u64(1);
+                            if (__v_61 != __v_62) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_61.as_canonical_u64(), rhs: __v_62.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __v_63: G = __r_arr[0];
+                            let __v_64: G = (__v_63 - __v_18);
+                            let __v_65: G = G::from_bool((__v_64 == G::ZERO));
+                            let __v_66: G = G::from_u64(1);
+                            if (__v_65 != __v_66) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_65.as_canonical_u64(), rhs: __v_66.as_canonical_u64() });
+                            }
+                            let __v_67: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                            let __v_68: G = __r_arr[0];
+                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_10, __v_27, __v_68, __v_0, __v_28, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                            let __v_69: G = __r_arr[0];
+                            let __v_70: G = G::from_u64(1);
+                            if (__v_69 != __v_70) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_69.as_canonical_u64(), rhs: __v_70.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __v_71: G = __r_arr[0];
+                            let __v_72: G = (__v_71 - __v_18);
+                            let __v_73: G = G::from_bool((__v_72 == G::ZERO));
+                            let __v_74: G = G::from_u64(1);
+                            if (__v_73 != __v_74) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_73.as_canonical_u64(), rhs: __v_74.as_canonical_u64() });
+                            }
+                            let __v_75: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                            let __v_76: G = __r_arr[0];
+                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_11, __v_32, __v_76, __v_0, __v_33, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                            let __v_77: G = __r_arr[0];
+                            let __v_78: G = G::from_u64(1);
+                            if (__v_77 != __v_78) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_77.as_canonical_u64(), rhs: __v_78.as_canonical_u64() });
+                            }
+                            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                            let __v_79: G = __r_arr[0];
+                            let __v_80: G = (__v_79 - __v_18);
+                            let __v_81: G = G::from_bool((__v_80 == G::ZERO));
+                            let __v_82: G = G::from_u64(1);
+                            if (__v_81 != __v_82) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_81.as_canonical_u64(), rhs: __v_82.as_canonical_u64() });
+                            }
+                            let __v_83: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_15, __v_19, __v_18, __v_83]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+                            let __v_84: G = __r_arr[0];
+                            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_12, __v_37, __v_84, __v_0, __v_38, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                            let __v_85: G = __r_arr[0];
+                            let __v_86: G = G::from_u64(1);
+                            if (__v_85 != __v_86) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64() });
+                            }
+                            let __v_87: G = (__v_44 - __v_20);
+                            let __v_88: G = G::from_bool((__v_87 == G::ZERO));
+                            let __v_89: G = G::from_u64(1);
+                            if (__v_88 != __v_89) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_88.as_canonical_u64(), rhs: __v_89.as_canonical_u64() });
+                            }
+                            let __v_90: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+                            let __v_91: G = __r_arr[0];
+                            let __v_92: G = __r_arr[1];
+                            let __r_arr: [G; OUT_23] = { let __args: [G; IN_23] = [__v_91, __v_92, __v_50, __v_51]; let __cu = unconstrained; if let Some(result) = record.function_queries[23].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_23] = unsafe { *(result.output.as_ptr() as *const [G; OUT_23]) }; __ret } else { aiur_fn_23(__args, record, io_buffer, __cu)? } };
+                            let __v_93: G = __r_arr[0];
+                            let __v_94: G = G::from_u64(1);
+                            if (__v_93 != __v_94) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_93.as_canonical_u64(), rhs: __v_94.as_canonical_u64() });
+                            }
+                            let __v_95: G = G::from_u64(1);
+                            let __ret: [G; OUT_144] = [__v_95];
+                            record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                            return Ok(__ret);
+                          },
+                        }
+                      },
+                      _ => {
+                        return Err(ExecError::MatchNoCase(__v_43.as_canonical_u64()));
+                      },
+                    }
+                  },
+                }
+              },
+            }
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_145: usize = 25;
+const IN_145: usize = 25;
+const OUT_145: usize = 1;
+fn aiur_fn_145(
+  inp: [G; IN_145],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_145], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
+    let __v_18: G = inp[18];
+    let __v_19: G = inp[19];
+    let __v_20: G = inp[20];
+    let __v_21: G = inp[21];
+    let __v_22: G = inp[22];
+    let __v_23: G = inp[23];
+    let __v_24: G = inp[24];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_25: G = __loaded[0];
     let __v_26: G = __loaded[1];
@@ -12360,21 +12411,21 @@ fn aiur_fn_144(
     match __v_25.as_canonical_u64() {
       1u64 => {
         let __v_29: G = G::from_u64(1);
-        let __ret: [G; OUT_144] = [__v_29];
-        record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_145] = [__v_29];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = __r_arr[1];
         let __v_31: G = __r_arr[2];
-        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
-        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
         let __v_33: G = __r_arr[0];
-        let __ret: [G; OUT_144] = [__v_33];
-        record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_145] = [__v_33];
+        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -12384,15 +12435,15 @@ fn aiur_fn_144(
   })
 }
 
-const INPUT_SIZE_145: usize = 31;
-const IN_145: usize = 31;
-const OUT_145: usize = 1;
-fn aiur_fn_145(
-  inp: [G; IN_145],
+const INPUT_SIZE_146: usize = 31;
+const IN_146: usize = 31;
+const OUT_146: usize = 1;
+fn aiur_fn_146(
+  inp: [G; IN_146],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_145], ExecError> {
+) -> Result<[G; OUT_146], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12427,7 +12478,7 @@ fn aiur_fn_145(
     let __v_30: G = inp[30];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_31: G = __r_arr[0];
         let __v_32: G = G::from_u64(1);
         let __v_33: G = G::from_u64(1);
@@ -12440,12 +12491,12 @@ fn aiur_fn_145(
         let __v_37: G = __r_arr[0];
         let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_1, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = G::from_u64(1);
         let __v_41: G = G::from_u64(1);
         let __v_42: G = { let __values: [G; 3] = [__v_40, __v_41, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_39, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
         let __v_43: G = __r_arr[0];
         let __v_44: G = __r_arr[1];
         let __v_45: G = __r_arr[2];
@@ -12476,7 +12527,7 @@ fn aiur_fn_145(
         let __v_67: G = { let __values: [G; 3] = [__v_65, __v_66, __v_66]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
         let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_9, __v_67]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
         let __v_68: G = __r_arr[0];
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_64, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_69: G = __r_arr[0];
         let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_69, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_70: G = __r_arr[0];
@@ -12484,7 +12535,7 @@ fn aiur_fn_145(
         let __v_71: G = __r_arr[0];
         let __v_72: G = __r_arr[1];
         let __v_73: G = (__v_31 + __v_27);
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
         let __v_74: G = __r_arr[0];
         let __v_75: G = (__v_74 - __v_31);
         let __v_76: G = G::from_bool((__v_75 == G::ZERO));
@@ -12492,7 +12543,7 @@ fn aiur_fn_145(
         if (__v_76 != __v_77) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_78: G = __r_arr[0];
         let __v_79: G = (__v_78 - __v_28);
         let __v_80: G = G::from_bool((__v_79 == G::ZERO));
@@ -12500,45 +12551,24 @@ fn aiur_fn_145(
         if (__v_80 != __v_81) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_80.as_canonical_u64(), rhs: __v_81.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_82: G = __r_arr[0];
         let __v_83: G = G::from_u64(1);
         if (__v_82 != __v_83) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_82.as_canonical_u64(), rhs: __v_83.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_71, __v_72, __v_8, __v_61, __v_62, __v_1, __v_2, __v_3, __v_4, __v_5, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_73, __v_63, __v_6, __v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
         let __v_84: G = __r_arr[0];
-        let __ret: [G; OUT_145] = [__v_84];
-        record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_146] = [__v_84];
+        record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_146: usize = 2;
-const IN_146: usize = 2;
-const OUT_146: usize = 1;
-fn aiur_fn_146(
-  inp: [G; IN_146],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_146], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_bool((__v_0 == G::ZERO));
-    let __v_3: G = G::from_bool((__v_1 == G::ZERO));
-    let __v_4: G = (__v_2 * __v_3);
-    let __ret: [G; OUT_146] = [__v_4];
-    record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_147: usize = 1;
-const IN_147: usize = 1;
+const INPUT_SIZE_147: usize = 2;
+const IN_147: usize = 2;
 const OUT_147: usize = 1;
 fn aiur_fn_147(
   inp: [G; IN_147],
@@ -12546,6 +12576,27 @@ fn aiur_fn_147(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_147], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_bool((__v_0 == G::ZERO));
+    let __v_3: G = G::from_bool((__v_1 == G::ZERO));
+    let __v_4: G = (__v_2 * __v_3);
+    let __ret: [G; OUT_147] = [__v_4];
+    record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_148: usize = 1;
+const IN_148: usize = 1;
+const OUT_148: usize = 1;
+fn aiur_fn_148(
+  inp: [G; IN_148],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_148], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -12556,8 +12607,8 @@ fn aiur_fn_147(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_147] = [__v_5];
-        record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_148] = [__v_5];
+        record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -12568,17 +12619,17 @@ fn aiur_fn_147(
         let __v_8: G = __loaded[3];
         match __v_5.as_canonical_u64() {
           1u64 => {
-            let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_147] = [__v_9];
-            record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_148] = [__v_9];
+            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_147] = [__v_9];
-            record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_148] = [__v_9];
+            record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -12590,15 +12641,15 @@ fn aiur_fn_147(
   })
 }
 
-const INPUT_SIZE_148: usize = 9;
-const IN_148: usize = 9;
-const OUT_148: usize = 1;
-fn aiur_fn_148(
-  inp: [G; IN_148],
+const INPUT_SIZE_149: usize = 9;
+const IN_149: usize = 9;
+const OUT_149: usize = 1;
+fn aiur_fn_149(
+  inp: [G; IN_149],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_148], ExecError> {
+) -> Result<[G; OUT_149], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12625,21 +12676,21 @@ fn aiur_fn_148(
     let __v_22: G = { let __values: [G; 3] = [__v_11, __v_2, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_23: G = { let __values: [G; 3] = [__v_10, __v_1, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_24: G = { let __values: [G; 3] = [__v_9, __v_0, __v_23]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_148] = [__v_24];
-    record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_149] = [__v_24];
+    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_149: usize = 33;
-const IN_149: usize = 33;
-const OUT_149: usize = 1;
-fn aiur_fn_149(
-  inp: [G; IN_149],
+const INPUT_SIZE_150: usize = 33;
+const IN_150: usize = 33;
+const OUT_150: usize = 1;
+fn aiur_fn_150(
+  inp: [G; IN_150],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_149], ExecError> {
+) -> Result<[G; OUT_150], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12674,29 +12725,29 @@ fn aiur_fn_149(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __ret: [G; OUT_149] = [__v_36];
-    record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_150] = [__v_36];
+    record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_150: usize = 2;
-const IN_150: usize = 2;
-const OUT_150: usize = 1;
-fn aiur_fn_150(
-  inp: [G; IN_150],
+const INPUT_SIZE_151: usize = 2;
+const IN_151: usize = 2;
+const OUT_151: usize = 1;
+fn aiur_fn_151(
+  inp: [G; IN_151],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_150], ExecError> {
+) -> Result<[G; OUT_151], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12737,61 +12788,16 @@ fn aiur_fn_150(
     let __v_35: G = __loaded[33];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_150] = [__v_1];
-        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
-        let __v_36: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-        let __v_37: G = __r_arr[0];
-        let __ret: [G; OUT_150] = [__v_37];
-        record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_151: usize = 2;
-const IN_151: usize = 2;
-const OUT_151: usize = 1;
-fn aiur_fn_151(
-  inp: [G; IN_151],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_151], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
         let __ret: [G; OUT_151] = [__v_1];
         record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(0);
-        let __v_11: G = G::from_u64(0);
-        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_151] = [__v_13];
+        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_35, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+        let __v_36: G = __r_arr[0];
+        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+        let __v_37: G = __r_arr[0];
+        let __ret: [G; OUT_151] = [__v_37];
         record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -12804,7 +12810,7 @@ fn aiur_fn_151(
 
 const INPUT_SIZE_152: usize = 2;
 const IN_152: usize = 2;
-const OUT_152: usize = 3;
+const OUT_152: usize = 1;
 fn aiur_fn_152(
   inp: [G; IN_152],
   record: &mut QueryRecord,
@@ -12814,14 +12820,59 @@ fn aiur_fn_152(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_152] = [__v_1];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(0);
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = G::from_u64(0);
+        let __v_11: G = G::from_u64(0);
+        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __ret: [G; OUT_152] = [__v_13];
+        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_153: usize = 2;
+const IN_153: usize = 2;
+const OUT_153: usize = 3;
+fn aiur_fn_153(
+  inp: [G; IN_153],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_153], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_152] = [__v_3, __v_0, __v_4];
-        record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_153] = [__v_3, __v_0, __v_4];
+        record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -12874,8 +12925,8 @@ fn aiur_fn_152(
         let __v_47: G = __loaded[2];
         match __v_45.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_152] = [__v_46, __v_40, __v_47];
-            record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_153] = [__v_46, __v_40, __v_47];
+            record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -12887,56 +12938,6 @@ fn aiur_fn_152(
         return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
-  })
-}
-
-const INPUT_SIZE_153: usize = 2;
-const IN_153: usize = 2;
-const OUT_153: usize = 10;
-fn aiur_fn_153(
-  inp: [G; IN_153],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_153], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __v_3: G = __r_arr[1];
-    let __v_4: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __v_6: G = __r_arr[1];
-    let __v_7: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_8: G = __r_arr[0];
-    let __v_9: G = __r_arr[1];
-    let __v_10: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_11: G = __r_arr[0];
-    let __v_12: G = __r_arr[1];
-    let __v_13: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __v_15: G = __r_arr[1];
-    let __v_16: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_17: G = __r_arr[0];
-    let __v_18: G = __r_arr[1];
-    let __v_19: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_20: G = __r_arr[0];
-    let __v_21: G = __r_arr[1];
-    let __v_22: G = __r_arr[2];
-    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-    let __v_23: G = __r_arr[0];
-    let __v_24: G = __r_arr[1];
-    let __v_25: G = __r_arr[2];
-    let __ret: [G; OUT_153] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
-    record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
   })
 }
 
@@ -12956,44 +12957,43 @@ fn aiur_fn_154(
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
-    let __v_5: G = __r_arr[3];
-    let __v_6: G = __r_arr[4];
-    let __v_7: G = __r_arr[5];
-    let __v_8: G = __r_arr[6];
-    let __v_9: G = __r_arr[7];
-    let __v_10: G = __r_arr[8];
-    let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_11] = { let __args: [G; IN_11] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[11].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_11] = unsafe { *(result.output.as_ptr() as *const [G; OUT_11]) }; __ret } else { aiur_fn_11(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    match __v_12.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_154] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = __r_arr[1];
-        let __v_15: G = __r_arr[2];
-        let __v_16: G = __r_arr[3];
-        let __v_17: G = __r_arr[4];
-        let __v_18: G = __r_arr[5];
-        let __v_19: G = __r_arr[6];
-        let __v_20: G = __r_arr[7];
-        let __v_21: G = __r_arr[8];
-        let __v_22: G = __r_arr[9];
-        let __ret: [G; OUT_154] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
-        record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __v_6: G = __r_arr[1];
+    let __v_7: G = __r_arr[2];
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __v_9: G = __r_arr[1];
+    let __v_10: G = __r_arr[2];
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_11: G = __r_arr[0];
+    let __v_12: G = __r_arr[1];
+    let __v_13: G = __r_arr[2];
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __v_15: G = __r_arr[1];
+    let __v_16: G = __r_arr[2];
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_17: G = __r_arr[0];
+    let __v_18: G = __r_arr[1];
+    let __v_19: G = __r_arr[2];
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_20: G = __r_arr[0];
+    let __v_21: G = __r_arr[1];
+    let __v_22: G = __r_arr[2];
+    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __v_23: G = __r_arr[0];
+    let __v_24: G = __r_arr[1];
+    let __v_25: G = __r_arr[2];
+    let __ret: [G; OUT_154] = [__v_2, __v_5, __v_8, __v_11, __v_14, __v_17, __v_20, __v_23, __v_24, __v_25];
+    record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
 const INPUT_SIZE_155: usize = 2;
 const IN_155: usize = 2;
-const OUT_155: usize = 18;
+const OUT_155: usize = 10;
 fn aiur_fn_155(
   inp: [G; IN_155],
   record: &mut QueryRecord,
@@ -13014,7 +13014,58 @@ fn aiur_fn_155(
     let __v_9: G = __r_arr[7];
     let __v_10: G = __r_arr[8];
     let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_11] = { let __args: [G; IN_11] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[11].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_11] = unsafe { *(result.output.as_ptr() as *const [G; OUT_11]) }; __ret } else { aiur_fn_11(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    match __v_12.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = __r_arr[1];
+        let __v_15: G = __r_arr[2];
+        let __v_16: G = __r_arr[3];
+        let __v_17: G = __r_arr[4];
+        let __v_18: G = __r_arr[5];
+        let __v_19: G = __r_arr[6];
+        let __v_20: G = __r_arr[7];
+        let __v_21: G = __r_arr[8];
+        let __v_22: G = __r_arr[9];
+        let __ret: [G; OUT_155] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22];
+        record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_156: usize = 2;
+const IN_156: usize = 2;
+const OUT_156: usize = 18;
+fn aiur_fn_156(
+  inp: [G; IN_156],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_156], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __v_3: G = __r_arr[1];
+    let __v_4: G = __r_arr[2];
+    let __v_5: G = __r_arr[3];
+    let __v_6: G = __r_arr[4];
+    let __v_7: G = __r_arr[5];
+    let __v_8: G = __r_arr[6];
+    let __v_9: G = __r_arr[7];
+    let __v_10: G = __r_arr[8];
+    let __v_11: G = __r_arr[9];
+    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = __r_arr[1];
     let __v_14: G = __r_arr[2];
@@ -13025,21 +13076,21 @@ fn aiur_fn_155(
     let __v_19: G = __r_arr[7];
     let __v_20: G = __r_arr[8];
     let __v_21: G = __r_arr[9];
-    let __ret: [G; OUT_155] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
-    record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_156] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
+    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_156: usize = 8;
-const IN_156: usize = 8;
-const OUT_156: usize = 1;
-fn aiur_fn_156(
-  inp: [G; IN_156],
+const INPUT_SIZE_157: usize = 8;
+const IN_157: usize = 8;
+const OUT_157: usize = 1;
+fn aiur_fn_157(
+  inp: [G; IN_157],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_156], ExecError> {
+) -> Result<[G; OUT_157], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13124,37 +13175,37 @@ fn aiur_fn_156(
     let __v_72: G = G::from_u64(1);
     let __v_73: G = G::from_u64(1);
     let __v_74: G = { let __values: [G; 3] = [__v_72, __v_73, __v_73]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_76: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_48, __v_49, __v_50, __v_51, __v_52, __v_53, __v_54, __v_55, __v_76]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_77: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_77]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_78: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_80: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_82: G = __r_arr[0];
-    let __ret: [G; OUT_156] = [__v_82];
-    record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_157] = [__v_82];
+    record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_157: usize = 2;
-const IN_157: usize = 2;
-const OUT_157: usize = 1;
-fn aiur_fn_157(
-  inp: [G; IN_157],
+const INPUT_SIZE_158: usize = 2;
+const IN_158: usize = 2;
+const OUT_158: usize = 1;
+fn aiur_fn_158(
+  inp: [G; IN_158],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_157], ExecError> {
+) -> Result<[G; OUT_158], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13163,8 +13214,8 @@ fn aiur_fn_157(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_157] = [__v_4];
-        record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_158] = [__v_4];
+        record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13177,11 +13228,11 @@ fn aiur_fn_157(
             let __v_5: G = G::from_u64(0);
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_1 - __v_6);
-            let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_157] = [__v_9];
-            record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_158] = [__v_9];
+            record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -13193,20 +13244,20 @@ fn aiur_fn_157(
   })
 }
 
-const INPUT_SIZE_158: usize = 3;
-const IN_158: usize = 3;
-const OUT_158: usize = 3;
-fn aiur_fn_158(
-  inp: [G; IN_158],
+const INPUT_SIZE_159: usize = 3;
+const IN_159: usize = 3;
+const OUT_159: usize = 3;
+fn aiur_fn_159(
+  inp: [G; IN_159],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_158], ExecError> {
+) -> Result<[G; OUT_159], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __v_5: G = __r_arr[2];
@@ -13217,25 +13268,25 @@ fn aiur_fn_158(
     let __v_10: G = __r_arr[7];
     let __v_11: G = __r_arr[8];
     let __v_12: G = __r_arr[9];
-    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __ret: [G; OUT_158] = [__v_14, __v_11, __v_12];
-    record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_159] = [__v_14, __v_11, __v_12];
+    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_159: usize = 9;
-const IN_159: usize = 9;
-const OUT_159: usize = 1;
-fn aiur_fn_159(
-  inp: [G; IN_159],
+const INPUT_SIZE_160: usize = 9;
+const IN_160: usize = 9;
+const OUT_160: usize = 1;
+fn aiur_fn_160(
+  inp: [G; IN_160],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_159], ExecError> {
+) -> Result<[G; OUT_160], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13249,36 +13300,11 @@ fn aiur_fn_159(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __ret: [G; OUT_159] = [__v_13];
-    record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_160: usize = 2;
-const IN_160: usize = 2;
-const OUT_160: usize = 1;
-fn aiur_fn_160(
-  inp: [G; IN_160],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_160], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_u64(1);
-    let __v_3: G = G::from_u64(1);
-    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
-    let __v_6: G = __r_arr[0];
-    let __ret: [G; OUT_160] = [__v_6];
+    let __ret: [G; OUT_160] = [__v_13];
     record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
@@ -13296,36 +13322,16 @@ fn aiur_fn_161(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    let __v_9: G = __loaded[7];
-    let __v_10: G = __loaded[8];
-    let __v_11: G = __loaded[9];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_161] = [__v_1];
-        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_161] = [__v_13];
-        record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
+    let __v_2: G = G::from_u64(1);
+    let __v_3: G = G::from_u64(1);
+    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __v_6: G = __r_arr[0];
+    let __ret: [G; OUT_161] = [__v_6];
+    record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
@@ -13341,10 +13347,17 @@ fn aiur_fn_162(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    let __v_9: G = __loaded[7];
+    let __v_10: G = __loaded[8];
+    let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __ret: [G; OUT_162] = [__v_1];
@@ -13352,22 +13365,11 @@ fn aiur_fn_162(
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        let __v_7: G = __r_arr[2];
-        let __v_8: G = __r_arr[3];
-        let __v_9: G = __r_arr[4];
-        let __v_10: G = __r_arr[5];
-        let __v_11: G = __r_arr[6];
-        let __v_12: G = __r_arr[7];
-        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
-        let __v_14: G = __r_arr[0];
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __ret: [G; OUT_162] = [__v_15];
+        let __ret: [G; OUT_162] = [__v_13];
         record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -13390,7 +13392,56 @@ fn aiur_fn_163(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_163] = [__v_1];
+        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        let __v_7: G = __r_arr[2];
+        let __v_8: G = __r_arr[3];
+        let __v_9: G = __r_arr[4];
+        let __v_10: G = __r_arr[5];
+        let __v_11: G = __r_arr[6];
+        let __v_12: G = __r_arr[7];
+        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __v_14: G = __r_arr[0];
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __ret: [G; OUT_163] = [__v_15];
+        record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_164: usize = 2;
+const IN_164: usize = 2;
+const OUT_164: usize = 1;
+fn aiur_fn_164(
+  inp: [G; IN_164],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_164], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -13399,25 +13450,25 @@ fn aiur_fn_163(
     let __v_7: G = __r_arr[5];
     let __v_8: G = __r_arr[6];
     let __v_9: G = __r_arr[7];
-    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
-    let __ret: [G; OUT_163] = [__v_11];
-    record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_164] = [__v_11];
+    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_164: usize = 1;
-const IN_164: usize = 1;
-const OUT_164: usize = 1;
-fn aiur_fn_164(
-  inp: [G; IN_164],
+const INPUT_SIZE_165: usize = 1;
+const IN_165: usize = 1;
+const OUT_165: usize = 1;
+fn aiur_fn_165(
+  inp: [G; IN_165],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_164], ExecError> {
+) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(0);
@@ -13462,21 +13513,21 @@ fn aiur_fn_164(
     let __v_40: G = { let __values: [G; 3] = [__v_5, __v_6, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_41: G = { let __values: [G; 3] = [__v_3, __v_4, __v_40]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_42: G = { let __values: [G; 3] = [__v_1, __v_2, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_164] = [__v_42];
-    record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_165] = [__v_42];
+    record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_165: usize = 2;
-const IN_165: usize = 2;
-const OUT_165: usize = 1;
-fn aiur_fn_165(
-  inp: [G; IN_165],
+const INPUT_SIZE_166: usize = 2;
+const IN_166: usize = 2;
+const OUT_166: usize = 1;
+fn aiur_fn_166(
+  inp: [G; IN_166],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_165], ExecError> {
+) -> Result<[G; OUT_166], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13485,13 +13536,13 @@ fn aiur_fn_165(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 34] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_165] = [__v_4];
-        record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_166] = [__v_4];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
-        let __ret: [G; OUT_165] = [__v_1];
-        record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_166] = [__v_1];
+        record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -13501,15 +13552,15 @@ fn aiur_fn_165(
   })
 }
 
-const INPUT_SIZE_166: usize = 9;
-const IN_166: usize = 9;
-const OUT_166: usize = 9;
-fn aiur_fn_166(
-  inp: [G; IN_166],
+const INPUT_SIZE_167: usize = 9;
+const IN_167: usize = 9;
+const OUT_167: usize = 9;
+fn aiur_fn_167(
+  inp: [G; IN_167],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_166], ExecError> {
+) -> Result<[G; OUT_167], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13523,24 +13574,24 @@ fn aiur_fn_166(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_7, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_6, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_3, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_2, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
-    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
     let __v_19: G = G::from_u64(1);
     let __v_20: G = G::from_u64(1);
     let __v_21: G = { let __values: [G; 3] = [__v_19, __v_20, __v_20]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_18, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
     let __v_24: G = __r_arr[2];
@@ -13559,14 +13610,14 @@ fn aiur_fn_166(
     let __v_37: G = __r_arr[15];
     let __v_38: G = __r_arr[16];
     let __v_39: G = __r_arr[17];
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_38, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_40, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = G::from_u64(1);
     let __v_43: G = G::from_u64(1);
     let __v_44: G = { let __values: [G; 3] = [__v_42, __v_43, __v_43]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_41, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
     let __v_46: G = __r_arr[1];
     let __v_47: G = __r_arr[2];
@@ -13585,23 +13636,23 @@ fn aiur_fn_166(
     let __v_60: G = __r_arr[15];
     let __v_61: G = __r_arr[16];
     let __v_62: G = __r_arr[17];
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_61, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_51, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_63: G = __r_arr[0];
-    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_63, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
     let __v_64: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_64, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_65: G = __r_arr[0];
     let __v_66: G = G::from_u64(1);
     let __v_67: G = G::from_u64(1);
     let __v_68: G = { let __values: [G; 3] = [__v_66, __v_67, __v_67]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_8, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_65, __v_69]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_70: G = __r_arr[0];
     let __v_71: G = G::from_u64(1);
     let __v_72: G = G::from_u64(1);
     let __v_73: G = { let __values: [G; 3] = [__v_71, __v_72, __v_72]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_70, __v_73]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_74: G = __r_arr[0];
     let __v_75: G = __r_arr[1];
     let __v_76: G = __r_arr[2];
@@ -13620,12 +13671,12 @@ fn aiur_fn_166(
     let __v_89: G = __r_arr[15];
     let __v_90: G = __r_arr[16];
     let __v_91: G = __r_arr[17];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_90, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_92: G = __r_arr[0];
     let __v_93: G = G::from_u64(1);
     let __v_94: G = G::from_u64(1);
     let __v_95: G = { let __values: [G; 3] = [__v_93, __v_94, __v_94]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_156] = { let __args: [G; IN_156] = [__v_92, __v_95]; let __cu = unconstrained; if let Some(result) = record.function_queries[156].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_156] = unsafe { *(result.output.as_ptr() as *const [G; OUT_156]) }; __ret } else { aiur_fn_156(__args, record, io_buffer, __cu)? } };
     let __v_96: G = __r_arr[0];
     let __v_97: G = __r_arr[1];
     let __v_98: G = __r_arr[2];
@@ -13660,51 +13711,15 @@ fn aiur_fn_166(
     let __v_120: G = __r_arr[0];
     let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_104, __v_105, __v_106, __v_107, __v_108, __v_109, __v_110, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
     let __v_121: G = __r_arr[0];
-    let __ret: [G; OUT_166] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
-    record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_167] = [__v_114, __v_115, __v_116, __v_117, __v_118, __v_119, __v_120, __v_121, __v_112];
+    record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_167: usize = 3;
-const IN_167: usize = 3;
-const OUT_167: usize = 2;
-fn aiur_fn_167(
-  inp: [G; IN_167],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_167], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_167] = [__v_0, __v_1];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __v_4: G = __r_arr[1];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_2 - __v_5);
-        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = __r_arr[1];
-        let __ret: [G; OUT_167] = [__v_7, __v_8];
-        record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_168: usize = 1;
-const IN_168: usize = 1;
-const OUT_168: usize = 1;
+const INPUT_SIZE_168: usize = 3;
+const IN_168: usize = 3;
+const OUT_168: usize = 2;
 fn aiur_fn_168(
   inp: [G; IN_168],
   record: &mut QueryRecord,
@@ -13713,202 +13728,24 @@ fn aiur_fn_168(
 ) -> Result<[G; OUT_168], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    match __v_2.as_canonical_u64() {
       0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(18446744069414584320);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(281474976710656);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(18446744069397807105);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(17293822564807737345);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(70368744161280);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(549755813888);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(17870292113338400769);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(13797081185216407910);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(1803076106186727246);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(11353340290879379826);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(455906449640507599);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(17492915097719143606);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(1532612707718625687);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16207902636198568418);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(17776499369601055404);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(6115771955107415310);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(12380578893860276750);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      18u64 => {
-        let __v_1: G = G::from_u64(9306717745644682924);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      19u64 => {
-        let __v_1: G = G::from_u64(18146160046829613826);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      20u64 => {
-        let __v_1: G = G::from_u64(3511170319078647661);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      21u64 => {
-        let __v_1: G = G::from_u64(17654865857378133588);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      22u64 => {
-        let __v_1: G = G::from_u64(5416168637041100469);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      23u64 => {
-        let __v_1: G = G::from_u64(16905767614792059275);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      24u64 => {
-        let __v_1: G = G::from_u64(9713644485405565297);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      25u64 => {
-        let __v_1: G = G::from_u64(5456943929260765144);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      26u64 => {
-        let __v_1: G = G::from_u64(17096174751763063430);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      27u64 => {
-        let __v_1: G = G::from_u64(1213594585890690845);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      28u64 => {
-        let __v_1: G = G::from_u64(6414415596519834757);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      29u64 => {
-        let __v_1: G = G::from_u64(16116352524544190054);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      30u64 => {
-        let __v_1: G = G::from_u64(9123114210336311365);
-        let __ret: [G; OUT_168] = [__v_1];
-        record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      31u64 => {
-        let __v_1: G = G::from_u64(4614640910117430873);
-        let __ret: [G; OUT_168] = [__v_1];
+        let __ret: [G; OUT_168] = [__v_0, __v_1];
         record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_1: G = G::from_u64(1753635133440165772);
-        let __ret: [G; OUT_168] = [__v_1];
+        let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = __r_arr[1];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_2 - __v_5);
+        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_3, __v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = __r_arr[1];
+        let __ret: [G; OUT_168] = [__v_7, __v_8];
         record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -13916,9 +13753,9 @@ fn aiur_fn_168(
   })
 }
 
-const INPUT_SIZE_169: usize = 3;
-const IN_169: usize = 3;
-const OUT_169: usize = 2;
+const INPUT_SIZE_169: usize = 1;
+const IN_169: usize = 1;
+const OUT_169: usize = 1;
 fn aiur_fn_169(
   inp: [G; IN_169],
   record: &mut QueryRecord,
@@ -13927,25 +13764,212 @@ fn aiur_fn_169(
 ) -> Result<[G; OUT_169], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = G::from_u64(0);
-    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __v_8: G = __r_arr[1];
-    let __ret: [G; OUT_169] = [__v_7, __v_8];
-    record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(18446744069414584320);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(281474976710656);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(18446744069397807105);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(17293822564807737345);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(70368744161280);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(549755813888);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(17870292113338400769);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(13797081185216407910);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(1803076106186727246);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(11353340290879379826);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(455906449640507599);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(17492915097719143606);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(1532612707718625687);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16207902636198568418);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(17776499369601055404);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(6115771955107415310);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(12380578893860276750);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      18u64 => {
+        let __v_1: G = G::from_u64(9306717745644682924);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      19u64 => {
+        let __v_1: G = G::from_u64(18146160046829613826);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      20u64 => {
+        let __v_1: G = G::from_u64(3511170319078647661);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      21u64 => {
+        let __v_1: G = G::from_u64(17654865857378133588);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      22u64 => {
+        let __v_1: G = G::from_u64(5416168637041100469);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      23u64 => {
+        let __v_1: G = G::from_u64(16905767614792059275);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      24u64 => {
+        let __v_1: G = G::from_u64(9713644485405565297);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      25u64 => {
+        let __v_1: G = G::from_u64(5456943929260765144);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      26u64 => {
+        let __v_1: G = G::from_u64(17096174751763063430);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      27u64 => {
+        let __v_1: G = G::from_u64(1213594585890690845);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      28u64 => {
+        let __v_1: G = G::from_u64(6414415596519834757);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      29u64 => {
+        let __v_1: G = G::from_u64(16116352524544190054);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      30u64 => {
+        let __v_1: G = G::from_u64(9123114210336311365);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      31u64 => {
+        let __v_1: G = G::from_u64(4614640910117430873);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(1753635133440165772);
+        let __ret: [G; OUT_169] = [__v_1];
+        record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
 const INPUT_SIZE_170: usize = 3;
 const IN_170: usize = 3;
-const OUT_170: usize = 8;
+const OUT_170: usize = 2;
 fn aiur_fn_170(
   inp: [G; IN_170],
   record: &mut QueryRecord,
@@ -13956,10 +13980,37 @@ fn aiur_fn_170(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = G::from_u64(0);
+    let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __v_8: G = __r_arr[1];
+    let __ret: [G; OUT_170] = [__v_7, __v_8];
+    record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_171: usize = 3;
+const IN_171: usize = 3;
+const OUT_171: usize = 8;
+fn aiur_fn_171(
+  inp: [G; IN_171],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_171], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_5: G = __r_arr[0];
     let __r_arr: [G; OUT_16] = { let __args: [G; IN_16] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[16].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_16] = unsafe { *(result.output.as_ptr() as *const [G; OUT_16]) }; __ret } else { aiur_fn_16(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
@@ -13985,21 +14036,21 @@ fn aiur_fn_170(
     let __r_arr: [G; OUT_21] = { let __args: [G; IN_21] = [__v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[21].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_21] = unsafe { *(result.output.as_ptr() as *const [G; OUT_21]) }; __ret } else { aiur_fn_21(__args, record, io_buffer, __cu)? } };
     let __v_21: G = __r_arr[0];
     let __v_22: G = __r_arr[1];
-    let __ret: [G; OUT_170] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
-    record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_171] = [__v_11, __v_12, __v_16, __v_17, __v_19, __v_20, __v_21, __v_22];
+    record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_171: usize = 23;
-const IN_171: usize = 23;
-const OUT_171: usize = 1;
-fn aiur_fn_171(
-  inp: [G; IN_171],
+const INPUT_SIZE_172: usize = 23;
+const IN_172: usize = 23;
+const OUT_172: usize = 1;
+fn aiur_fn_172(
+  inp: [G; IN_172],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_171], ExecError> {
+) -> Result<[G; OUT_172], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14026,52 +14077,52 @@ fn aiur_fn_171(
     let __v_22: G = inp[22];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = G::from_bool((__v_23 == G::ZERO));
         let __v_25: G = G::from_u64(0);
         if (__v_24 != __v_25) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         if (__v_26 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         if (__v_28 != __v_23) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_23.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         let __v_30: G = G::from_u64(1);
         if (__v_29 != __v_30) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_30.as_canonical_u64() });
         }
         let __v_31: G = G::from_u64(1);
-        let __ret: [G; OUT_171] = [__v_31];
-        record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_172] = [__v_31];
+        record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_172: usize = 6;
-const IN_172: usize = 6;
-const OUT_172: usize = 2;
-fn aiur_fn_172(
-  inp: [G; IN_172],
+const INPUT_SIZE_173: usize = 6;
+const IN_173: usize = 6;
+const OUT_173: usize = 2;
+fn aiur_fn_173(
+  inp: [G; IN_173],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_172], ExecError> {
+) -> Result<[G; OUT_173], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14085,21 +14136,21 @@ fn aiur_fn_172(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_6, __v_7, __v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_172] = [__v_8, __v_9];
-    record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_173] = [__v_8, __v_9];
+    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_173: usize = 4;
-const IN_173: usize = 4;
-const OUT_173: usize = 2;
-fn aiur_fn_173(
-  inp: [G; IN_173],
+const INPUT_SIZE_174: usize = 4;
+const IN_174: usize = 4;
+const OUT_174: usize = 2;
+fn aiur_fn_174(
+  inp: [G; IN_174],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_173], ExecError> {
+) -> Result<[G; OUT_174], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14113,21 +14164,21 @@ fn aiur_fn_173(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
-    let __ret: [G; OUT_173] = [__v_8, __v_9];
-    record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_174] = [__v_8, __v_9];
+    record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_174: usize = 1;
-const IN_174: usize = 1;
-const OUT_174: usize = 1;
-fn aiur_fn_174(
-  inp: [G; IN_174],
+const INPUT_SIZE_175: usize = 1;
+const IN_175: usize = 1;
+const OUT_175: usize = 1;
+fn aiur_fn_175(
+  inp: [G; IN_175],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_174], ExecError> {
+) -> Result<[G; OUT_175], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14140,8 +14191,8 @@ fn aiur_fn_174(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_174] = [__v_7];
-        record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_175] = [__v_7];
+        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14153,14 +14204,14 @@ fn aiur_fn_174(
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_9: G = G::from_u64(0);
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
             let __v_10: G = __r_arr[0];
             let __v_11: G = __r_arr[1];
-            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_174] = [__v_13];
-            record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_175] = [__v_13];
+            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -14175,15 +14226,15 @@ fn aiur_fn_174(
   })
 }
 
-const INPUT_SIZE_175: usize = 15;
-const IN_175: usize = 15;
-const OUT_175: usize = 2;
-fn aiur_fn_175(
-  inp: [G; IN_175],
+const INPUT_SIZE_176: usize = 15;
+const IN_176: usize = 15;
+const OUT_176: usize = 2;
+fn aiur_fn_176(
+  inp: [G; IN_176],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_175], ExecError> {
+) -> Result<[G; OUT_176], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14200,7 +14251,7 @@ fn aiur_fn_175(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __v_16: G = __r_arr[1];
     let __v_17: G = __r_arr[2];
@@ -14208,8 +14259,8 @@ fn aiur_fn_175(
     match __v_15.as_canonical_u64() {
       0u64 => {
         let __v_19: G = G::from_u64(0);
-        let __ret: [G; OUT_175] = [__v_16, __v_19];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_16, __v_19];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -14217,129 +14268,129 @@ fn aiur_fn_175(
         let __v_20: G = (__v_16 + __v_19);
         match __v_20.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_21, __v_22];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_21, __v_22];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           2u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_21, __v_22];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           3u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_21, __v_22];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           4u64 => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_21, __v_22];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_175] = [__v_21, __v_22];
-            record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_176] = [__v_21, __v_22];
+            record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
       },
       2u64 => {
-        let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_19, __v_20];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_19, __v_20];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       3u64 => {
-        let __ret: [G; OUT_175] = [__v_9, __v_10];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_9, __v_10];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       4u64 => {
-        let __ret: [G; OUT_175] = [__v_11, __v_12];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_11, __v_12];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       5u64 => {
-        let __ret: [G; OUT_175] = [__v_13, __v_14];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_13, __v_14];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       6u64 => {
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_23, __v_24];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_23, __v_24];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       7u64 => {
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_23, __v_24];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_23, __v_24];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       8u64 => {
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_19, __v_20, __v_21, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_23: G = __r_arr[0];
         let __v_24: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_23, __v_24];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_23, __v_24];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       9u64 => {
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
         let __r_arr: [G; OUT_19] = { let __args: [G; IN_19] = [__v_19, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[19].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_19] = unsafe { *(result.output.as_ptr() as *const [G; OUT_19]) }; __ret } else { aiur_fn_19(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
-        let __ret: [G; OUT_175] = [__v_21, __v_22];
-        record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_176] = [__v_21, __v_22];
+        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14349,15 +14400,15 @@ fn aiur_fn_175(
   })
 }
 
-const INPUT_SIZE_176: usize = 19;
-const IN_176: usize = 19;
-const OUT_176: usize = 2;
-fn aiur_fn_176(
-  inp: [G; IN_176],
+const INPUT_SIZE_177: usize = 19;
+const IN_177: usize = 19;
+const OUT_177: usize = 2;
+fn aiur_fn_177(
+  inp: [G; IN_177],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_176], ExecError> {
+) -> Result<[G; OUT_177], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14384,22 +14435,22 @@ fn aiur_fn_176(
     let __v_21: G = __loaded[2];
     match __v_19.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_176] = [__v_0, __v_1];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_177] = [__v_0, __v_1];
+        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
-        let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __v_25: G = __r_arr[1];
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
-        let __ret: [G; OUT_176] = [__v_26, __v_27];
-        record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_177] = [__v_26, __v_27];
+        record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14409,15 +14460,15 @@ fn aiur_fn_176(
   })
 }
 
-const INPUT_SIZE_177: usize = 8;
-const IN_177: usize = 8;
-const OUT_177: usize = 4;
-fn aiur_fn_177(
-  inp: [G; IN_177],
+const INPUT_SIZE_178: usize = 8;
+const IN_178: usize = 8;
+const OUT_178: usize = 4;
+fn aiur_fn_178(
+  inp: [G; IN_178],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_177], ExecError> {
+) -> Result<[G; OUT_178], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14450,21 +14501,21 @@ fn aiur_fn_177(
     let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_18, __v_19, __v_20, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
     let __v_22: G = __r_arr[0];
     let __v_23: G = __r_arr[1];
-    let __ret: [G; OUT_177] = [__v_16, __v_17, __v_22, __v_23];
-    record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_178] = [__v_16, __v_17, __v_22, __v_23];
+    record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_178: usize = 19;
-const IN_178: usize = 19;
-const OUT_178: usize = 4;
-fn aiur_fn_178(
-  inp: [G; IN_178],
+const INPUT_SIZE_179: usize = 19;
+const IN_179: usize = 19;
+const OUT_179: usize = 4;
+fn aiur_fn_179(
+  inp: [G; IN_179],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_178], ExecError> {
+) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14495,29 +14546,29 @@ fn aiur_fn_178(
         let __v_23: G = G::from_u64(0);
         let __v_24: G = G::from_u64(0);
         let __v_25: G = G::from_u64(0);
-        let __ret: [G; OUT_178] = [__v_22, __v_23, __v_24, __v_25];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_22, __v_23, __v_24, __v_25];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
         let __v_24: G = __r_arr[2];
         let __v_25: G = __r_arr[3];
-        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
         let __v_28: G = __r_arr[2];
         let __v_29: G = __r_arr[3];
-        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
         let __v_30: G = __r_arr[0];
         let __v_31: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_26, __v_27, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
         let __v_33: G = __r_arr[1];
-        let __ret: [G; OUT_178] = [__v_32, __v_33, __v_28, __v_29];
-        record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_179] = [__v_32, __v_33, __v_28, __v_29];
+        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14527,15 +14578,15 @@ fn aiur_fn_178(
   })
 }
 
-const INPUT_SIZE_179: usize = 32;
-const IN_179: usize = 32;
-const OUT_179: usize = 6;
-fn aiur_fn_179(
-  inp: [G; IN_179],
+const INPUT_SIZE_180: usize = 32;
+const IN_180: usize = 32;
+const OUT_180: usize = 6;
+fn aiur_fn_180(
+  inp: [G; IN_180],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_179], ExecError> {
+) -> Result<[G; OUT_180], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14576,8 +14627,8 @@ fn aiur_fn_179(
     let __v_35: G = __loaded[3];
     match __v_32.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_179] = [__v_0, __v_1, __v_6, __v_7, __v_8, __v_9];
-        record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_180] = [__v_0, __v_1, __v_6, __v_7, __v_8, __v_9];
+        record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14586,16 +14637,16 @@ fn aiur_fn_179(
             let __v_36: G = G::from_u64(2);
             let __v_37: G = (__v_5 + __v_5);
             let __v_38: G = (__v_36 + __v_37);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_23, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_39: G = __r_arr[0];
             let __v_40: G = __r_arr[1];
             let __v_41: G = G::from_u64(3);
             let __v_42: G = (__v_5 + __v_5);
             let __v_43: G = (__v_41 + __v_42);
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_23, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_23, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_44: G = __r_arr[0];
             let __v_45: G = __r_arr[1];
-            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_34, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_34, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
             let __v_46: G = __r_arr[0];
             let __v_47: G = __r_arr[1];
             let __v_48: G = __r_arr[2];
@@ -14606,7 +14657,7 @@ fn aiur_fn_179(
             let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_48, __v_49, __v_12, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
             let __v_52: G = __r_arr[0];
             let __v_53: G = __r_arr[1];
-            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_50, __v_51, __v_52, __v_53, __v_39, __v_40, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_178] = { let __args: [G; IN_178] = [__v_50, __v_51, __v_52, __v_53, __v_39, __v_40, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[178].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_178] = unsafe { *(result.output.as_ptr() as *const [G; OUT_178]) }; __ret } else { aiur_fn_178(__args, record, io_buffer, __cu)? } };
             let __v_54: G = __r_arr[0];
             let __v_55: G = __r_arr[1];
             let __v_56: G = __r_arr[2];
@@ -14616,13 +14667,13 @@ fn aiur_fn_179(
             let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_54, __v_55, __v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
             let __v_60: G = __r_arr[0];
             let __v_61: G = __r_arr[1];
-            let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_0, __v_1, __v_2, __v_3, __v_60, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2, __v_3, __v_60, __v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_62: G = __r_arr[0];
             let __v_63: G = __r_arr[1];
-            let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_62, __v_63, __v_2, __v_3, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_62, __v_63, __v_2, __v_3, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
             let __v_64: G = __r_arr[0];
             let __v_65: G = __r_arr[1];
-            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_18, __v_33, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_18, __v_33, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
             let __v_66: G = __r_arr[0];
             let __v_67: G = __r_arr[1];
             let __v_68: G = G::from_u64(1);
@@ -14639,15 +14690,15 @@ fn aiur_fn_179(
             let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_8, __v_9, __v_74, __v_75]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
             let __v_76: G = __r_arr[0];
             let __v_77: G = __r_arr[1];
-            let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_64, __v_65, __v_2, __v_3, __v_35, __v_69, __v_72, __v_73, __v_76, __v_77, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_64, __v_65, __v_2, __v_3, __v_35, __v_69, __v_72, __v_73, __v_76, __v_77, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
             let __v_78: G = __r_arr[0];
             let __v_79: G = __r_arr[1];
             let __v_80: G = __r_arr[2];
             let __v_81: G = __r_arr[3];
             let __v_82: G = __r_arr[4];
             let __v_83: G = __r_arr[5];
-            let __ret: [G; OUT_179] = [__v_78, __v_79, __v_80, __v_81, __v_82, __v_83];
-            record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_180] = [__v_78, __v_79, __v_80, __v_81, __v_82, __v_83];
+            record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -14659,15 +14710,15 @@ fn aiur_fn_179(
   })
 }
 
-const INPUT_SIZE_180: usize = 18;
-const IN_180: usize = 18;
-const OUT_180: usize = 2;
-fn aiur_fn_180(
-  inp: [G; IN_180],
+const INPUT_SIZE_181: usize = 18;
+const IN_181: usize = 18;
+const OUT_181: usize = 2;
+fn aiur_fn_181(
+  inp: [G; IN_181],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_180], ExecError> {
+) -> Result<[G; OUT_181], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14689,59 +14740,59 @@ fn aiur_fn_180(
     let __v_17: G = inp[17];
     let __v_18: G = G::from_u64(0);
     let __v_19: G = G::from_u64(0);
-    let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_18, __v_19, __v_16, __v_17, __v_1, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_18, __v_19, __v_16, __v_17, __v_1, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
     let __v_20: G = __r_arr[0];
     let __v_21: G = __r_arr[1];
     let __v_22: G = G::from_u64(0);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_23: G = __r_arr[0];
     let __v_24: G = __r_arr[1];
     let __v_25: G = G::from_u64(1);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_26: G = __r_arr[0];
     let __v_27: G = __r_arr[1];
     let __v_28: G = G::from_u64(2);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_29: G = __r_arr[0];
     let __v_30: G = __r_arr[1];
     let __v_31: G = G::from_u64(3);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_32: G = __r_arr[0];
     let __v_33: G = __r_arr[1];
     let __v_34: G = G::from_u64(4);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
     let __v_36: G = __r_arr[1];
     let __v_37: G = G::from_u64(5);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_38: G = __r_arr[0];
     let __v_39: G = __r_arr[1];
     let __v_40: G = G::from_u64(6);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = __r_arr[1];
     let __v_43: G = G::from_u64(7);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_9, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_9, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_44: G = __r_arr[0];
     let __v_45: G = __r_arr[1];
     let __v_46: G = G::from_u64(0);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_47: G = __r_arr[0];
     let __v_48: G = __r_arr[1];
     let __v_49: G = G::from_u64(1);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_7, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_7, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
     let __v_51: G = __r_arr[1];
     let __v_52: G = G::from_u64(0);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_53: G = __r_arr[0];
     let __v_54: G = __r_arr[1];
     let __v_55: G = G::from_u64(1);
-    let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_8, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_8, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
     let __v_56: G = __r_arr[0];
     let __v_57: G = __r_arr[1];
     let __v_58: G = G::from_u64(0);
-    let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_20, __v_21, __v_16, __v_17, __v_2, __v_58, __v_47, __v_48, __v_50, __v_51, __v_23, __v_24, __v_26, __v_27, __v_29, __v_30, __v_32, __v_33, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_20, __v_21, __v_16, __v_17, __v_2, __v_58, __v_47, __v_48, __v_50, __v_51, __v_23, __v_24, __v_26, __v_27, __v_29, __v_30, __v_32, __v_33, __v_0, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
     let __v_59: G = __r_arr[0];
     let __v_60: G = __r_arr[1];
     let __v_61: G = __r_arr[2];
@@ -14754,7 +14805,7 @@ fn aiur_fn_180(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_65, __v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_67: G = __r_arr[0];
     let __v_68: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_59, __v_60, __v_16, __v_17, __v_67, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_59, __v_60, __v_16, __v_17, __v_67, __v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_69: G = __r_arr[0];
     let __v_70: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_50, __v_51, __v_38, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14763,7 +14814,7 @@ fn aiur_fn_180(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_10, __v_11, __v_71, __v_72]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_73: G = __r_arr[0];
     let __v_74: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_69, __v_70, __v_16, __v_17, __v_73, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_69, __v_70, __v_16, __v_17, __v_73, __v_74]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_75: G = __r_arr[0];
     let __v_76: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_53, __v_54]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14772,7 +14823,7 @@ fn aiur_fn_180(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_14, __v_15, __v_77, __v_78]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_79: G = __r_arr[0];
     let __v_80: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_75, __v_76, __v_16, __v_17, __v_79, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_75, __v_76, __v_16, __v_17, __v_79, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
     let __v_82: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_63, __v_64, __v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14781,7 +14832,7 @@ fn aiur_fn_180(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_14, __v_15, __v_83, __v_84]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_85: G = __r_arr[0];
     let __v_86: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_81, __v_82, __v_16, __v_17, __v_85, __v_86]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_81, __v_82, __v_16, __v_17, __v_85, __v_86]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_87: G = __r_arr[0];
     let __v_88: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_61, __v_62, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14790,7 +14841,7 @@ fn aiur_fn_180(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_12, __v_13, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_91: G = __r_arr[0];
     let __v_92: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_87, __v_88, __v_16, __v_17, __v_91, __v_92]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_87, __v_88, __v_16, __v_17, __v_91, __v_92]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_93: G = __r_arr[0];
     let __v_94: G = __r_arr[1];
     let __r_arr: [G; OUT_18] = { let __args: [G; IN_18] = [__v_63, __v_64, __v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[18].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_18] = unsafe { *(result.output.as_ptr() as *const [G; OUT_18]) }; __ret } else { aiur_fn_18(__args, record, io_buffer, __cu)? } };
@@ -14799,24 +14850,24 @@ fn aiur_fn_180(
     let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_12, __v_13, __v_95, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
     let __v_97: G = __r_arr[0];
     let __v_98: G = __r_arr[1];
-    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_93, __v_94, __v_16, __v_17, __v_97, __v_98]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_93, __v_94, __v_16, __v_17, __v_97, __v_98]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
     let __v_99: G = __r_arr[0];
     let __v_100: G = __r_arr[1];
-    let __ret: [G; OUT_180] = [__v_99, __v_100];
-    record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_181] = [__v_99, __v_100];
+    record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_181: usize = 8;
-const IN_181: usize = 8;
-const OUT_181: usize = 1;
-fn aiur_fn_181(
-  inp: [G; IN_181],
+const INPUT_SIZE_182: usize = 8;
+const IN_182: usize = 8;
+const OUT_182: usize = 1;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14853,21 +14904,21 @@ fn aiur_fn_181(
     let __v_32: G = { let __values: [G; 4] = [__v_12, __v_2, __v_13, __v_31]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_33: G = { let __values: [G; 4] = [__v_10, __v_1, __v_11, __v_32]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_34: G = { let __values: [G; 4] = [__v_8, __v_0, __v_9, __v_33]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_181] = [__v_34];
-    record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_182] = [__v_34];
+    record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_182: usize = 5;
-const IN_182: usize = 5;
-const OUT_182: usize = 2;
-fn aiur_fn_182(
-  inp: [G; IN_182],
+const INPUT_SIZE_183: usize = 5;
+const IN_183: usize = 5;
+const OUT_183: usize = 2;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14883,8 +14934,8 @@ fn aiur_fn_182(
       1u64 => {
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_182] = [__v_9, __v_10];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_9, __v_10];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -14894,14 +14945,14 @@ fn aiur_fn_182(
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_3, __v_4, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_8, __v_1, __v_2, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_9, __v_10, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
-        let __ret: [G; OUT_182] = [__v_15, __v_16];
-        record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_183] = [__v_15, __v_16];
+        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -14911,145 +14962,145 @@ fn aiur_fn_182(
   })
 }
 
-const INPUT_SIZE_183: usize = 1;
-const IN_183: usize = 1;
-const OUT_183: usize = 1;
-fn aiur_fn_183(
-  inp: [G; IN_183],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_183] = [__v_1];
-        record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_184: usize = 4;
-const IN_184: usize = 4;
-const OUT_184: usize = 2;
+const INPUT_SIZE_184: usize = 1;
+const IN_184: usize = 1;
+const OUT_184: usize = 1;
 fn aiur_fn_184(
   inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_184], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(2);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(4);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(4);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(32);
+        let __ret: [G; OUT_184] = [__v_1];
+        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_185: usize = 4;
+const IN_185: usize = 4;
+const OUT_185: usize = 2;
+fn aiur_fn_185(
+  inp: [G; IN_185],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15063,8 +15114,8 @@ fn aiur_fn_184(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_184] = [__v_6, __v_9];
-        record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_185] = [__v_6, __v_9];
+        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       1u64 => {
@@ -15076,21 +15127,21 @@ fn aiur_fn_184(
             let __v_7: G = G::from_u64(1);
             let __v_8: G = G::from_u64(1);
             let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_184] = [__v_6, __v_9];
-            record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_6, __v_9];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = G::from_u64(1);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_184] = [__v_6, __v_8];
-            record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_185] = [__v_6, __v_8];
+            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -15105,15 +15156,15 @@ fn aiur_fn_184(
   })
 }
 
-const INPUT_SIZE_185: usize = 20;
-const IN_185: usize = 20;
-const OUT_185: usize = 1;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_186: usize = 20;
+const IN_186: usize = 20;
+const OUT_186: usize = 1;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15146,43 +15197,43 @@ fn aiur_fn_185(
     match __v_20.as_canonical_u64() {
       1u64 => {
         let __v_27: G = G::from_u64(1);
-        let __ret: [G; OUT_185] = [__v_27];
-        record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_186] = [__v_27];
+        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         match __v_21.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_27: G = __r_arr[0];
-            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_29: G = __r_arr[0];
             let __v_30: G = __r_arr[1];
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_31: G = __r_arr[0];
             let __v_32: G = G::from_u64(0);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_33: G = __r_arr[0];
             let __v_34: G = G::from_u64(1);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_31, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_31, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_35: G = __r_arr[0];
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_36: G = __r_arr[0];
             let __v_37: G = G::from_u64(0);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = G::from_u64(1);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_36, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_40: G = __r_arr[0];
-            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
             let __v_41: G = __r_arr[0];
             let __v_42: G = __r_arr[1];
-            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_6, __v_7, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_6, __v_7, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
             let __v_43: G = __r_arr[0];
             let __v_44: G = __r_arr[1];
-            let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
             let __v_45: G = __r_arr[0];
             let __v_46: G = __r_arr[1];
             let __v_47: G = __r_arr[2];
@@ -15191,27 +15242,27 @@ fn aiur_fn_185(
             let __v_50: G = __r_arr[5];
             let __v_51: G = __r_arr[6];
             let __v_52: G = __r_arr[7];
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_29, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_12, __v_13, __v_14, __v_15, __v_10, __v_11, __v_29, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_53: G = __r_arr[0];
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_21, __v_23, __v_25, __v_33, __v_35, __v_43, __v_44, __v_38, __v_40, __v_53, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_21, __v_23, __v_25, __v_33, __v_35, __v_43, __v_44, __v_38, __v_40, __v_53, __v_45, __v_46, __v_47, __v_48, __v_49, __v_50, __v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
             let __v_54: G = __r_arr[0];
             let __v_55: G = __r_arr[1];
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_56: G = __r_arr[0];
             let __v_57: G = G::from_u64(0);
-            let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_56, __v_57]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
             let __v_58: G = __r_arr[0];
-            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_59: G = __r_arr[0];
-            let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_18, __v_19, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
             let __v_60: G = __r_arr[0];
             let __v_61: G = __r_arr[1];
             let __v_62: G = G::from_u64(1);
             let __v_63: G = G::from_u64(0);
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_59, __v_60, __v_61, __v_62, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_59, __v_60, __v_61, __v_62, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
             let __v_64: G = __r_arr[0];
             let __v_65: G = __r_arr[1];
-            let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
             let __v_66: G = __r_arr[0];
             let __v_67: G = (__v_66 - __v_28);
             let __v_68: G = G::from_bool((__v_67 == G::ZERO));
@@ -15230,10 +15281,10 @@ fn aiur_fn_185(
             }
             let __v_74: G = G::from_u64(1);
             let __v_75: G = (__v_9 + __v_74);
-            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_26, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_75, __v_29, __v_30, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_26, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_75, __v_29, __v_30, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
             let __v_76: G = __r_arr[0];
-            let __ret: [G; OUT_185] = [__v_76];
-            record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_186] = [__v_76];
+            record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
         }
@@ -15245,15 +15296,15 @@ fn aiur_fn_185(
   })
 }
 
-const INPUT_SIZE_186: usize = 3;
-const IN_186: usize = 3;
-const OUT_186: usize = 2;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_187: usize = 3;
+const IN_187: usize = 3;
+const OUT_187: usize = 2;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15273,15 +15324,15 @@ fn aiur_fn_186(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_186] = [__v_13, __v_14];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_13, __v_14];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __r_arr: [G; OUT_10] = { let __args: [G; IN_10] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[10].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_10] = unsafe { *(result.output.as_ptr() as *const [G; OUT_10]) }; __ret } else { aiur_fn_10(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = G::from_u64(0);
-        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
         let __v_16: G = __r_arr[1];
         let __r_arr: [G; OUT_20] = { let __args: [G; IN_20] = [__v_0, __v_1, __v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[20].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_20] = unsafe { *(result.output.as_ptr() as *const [G; OUT_20]) }; __ret } else { aiur_fn_20(__args, record, io_buffer, __cu)? } };
@@ -15290,8 +15341,8 @@ fn aiur_fn_186(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_13, __v_14, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_186] = [__v_19, __v_20];
-        record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_187] = [__v_19, __v_20];
+        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15301,15 +15352,15 @@ fn aiur_fn_186(
   })
 }
 
-const INPUT_SIZE_187: usize = 7;
-const IN_187: usize = 7;
-const OUT_187: usize = 2;
-fn aiur_fn_187(
-  inp: [G; IN_187],
+const INPUT_SIZE_188: usize = 7;
+const IN_188: usize = 7;
+const OUT_188: usize = 2;
+fn aiur_fn_188(
+  inp: [G; IN_188],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
+) -> Result<[G; OUT_188], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15324,12 +15375,12 @@ fn aiur_fn_187(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_187] = [__v_0, __v_1];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_188] = [__v_0, __v_1];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_3, __v_4, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
@@ -15341,11 +15392,11 @@ fn aiur_fn_187(
         let __r_arr: [G; OUT_17] = { let __args: [G; IN_17] = [__v_0, __v_1, __v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[17].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_17] = unsafe { *(result.output.as_ptr() as *const [G; OUT_17]) }; __ret } else { aiur_fn_17(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = __r_arr[1];
-        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_16, __v_17, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
         let __v_18: G = __r_arr[0];
         let __v_19: G = __r_arr[1];
-        let __ret: [G; OUT_187] = [__v_18, __v_19];
-        record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_188] = [__v_18, __v_19];
+        record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15355,15 +15406,15 @@ fn aiur_fn_187(
   })
 }
 
-const INPUT_SIZE_188: usize = 36;
-const IN_188: usize = 36;
-const OUT_188: usize = 1;
-fn aiur_fn_188(
-  inp: [G; IN_188],
+const INPUT_SIZE_189: usize = 36;
+const IN_189: usize = 36;
+const OUT_189: usize = 1;
+fn aiur_fn_189(
+  inp: [G; IN_189],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_189], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15407,15 +15458,15 @@ fn aiur_fn_188(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
                 let __v_36: G = __r_arr[0];
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_37: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
-                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
                     let __v_38: G = __r_arr[0];
-                    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_7, __v_12, __v_38, __v_13, __v_14, __v_15, __v_17, __v_35, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
                     let __v_39: G = __r_arr[0];
                     let __v_40: G = __r_arr[1];
                     let __v_41: G = __r_arr[2];
@@ -15427,21 +15478,21 @@ fn aiur_fn_188(
                     let __v_47: G = __r_arr[8];
                     let __v_48: G = G::from_u64(0);
                     let __v_49: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_48, __v_49, __v_35, __v_39, __v_40, __v_41, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
                     let __v_50: G = __r_arr[0];
                     let __v_51: G = __r_arr[1];
                     let __v_52: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_36, __v_37, __v_17, __v_16, __v_33, __v_34, __v_31, __v_32, __v_30, __v_52, __v_50, __v_51, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
                     let __v_53: G = __r_arr[0];
-                    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
                     let __v_54: G = __r_arr[0];
                     let __v_55: G = G::from_u64(1);
                     if (__v_54 != __v_55) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_54.as_canonical_u64(), rhs: __v_55.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                     let __v_56: G = __r_arr[0];
-                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_57: G = __r_arr[0];
                     let __v_58: G = (__v_56 - __v_57);
                     let __v_59: G = G::from_bool((__v_58 == G::ZERO));
@@ -15449,9 +15500,9 @@ fn aiur_fn_188(
                     if (__v_59 != __v_60) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_59.as_canonical_u64(), rhs: __v_60.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_61: G = __r_arr[0];
-                    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
                     let __v_62: G = __r_arr[0];
                     let __v_63: G = (__v_61 - __v_62);
                     let __v_64: G = G::from_bool((__v_63 == G::ZERO));
@@ -15459,12 +15510,12 @@ fn aiur_fn_188(
                     if (__v_64 != __v_65) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64() });
                     }
-                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
                     let __v_66: G = __r_arr[0];
-                    let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_47, __v_33, __v_34, __v_30, __v_31, __v_32, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_13, __v_14, __v_15, __v_38, __v_37, __v_17, __v_45, __v_46, __v_66, __v_0, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
                     let __v_67: G = __r_arr[0];
-                    let __ret: [G; OUT_188] = [__v_67];
-                    record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                    let __ret: [G; OUT_189] = [__v_67];
+                    record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                     return Ok(__ret);
                   },
                 }
@@ -15477,15 +15528,15 @@ fn aiur_fn_188(
   })
 }
 
-const INPUT_SIZE_189: usize = 1;
-const IN_189: usize = 1;
-const OUT_189: usize = 1;
-fn aiur_fn_189(
-  inp: [G; IN_189],
+const INPUT_SIZE_190: usize = 1;
+const IN_190: usize = 1;
+const OUT_190: usize = 1;
+fn aiur_fn_190(
+  inp: [G; IN_190],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
+) -> Result<[G; OUT_190], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -15495,8 +15546,8 @@ fn aiur_fn_189(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_189] = [__v_4];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_190] = [__v_4];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15507,81 +15558,14 @@ fn aiur_fn_189(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64() });
         }
-        let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_189] = [__v_8];
-        record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_190] = [__v_8];
+        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_190: usize = 2;
-const IN_190: usize = 2;
-const OUT_190: usize = 1;
-fn aiur_fn_190(
-  inp: [G; IN_190],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_190], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = G::from_u64(1);
-        let __v_11: G = { let __values: [G; 7] = [__v_9, __v_10, __v_10, __v_10, __v_10, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_190] = [__v_11];
-        record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_9: G = __loaded[0];
-        let __v_10: G = __loaded[1];
-        let __v_11: G = __loaded[2];
-        match __v_9.as_canonical_u64() {
-          0u64 => {
-            match __v_10.as_canonical_u64() {
-              0u64 => {
-                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
-                let __v_12: G = __r_arr[0];
-                let __ret: [G; OUT_190] = [__v_12];
-                record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                return Ok(__ret);
-              },
-              _ => {
-                let __v_12: G = G::from_u64(0);
-                let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
-                let __v_13: G = __r_arr[0];
-                let __v_14: G = { let __values: [G; 7] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_190] = [__v_14];
-                record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-                return Ok(__ret);
-              },
-            }
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
-          },
-        }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -15599,6 +15583,73 @@ fn aiur_fn_191(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = G::from_u64(1);
+        let __v_11: G = { let __values: [G; 7] = [__v_9, __v_10, __v_10, __v_10, __v_10, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_191] = [__v_11];
+        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_9: G = __loaded[0];
+        let __v_10: G = __loaded[1];
+        let __v_11: G = __loaded[2];
+        match __v_9.as_canonical_u64() {
+          0u64 => {
+            match __v_10.as_canonical_u64() {
+              0u64 => {
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __v_12: G = __r_arr[0];
+                let __ret: [G; OUT_191] = [__v_12];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                return Ok(__ret);
+              },
+              _ => {
+                let __v_12: G = G::from_u64(0);
+                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __v_13: G = __r_arr[0];
+                let __v_14: G = { let __values: [G; 7] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                let __ret: [G; OUT_191] = [__v_14];
+                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                return Ok(__ret);
+              },
+            }
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_192: usize = 2;
+const IN_192: usize = 2;
+const OUT_192: usize = 1;
+fn aiur_fn_192(
+  inp: [G; IN_192],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_192], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
@@ -15609,8 +15660,8 @@ fn aiur_fn_191(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_8];
-        record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_192] = [__v_8];
+        record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
@@ -15622,19 +15673,19 @@ fn aiur_fn_191(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_191] = [__v_9];
-                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_192] = [__v_9];
+                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_191] = [__v_11];
-                record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+                let __ret: [G; OUT_192] = [__v_11];
+                record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
                 return Ok(__ret);
               },
             }
@@ -15651,31 +15702,8 @@ fn aiur_fn_191(
   })
 }
 
-const INPUT_SIZE_192: usize = 1;
-const IN_192: usize = 1;
-const OUT_192: usize = 2;
-fn aiur_fn_192(
-  inp: [G; IN_192],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_192] = [__v_3, __v_4];
-    record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_193: usize = 2;
-const IN_193: usize = 2;
+const INPUT_SIZE_193: usize = 1;
+const IN_193: usize = 1;
 const OUT_193: usize = 2;
 fn aiur_fn_193(
   inp: [G; IN_193],
@@ -15685,37 +15713,20 @@ fn aiur_fn_193(
 ) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_193] = [__v_4, __v_0];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
-        let __v_2: G = __r_arr[0];
-        let __v_3: G = __r_arr[1];
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = (__v_1 - __v_4);
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_193] = [__v_9, __v_7];
-        record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-    }
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_193] = [__v_3, __v_4];
+    record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_194: usize = 1;
-const IN_194: usize = 1;
+const INPUT_SIZE_194: usize = 2;
+const IN_194: usize = 2;
 const OUT_194: usize = 2;
 fn aiur_fn_194(
   inp: [G; IN_194],
@@ -15725,20 +15736,37 @@ fn aiur_fn_194(
 ) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_194] = [__v_3, __v_4];
-    record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-    return Ok(__ret);
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_194] = [__v_4, __v_0];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = (__v_1 - __v_4);
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = __r_arr[1];
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = { let __values: [G; 3] = [__v_8, __v_2, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_194] = [__v_9, __v_7];
+        record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_195: usize = 2;
-const IN_195: usize = 2;
+const INPUT_SIZE_195: usize = 1;
+const IN_195: usize = 1;
 const OUT_195: usize = 2;
 fn aiur_fn_195(
   inp: [G; IN_195],
@@ -15748,14 +15776,37 @@ fn aiur_fn_195(
 ) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_26] = { let __args: [G; IN_26] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[26].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_26] = unsafe { *(result.output.as_ptr() as *const [G; OUT_26]) }; __ret } else { aiur_fn_26(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_195] = [__v_3, __v_4];
+    record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_196: usize = 2;
+const IN_196: usize = 2;
+const OUT_196: usize = 2;
+fn aiur_fn_196(
+  inp: [G; IN_196],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_196], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_195] = [__v_4, __v_0];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_4, __v_0];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -15771,28 +15822,28 @@ fn aiur_fn_195(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_195] = [__v_16, __v_14];
-        record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_196] = [__v_16, __v_14];
+        record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_196: usize = 64;
-const IN_196: usize = 64;
-const OUT_196: usize = 0;
-fn aiur_fn_196(
-  inp: [G; IN_196],
+const INPUT_SIZE_197: usize = 64;
+const IN_197: usize = 64;
+const OUT_197: usize = 0;
+fn aiur_fn_197(
+  inp: [G; IN_197],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
+) -> Result<[G; OUT_197], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15915,7 +15966,7 @@ fn aiur_fn_196(
     let __v_113: G = G::from_u64(2);
     let __r_arr: [G; OUT_0] = { let __args: [G; IN_0] = [__v_113, __v_111, __v_112]; let __cu = true; if let Some(result) = record.function_queries[0].get_mut(&__args[..]) { let __ret: [G; OUT_0] = unsafe { *(result.output.as_ptr() as *const [G; OUT_0]) }; __ret } else { aiur_fn_0(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = __r_arr[1];
     let __v_117: G = (__v_66 + __v_67);
@@ -16266,59 +16317,21 @@ fn aiur_fn_196(
     if (__v_250 != __v_252) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_250.as_canonical_u64(), rhs: __v_252.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_172] = { let __args: [G; IN_172] = [__v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[172].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_172] = unsafe { *(result.output.as_ptr() as *const [G; OUT_172]) }; __ret } else { aiur_fn_172(__args, record, io_buffer, __cu)? } };
     let __v_253: G = __r_arr[0];
     let __v_254: G = G::from_u64(1);
     if (__v_253 != __v_254) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_253.as_canonical_u64(), rhs: __v_254.as_canonical_u64() });
     }
-    let __r_arr: [G; OUT_188] = { let __args: [G; IN_188] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[188].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_188] = unsafe { *(result.output.as_ptr() as *const [G; OUT_188]) }; __ret } else { aiur_fn_188(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_107, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_115]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
     let __v_255: G = __r_arr[0];
     let __v_256: G = G::from_u64(1);
     if (__v_255 != __v_256) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_255.as_canonical_u64(), rhs: __v_256.as_canonical_u64() });
     }
-    let __ret: [G; OUT_196] = [];
-    record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+    let __ret: [G; OUT_197] = [];
+    record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
     return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_197: usize = 1;
-const IN_197: usize = 1;
-const OUT_197: usize = 1;
-fn aiur_fn_197(
-  inp: [G; IN_197],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_197] = [__v_4];
-        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_197] = [__v_6];
-        record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
   })
 }
 
@@ -16339,14 +16352,17 @@ fn aiur_fn_198(
     let __v_3: G = __loaded[2];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __v_4: G = G::from_u64(1);
+        let __v_4: G = G::from_u64(0);
         let __ret: [G; OUT_198] = [__v_4];
         record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_198] = [__v_4];
+        let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_4 + __v_5);
+        let __ret: [G; OUT_198] = [__v_6];
         record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16357,9 +16373,9 @@ fn aiur_fn_198(
   })
 }
 
-const INPUT_SIZE_199: usize = 2;
-const IN_199: usize = 2;
-const OUT_199: usize = 2;
+const INPUT_SIZE_199: usize = 1;
+const IN_199: usize = 1;
+const OUT_199: usize = 1;
 fn aiur_fn_199(
   inp: [G; IN_199],
   record: &mut QueryRecord,
@@ -16368,8 +16384,43 @@ fn aiur_fn_199(
 ) -> Result<[G; OUT_199], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_4: G = G::from_u64(1);
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_4: G = G::from_u64(0);
+        let __ret: [G; OUT_199] = [__v_4];
+        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_200: usize = 2;
+const IN_200: usize = 2;
+const OUT_200: usize = 2;
+fn aiur_fn_200(
+  inp: [G; IN_200],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_200], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16378,8 +16429,8 @@ fn aiur_fn_199(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_199] = [__v_4, __v_5];
-        record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_200] = [__v_4, __v_5];
+        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16389,15 +16440,15 @@ fn aiur_fn_199(
   })
 }
 
-const INPUT_SIZE_200: usize = 1;
-const IN_200: usize = 1;
-const OUT_200: usize = 8;
-fn aiur_fn_200(
-  inp: [G; IN_200],
+const INPUT_SIZE_201: usize = 1;
+const IN_201: usize = 1;
+const OUT_201: usize = 8;
+fn aiur_fn_201(
+  inp: [G; IN_201],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_200], ExecError> {
+) -> Result<[G; OUT_201], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
@@ -16421,12 +16472,12 @@ fn aiur_fn_200(
         let __v_16: G = G::from_u64(0);
         let __v_17: G = G::from_u64(0);
         let __v_18: G = G::from_u64(0);
-        let __ret: [G; OUT_200] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = __r_arr[1];
         let __v_13: G = __r_arr[2];
@@ -16444,8 +16495,8 @@ fn aiur_fn_200(
         let __v_24: G = __r_arr[5];
         let __v_25: G = __r_arr[6];
         let __v_26: G = __r_arr[7];
-        let __ret: [G; OUT_200] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
-        record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_201] = [__v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26];
+        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16455,39 +16506,8 @@ fn aiur_fn_200(
   })
 }
 
-const INPUT_SIZE_201: usize = 2;
-const IN_201: usize = 2;
-const OUT_201: usize = 1;
-fn aiur_fn_201(
-  inp: [G; IN_201],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_201], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_201] = [__v_4];
-        record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_202: usize = 1;
-const IN_202: usize = 1;
+const INPUT_SIZE_202: usize = 2;
+const IN_202: usize = 2;
 const OUT_202: usize = 1;
 fn aiur_fn_202(
   inp: [G; IN_202],
@@ -16497,30 +16517,21 @@ fn aiur_fn_202(
 ) -> Result<[G; OUT_202], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_202] = [__v_6];
-        record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    match __v_3.as_canonical_u64() {
       0u64 => {
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_202] = [__v_8];
+        let __ret: [G; OUT_202] = [__v_4];
         record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
@@ -16537,24 +16548,25 @@ fn aiur_fn_203(
 ) -> Result<[G; OUT_203], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
     let __v_3: G = __loaded[2];
     let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_203] = [__v_5];
+        let __v_6: G = G::from_u64(0);
+        let __ret: [G; OUT_203] = [__v_6];
         record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_203] = [__v_7];
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_6 + __v_7);
+        let __ret: [G; OUT_203] = [__v_8];
         record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
@@ -16565,8 +16577,8 @@ fn aiur_fn_203(
   })
 }
 
-const INPUT_SIZE_204: usize = 2;
-const IN_204: usize = 2;
+const INPUT_SIZE_204: usize = 1;
+const IN_204: usize = 1;
 const OUT_204: usize = 1;
 fn aiur_fn_204(
   inp: [G; IN_204],
@@ -16574,6 +16586,45 @@ fn aiur_fn_204(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_204], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_204] = [__v_5];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = (__v_5 + __v_6);
+        let __ret: [G; OUT_204] = [__v_7];
+        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_205: usize = 2;
+const IN_205: usize = 2;
+const OUT_205: usize = 1;
+fn aiur_fn_205(
+  inp: [G; IN_205],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_205], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16590,17 +16641,17 @@ fn aiur_fn_204(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_204] = [__v_1];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_1];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_204] = [__v_14];
-        record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_205] = [__v_14];
+        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16610,15 +16661,15 @@ fn aiur_fn_204(
   })
 }
 
-const INPUT_SIZE_205: usize = 1;
-const IN_205: usize = 1;
-const OUT_205: usize = 8;
-fn aiur_fn_205(
-  inp: [G; IN_205],
+const INPUT_SIZE_206: usize = 1;
+const IN_206: usize = 1;
+const OUT_206: usize = 8;
+fn aiur_fn_206(
+  inp: [G; IN_206],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_205], ExecError> {
+) -> Result<[G; OUT_206], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -16635,12 +16686,12 @@ fn aiur_fn_205(
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_205] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_206] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = __r_arr[1];
         let __v_6: G = __r_arr[2];
@@ -16658,50 +16709,12 @@ fn aiur_fn_205(
         let __v_17: G = __r_arr[5];
         let __v_18: G = __r_arr[6];
         let __v_19: G = __r_arr[7];
-        let __ret: [G; OUT_205] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
-        record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_206] = [__v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19];
+        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_206: usize = 2;
-const IN_206: usize = 2;
-const OUT_206: usize = 1;
-fn aiur_fn_206(
-  inp: [G; IN_206],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_206], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_206] = [__v_1];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_206] = [__v_7];
-        record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -16719,38 +16732,34 @@ fn aiur_fn_207(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_207] = [__v_1];
+        record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
       0u64 => {
-        let __ret: [G; OUT_207] = [__v_0];
+        let __v_5: G = G::from_u64(0);
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_207] = [__v_7];
         record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_207] = [__v_7];
-            record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_208: usize = 1;
-const IN_208: usize = 1;
+const INPUT_SIZE_208: usize = 2;
+const IN_208: usize = 2;
 const OUT_208: usize = 1;
 fn aiur_fn_208(
   inp: [G; IN_208],
@@ -16760,32 +16769,32 @@ fn aiur_fn_208(
 ) -> Result<[G; OUT_208], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    let __v_6: G = __loaded[5];
-    let __v_7: G = __loaded[6];
+    let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_208] = [__v_8];
-        record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
       0u64 => {
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-        let __v_8: G = __r_arr[0];
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_208] = [__v_10];
+        let __ret: [G; OUT_208] = [__v_0];
         record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_208] = [__v_7];
+            record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
@@ -16802,6 +16811,48 @@ fn aiur_fn_209(
 ) -> Result<[G; OUT_209], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    let __v_6: G = __loaded[5];
+    let __v_7: G = __loaded[6];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_209] = [__v_8];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __v_8: G = __r_arr[0];
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_8 + __v_9);
+        let __ret: [G; OUT_209] = [__v_10];
+        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_210: usize = 1;
+const IN_210: usize = 1;
+const OUT_210: usize = 1;
+fn aiur_fn_210(
+  inp: [G; IN_210],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_210], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -16816,17 +16867,17 @@ fn aiur_fn_209(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_209] = [__v_11];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_11];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_u64(1);
         let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_209] = [__v_13];
-        record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        let __ret: [G; OUT_210] = [__v_13];
+        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
@@ -16836,43 +16887,9 @@ fn aiur_fn_209(
   })
 }
 
-const INPUT_SIZE_210: usize = 2;
-const IN_210: usize = 2;
-const OUT_210: usize = 4;
-fn aiur_fn_210(
-  inp: [G; IN_210],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_210], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    let __v_6: G = __loaded[3];
-    let __v_7: G = __loaded[4];
-    let __v_8: G = __loaded[5];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_210] = [__v_4, __v_5, __v_6, __v_7];
-        record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
 const INPUT_SIZE_211: usize = 2;
 const IN_211: usize = 2;
-const OUT_211: usize = 32;
+const OUT_211: usize = 4;
 fn aiur_fn_211(
   inp: [G; IN_211],
   record: &mut QueryRecord,
@@ -16883,6 +16900,40 @@ fn aiur_fn_211(
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    let __v_6: G = __loaded[3];
+    let __v_7: G = __loaded[4];
+    let __v_8: G = __loaded[5];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_211] = [__v_4, __v_5, __v_6, __v_7];
+        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_212: usize = 2;
+const IN_212: usize = 2;
+const OUT_212: usize = 32;
+fn aiur_fn_212(
+  inp: [G; IN_212],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_212], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -16921,55 +16972,12 @@ fn aiur_fn_211(
     let __v_36: G = __loaded[33];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_211] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
-        record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_212: usize = 2;
-const IN_212: usize = 2;
-const OUT_212: usize = 1;
-fn aiur_fn_212(
-  inp: [G; IN_212],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_212], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_212] = [__v_0];
+        let __ret: [G; OUT_212] = [__v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35];
         record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        let __v_8: G = __loaded[3];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_212] = [__v_8];
-            record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
@@ -16998,16 +17006,14 @@ fn aiur_fn_213(
         let __v_3: G = (__v_1 - __v_2);
         let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
-        let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
         let __v_6: G = __loaded[1];
         let __v_7: G = __loaded[2];
         let __v_8: G = __loaded[3];
-        let __v_9: G = __loaded[4];
-        let __v_10: G = __loaded[5];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_213] = [__v_10];
+            let __ret: [G; OUT_213] = [__v_8];
             record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
@@ -17042,6 +17048,51 @@ fn aiur_fn_214(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
         let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        let __v_8: G = __loaded[3];
+        let __v_9: G = __loaded[4];
+        let __v_10: G = __loaded[5];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_214] = [__v_10];
+            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_215: usize = 2;
+const IN_215: usize = 2;
+const OUT_215: usize = 1;
+fn aiur_fn_215(
+  inp: [G; IN_215],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_215], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_215] = [__v_0];
+        record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 34] = { let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 34 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 34] = __args[..34].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -17080,8 +17131,8 @@ fn aiur_fn_214(
         let __v_38: G = __loaded[33];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_214] = [__v_38];
-            record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
+            let __ret: [G; OUT_215] = [__v_38];
+            record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained));
             return Ok(__ret);
           },
           _ => {
@@ -18173,6 +18224,11 @@ pub(crate) fn execute_generated(
     214u64 => {
       let __inp: [G; IN_214] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_214(__inp, record, io_buffer, false)?;
+      return Ok(__out.to_vec());
+    },
+    215u64 => {
+      let __inp: [G; IN_215] = args.try_into().expect("input size mismatch");
+      let __out = aiur_fn_215(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -129,6 +129,10 @@ lean_exe «bench-recursive-verifier» where
   root := `Benchmarks.RecursiveVerifier
   supportInterpreter := true
 
+lean_exe «bench-recursion-debug» where
+  root := `Benchmarks.RecursionDebug
+  supportInterpreter := true
+
 /- The lean4lean replay machinery as an importable lib: the
 `bench-lean4lean` exe root and the ignored `lean4lean` test runner both
 import `Benchmarks.Lean4Lean`, and modules under `Benchmarks/` belong to


### PR DESCRIPTION
The in-circuit verifier passed the full query-index bit list and log_gmax to mmcs_verify for all four input batches. That is only correct when the batch's own max height equals the global max — always true for the stage_1/stage_2/quotient batches (they contain every circuit), but not for the preprocessed batch, whose tree only spans circuits carrying a preprocessed matrix. When the tallest circuits have no preprocessed matrix (e.g. the Array.extract_append closure: log_gmax 25 vs prep tree height 18), mmcs_fold exhausted the shorter authentication path, recomposed the leftover index bits into a nonzero cap index, and list_lookup walked off the single-digest cap — rejecting valid proofs with "no match case for value 1" (a Cons destructure hitting Nil). Small closures like Nat.add_comm dodged the bug because their prep tree height coincided with log_gmax.

Mirror Plonky3's verify_fri per-batch reduction
(index >> (log_global_max - log_batch_max), i.e. dropping the low bits of the LSB-first list) and verify against the batch's own max height (heights_max over heights_prep). The reduced-opening x-coordinates were already per-height reduced in ri_apply and need no change.

Also adds `bench-recursion-debug`, a debugging harness that proves one constant's typecheck, saves the proof/vk/claims blobs under recursion-debug/, and replays verify_multi_stark_proof from the saved blobs under the codegen'd, bytecode-interpreter, or Lean debug-interpreter backends — so a 72 s prove runs once while the verifier is iterated on.

Validated on saved proofs (native + bytecode, matching fft-costs): Array.extract_append now accepted (was rejected), Nat.add_comm unchanged; `IxTests multi-stark` and `IxTests recursive-verifier` (incl. tampered proof/claim rejections and codegen/interpreter parity) pass. aiur_multi_stark.rs regenerated via `ix codegen`; aiur_ixvm.rs unchanged.