### PR TITLE
bench/aiur recursive ixvm

### DIFF
--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -245,10 +245,12 @@ jobs:
   #   - decompile: the inverse of compile. Roundtrip correctness is
   #     checked elsewhere (`ix validate` / roundtrip tests) — this only
   #     measures speed and memory.
-  #   - aiur-recursive: proves small fixed statements, runs the
-  #     in-circuit verifier over each proof, then proves THAT — the cost
-  #     of recursion. Env-independent: its `env` field only names the
-  #     (already-cached) `.ixe` the shared restore step pulls.
+  #   - aiur-recursive: proves the IxVM typecheck of two fixed constants
+  #     (Nat.add_comm, Array.extract_append), runs the in-circuit
+  #     verifier over each proof, then proves THAT — the cost of
+  #     recursion at kernel scale. A fixed subset instead of the
+  #     Vectors.csv fan-out: its `env` field names the (already-cached)
+  #     `.ixe` the shared restore step pulls and the constants resolve in.
   benchmark:
     name: ${{ matrix.params.label }}
     needs: [compile, plan]

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -32,8 +32,9 @@
 #   - zisk / sp1 / ooc: `execute`.
 #   - compile: `ix compile <env>.lean` → `<env>.ixe`.
 #   - decompile: `ix decompile` over the compile run's fresh `.ixe`.
-#   - aiur-recursive: fixed IxVM statements (Nat.add_comm,
-#     Array.extract_append) proved and recursively verified via
+#   - aiur-recursive: a fixed IxVM statement (Nat.add_comm; the heavy-tier
+#     Array.extract_append is dropped for now — significantly more
+#     expensive even at 50 queries) proved and recursively verified via
 #     bench-typecheck --recursive; always schedules exactly one run
 #     regardless of BENCH_ENVS (the constants resolve in whichever env's
 #     .ixe the entry carries).

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -32,8 +32,11 @@
 #   - zisk / sp1 / ooc: `execute`.
 #   - compile: `ix compile <env>.lean` → `<env>.ixe`.
 #   - decompile: `ix decompile` over the compile run's fresh `.ixe`.
-#   - aiur-recursive: fixed toy statements; env-independent, so it always
-#     schedules exactly one run regardless of BENCH_ENVS.
+#   - aiur-recursive: fixed IxVM statements (Nat.add_comm,
+#     Array.extract_append) proved and recursively verified via
+#     bench-typecheck --recursive; always schedules exactly one run
+#     regardless of BENCH_ENVS (the constants resolve in whichever env's
+#     .ixe the entry carries).
 # The bare `fresh` token skips the bencher fetch and re-measures the main
 # side with a local base-SHA run. Nothing in this workflow uploads to
 # bencher, so the canonical baseline is never touched.

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -86,7 +86,7 @@ def recCommitParams (args : List String) : Aiur.CommitmentParameters :=
 def innerFri (args : List String) : Aiur.FriParameters :=
   { logFinalPolyLen := argNat args "--final-poly" 0, maxLogArity := 1,
     numQueries := argNat args "--queries" 100,
-    commitProofOfWorkBits := 0, queryProofOfWorkBits := argNat args "--pow" 20 }
+    commitProofOfWorkBits := 0, queryProofOfWorkBits := argNat args "--pow" 0 }
 
 def secs (t0 t1 : Nat) : Float := (Float.ofNat (t1 - t0)) / 1e9
 

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -26,7 +26,7 @@ lake exe bench-recursive-verifier --execute-only  # skip the outer prove (FFT/ex
   --queries N      FRI query count (default 100 = soundness level; pass a
                    small value for a cheap local run)
   --log-blowup N   log2 blowup            (default 2)
-  --pow N          query PoW bits         (default 20)
+  --pow N          query PoW bits         (default 0)
   --json <path>    write a benchmark results row (Ix.Benchmark.Results); the
                    row lands after the verifier execute and is refined after
                    the outer prove, so a kill mid-prove keeps the execute

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -30,8 +30,9 @@ lake exe bench-recursive-verifier --execute-only  # skip the outer prove (FFT/ex
   --json <path>    write a benchmark results row (Ix.Benchmark.Results); the
                    row lands after the verifier execute and is refined after
                    the outer prove, so a kill mid-prove keeps the execute
-                   metrics. `ix bench run --backend aiur-recursive`
-                   drives this.
+                   metrics. (A local harness only: CI's aiur-recursive
+                   backend instead drives `bench-typecheck --recursive`
+                   over fixed IxVM statements.)
   --json-name <n>  row key (default: the inner entrypoint name)
   --texray         tracing-texray timeline + RAM; with --json, spans also land
                    at `<json>.spans` for the CI drill-down

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -132,16 +132,19 @@ def recursiveCommitmentParameters : Aiur.CommitmentParameters := {
 }
 
 /-- Recursion FRI parameters for `--recursive`. The query count IS the
-    soundness level, so a real (secure) recursive proof needs the full query
-    count, not a toy handful. The in-circuit verifier's cost scales with that
-    count, so at IxVM scale the run is expected to exceed even a 128 GB host —
-    an OOM row here documents the gap between secure recursion and what fits
-    today. `--recursive` runs the WHOLE system, inner prove included, under
+    soundness level, so a real (secure) recursive proof needs a full query
+    count, not a toy handful: 50 queries at log-blowup 2 target ~100 bits,
+    halving the in-circuit verifier's query-proportional work (and the
+    outer prove's footprint) relative to the previous 100-query setting —
+    sized so the run has a chance of fitting CI's weaker hosts. The
+    in-circuit verifier's cost scales with the count; an OOM row still
+    documents the gap between secure recursion and what fits today.
+    `--recursive` runs the WHOLE system, inner prove included, under
     these, so its rows are not comparable to the standard `prove` run's. -/
 def recursiveFriParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
-  numQueries := 100
+  numQueries := 50
   commitProofOfWorkBits := 0
   queryProofOfWorkBits := 0
 }

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -121,7 +121,7 @@ def friParameters : Aiur.FriParameters := {
   maxLogArity := 1
   numQueries := 100
   commitProofOfWorkBits := 0
-  queryProofOfWorkBits := 20
+  queryProofOfWorkBits := 0
 }
 
 /-- Recursion-tuned commitment parameters for `--recursive`, matching
@@ -143,7 +143,7 @@ def recursiveFriParameters : Aiur.FriParameters := {
   maxLogArity := 1
   numQueries := 100
   commitProofOfWorkBits := 0
-  queryProofOfWorkBits := 20
+  queryProofOfWorkBits := 0
 }
 
 

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -59,9 +59,12 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  parameters (`recursiveFriParameters`), so recursive rows are
                  NOT comparable to the standard prove run — they land on
                  their own testbed (`ix bench run --backend aiur --mode
-                 recursive`). An IxVM-scale verifier execute needs >108 GB,
-                 so a watchdog kill landing as a `status: oom` row (dropped
-                 by bmf) is the expected shape there. With --texray, both
+                 recursive`; the fixed two-constant subset runs in CI as
+                 `--backend aiur-recursive`). At IxVM scale the recursion
+                 exceeds the CI RAM ceiling (even Nat.add_comm's outer
+                 prove peaks ~195 GiB as of 2026-08), so a watchdog kill
+                 landing as a `status: oom` row (dropped by bmf) is the
+                 expected shape there. With --texray, both
                  proves stream the same `stark/...` span names, so the summed
                  `phase-stark-*` fields cover the pair. Conflicts with
                  --execute-only.

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -344,6 +344,12 @@ def runTypecheckCmd (p : Cli.Parsed) : IO UInt32 := do
   let (commitParams, friParams) :=
     if recursive then (recursiveCommitmentParameters, recursiveFriParameters)
     else (commitmentParameters, friParameters)
+  -- `--queries N` overrides the selected parameter set's FRI query count
+  -- (inner and outer proof alike in --recursive mode, which builds both
+  -- systems from `friParams`).
+  let friParams := match (p.flag? "queries").map (·.as! Nat) with
+    | some n => { friParams with numQueries := n }
+    | none => friParams
   let aiurSystem := Aiur.AiurSystem.build compiled.bytecode commitParams friParams
   -- The recursive-verifier context, compiled and built ONCE: the verifier
   -- toplevel is constant-independent, and its prover system (same recursion
@@ -608,6 +614,7 @@ def typecheckCmd : Cli.Cmd := `[Cli|
     "skip-deps";          "Check only each target itself (verify_const, trusting its deps) instead of re-checking its whole transitive closure (verify_claim). Same flag as `zisk-host --skip-deps`."
     "execute-only";       "Execute only (Phase 1: constants / fft-cost / execute-time) and skip proving. The fast per-PR `execute`-mode signal."
     "recursive";          "After each prove, execute and then prove the in-circuit multi-stark verifier over the fresh proof (the recursive-* metrics; see the module docstring). Uses recursion-tuned FRI parameters. Conflicts with --execute-only."
+    "queries"   : Nat;    "Override the FRI query count of the selected parameter set (default 100, or 50 with --recursive; applies to inner and outer proof alike)."
     texray;               "Enable the tracing-texray timeline + RAM breakdown (per-prove spans on stderr). Combined with --json, per-phase span timings are additionally written to `<json>.spans` as JSON Lines for the CI drill-down. Off by default."
 
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=be1755e216691a2a7856c818ee83f5488cd2d90f#be1755e216691a2a7856c818ee83f5488cd2d90f"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=5023feee459101b52e5a59091cf46495027fad18#5023feee459101b52e5a59091cf46495027fad18"
 dependencies = [
  "bincode",
  "p3-air",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "be1755e216691a2a7856c818ee83f5488cd2d90f" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "5023feee459101b52e5a59091cf46495027fad18" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -10,8 +10,8 @@
   2. resolves the env's `.ixe` (an explicit `--ixe` path, else `ix
      compile` — except for the `compile` backend, where the compile IS
      the benchmark);
-  3. spawns the run's measured tool — `bench-typecheck` (aiur),
-     `zisk-host`/`sp1-host` (zkVM execute), `ix check-rs` (ooc),
+  3. spawns the run's measured tool — `bench-typecheck` (aiur,
+     aiur-recursive), `zisk-host`/`sp1-host` (zkVM execute), `ix check-rs` (ooc),
      `bench-lean4lean` (lean4lean; olean-driven, no `.ixe`),
      `ix compile` (compile) — wrapped in the RAM watchdog (`watchdog.sh`:
      cgroup `memory.max` via a systemd user scope; the kernel OOM-kills
@@ -151,8 +151,9 @@ def findEnv (token : String) : Option EnvSpec :=
         gaining rows, not by a registry flag. The prove/execute backends
         (aiur, zisk, sp1).
       · `perConstantWithEnv` — `perConstant` plus a whole-env row (ooc).
-      · `fixedConfigs` — env-independent fixed configs, a single matrix entry
-        (aiur-recursive: fixed toy statements, no `.ixe`). -/
+      · `fixedConfigs` — a fixed constant list, a single matrix entry no
+        matter how many envs are requested (aiur-recursive:
+        `recursiveConstants`, resolved in the one env the entry carries). -/
 inductive BenchInputs
   | perEnv
   | perConstant
@@ -217,11 +218,13 @@ def backendSpecs : List BackendSpec := [
   -- multi-stark verifier on prove: execute it over each fresh proof, then
   -- prove that execution — the recursion run. It runs under the
   -- recursion-tuned FRI parameters, so even its shared-name metrics
-  -- (prove-time, peak-rss) are not comparable to the prove run's. An
-  -- IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling; the
-  -- kill lands as a `status: oom` row that bmf drops, which is why it's
-  -- marked `unscheduled`: a testbed for local `--mode recursive` runs only —
-  -- never uploaded to bencher, never plotted.
+  -- (prove-time, peak-rss) are not comparable to the prove run's. Over the
+  -- full Vectors.csv selection the run is too heavy for per-push CI (the
+  -- large closures exceed the RAM ceiling and land as `status: oom` rows
+  -- that bmf drops), which is why it's marked `unscheduled`: a testbed for
+  -- local `--mode recursive` runs only — never uploaded to bencher, never
+  -- plotted. CI tracks the same measurement over the fixed two-constant
+  -- subset via the aiur-recursive backend below.
   { name := "aiur", defaultMode := "prove", inputs := .perConstant,
     testbeds := [("prove", "aiur-check-prove-x64-32x"),
                  ("execute", "aiur-check-execute-x64-32x"),
@@ -244,11 +247,13 @@ def backendSpecs : List BackendSpec := [
                    ("prove-time", "0.10", "_"), ("verify-time", "0.10", "_"),
                    ("proof-size", "0.05", "_"), ("execute-time", "0.10", "_"),
                    ("peak-rss", "0.10", "_"), ("throughput", "_", "0.10")] },
-  -- The aiur-recursive toy (bench-recursive-verifier): fixed tiny
-  -- statements (`recursiveConfigs`), proving the in-circuit multi-stark
-  -- verifier end-to-end. Env-independent: the run ignores --env and never
-  -- needs an .ixe. Unlike the aiur recursive mode above, the floor
-  -- config's outer prove fits a 128 GB host, so CI schedules this testbed.
+  -- The aiur-recursive run (bench-typecheck --recursive over
+  -- `recursiveConstants`): IxVM recursion on real statements — prove each
+  -- constant's typecheck, execute the in-circuit multi-stark verifier
+  -- over the fresh proof, then prove THAT execution. The same measurement
+  -- as the aiur recursive mode above, but over a fixed two-constant
+  -- subset so CI schedules exactly one entry instead of the whole
+  -- Vectors.csv fan-out.
   { name := "aiur-recursive", defaultMode := "prove", inputs := .fixedConfigs,
     testbeds := [("prove", "aiur-recursive-x64-32x")],
     metrics := [("prove", ["recursive-prove-time", "recursive-peak-rss",
@@ -335,18 +340,20 @@ def backendSpecs : List BackendSpec := [
 def findBackend (name : String) : Option BackendSpec :=
   backendSpecs.find? (·.name == name)
 
-/-- The `aiur-recursive` backend's rows: (row name, bench-recursive-verifier
-    config args). Fixed configs, not `Vectors.csv` constants. The FRI query
-    count IS the soundness level, so a benchmark of *secure* recursion uses the
-    real security requirement (~100 queries) throughout; the two rows vary the
-    inner statement and blowup (`square`, trivial + blowup 1, is the lighter
-    end; `factorial`, recursive + blowup 2, the heavier). At this query count
-    both outer proves strain a 128 GB host, so an OOM row is the honest signal
-    that secure recursion does not yet fit. -/
-def recursiveConfigs : List (String × Array String) := [
-  ("square-q100-b1", #["--trivial", "--queries", "100", "--log-blowup", "1"]),
-  ("factorial-q100-b2", #["--queries", "100"])
-]
+/-- The `aiur-recursive` backend's rows: fixed IxVM statements, proved and
+    recursively verified by `bench-typecheck --recursive` under the
+    recursion-tuned parameters (the ~100-query count IS the soundness
+    level, so this benchmarks *secure* recursion). The two constants span
+    the IxVM cost range: `Nat.add_comm` (cheap tier — the small end) and
+    `Array.extract_append` (heavy tier — kernel scale). A stage that
+    exceeds the CI RAM ceiling lands as an OOM row — the honest signal
+    that secure recursion at that scale does not yet fit. (Measured
+    2026-08: even `Nat.add_comm`'s outer prove peaks ~195 GiB, so on the
+    ~123 GiB runners expect OOM rows on both until the verifier prover
+    slims down — the rows then track exactly when recursion starts to
+    fit.) -/
+def recursiveConstants : List String :=
+  ["Nat.add_comm", "Array.extract_append"]
 
 def BackendSpec.testbedFor (b : BackendSpec) (mode : String) : Option String :=
   (b.testbeds.find? (·.1 == mode)).map (·.2)
@@ -402,7 +409,7 @@ def BackendSpec.benchmarkNames (b : BackendSpec) (rows : Array VectorRow)
     (mode : String) : Array String := Id.run do
   match b.inputs with
   | .perEnv => return (envSpecs.map (·.name)).toArray
-  | .fixedConfigs => return (recursiveConfigs.map (·.1)).toArray
+  | .fixedConfigs => return recursiveConstants.toArray
   | .perConstant | .perConstantWithEnv =>
     let mut ns : Array String := #[]
     for env in b.envNames rows do
@@ -696,7 +703,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
   let names := selected.map (·.name)
   match backend with
   | "aiur-recursive" =>
-    IO.eprintln s!"[bench] run {backend}-{mode}: {recursiveConfigs.length} config(s)"
+    IO.eprintln s!"[bench] run {backend}-{mode}: {recursiveConstants.length} constant(s)"
   | _ =>
     IO.eprintln s!"[bench] run {backend}-{env}-{mode}: {names.size} constant(s)"
 
@@ -784,15 +791,17 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
         (#["--ixe", ixe, "--consts", name, "--json", out, "--texray"]
           ++ modeArgs)
   | "aiur-recursive" =>
-    -- Fixed-config rows; no env, no .ixe. One process per config under the
-    -- watchdog, self-reporting through the rows contract like every other
-    -- per-row backend.
-    let brv ← resolveBin repo "bench-recursive-verifier"
-    runPerConstant out (recursiveConfigs.map (·.1)).toArray "recursive-prove-time"
+    -- Fixed IxVM statements, resolved in the run's `.ixe`: the same
+    -- spawn as the aiur recursive mode, over `recursiveConstants`
+    -- instead of the Vectors.csv selection. One process per constant
+    -- under the watchdog.
+    let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))
+    let bt ← resolveBin repo "bench-typecheck"
+    runPerConstant out recursiveConstants.toArray "recursive-prove-time"
       fun name =>
-        let cfgArgs := ((recursiveConfigs.find? (·.1 == name)).map (·.2)).getD #[]
-        runGuarded watchdog ceilingGb brv
-          (cfgArgs ++ #["--json", out, "--json-name", name, "--texray"])
+        runGuarded watchdog ceilingGb bt
+          #["--ixe", ixe, "--consts", name, "--json", out, "--texray",
+            "--recursive"]
   | "zisk" | "sp1" =>
     if mode != "execute" then
       p.printError s!"error: {backend} supports only execute mode"
@@ -845,7 +854,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
     | "compile" => #[info.name]
     | "decompile" => #[info.name]
     | "ooc" | "lean4lean" => #[info.name] ++ names
-    | "aiur-recursive" => (recursiveConfigs.map (·.1)).toArray
+    | "aiur-recursive" => recursiveConstants.toArray
     | _ => names
   let code ← gate out expected
   if code == 0 || code == exitRejected then

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -343,17 +343,18 @@ def findBackend (name : String) : Option BackendSpec :=
 /-- The `aiur-recursive` backend's rows: fixed IxVM statements, proved and
     recursively verified by `bench-typecheck --recursive` under the
     recursion-tuned parameters (50 queries at log-blowup 2, ~100-bit
-    soundness — this benchmarks *secure* recursion). The two constants span
-    the IxVM cost range: `Nat.add_comm` (cheap tier — the small end) and
-    `Array.extract_append` (heavy tier — kernel scale). A stage that
-    exceeds the CI RAM ceiling lands as an OOM row — the honest signal
-    that secure recursion at that scale does not yet fit. (Measured
-    2026-08: even `Nat.add_comm`'s outer prove peaks ~195 GiB, so on the
-    ~123 GiB runners expect OOM rows on both until the verifier prover
-    slims down — the rows then track exactly when recursion starts to
+    soundness — this benchmarks *secure* recursion). Currently only
+    `Nat.add_comm` (cheap tier — the small end of the IxVM cost range):
+    `Array.extract_append` (heavy tier — kernel scale) is dropped for now,
+    its recursion being significantly more expensive even at 50 queries;
+    re-add it when the verifier prover slims down. A stage that exceeds
+    the CI RAM ceiling lands as an OOM row — the honest signal that
+    secure recursion at that scale does not yet fit. (Measured 2026-08 at
+    100 queries: `Nat.add_comm`'s outer prove peaked ~195 GiB on the
+    ~123 GiB runners; the 50-query halving is what gives it a chance to
     fit.) -/
 def recursiveConstants : List String :=
-  ["Nat.add_comm", "Array.extract_append"]
+  ["Nat.add_comm"]
 
 def BackendSpec.testbedFor (b : BackendSpec) (mode : String) : Option String :=
   (b.testbeds.find? (·.1 == mode)).map (·.2)

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -342,8 +342,8 @@ def findBackend (name : String) : Option BackendSpec :=
 
 /-- The `aiur-recursive` backend's rows: fixed IxVM statements, proved and
     recursively verified by `bench-typecheck --recursive` under the
-    recursion-tuned parameters (the ~100-query count IS the soundness
-    level, so this benchmarks *secure* recursion). The two constants span
+    recursion-tuned parameters (50 queries at log-blowup 2, ~100-bit
+    soundness — this benchmarks *secure* recursion). The two constants span
     the IxVM cost range: `Nat.add_comm` (cheap tier — the small end) and
     `Array.extract_append` (heavy tier — kernel scale). A stage that
     exceeds the CI RAM ceiling lands as an OOM row — the honest signal

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -95,9 +95,10 @@ def plotTitle (workload measure : String) : String :=
     exactly — the decompile run tracks only its own decompile-time /
     throughput / peak-rss trends. The aiur-recursive run's plain
     prove-time / proof-size / verify-time / peak-rss measure the INNER
-    toy-statement proof — tracked for the compare table, but the
-    dashboard trend that matters is the recursion layer's own
-    `recursive-*` series, so the inner metrics aren't plotted. -/
+    IxVM typecheck proof (under recursion-tuned parameters) — tracked for
+    the compare table, but the dashboard trend that matters is the
+    recursion layer's own `recursive-*` series, so the inner metrics
+    aren't plotted. -/
 def plotSkips : List (String × String) :=
   [("aiur-check-prove", "execute-time"), ("aiur-check-execute", "fft-cost"),
    ("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -578,7 +578,6 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     rowNoun :=
       if backend == "compile" then "env"
       else if backend == "ooc" then "env/constant"
-      else if backend == "aiur-recursive" then "proof"
       else "constant"
   }
   -- Per-constant attribution drill-down: rendered whenever an
@@ -1105,10 +1104,10 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut entries : Array Json := #[]
   for b in backends do
     -- The fixed-config backend (`inputs := .fixedConfigs` — aiur-recursive)
-    -- is env-independent (fixed toy statements, no `.ixe`): one run no
-    -- matter how many envs BENCH_ENVS lists. The env kept is the first
-    -- requested one, so the run's `.ixe` restore (an unconditional workflow
-    -- step) still finds a compiled artifact.
+    -- runs a fixed constant list: one run no matter how many envs
+    -- BENCH_ENVS lists. The env kept is the first requested one — its
+    -- compiled `.ixe` is where the run resolves the fixed constants (any
+    -- registry env's closure contains them).
     let runEnvs := if b.inputs == .fixedConfigs then (envsFor b).take 1
       else envsFor b
     for e in runEnvs do

--- a/crates/ixvm-codegen/src/aiur_ixvm_witness.rs
+++ b/crates/ixvm-codegen/src/aiur_ixvm_witness.rs
@@ -118,8 +118,14 @@ fn add_entries_parallel(
   let ch_hint = G::from_u8(3);
   let ch_blob = G::from_u8(4);
 
-  // Pull the set of addrs we'll touch as a Vec for parallel iteration.
-  let closure_vec: Vec<Address> = closure.iter().cloned().collect();
+  // Pull the set of addrs we'll touch as a Vec for parallel iteration,
+  // SORTED: the closure set is unioned by racing threads (DashSet), so its
+  // iteration order varies run to run; the arena indices assigned below
+  // follow this order and flow into the trace via ioGetInfo, so an
+  // unsorted walk makes proof bytes nondeterministic (semantically
+  // equivalent, but bytes and FRI queries reshuffle every run).
+  let mut closure_vec: Vec<Address> = closure.iter().cloned().collect();
+  closure_vec.sort_unstable();
 
   // Phase A: parallel byte conversion per closure addr. Each thread
   // produces its own partial `ChannelEntries`. A constant goes to ch 2

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -78,8 +78,9 @@ ix bench fetch-main --sha $(git merge-base origin/main HEAD) \
 ix bench compare --backend aiur --env InitStd --mode prove \
   --main main.json --pr .lake/benches/aiur-InitStd-prove.json
 
-# The recursion cell — fixed toy statements, no env or .ixe needed:
-ix bench run --backend aiur-recursive
+# The recursion cell — fixed IxVM statements (Nat.add_comm,
+# Array.extract_append), resolved in the env's .ixe:
+ix bench run --backend aiur-recursive --env InitStd --ixe InitStd.ixe
 
 # The lean4lean reference kernel over InitStd — whole-library replay plus
 # per-primary closure rows, from oleans (no .ixe needed). Read next to the
@@ -102,8 +103,8 @@ a PR tree and compare them — exactly what the PR workflow does.
 
 | backend | what it measures | tool |
 |---|---|---|
-| `aiur`    | Aiur STARK check, one bench-main cell per mode on its own testbed: prove — the real-workload simulation (prove-time, proof-size, verify-time, peak-rss, plus fft-cost / execute-time from its own Phase 1) — and execute, the fast Phase-1-only signal (fft-cost, execute-time, throughput, peak-rss). `!benchmark aiur [execute]` picks the mode. A third mode, recursive (`bench-typecheck --recursive`), additionally executes AND proves the in-circuit multi-stark verifier over each fresh proof — the whole system runs under recursion-tuned FRI parameters, so its rows land on their own testbed (`aiur-check-recursive`) and are not comparable to the prove cell's. Unscheduled (an IxVM-scale verifier execute needs >108 GB, beyond the CI ceiling, so no CI job runs it and nothing uploads to its testbed): run it locally (`ix bench run --backend aiur --mode recursive`) or request it on demand with `!benchmark aiur recursive` — on the standard CI host the OOM renders as an empty table, so the token is meant for a bigger manual dispatch | `bench-typecheck` |
-| `aiur-recursive` | the aiur-recursive toy: prove a fixed tiny statement per config, both at the ~100-query soundness level (`square-q100-b1`, the lighter trivial-statement end; `factorial-q100-b2`, the heavier recursive one), run the in-circuit multi-stark verifier over the proof (recursive-execute-time, recursive-fft-cost — the recursion-cost proxy), then prove that execution end-to-end (recursive-prove-time, recursive-peak-rss, recursive-proof-size, recursive-verify-time). Env-independent: fixed configs instead of `Vectors.csv` constants, no `.ixe`, always exactly one cell regardless of `BENCH_ENVS` | `bench-recursive-verifier` |
+| `aiur`    | Aiur STARK check, one bench-main cell per mode on its own testbed: prove — the real-workload simulation (prove-time, proof-size, verify-time, peak-rss, plus fft-cost / execute-time from its own Phase 1) — and execute, the fast Phase-1-only signal (fft-cost, execute-time, throughput, peak-rss). `!benchmark aiur [execute]` picks the mode. A third mode, recursive (`bench-typecheck --recursive`), additionally executes AND proves the in-circuit multi-stark verifier over each fresh proof — the whole system runs under recursion-tuned FRI parameters, so its rows land on their own testbed (`aiur-check-recursive`) and are not comparable to the prove cell's. Unscheduled (the full selection is too heavy for per-push CI — the large closures exceed the RAM ceiling and land as OOM rows — so no CI job runs it and nothing uploads to its testbed; the `aiur-recursive` cell below tracks the same measurement over a fixed two-constant subset): run it locally (`ix bench run --backend aiur --mode recursive`) or request it on demand with `!benchmark aiur recursive` — meant for a bigger manual dispatch | `bench-typecheck` |
+| `aiur-recursive` | IxVM recursion on two fixed constants at the ~100-query soundness level (`Nat.add_comm`, the cheap-tier small end; `Array.extract_append`, the heavy-tier kernel-scale one): prove each constant's IxVM typecheck, run the in-circuit multi-stark verifier over the fresh proof (recursive-execute-time, recursive-fft-cost — the recursion-cost proxy), then prove that execution end-to-end (recursive-prove-time, recursive-peak-rss, recursive-proof-size, recursive-verify-time). The same measurement as aiur's recursive mode, but over a fixed subset instead of the `Vectors.csv` fan-out: always exactly one cell regardless of `BENCH_ENVS`, with the constants resolved in whichever env's `.ixe` the cell carries | `bench-typecheck --recursive` |
 | `zisk`    | ZisK VM execute: cycles, execute-time, throughput, peak-rss, constants (pre-shard closure count, same universe as aiur's), shards (1 when unsharded) | `zisk-host` |
 | `sp1`     | SP1 VM execute (currently disabled in the registry) | `sp1-host` |
 | `ooc`     | out-of-circuit Rust kernel: whole-env row + one full-closure row per primary (`check-time` wraps only the check — the env loads once, outside every row's timed window) | `ix check-rs --json` |
@@ -112,9 +113,10 @@ a PR tree and compare them — exactly what the PR workflow does.
 | `decompile` | inverse of compile — `ix decompile <env>.ixe → Lean consts`: decompile-time, throughput, peak-rss, constants, file-size (input `.ixe`). Consumes the compile cell's `.ixe` rather than producing one; a malformed decompile reddens the cell. Deep roundtrip fidelity is gated by the canonical checks (`ix validate` / roundtrip tests), which need the original Lean env the `.ixe` can't supply | `ix decompile --json` |
 
 All tools emit the same rows, and all the constant-driven ones take the same
-`--consts`/`--consts-file` grammar (`bench-recursive-verifier` instead takes
-its config as flags — `--trivial`, `--queries`, `--log-blowup` — with the row
-name supplied via `--json-name`). The ooc and zkVM cells share per-constant
+`--consts`/`--consts-file` grammar. (`bench-recursive-verifier`, the local
+toy-statement harness for parameter sweeps, instead takes its config as
+flags — `--trivial`, `--queries`, `--log-blowup` — with the row name
+supplied via `--json-name`.) The ooc and zkVM cells share per-constant
 **full-closure** scope, so their delta isolates in-circuit vs out-of-circuit
 overhead.
 
@@ -211,8 +213,8 @@ SHA) → `plan` (`ix bench ci matrix` → job matrices) + `compile` (per env:
 `ix bench run --backend compile`, cache the `.ixe` + pre-cut zisk shards) →
 `aiur` (execute + prove cells) / `zkvm-execute` / `ooc-check` (each: restore caches, one
 `ix bench run … --ixe`, `ix bench bmf`, upload via
-`.github/actions/bencher-track`) / `aiur-recursive` (same shape, but needing only
-the staged binaries — no `.ixe`, so it waits on `build` alone). A kernel
+`.github/actions/bencher-track`) / `aiur-recursive` (same shape — it
+restores the cached `.ixe` its fixed constants resolve in). A kernel
 rejection exits 3 and reddens the
 run step while the clean rows still upload.
 
@@ -248,10 +250,10 @@ write token, running no PR code).
   re-enable it there and it returns to the matrices and the parser.
 - **Non-`main` base branches** — `fetch-main` queries `branch=main`; a PR
   against another base always pays the local base run.
-- **aiur recursive in CI** — `bench-typecheck --recursive` layers the
-  in-circuit multi-stark verifier on real constants, but an IxVM-scale
-  verifier execute needs >108 GB, beyond the CI ceiling, so the
-  `aiur-check-recursive` testbed is registered but unscheduled: no
-  bench-main job and no `!benchmark` token (the `aiur-recursive` token is
-  the toy backend). Run it locally with
-  `ix bench run --backend aiur --mode recursive`.
+- **aiur recursive over the full selection in CI** — the `aiur-recursive`
+  cell tracks IxVM recursion on its two fixed constants, but the full
+  `Vectors.csv` fan-out of `bench-typecheck --recursive` is too heavy for
+  per-push CI (the large closures exceed the RAM ceiling and land as OOM
+  rows), so the `aiur-check-recursive` testbed is registered but
+  unscheduled: no bench-main job and no `!benchmark` token. Run it
+  locally with `ix bench run --backend aiur --mode recursive`.


### PR DESCRIPTION
# Bench: track IxVM recursion in CI, deterministically

The `aiur-recursive` bench backend now tracks real IxVM recursion — `Nat.add_comm` proved by the kernel and recursively verified via `bench-typecheck --recursive` — instead of toy factorial/fibonacci statements.

Tracking `recursive-fft-cost` in CI only works if the number is stable, and it wasn't: three sources of nondeterminism made every run produce different proof bytes and therefore different in-circuit verifier statistics. This PR closes all three:

- **`ixvm witness: deterministic IOBuffer arena order`** — the witness builder walked the closure in the iteration order of a set unioned by racing threads; the arena indices assigned during that walk flow into the trace via `ioGetInfo`, so kernel proofs were semantically equivalent but byte-different every run. The closure is now sorted before walking (as the assumption-tree path already
did).
- **`bench-typecheck: no query proof-of-work`** — PoW grinding adds a nondeterministic witness search to every proof without changing any measured cost; both parameter sets go to 0 bits.
- **multi-stark bump ([`5023fee`](https://github.com/argumentcomputer/multi-stark/commit/5023feee459101b52e5a59091cf46495027fad18))** — even at 0 bits, p3's `SerializingChallenger64::grind` raced `find_any` over candidates that all pass, landing a thread-race-dependent witness in the proof bytes. The challenger wrapper returns the canonical `ZERO` instead. Transcript semantics are untouched
(at 0 bits neither side observes the witness), so the recursive verifier needs no change — its `pcs_check_witness` already short-circuits identically. `bench-recursive-verifier --pow` defaults to 0 to match; test suites keep PoW 20 for grinding-path coverage.

Result: back-to-back runs of the CI workload produce identical `recursive-fft-cost = 73188318152.368744` to the last decimal.

## Testing

`recursive-verifier` (6 ✓), `multi-stark` (12 ✓), `aiur-prove`, and `cargo test -p aiur` all pass against the bumped rev; A/A determinism verified on the exact CI invocation.
