### PR TITLE
bench: aiur measures the whole proof pipeline

### DIFF
--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -234,7 +234,9 @@ jobs:
   #   - aiur: the proof pipeline — per constant, every stage plus the
   #     total: prove the IxVM typecheck (stage 1), then execute and
   #     prove the in-circuit multi-stark verifier over that fresh proof
-  #     (stage 2); the KZG stages will fold in as they land. One
+  #     (stage 2); the KZG stages will fold in as they land. Runs the
+  #     registry's fixed pipeline selection rather than the primary
+  #     subset — every stage is paid per constant. One
   #     subprocess per constant under the RAM watchdog; a too-large
   #     prove is killed and recorded as a `status: oom` row.
   #   - zisk: executes the same constants in the zkVM (deterministic

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -14,7 +14,7 @@ name: Benchmark main
 #                  compile benchmark) and caches the file for stage 3.
 #   3. benchmark — one job per remaining entry: restore the `.ixe` and
 #                  run the entry's backend over it (aiur, zisk, ooc,
-#                  decompile, aiur-recursive).
+#                  decompile).
 #
 # Each entry uploads to its own bencher testbed/workload, so a threshold
 # reset for one workload never touches another. When the kernel REJECTS a
@@ -231,12 +231,12 @@ jobs:
   # restores the compile job's cached `.ixe` — nothing recompiles here.
   #
   # What each backend measures:
-  #   - aiur prove: the real workload — a full STARK prove per constant,
-  #     one subprocess per constant under the RAM watchdog; a too-large
+  #   - aiur: the proof pipeline — per constant, every stage plus the
+  #     total: prove the IxVM typecheck (stage 1), then execute and
+  #     prove the in-circuit multi-stark verifier over that fresh proof
+  #     (stage 2); the KZG stages will fold in as they land. One
+  #     subprocess per constant under the RAM watchdog; a too-large
   #     prove is killed and recorded as a `status: oom` row.
-  #     aiur execute: the fast signal — witness generation only.
-  #     The two modes upload to separate testbeds; shared measure names
-  #     (peak-rss, throughput) mean that mode's phase.
   #   - zisk: executes the same constants in the zkVM (deterministic
   #     cycle counts; proving would need a GPU, so execute-only). Reuses
   #     the pre-cut zkshards-<env>/ dirs; builds its Rust host in-job.
@@ -245,12 +245,6 @@ jobs:
   #   - decompile: the inverse of compile. Roundtrip correctness is
   #     checked elsewhere (`ix validate` / roundtrip tests) — this only
   #     measures speed and memory.
-  #   - aiur-recursive: proves the IxVM typecheck of three fixed constants
-  #     (Nat.add_comm, Vector.append, String.split), runs the in-circuit
-  #     verifier over each proof, then proves THAT — the cost of
-  #     recursion at kernel scale. A fixed subset instead of the
-  #     Vectors.csv fan-out: its `env` field names the (already-cached)
-  #     `.ixe` the shared restore step pulls and the constants resolve in.
   benchmark:
     name: ${{ matrix.params.label }}
     needs: [compile, plan]

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -26,7 +26,13 @@
 #   - aiur: `prove` — the full proof pipeline per constant (stage 1
 #     proves the IxVM typecheck, stage 2 executes and proves the
 #     in-circuit multi-stark verifier over that fresh proof), reported
-#     as the per-stage wall clocks plus their total. The bare `execute`
+#     as one comparison table per stage — witness execute, prove, peak
+#     RAM, proof size, verify — closing with the pipeline ledger (total
+#     time and the run's RAM ceiling). Its default selection is a fixed
+#     three-constant list, not the primary subset (`fixedSelections` in
+#     Ix/Cli/BenchCmd.lean): every stage is paid per constant, so the
+#     default set is what one host can finish. BENCH_FULL=1 and
+#     BENCH_CONSTS still override. The bare `execute`
 #     token switches it to the fast Phase-1-only mode (witness
 #     generation; no bencher baseline exists for that, so the main side
 #     comes from a base-SHA run).

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,7 +1,7 @@
 # `!benchmark` PR command: run the curated constant set (Benchmarks/Vectors.csv)
 # through chosen prover backend(s) and post a main-vs-PR comparison table.
 #
-#   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [decompile] [aiur-recursive] | all) [execute]
+#   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [decompile] | all) [execute]
 #     (sp1 is disabled in the registry (Ix/Cli/BenchCmd.lean) — the parser skips it
 #      with a note in the config summary)
 #   BENCH_ENVS=InitStd,Mathlib     # which compiled envs (case-insensitive, any registry env;
@@ -23,21 +23,16 @@
 #                                  # its own row instead of the default run's
 #
 # Each backend runs its registry default mode:
-#   - aiur: `prove` (the real workload; the report also shows the
-#     fft-cost / execute-time measured on the way). The bare `execute`
-#     token switches aiur to the fast execute-only mode; the bare
-#     `recursive` token switches it to recursive mode (no bencher
-#     baseline exists for that, and it needs more RAM than CI has — meant
-#     for a bigger manual dispatch).
+#   - aiur: `prove` — the full proof pipeline per constant (stage 1
+#     proves the IxVM typecheck, stage 2 executes and proves the
+#     in-circuit multi-stark verifier over that fresh proof), reported
+#     as the per-stage wall clocks plus their total. The bare `execute`
+#     token switches it to the fast Phase-1-only mode (witness
+#     generation; no bencher baseline exists for that, so the main side
+#     comes from a base-SHA run).
 #   - zisk / sp1 / ooc: `execute`.
 #   - compile: `ix compile <env>.lean` → `<env>.ixe`.
 #   - decompile: `ix decompile` over the compile run's fresh `.ixe`.
-#   - aiur-recursive: fixed IxVM statements (Nat.add_comm plus the
-#     heavy-tier Vector.append and String.split; Array.extract_append
-#     is dropped for now — it OOMs on CI) proved and recursively verified via
-#     bench-typecheck --recursive; always schedules exactly one run
-#     regardless of BENCH_ENVS (the constants resolve in whichever env's
-#     .ixe the entry carries).
 # The bare `fresh` token skips the bencher fetch and re-measures the main
 # side with a local base-SHA run. Nothing in this workflow uploads to
 # bencher, so the canonical baseline is never touched.

--- a/.github/workflows/bencher-thresholds-reset.yml
+++ b/.github/workflows/bencher-thresholds-reset.yml
@@ -22,7 +22,7 @@ name: Bencher thresholds reset
 #     cancel by removing it before merge. Naming convention: one label per token,
 #     `bencher-thresholds-reset:<token>` where <token> is a workload (a backend
 #     testbed in Ix/Cli/BenchCmd.lean (backendSpecs) minus its runner-arch suffix:
-#     `ix-compile`, `ix-decompile`, `aiur-check-execute`, `aiur-check-prove`, `aiur-check-recursive`, `aiur-recursive`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
+#     `ix-compile`, `ix-decompile`, `aiur`, `zisk-check-execute`, `sp1-check-execute`, `ooc-check`) or
 #     `all` (the merge step expands an `all` label into every workload). Labeling
 #     requires Triage+, so PR authors from forks cannot self-queue a reset. The
 #     label shares the command/workflow name; the ref it moves is
@@ -44,7 +44,7 @@ on:
         # GitHub requires literal choice options, so this list stays static:
         # keep it (and the jobs' valid= lists below) in sync with the
         # backend testbeds in Ix/Cli/BenchCmd.lean (backendSpecs).
-        options: [ix-compile, ix-decompile, aiur-check-execute, aiur-check-prove, aiur-check-recursive, aiur-recursive, zisk-check-execute, sp1-check-execute, ooc-check, all]
+        options: [ix-compile, ix-decompile, aiur, zisk-check-execute, sp1-check-execute, ooc-check, all]
       sha:
         description: "Commit to anchor to (default: HEAD)"
         required: false
@@ -77,7 +77,7 @@ jobs:
           # (backendSpecs) minus the runner-arch suffix. Static because this
           # job runs on a cheap runner with no built `ix`; keep in sync when
           # adding a backend.
-          valid="aiur-check-execute aiur-check-prove aiur-check-recursive aiur-recursive ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
+          valid="aiur ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
           if [ "$EVENT" = workflow_dispatch ]; then
             # Reset the chosen workload(s) at the given commit; no PR scan.
             sha="${INPUT_SHA:-$HEAD_SHA}"
@@ -133,7 +133,7 @@ jobs:
           # which the merge job expands into every workload). Same static
           # list as the reset job; keep both in sync with backendSpecs in
           # Ix/Cli/BenchCmd.lean.
-          valid="aiur-check-execute aiur-check-prove aiur-check-recursive aiur-recursive ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
+          valid="aiur ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
           accepted="$valid all"
           # Parse the workload token(s) after the command, lowercased.
           workloads=$(printf '%s' "$BODY" \

--- a/Benchmarks/RecursiveVerifier.lean
+++ b/Benchmarks/RecursiveVerifier.lean
@@ -30,9 +30,9 @@ lake exe bench-recursive-verifier --execute-only  # skip the outer prove (FFT/ex
   --json <path>    write a benchmark results row (Ix.Benchmark.Results); the
                    row lands after the verifier execute and is refined after
                    the outer prove, so a kill mid-prove keeps the execute
-                   metrics. (A local harness only: CI's aiur-recursive
-                   backend instead drives `bench-typecheck --recursive`
-                   over fixed IxVM statements.)
+                   metrics. (A local harness only: CI's aiur backend
+                   instead drives `bench-typecheck --recursive` over the
+                   curated Vectors.csv constants.)
   --json-name <n>  row key (default: the inner entrypoint name)
   --texray         tracing-texray timeline + RAM; with --json, spans also land
                    at `<json>.spans` for the CI drill-down

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -141,15 +141,17 @@ def recursiveCommitmentParameters : Aiur.CommitmentParameters := {
     alike. The query count IS the soundness level, so a real (secure)
     recursive proof needs a full query count, not a toy handful — but the
     in-circuit verifier's work (and the outer prove's footprint) scales
-    with it: 50 queries still OOMs the ~123 GiB CI hosts on the heavy end
-    of the selection, so 40 is the count sized to fit. An OOM row still
-    documents the gap between secure recursion and what fits today.
+    with it, and at the heavy end of the selection the outer prove runs
+    close enough to the CI host's RAM ceiling that a constant can cross
+    it. That is the intended trade: prefer the soundness and let a
+    constant that does not fit land as an OOM row, documenting the gap
+    between secure recursion and what fits today.
     `--recursive` runs the WHOLE system, inner prove included, under
     these, so its rows are not comparable to a plain `prove` run's. -/
 def recursiveFriParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
-  numQueries := 40
+  numQueries := 50
   commitProofOfWorkBits := 0
   queryProofOfWorkBits := 0
 }
@@ -654,7 +656,7 @@ def typecheckCmd : Cli.Cmd := `[Cli|
     "execute-only";       "Execute only (Phase 1: constants / fft-cost / execute-time) and skip proving. The fast per-PR `execute`-mode signal."
     "recursive";          "After each prove, execute and then prove the in-circuit multi-stark verifier over the fresh proof (the recursive-* metrics; see the module docstring). Uses recursion-tuned FRI parameters. Conflicts with --execute-only."
     "interp";             "Route execution through the generic Aiur bytecode interpreter instead of the codegen'd IxVM kernel - no `lake exe ix codegen` + cargo rebuild needed after `Ix/IxVM/*.lean` edits. Applies to Phase 1, the prove's witness generation, and both --recursive steps. Slower; execute-time rows are not comparable to codegen-mode runs (fft-cost is)."
-    "queries"   : Nat;    "Override the FRI query count of the selected parameter set (default 100, or 40 with --recursive; applies to inner and outer proof alike)."
+    "queries"   : Nat;    "Override the FRI query count of the selected parameter set (default 100, or 50 with --recursive; applies to inner and outer proof alike)."
     texray;               "Enable the tracing-texray timeline + RAM breakdown (per-prove spans on stderr). Combined with --json, per-phase span timings are additionally written to `<json>.spans` as JSON Lines for the CI drill-down. Off by default."
 
 ]

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -55,10 +55,11 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  recursion-cost proxy), then prove that execution end-to-end
                  (`recursive-prove-time`, `recursive-peak-rss`,
                  `recursive-proof-size`, `recursive-verify-time`), and close the
-                 row with the stage ledger — `stage1-time` (witness execute +
-                 inner prove), `stage2-time` (verifier execute + outer prove),
-                 `total-time` (their sum; later pipeline stages will fold in
-                 as they land), and `pipeline-peak-rss` (the maximum over
+                 row with the pipeline ledger — `total-time` (each stage's
+                 prove, summed; a prove already contains its own witness
+                 execution, so the standalone execute times are NOT added,
+                 and later pipeline stages will fold in as they land) and
+                 `pipeline-peak-rss` (the maximum over
                  every phase window — the run's true RAM ceiling, which no
                  single windowed peak reports). The whole system, inner prove included,
                  switches to the recursion-tuned parameters
@@ -101,8 +102,8 @@ The JSON is a flat shape (`{ "<name>": { "constants": …, "fft-cost": …,
 "execute-time": …, "prove-time": …, "proof-size": …, "verify-time": …,
 "throughput": …, "peak-rss": …, and with --recursive also "recursive-execute-time": …,
 "recursive-fft-cost": …, "recursive-prove-time": …, "recursive-peak-rss": …,
-"recursive-proof-size": …, "recursive-verify-time": …, plus the stage ledger
-"stage1-time": …, "stage2-time": …, "total-time": …, "pipeline-peak-rss": …
+"recursive-proof-size": …, "recursive-verify-time": …, plus the pipeline
+ledger "total-time": …, "pipeline-peak-rss": …
 once the pipeline completes } }`). `peak-rss` and `throughput` are
 phase-scoped by MODE: an `--execute-only` row carries the Phase-1 RSS
 high-water and constants/sec over the execute; a prove row carries the
@@ -276,23 +277,24 @@ def Result.toJsonEntry (executeOnly : Bool) (r : Result) : String × Json :=
     let fields := match r.recursiveVerifySec with
       | some v => fields ++ [ ("recursive-verify-time", jsonRound 6 v) ]
       | none => fields
-    -- The stage ledger, once the whole pipeline has run: each stage's
-    -- wall clock is its witness execution plus its prove (verification
-    -- is a consumer cost, not a production one), and `total-time` is
-    -- their sum — the headline the `aiur` benchmark sorts on.
+    -- The pipeline ledger, once the whole pipeline has run.
+    -- `total-time` is each stage's prove, summed. A stage's prove is
+    -- the WHOLE cost of producing that stage's proof: `prove_ixvm` runs
+    -- the executor itself (the `aiur/execute_ixvm` span) before
+    -- generating the witness, so the Phase-1 `execute-time` beside it is
+    -- a SECOND, standalone run — instrumentation for `constants` and
+    -- `fft-cost`, not a step of proving. Adding the two would count the
+    -- execution twice. Verification is likewise excluded: a consumer
+    -- cost, not a production one.
     -- `pipeline-peak-rss` is the whole run's RAM high-water: the
     -- per-phase windows reset, so no single `peak-rss` answers "how much
     -- RAM does this pipeline need" — their maximum does. Emitted
     -- only with every component present, so it doubles as the row's
     -- completion marker (the orchestrator's teardown-kill `doneKey`).
     let fields := match r.proveSec, r.recursiveExecuteSec, r.recursiveProveSec with
-      | some p, some re, some rp =>
-        let stage1 := r.executeSec + p
-        let stage2 := re + rp
+      | some p, some _, some rp =>
         let peaks := [r.executePeakRss, r.peakRss, r.recursivePeakRss].reduceOption
-        fields ++ [ ("stage1-time", jsonRound 6 stage1)
-                  , ("stage2-time", jsonRound 6 stage2)
-                  , ("total-time", jsonRound 6 (stage1 + stage2)) ]
+        fields ++ [ ("total-time", jsonRound 6 (p + rp)) ]
           ++ (match peaks.max? with
               | some n => [("pipeline-peak-rss", Lean.toJson n)]
               | none => [])

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -54,17 +54,17 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  execute it (`recursive-execute-time`, `recursive-fft-cost` — the
                  recursion-cost proxy), then prove that execution end-to-end
                  (`recursive-prove-time`, `recursive-peak-rss`,
-                 `recursive-proof-size`, `recursive-verify-time`). The whole
-                 system, inner prove included, switches to the recursion-tuned
-                 parameters (`recursiveFriParameters`), so recursive rows are
-                 NOT comparable to the standard prove run — they land on
-                 their own testbed (`ix bench run --backend aiur --mode
-                 recursive`; the fixed two-constant subset runs in CI as
-                 `--backend aiur-recursive`). At IxVM scale the recursion
-                 exceeds the CI RAM ceiling (even Nat.add_comm's outer
-                 prove peaks ~195 GiB as of 2026-08), so a watchdog kill
-                 landing as a `status: oom` row (dropped by bmf) is the
-                 expected shape there. With --texray, both
+                 `recursive-proof-size`, `recursive-verify-time`), and close the
+                 row with the stage ledger — `stage1-time` (witness execute +
+                 inner prove), `stage2-time` (verifier execute + outer prove),
+                 `total-time` (their sum; later pipeline stages will fold in
+                 as they land). The whole system, inner prove included,
+                 switches to the recursion-tuned parameters
+                 (`recursiveFriParameters`), so recursive rows are NOT
+                 comparable to a plain prove run's. This is the mode CI's
+                 `aiur` benchmark runs (`ix bench run --backend aiur`): the
+                 full proof pipeline, per constant, over the curated
+                 Vectors.csv selection. With --texray, both
                  proves stream the same `stark/...` span names, so the summed
                  `phase-stark-*` fields cover the pair. Conflicts with
                  --execute-only.
@@ -99,7 +99,9 @@ The JSON is a flat shape (`{ "<name>": { "constants": …, "fft-cost": …,
 "execute-time": …, "prove-time": …, "proof-size": …, "verify-time": …,
 "throughput": …, "peak-rss": …, and with --recursive also "recursive-execute-time": …,
 "recursive-fft-cost": …, "recursive-prove-time": …, "recursive-peak-rss": …,
-"recursive-proof-size": …, "recursive-verify-time": … } }`). `peak-rss` and `throughput` are
+"recursive-proof-size": …, "recursive-verify-time": …, plus the stage ledger
+"stage1-time": …, "stage2-time": …, "total-time": … once the pipeline
+completes } }`). `peak-rss` and `throughput` are
 phase-scoped by MODE: an `--execute-only` row carries the Phase-1 RSS
 high-water and constants/sec over the execute; a prove row carries the
 prover's high-water and constants/sec over the prove (with `prove-time`,
@@ -131,20 +133,20 @@ def recursiveCommitmentParameters : Aiur.CommitmentParameters := {
   capHeight := 0
 }
 
-/-- Recursion FRI parameters for `--recursive`. The query count IS the
-    soundness level, so a real (secure) recursive proof needs a full query
-    count, not a toy handful: 50 queries at log-blowup 2 target ~100 bits,
-    halving the in-circuit verifier's query-proportional work (and the
-    outer prove's footprint) relative to the previous 100-query setting —
-    sized so the run has a chance of fitting CI's weaker hosts. The
-    in-circuit verifier's cost scales with the count; an OOM row still
+/-- Recursion FRI parameters for `--recursive` — the CI `aiur` pipeline
+    benchmark's parameters, applied to the stage-1 and stage-2 proofs
+    alike. The query count IS the soundness level, so a real (secure)
+    recursive proof needs a full query count, not a toy handful — but the
+    in-circuit verifier's work (and the outer prove's footprint) scales
+    with it: 50 queries still OOMs the ~123 GiB CI hosts on the heavy end
+    of the selection, so 40 is the count sized to fit. An OOM row still
     documents the gap between secure recursion and what fits today.
     `--recursive` runs the WHOLE system, inner prove included, under
-    these, so its rows are not comparable to the standard `prove` run's. -/
+    these, so its rows are not comparable to a plain `prove` run's. -/
 def recursiveFriParameters : Aiur.FriParameters := {
   logFinalPolyLen := 0
   maxLogArity := 1
-  numQueries := 50
+  numQueries := 40
   commitProofOfWorkBits := 0
   queryProofOfWorkBits := 0
 }
@@ -218,8 +220,8 @@ def jsonRound (d : Nat) (f : Float) : Json :=
     `peak-rss` and `throughput` are PHASE-SCOPED BY MODE, not by name: an
     execute-only run's row carries the Phase-1 peak and constants/sec over
     the execute; a prove run's row carries the prove-phase peak and
-    constants/sec over the prove. The two modes upload to separate bencher
-    testbeds (aiur-check-execute-* / aiur-check-prove-*), so the shared names never
+    constants/sec over the prove. The two modes store on separate bencher
+    testbeds (aiur-execute-* / aiur-*), so the shared names never
     collide — run the execute run when you want execute-side numbers. -/
 def Result.toJsonEntry (executeOnly : Bool) (r : Result) : String × Json :=
   if r.failed then
@@ -272,6 +274,20 @@ def Result.toJsonEntry (executeOnly : Bool) (r : Result) : String × Json :=
     let fields := match r.recursiveVerifySec with
       | some v => fields ++ [ ("recursive-verify-time", jsonRound 6 v) ]
       | none => fields
+    -- The stage ledger, once the whole pipeline has run: each stage's
+    -- wall clock is its witness execution plus its prove (verification
+    -- is a consumer cost, not a production one), and `total-time` is
+    -- their sum — the headline the `aiur` benchmark sorts on. Emitted
+    -- only with every component present, so it doubles as the row's
+    -- completion marker (the orchestrator's teardown-kill `doneKey`).
+    let fields := match r.proveSec, r.recursiveExecuteSec, r.recursiveProveSec with
+      | some p, some re, some rp =>
+        let stage1 := r.executeSec + p
+        let stage2 := re + rp
+        fields ++ [ ("stage1-time", jsonRound 6 stage1)
+                  , ("stage2-time", jsonRound 6 stage2)
+                  , ("total-time", jsonRound 6 (stage1 + stage2)) ]
+      | _, _, _ => fields
     (r.name, Json.mkObj fields)
 
 /-- Time a thunk, returning its value and the elapsed seconds. The result is
@@ -627,7 +643,7 @@ def typecheckCmd : Cli.Cmd := `[Cli|
     "execute-only";       "Execute only (Phase 1: constants / fft-cost / execute-time) and skip proving. The fast per-PR `execute`-mode signal."
     "recursive";          "After each prove, execute and then prove the in-circuit multi-stark verifier over the fresh proof (the recursive-* metrics; see the module docstring). Uses recursion-tuned FRI parameters. Conflicts with --execute-only."
     "interp";             "Route execution through the generic Aiur bytecode interpreter instead of the codegen'd IxVM kernel - no `lake exe ix codegen` + cargo rebuild needed after `Ix/IxVM/*.lean` edits. Applies to Phase 1, the prove's witness generation, and both --recursive steps. Slower; execute-time rows are not comparable to codegen-mode runs (fft-cost is)."
-    "queries"   : Nat;    "Override the FRI query count of the selected parameter set (default 100, or 50 with --recursive; applies to inner and outer proof alike)."
+    "queries"   : Nat;    "Override the FRI query count of the selected parameter set (default 100, or 40 with --recursive; applies to inner and outer proof alike)."
     texray;               "Enable the tracing-texray timeline + RAM breakdown (per-prove spans on stderr). Combined with --json, per-phase span timings are additionally written to `<json>.spans` as JSON Lines for the CI drill-down. Off by default."
 
 ]

--- a/Benchmarks/Typecheck.lean
+++ b/Benchmarks/Typecheck.lean
@@ -58,7 +58,9 @@ lake exe bench-typecheck --ixe <path> --consts <n1,n2,…> [--consts-file <p>] [
                  row with the stage ledger — `stage1-time` (witness execute +
                  inner prove), `stage2-time` (verifier execute + outer prove),
                  `total-time` (their sum; later pipeline stages will fold in
-                 as they land). The whole system, inner prove included,
+                 as they land), and `pipeline-peak-rss` (the maximum over
+                 every phase window — the run's true RAM ceiling, which no
+                 single windowed peak reports). The whole system, inner prove included,
                  switches to the recursion-tuned parameters
                  (`recursiveFriParameters`), so recursive rows are NOT
                  comparable to a plain prove run's. This is the mode CI's
@@ -100,8 +102,8 @@ The JSON is a flat shape (`{ "<name>": { "constants": …, "fft-cost": …,
 "throughput": …, "peak-rss": …, and with --recursive also "recursive-execute-time": …,
 "recursive-fft-cost": …, "recursive-prove-time": …, "recursive-peak-rss": …,
 "recursive-proof-size": …, "recursive-verify-time": …, plus the stage ledger
-"stage1-time": …, "stage2-time": …, "total-time": … once the pipeline
-completes } }`). `peak-rss` and `throughput` are
+"stage1-time": …, "stage2-time": …, "total-time": …, "pipeline-peak-rss": …
+once the pipeline completes } }`). `peak-rss` and `throughput` are
 phase-scoped by MODE: an `--execute-only` row carries the Phase-1 RSS
 high-water and constants/sec over the execute; a prove row carries the
 prover's high-water and constants/sec over the prove (with `prove-time`,
@@ -277,16 +279,23 @@ def Result.toJsonEntry (executeOnly : Bool) (r : Result) : String × Json :=
     -- The stage ledger, once the whole pipeline has run: each stage's
     -- wall clock is its witness execution plus its prove (verification
     -- is a consumer cost, not a production one), and `total-time` is
-    -- their sum — the headline the `aiur` benchmark sorts on. Emitted
+    -- their sum — the headline the `aiur` benchmark sorts on.
+    -- `pipeline-peak-rss` is the whole run's RAM high-water: the
+    -- per-phase windows reset, so no single `peak-rss` answers "how much
+    -- RAM does this pipeline need" — their maximum does. Emitted
     -- only with every component present, so it doubles as the row's
     -- completion marker (the orchestrator's teardown-kill `doneKey`).
     let fields := match r.proveSec, r.recursiveExecuteSec, r.recursiveProveSec with
       | some p, some re, some rp =>
         let stage1 := r.executeSec + p
         let stage2 := re + rp
+        let peaks := [r.executePeakRss, r.peakRss, r.recursivePeakRss].reduceOption
         fields ++ [ ("stage1-time", jsonRound 6 stage1)
                   , ("stage2-time", jsonRound 6 stage2)
                   , ("total-time", jsonRound 6 (stage1 + stage2)) ]
+          ++ (match peaks.max? with
+              | some n => [("pipeline-peak-rss", Lean.toJson n)]
+              | none => [])
       | _, _, _ => fields
     (r.name, Json.mkObj fields)
 

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -10,8 +10,8 @@
   2. resolves the env's `.ixe` (an explicit `--ixe` path, else `ix
      compile` — except for the `compile` backend, where the compile IS
      the benchmark);
-  3. spawns the run's measured tool — `bench-typecheck` (aiur,
-     aiur-recursive), `zisk-host`/`sp1-host` (zkVM execute), `ix check-rs` (ooc),
+  3. spawns the run's measured tool — `bench-typecheck` (aiur),
+     `zisk-host`/`sp1-host` (zkVM execute), `ix check-rs` (ooc),
      `bench-lean4lean` (lean4lean; olean-driven, no `.ixe`),
      `ix compile` (compile) — wrapped in the RAM watchdog (`watchdog.sh`:
      cgroup `memory.max` via a systemd user scope; the kernel OOM-kills
@@ -103,7 +103,7 @@ def selectNames (rows : Array VectorRow) (env : String) (backend : String)
     Array VectorRow := Id.run do
   let effTier :=
     if tier != "" then tier
-    else if (mode == "prove" || mode == "recursive") && full then "cheap"
+    else if mode == "prove" && full then "cheap"
     else "all"
   rows.filter fun r =>
     r.env == env
@@ -150,15 +150,11 @@ def findEnv (token : String) : Option EnvSpec :=
         the envs whose CSV rows select any — an env joins this fan-out by
         gaining rows, not by a registry flag. The prove/execute backends
         (aiur, zisk, sp1).
-      · `perConstantWithEnv` — `perConstant` plus a whole-env row (ooc).
-      · `fixedConfigs` — a fixed constant list, a single matrix entry no
-        matter how many envs are requested (aiur-recursive:
-        `recursiveConstants`, resolved in the one env the entry carries). -/
+      · `perConstantWithEnv` — `perConstant` plus a whole-env row (ooc). -/
 inductive BenchInputs
   | perEnv
   | perConstant
   | perConstantWithEnv
-  | fixedConfigs
   deriving BEq
 
 /-- A testbed minus its runner-arch suffix — the workload key the threshold
@@ -212,67 +208,46 @@ structure BackendSpec where
   thresholds : List (String × String × String) := []
 
 def backendSpecs : List BackendSpec := [
-  -- prove is aiur's default: the real-workload simulation (it measures
-  -- Phase 1 — execute-time, fft-cost — inside the same process en route).
-  -- execute is the fast Phase-1-only signal. recursive layers the in-circuit
-  -- multi-stark verifier on prove: execute it over each fresh proof, then
-  -- prove that execution — the recursion run. It runs under the
-  -- recursion-tuned FRI parameters, so even its shared-name metrics
-  -- (prove-time, peak-rss) are not comparable to the prove run's. Over the
-  -- full Vectors.csv selection the run is too heavy for per-push CI (the
-  -- large closures exceed the RAM ceiling and land as `status: oom` rows
-  -- that bmf drops), which is why it's marked `unscheduled`: a testbed for
-  -- local `--mode recursive` runs only — never uploaded to bencher, never
-  -- plotted. CI tracks the same measurement over the fixed three-constant
-  -- subset via the aiur-recursive backend below.
+  -- aiur: the proof-pipeline benchmark (bench-typecheck --recursive) —
+  -- every stage of the pipeline, per constant, plus the total. Stage 1
+  -- proves the constant's IxVM typecheck; stage 2 executes the
+  -- in-circuit multi-stark verifier over the fresh stage-1 proof and
+  -- proves THAT execution; the KZG stages will join as stages 3/4 when
+  -- they land, folding into the same ledger. The headline columns are
+  -- the per-stage wall clocks (`stageN-time` = witness execute + prove)
+  -- and `total-time`, their sum. The whole system runs under the
+  -- recursion-tuned parameters — 40 FRI queries at log-blowup 2 for the
+  -- stage-1 and stage-2 proofs alike (50 OOMs the CI hosts; see
+  -- `recursiveFriParameters` in Benchmarks/Typecheck.lean). execute is
+  -- the fast Phase-1-only signal (witness generation, no proving),
+  -- `unscheduled`: a local / on-demand mode that never uploads.
   { name := "aiur", defaultMode := "prove", inputs := .perConstant,
-    testbeds := [("prove", "aiur-check-prove-x64-32x"),
-                 ("execute", "aiur-check-execute-x64-32x"),
-                 ("recursive", "aiur-check-recursive-x64-32x")],
-    unscheduled := ["recursive"],
-    metrics := [("prove", ["prove-time", "throughput", "peak-rss",
-                           "execute-time", "verify-time", "proof-size",
+    testbeds := [("prove", "aiur-x64-32x"),
+                 ("execute", "aiur-execute-x64-32x")],
+    unscheduled := ["execute"],
+    metrics := [("prove", ["total-time", "stage1-time", "stage2-time",
+                           "recursive-peak-rss", "recursive-proof-size",
+                           "recursive-verify-time", "recursive-fft-cost",
+                           "peak-rss", "proof-size", "verify-time",
                            "fft-cost"]),
                 ("execute", ["execute-time", "throughput", "peak-rss",
-                             "fft-cost"]),
-                ("recursive", ["recursive-prove-time", "recursive-peak-rss",
-                               "recursive-proof-size", "recursive-verify-time",
-                               "recursive-execute-time", "recursive-fft-cost",
-                               "prove-time", "proof-size"])],
+                             "fft-cost"])],
     -- fft-cost is deterministic but only ever drops on a real Aiur win →
-    -- upper-only 5% instead of a hard pin. peak-rss and throughput are
-    -- phase-scoped by the CELL (execute vs prove testbed);
-    -- prove/verify-time and proof-size exist only on the prove testbed.
+    -- upper-only 5% instead of a hard pin. recursive-fft-cost drifts
+    -- ~±15% run-to-run (the parallel prover emits byte-different valid
+    -- proofs, so the verifier authenticates different Merkle paths) →
+    -- the loose 25% bound. Proof sizes are structural (fixed query count
+    -- and path depth) → the tight 5%.
     thresholds := [("constants", "0", "0"), ("fft-cost", "0.05", "_"),
-                   ("prove-time", "0.10", "_"), ("verify-time", "0.10", "_"),
-                   ("proof-size", "0.05", "_"), ("execute-time", "0.10", "_"),
-                   ("peak-rss", "0.10", "_"), ("throughput", "_", "0.10")] },
-  -- The aiur-recursive run (bench-typecheck --recursive over
-  -- `recursiveConstants`): IxVM recursion on real statements — prove each
-  -- constant's typecheck, execute the in-circuit multi-stark verifier
-  -- over the fresh proof, then prove THAT execution. The same measurement
-  -- as the aiur recursive mode above, but over a fixed three-constant
-  -- subset so CI schedules exactly one entry instead of the whole
-  -- Vectors.csv fan-out.
-  { name := "aiur-recursive", defaultMode := "prove", inputs := .fixedConfigs,
-    testbeds := [("prove", "aiur-recursive-x64-32x")],
-    metrics := [("prove", ["recursive-prove-time", "recursive-peak-rss",
-                           "recursive-proof-size", "recursive-verify-time",
-                           "recursive-execute-time", "recursive-fft-cost",
-                           "prove-time", "proof-size", "verify-time",
-                           "peak-rss"])],
-    -- recursive-fft-cost drifts ~±15% run-to-run (the parallel prover
-    -- emits byte-different valid proofs, so the verifier authenticates
-    -- different Merkle paths) → the loose 25% bound; proof sizes are
-    -- structural (fixed query count and path depth) → the tight 5%.
-    thresholds := [("recursive-fft-cost", "0.25", "_"),
-                   ("recursive-execute-time", "0.10", "_"),
-                   ("recursive-prove-time", "0.10", "_"),
-                   ("recursive-verify-time", "0.10", "_"),
+                   ("recursive-fft-cost", "0.25", "_"),
+                   ("total-time", "0.10", "_"), ("stage1-time", "0.10", "_"),
+                   ("stage2-time", "0.10", "_"),
+                   ("peak-rss", "0.10", "_"),
                    ("recursive-peak-rss", "0.10", "_"),
+                   ("proof-size", "0.05", "_"),
                    ("recursive-proof-size", "0.05", "_"),
-                   ("prove-time", "0.10", "_"), ("proof-size", "0.05", "_"),
-                   ("verify-time", "0.10", "_"), ("peak-rss", "0.10", "_")] },
+                   ("verify-time", "0.10", "_"),
+                   ("recursive-verify-time", "0.10", "_")] },
   { name := "zisk", defaultMode := "execute", inputs := .perConstant,
     testbeds := [("execute", "zisk-check-execute-x64-32x")],
     metrics := [("execute", ["execute-time", "throughput", "peak-rss",
@@ -340,22 +315,6 @@ def backendSpecs : List BackendSpec := [
 def findBackend (name : String) : Option BackendSpec :=
   backendSpecs.find? (·.name == name)
 
-/-- The `aiur-recursive` backend's rows: fixed IxVM statements, proved and
-    recursively verified by `bench-typecheck --recursive` under the
-    recursion-tuned parameters (50 queries at log-blowup 2, ~100-bit
-    soundness — this benchmarks *secure* recursion). `Nat.add_comm`
-    (cheap tier) is the small end of the IxVM cost range;
-    `Vector.append` and `String.split` (heavy tier — kernel scale) are
-    the expensive end. `Array.extract_append` is dropped for now — it
-    OOMs on CI even at 50 queries; re-add it when the verifier prover
-    slims down. A stage that exceeds the CI RAM ceiling lands as an OOM
-    row — the honest signal that secure recursion at that scale does not
-    yet fit. (Measured 2026-08 at 100 queries: `Nat.add_comm`'s outer
-    prove peaked ~195 GiB on the ~123 GiB runners; the 50-query halving
-    is what gives it a chance to fit.) -/
-def recursiveConstants : List String :=
-  ["Nat.add_comm", "Vector.append", "String.split"]
-
 def BackendSpec.testbedFor (b : BackendSpec) (mode : String) : Option String :=
   (b.testbeds.find? (·.1 == mode)).map (·.2)
 
@@ -384,9 +343,7 @@ def BackendSpec.scheduledModes (b : BackendSpec) : List String :=
     least one primary constant is selected in ANY scheduled mode — an env
     joins their fan-out by gaining rows, not by a registry flag, and a
     constant excluded from one mode (e.g. prove) still keeps its env if
-    another scheduled mode (e.g. execute) runs it; the fixed-config
-    backend is env-independent, pinned to the head env so CI schedules
-    exactly one entry. -/
+    another scheduled mode (e.g. execute) runs it. -/
 def BackendSpec.envNames (b : BackendSpec) (rows : Array VectorRow) :
     List String :=
   let names := envSpecs.map (·.name)
@@ -397,20 +354,17 @@ def BackendSpec.envNames (b : BackendSpec) (rows : Array VectorRow) :
       b.scheduledModes.any fun m =>
         !(selectNames rows env b.name m
           (full := false) (tier := "") (shardOnly := false)).isEmpty
-  | .fixedConfigs => names.take 1
 
 /-- The benchmark row names this backend uploads — the bencher slugs the
     dashboard plots and compare table key on — from its `inputs`: env-keyed
     backends key one row per compiled env; the per-constant backends select
     from `Vectors.csv` over their env set (`perConstantWithEnv` prepends a
-    whole-env row); the fixed-config backend lists its configs. Dynamic
-    shard sub-rows (`<name>/shard-N`) are excluded — the parent row
-    carries the headline trend. -/
+    whole-env row). Dynamic shard sub-rows (`<name>/shard-N`) are
+    excluded — the parent row carries the headline trend. -/
 def BackendSpec.benchmarkNames (b : BackendSpec) (rows : Array VectorRow)
     (mode : String) : Array String := Id.run do
   match b.inputs with
   | .perEnv => return (envSpecs.map (·.name)).toArray
-  | .fixedConfigs => return recursiveConstants.toArray
   | .perConstant | .perConstantWithEnv =>
     let mut ns : Array String := #[]
     for env in b.envNames rows do
@@ -703,11 +657,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
         (rows.find? (fun r => r.name == n && r.env == env)).getD
           { name := n, env, tier := "cheap", shardTarget := false, primary := false }
   let names := selected.map (·.name)
-  match backend with
-  | "aiur-recursive" =>
-    IO.eprintln s!"[bench] run {backend}-{mode}: {recursiveConstants.length} constant(s)"
-  | _ =>
-    IO.eprintln s!"[bench] run {backend}-{env}-{mode}: {names.size} constant(s)"
+  IO.eprintln s!"[bench] run {backend}-{env}-{mode}: {names.size} constant(s)"
 
   -- Fresh accumulator per run.
   if ← FilePath.pathExists out then IO.FS.removeFile out
@@ -778,32 +728,20 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
       if exit != 0 && exit != exitRejected then
         IO.eprintln s!"[bench] per-constant closures failed (exit {exit})"
   | "aiur" =>
+    -- prove runs the whole pipeline (`bench-typecheck --recursive`):
+    -- every stage per constant, closed by the stage ledger. One process
+    -- per constant under the watchdog; `total-time` is the ledger's last
+    -- field, so it doubles as the completion marker — a kill before the
+    -- pipeline finishes records an honest oom/crash row.
     let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))
     let bt ← resolveBin repo "bench-typecheck"
-    let modeArgs := match mode with
-      | "execute" => #["--execute-only"]
-      | "recursive" => #["--recursive"]
-      | _ => #[]
-    let doneKey := match mode with
-      | "execute" => "execute-time"
-      | "recursive" => "recursive-prove-time"
-      | _ => "prove-time"
+    let (modeArgs, doneKey) := match mode with
+      | "execute" => (#["--execute-only"], "execute-time")
+      | _ => (#["--recursive"], "total-time")
     runPerConstant out names doneKey fun name =>
       runGuarded watchdog ceilingGb bt
         (#["--ixe", ixe, "--consts", name, "--json", out, "--texray"]
           ++ modeArgs)
-  | "aiur-recursive" =>
-    -- Fixed IxVM statements, resolved in the run's `.ixe`: the same
-    -- spawn as the aiur recursive mode, over `recursiveConstants`
-    -- instead of the Vectors.csv selection. One process per constant
-    -- under the watchdog.
-    let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))
-    let bt ← resolveBin repo "bench-typecheck"
-    runPerConstant out recursiveConstants.toArray "recursive-prove-time"
-      fun name =>
-        runGuarded watchdog ceilingGb bt
-          #["--ixe", ixe, "--consts", name, "--json", out, "--texray",
-            "--recursive"]
   | "zisk" | "sp1" =>
     if mode != "execute" then
       p.printError s!"error: {backend} supports only execute mode"
@@ -856,7 +794,6 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
     | "compile" => #[info.name]
     | "decompile" => #[info.name]
     | "ooc" | "lean4lean" => #[info.name] ++ names
-    | "aiur-recursive" => recursiveConstants.toArray
     | _ => names
   let code ← gate out expected
   if code == 0 || code == exitRejected then
@@ -899,9 +836,9 @@ def benchRunCmd : Cli.Cmd := `[Cli|
   "Execute one benchmark run (backend × env × mode), writing benchmark results JSON. Exits 0 on success (rows saved as the local baseline), 3 when the kernel rejected any constant, 1 when no rows were produced."
 
   FLAGS:
-    backend      : String; "aiur | zisk | sp1 | ooc | lean4lean | compile | decompile | aiur-recursive"
+    backend      : String; "aiur | zisk | sp1 | ooc | lean4lean | compile | decompile"
     env          : String; "Benchmark env from the registry (default: InitStd)"
-    mode         : String; "prove | execute | recursive (default: the backend's defaultMode)"
+    mode         : String; "prove | execute (default: the backend's defaultMode)"
     out          : String; "Benchmark results JSON output path (default: bench.json)"
     repo         : String; "Checkout to benchmark: tools resolve from <repo>/.lake/build/bin first, then PATH (default: .)"
     csv          : String; "Vectors path (default: <repo>/Benchmarks/Vectors.csv)"

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -102,13 +102,16 @@ def isExcluded (name backend mode : String) : Bool :=
     be `Vectors.csv` rows of the env being run — this narrows the curated
     selection, it does not add to it. -/
 def fixedSelections : List (String × String × List String) :=
-  [ -- The aiur pipeline's cost range: `Nat.add_comm` is the cheap end,
-    -- and the two heavy-tier proofs bracket the expensive end where the
-    -- stage-2 prover meets the host's RAM ceiling.
+  [ -- The aiur pipeline's cost range: two cheap-tier constants for the
+    -- small end, and four heavy-tier ones for the expensive end, where
+    -- the stage-2 prover meets the host's RAM ceiling.
     ("aiur", "prove",
       ["Nat.add_comm",
+       "String.append",
        "Array.extract_append",
-       "ByteArray.utf8DecodeChar?_utf8EncodeChar_append"]) ]
+       "ByteArray.utf8DecodeChar?_utf8EncodeChar_append",
+       "_private.Init.Data.Range.Polymorphic.SInt.0.Int64.instRxcHasSize_eq",
+       "Char.ofOrdinal_le_of_le"]) ]
 
 /-- The fixed default selection for this `(backend, mode)`, if any. -/
 def fixedSelectionFor (backend mode : String) : Option (List String) :=
@@ -256,8 +259,9 @@ def backendSpecs : List BackendSpec := [
   -- proves, summed — each prove already runs its own witness execution,
   -- so the standalone execute times are instrumentation and are not
   -- added) and the run's RAM ceiling. The whole system runs under the
-  -- recursion-tuned parameters — 40 FRI queries at log-blowup 2 for the
-  -- stage-1 and stage-2 proofs alike (50 OOMs the CI hosts; see
+  -- recursion-tuned parameters — 50 FRI queries at log-blowup 2 for the
+  -- stage-1 and stage-2 proofs alike, the soundness level taking
+  -- precedence over fitting every constant in the host's RAM (see
   -- `recursiveFriParameters` in Benchmarks/Typecheck.lean). execute is
   -- the fast Phase-1-only signal (witness generation, no proving),
   -- `unscheduled`: a local / on-demand mode that never uploads.
@@ -281,10 +285,12 @@ def backendSpecs : List BackendSpec := [
     -- ~±15% run-to-run (the parallel prover emits byte-different valid
     -- proofs, so the verifier authenticates different Merkle paths) →
     -- the loose 25% bound. Proof sizes are structural (fixed query count
-    -- and path depth) → the tight 5%.
+    -- and path depth) → the tight 5%. `total-time` carries NO bound: it
+    -- is the two prove times summed, and a sum cannot breach a
+    -- percentage bound unless one of its terms already breached the same
+    -- one — so it could only ever duplicate an alert the proves fired.
     thresholds := [("constants", "0", "0"), ("fft-cost", "0.05", "_"),
                    ("recursive-fft-cost", "0.25", "_"),
-                   ("total-time", "0.10", "_"),
                    ("execute-time", "0.10", "_"), ("prove-time", "0.10", "_"),
                    ("recursive-execute-time", "0.10", "_"),
                    ("recursive-prove-time", "0.10", "_"),

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -213,17 +213,17 @@ structure BackendSpec where
   /-- (mode, compare-table columns), rendered in list order; the head is
       the table's row sort key. Column convention: the mode's headline
       wall-clock time, throughput, peak-rss, then detail (secondary times,
-      sizes, deterministic counters). A mode listed in `stages` takes its
-      columns from there instead. -/
+      sizes, deterministic counters). For a mode listed in `stages` the
+      columns come from there, and this list instead names measures the
+      mode TRACKS without giving them a column — uploaded, thresholded,
+      and plotted like any other, just not tabled. -/
   metrics : List (String × List String)
   /-- (mode, [(stage title, that stage's measures)]) for a mode whose run
       walks a multi-stage pipeline: the compare table splits into one
       table per stage, so a stage's measures keep their plain names
       (`prove-time`, `peak-rss`) across stages instead of competing for
       one row. List order is render order, so the closing entry is the
-      ledger over the whole run. `metricsFor` reads a staged mode's
-      columns from here — the stage lists are the mode's measure list,
-      not a second copy of it. -/
+      ledger over the whole run. -/
   stages : List (String × List (String × List String)) := []
   /-- Regression bounds per tracked measure: (measure, upper, lower), each
       bound a percentage over the baseline as a decimal fraction ("0.10"),
@@ -271,10 +271,14 @@ def backendSpecs : List BackendSpec := [
          ["recursive-execute-time", "recursive-prove-time",
           "recursive-peak-rss", "recursive-proof-size",
           "recursive-verify-time", "recursive-fft-cost"]),
-       ("Pipeline total",
-         ["total-time", "stage1-time", "stage2-time",
-          "pipeline-peak-rss"])])],
-    metrics := [("execute", ["execute-time", "throughput", "peak-rss",
+       ("Pipeline total", ["total-time", "pipeline-peak-rss"])])],
+    -- The per-stage wall clocks get no column: each stage table already
+    -- shows the execute and prove that sum to them, so the ledger stays
+    -- the two numbers that describe the whole run. They stay tracked for
+    -- the dashboard, where a per-stage trend is what shows WHICH stage
+    -- moved the total.
+    metrics := [("prove", ["stage1-time", "stage2-time"]),
+                ("execute", ["execute-time", "throughput", "peak-rss",
                              "fft-cost"])],
     -- fft-cost is deterministic but only ever drops on a real Aiur win →
     -- upper-only 5% instead of a hard pin. recursive-fft-cost drifts
@@ -372,13 +376,15 @@ def BackendSpec.stagesFor (b : BackendSpec) (mode : String) :
     List (String × List String) :=
   ((b.stages.find? (·.1 == mode)).map (·.2)).getD []
 
-/-- The mode's tracked measures — the compare-table columns and the
-    dashboard's plot set. A staged mode's list is its stages concatenated,
-    so the stage tables and the plots can't drift apart. -/
+/-- Every measure the mode tracks — what the dashboard plots. For an
+    unstaged mode that is exactly its `metrics` columns; for a staged one
+    it is the stage tables' measures plus any `metrics` entry, which is
+    how a measure gets tracked and plotted without taking a column. -/
 def BackendSpec.metricsFor (b : BackendSpec) (mode : String) : List String :=
+  let extra := ((b.metrics.find? (·.1 == mode)).map (·.2)).getD []
   match b.stagesFor mode with
-  | [] => ((b.metrics.find? (·.1 == mode)).map (·.2)).getD []
-  | stages => (stages.map (·.2)).flatten
+  | [] => extra
+  | stages => ((stages.map (·.2)).flatten ++ extra).eraseDups
 
 /-- `thresholds` rendered as the bencher-track action's `--threshold-*`
     flags, one percentage-test triple per measure. `__WINDOW__` is the

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -252,8 +252,10 @@ def backendSpecs : List BackendSpec := [
   -- proves THAT execution; the KZG stages will join as stages 3/4 when
   -- they land, folding into the same ledger. Each stage reports the same
   -- five columns — witness execute, prove, peak RAM, proof size, verify
-  -- — and the closing ledger table carries `total-time` and the run's
-  -- RAM ceiling. The whole system runs under the
+  -- — and the closing ledger table carries `total-time` (the stages'
+  -- proves, summed — each prove already runs its own witness execution,
+  -- so the standalone execute times are instrumentation and are not
+  -- added) and the run's RAM ceiling. The whole system runs under the
   -- recursion-tuned parameters — 40 FRI queries at log-blowup 2 for the
   -- stage-1 and stage-2 proofs alike (50 OOMs the CI hosts; see
   -- `recursiveFriParameters` in Benchmarks/Typecheck.lean). execute is
@@ -272,13 +274,7 @@ def backendSpecs : List BackendSpec := [
           "recursive-peak-rss", "recursive-proof-size",
           "recursive-verify-time", "recursive-fft-cost"]),
        ("Pipeline total", ["total-time", "pipeline-peak-rss"])])],
-    -- The per-stage wall clocks get no column: each stage table already
-    -- shows the execute and prove that sum to them, so the ledger stays
-    -- the two numbers that describe the whole run. They stay tracked for
-    -- the dashboard, where a per-stage trend is what shows WHICH stage
-    -- moved the total.
-    metrics := [("prove", ["stage1-time", "stage2-time"]),
-                ("execute", ["execute-time", "throughput", "peak-rss",
+    metrics := [("execute", ["execute-time", "throughput", "peak-rss",
                              "fft-cost"])],
     -- fft-cost is deterministic but only ever drops on a real Aiur win →
     -- upper-only 5% instead of a hard pin. recursive-fft-cost drifts
@@ -288,8 +284,7 @@ def backendSpecs : List BackendSpec := [
     -- and path depth) → the tight 5%.
     thresholds := [("constants", "0", "0"), ("fft-cost", "0.05", "_"),
                    ("recursive-fft-cost", "0.25", "_"),
-                   ("total-time", "0.10", "_"), ("stage1-time", "0.10", "_"),
-                   ("stage2-time", "0.10", "_"),
+                   ("total-time", "0.10", "_"),
                    ("execute-time", "0.10", "_"), ("prove-time", "0.10", "_"),
                    ("recursive-execute-time", "0.10", "_"),
                    ("recursive-prove-time", "0.10", "_"),
@@ -794,7 +789,7 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
         IO.eprintln s!"[bench] per-constant closures failed (exit {exit})"
   | "aiur" =>
     -- prove runs the whole pipeline (`bench-typecheck --recursive`):
-    -- every stage per constant, closed by the stage ledger. One process
+    -- every stage per constant, closed by the pipeline ledger. One process
     -- per constant under the watchdog; `total-time` is the ledger's last
     -- field, so it doubles as the completion marker — a kill before the
     -- pipeline finishes records an honest oom/crash row.

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -93,8 +93,31 @@ def isExcluded (name backend mode : String) : Bool :=
   benchExclusions.any fun (n, b, m) =>
     n == name && (b == "*" || b == backend) && (m == "*" || m == mode)
 
+/-- `(backend, mode)` combinations whose default selection is this fixed
+    name list instead of the `Vectors.csv` primary subset. The primary
+    subset is sized for a one-prove benchmark; a run that walks the whole
+    proof pipeline pays every stage per constant, so its default set is
+    sized to what one CI host can finish. `--full`, `--shard-only`, and an
+    explicit `--consts` request all bypass it, and the names still have to
+    be `Vectors.csv` rows of the env being run — this narrows the curated
+    selection, it does not add to it. -/
+def fixedSelections : List (String × String × List String) :=
+  [ -- The aiur pipeline's cost range: `Nat.add_comm` is the cheap end,
+    -- and the two heavy-tier proofs bracket the expensive end where the
+    -- stage-2 prover meets the host's RAM ceiling.
+    ("aiur", "prove",
+      ["Nat.add_comm",
+       "Array.extract_append",
+       "ByteArray.utf8DecodeChar?_utf8EncodeChar_append"]) ]
+
+/-- The fixed default selection for this `(backend, mode)`, if any. -/
+def fixedSelectionFor (backend mode : String) : Option (List String) :=
+  (fixedSelections.find? fun (b, m, _) =>
+    b == backend && (m == "*" || m == mode)).map (·.2.2)
+
 /-- Manifest selection, mirroring the `!benchmark` config surface: the env's
-    rows, restricted to the primary subset unless `full`, to `tier` when
+    rows, restricted to the primary subset — or the `(backend, mode)`'s
+    `fixedSelections` list where it has one — unless `full`, to `tier` when
     given (prove-mode full runs default to `cheap` — the prove-feasible
     set), to shard targets under `shardOnly`, and minus the
     `(backend, mode)` exclusions in `benchExclusions`. -/
@@ -105,9 +128,13 @@ def selectNames (rows : Array VectorRow) (env : String) (backend : String)
     if tier != "" then tier
     else if mode == "prove" && full then "cheap"
     else "all"
+  let fixed := if full || shardOnly then none
+    else fixedSelectionFor backend mode
   rows.filter fun r =>
     r.env == env
-    && (full || r.primary)
+    && (match fixed with
+        | some names => names.contains r.name
+        | none => full || r.primary)
     && (effTier == "all" || r.tier == effTier)
     && (!shardOnly || r.shardTarget)
     && !isExcluded r.name backend mode
@@ -186,8 +213,18 @@ structure BackendSpec where
   /-- (mode, compare-table columns), rendered in list order; the head is
       the table's row sort key. Column convention: the mode's headline
       wall-clock time, throughput, peak-rss, then detail (secondary times,
-      sizes, deterministic counters). -/
+      sizes, deterministic counters). A mode listed in `stages` takes its
+      columns from there instead. -/
   metrics : List (String × List String)
+  /-- (mode, [(stage title, that stage's measures)]) for a mode whose run
+      walks a multi-stage pipeline: the compare table splits into one
+      table per stage, so a stage's measures keep their plain names
+      (`prove-time`, `peak-rss`) across stages instead of competing for
+      one row. List order is render order, so the closing entry is the
+      ledger over the whole run. `metricsFor` reads a staged mode's
+      columns from here — the stage lists are the mode's measure list,
+      not a second copy of it. -/
+  stages : List (String × List (String × List String)) := []
   /-- Regression bounds per tracked measure: (measure, upper, lower), each
       bound a percentage over the baseline as a decimal fraction ("0.10"),
       "0" for an exact pin, or "_" for unbounded on that side. Rendered by
@@ -213,9 +250,10 @@ def backendSpecs : List BackendSpec := [
   -- proves the constant's IxVM typecheck; stage 2 executes the
   -- in-circuit multi-stark verifier over the fresh stage-1 proof and
   -- proves THAT execution; the KZG stages will join as stages 3/4 when
-  -- they land, folding into the same ledger. The headline columns are
-  -- the per-stage wall clocks (`stageN-time` = witness execute + prove)
-  -- and `total-time`, their sum. The whole system runs under the
+  -- they land, folding into the same ledger. Each stage reports the same
+  -- five columns — witness execute, prove, peak RAM, proof size, verify
+  -- — and the closing ledger table carries `total-time` and the run's
+  -- RAM ceiling. The whole system runs under the
   -- recursion-tuned parameters — 40 FRI queries at log-blowup 2 for the
   -- stage-1 and stage-2 proofs alike (50 OOMs the CI hosts; see
   -- `recursiveFriParameters` in Benchmarks/Typecheck.lean). execute is
@@ -225,12 +263,18 @@ def backendSpecs : List BackendSpec := [
     testbeds := [("prove", "aiur-x64-32x"),
                  ("execute", "aiur-execute-x64-32x")],
     unscheduled := ["execute"],
-    metrics := [("prove", ["total-time", "stage1-time", "stage2-time",
-                           "recursive-peak-rss", "recursive-proof-size",
-                           "recursive-verify-time", "recursive-fft-cost",
-                           "peak-rss", "proof-size", "verify-time",
-                           "fft-cost"]),
-                ("execute", ["execute-time", "throughput", "peak-rss",
+    stages := [("prove",
+      [("Stage 1 — IxVM on FRI",
+         ["execute-time", "prove-time", "peak-rss", "proof-size",
+          "verify-time", "fft-cost"]),
+       ("Stage 2 — FRI recursion on FRI",
+         ["recursive-execute-time", "recursive-prove-time",
+          "recursive-peak-rss", "recursive-proof-size",
+          "recursive-verify-time", "recursive-fft-cost"]),
+       ("Pipeline total",
+         ["total-time", "stage1-time", "stage2-time",
+          "pipeline-peak-rss"])])],
+    metrics := [("execute", ["execute-time", "throughput", "peak-rss",
                              "fft-cost"])],
     -- fft-cost is deterministic but only ever drops on a real Aiur win →
     -- upper-only 5% instead of a hard pin. recursive-fft-cost drifts
@@ -242,8 +286,12 @@ def backendSpecs : List BackendSpec := [
                    ("recursive-fft-cost", "0.25", "_"),
                    ("total-time", "0.10", "_"), ("stage1-time", "0.10", "_"),
                    ("stage2-time", "0.10", "_"),
+                   ("execute-time", "0.10", "_"), ("prove-time", "0.10", "_"),
+                   ("recursive-execute-time", "0.10", "_"),
+                   ("recursive-prove-time", "0.10", "_"),
                    ("peak-rss", "0.10", "_"),
                    ("recursive-peak-rss", "0.10", "_"),
+                   ("pipeline-peak-rss", "0.10", "_"),
                    ("proof-size", "0.05", "_"),
                    ("recursive-proof-size", "0.05", "_"),
                    ("verify-time", "0.10", "_"),
@@ -318,8 +366,19 @@ def findBackend (name : String) : Option BackendSpec :=
 def BackendSpec.testbedFor (b : BackendSpec) (mode : String) : Option String :=
   (b.testbeds.find? (·.1 == mode)).map (·.2)
 
+/-- The pipeline stages this mode's compare table splits into, empty for
+    the single-table modes. -/
+def BackendSpec.stagesFor (b : BackendSpec) (mode : String) :
+    List (String × List String) :=
+  ((b.stages.find? (·.1 == mode)).map (·.2)).getD []
+
+/-- The mode's tracked measures — the compare-table columns and the
+    dashboard's plot set. A staged mode's list is its stages concatenated,
+    so the stage tables and the plots can't drift apart. -/
 def BackendSpec.metricsFor (b : BackendSpec) (mode : String) : List String :=
-  ((b.metrics.find? (·.1 == mode)).map (·.2)).getD []
+  match b.stagesFor mode with
+  | [] => ((b.metrics.find? (·.1 == mode)).map (·.2)).getD []
+  | stages => (stages.map (·.2)).flatten
 
 /-- `thresholds` rendered as the bencher-track action's `--threshold-*`
     flags, one percentage-test triple per measure. `__WINDOW__` is the

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -60,8 +60,8 @@ def plotTitle (workload measure : String) : String :=
   | "ix-decompile", "throughput"         => "Ix Decompile Throughput"
   | "ix-decompile", "peak-rss"           => "Ix Decompile Peak RAM Usage"
   | "aiur", "total-time"             => "Aiur Total Time"
-  | "aiur", "stage1-time"            => "Aiur Stage 1 Time"
-  | "aiur", "stage2-time"            => "Aiur Stage 2 Time"
+  | "aiur", "prove-time"             => "Aiur Stage 1 Time"
+  | "aiur", "recursive-prove-time"   => "Aiur Stage 2 Time"
   | "aiur", "fft-cost"               => "Aiur Stage 1 FFT Cost"
   | "aiur", "recursive-fft-cost"     => "Aiur Stage 2 FFT Cost"
   | "aiur", "recursive-verify-time"  => "Aiur Stage 2 Verify Time"
@@ -83,20 +83,20 @@ def plotTitle (workload measure : String) : String :=
     `ix-decompile` reuses the compile run's `.ixe`, so its `file-size` /
     `constants` duplicate "Ix Environment Size" / "Ix Input Constants"
     exactly — the decompile run tracks only its own decompile-time /
-    throughput / peak-rss trends. The aiur run's stage detail
-    (each stage's execute / prove split, stage-1 peak-rss / proof-size /
+    throughput / peak-rss trends. The aiur run's per-stage headline is
+    that stage's `prove-time` — a prove runs its own witness execution,
+    so it is the whole cost of producing the stage's proof, and the
+    standalone `execute-time` beside it is a second, instrumentation-only
+    run. The rest of the stage detail (stage-1 peak-rss / proof-size /
     verify-time, and the whole-run `pipeline-peak-rss`) is tracked for
-    the compare table, but the dashboard trends that matter are the
-    per-stage wall clocks, the total, and the terminal stage's own detail
-    series: an execute/prove split lives inside its `stageN-time`, the
-    stage-1 detail inside `stage1-time` and the deterministic `fft-cost`
-    trend, and the pipeline peak is the terminal stage's peak. -/
+    the compare table but not plotted: the stage-1 detail's cost is
+    inside `prove-time` and the deterministic `fft-cost` trend, and the
+    pipeline peak is the terminal stage's peak. -/
 def plotSkips : List (String × String) :=
   [("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),
    ("ix-decompile", "file-size"), ("ix-decompile", "constants"),
    ("aiur", "peak-rss"), ("aiur", "proof-size"), ("aiur", "verify-time"),
-   ("aiur", "execute-time"), ("aiur", "prove-time"),
-   ("aiur", "recursive-execute-time"), ("aiur", "recursive-prove-time"),
+   ("aiur", "execute-time"), ("aiur", "recursive-execute-time"),
    ("aiur", "pipeline-peak-rss")]
 
 /-- Canonical units per measure slug, asserted on every sync: bencher
@@ -127,8 +127,6 @@ def unitsFor (slug : String) : Option String :=
    ("recursive-peak-rss", "bytes (B)"),
    ("recursive-proof-size", "bytes (B)"),
    ("recursive-fft-cost", "FFTs"),
-   ("stage1-time", "seconds (s)"),
-   ("stage2-time", "seconds (s)"),
    ("total-time", "seconds (s)"),
    ("pipeline-peak-rss", "bytes (B)"),
    ("throughput", "constants / second")].lookup slug

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -83,16 +83,21 @@ def plotTitle (workload measure : String) : String :=
     `ix-decompile` reuses the compile run's `.ixe`, so its `file-size` /
     `constants` duplicate "Ix Environment Size" / "Ix Input Constants"
     exactly — the decompile run tracks only its own decompile-time /
-    throughput / peak-rss trends. The aiur run's stage-1 detail
-    (peak-rss / proof-size / verify-time) is tracked for the compare
-    table, but the dashboard trends that matter are the per-stage wall
-    clocks, the total, and the terminal stage's own detail series — the
-    stage-1 detail isn't plotted (its cost is inside `stage1-time` and
-    the deterministic `fft-cost` trend). -/
+    throughput / peak-rss trends. The aiur run's stage detail
+    (each stage's execute / prove split, stage-1 peak-rss / proof-size /
+    verify-time, and the whole-run `pipeline-peak-rss`) is tracked for
+    the compare table, but the dashboard trends that matter are the
+    per-stage wall clocks, the total, and the terminal stage's own detail
+    series: an execute/prove split lives inside its `stageN-time`, the
+    stage-1 detail inside `stage1-time` and the deterministic `fft-cost`
+    trend, and the pipeline peak is the terminal stage's peak. -/
 def plotSkips : List (String × String) :=
   [("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),
    ("ix-decompile", "file-size"), ("ix-decompile", "constants"),
-   ("aiur", "peak-rss"), ("aiur", "proof-size"), ("aiur", "verify-time")]
+   ("aiur", "peak-rss"), ("aiur", "proof-size"), ("aiur", "verify-time"),
+   ("aiur", "execute-time"), ("aiur", "prove-time"),
+   ("aiur", "recursive-execute-time"), ("aiur", "recursive-prove-time"),
+   ("aiur", "pipeline-peak-rss")]
 
 /-- Canonical units per measure slug, asserted on every sync: bencher
     auto-creates a measure with placeholder units ("Measure (units)") on
@@ -125,6 +130,7 @@ def unitsFor (slug : String) : Option String :=
    ("stage1-time", "seconds (s)"),
    ("stage2-time", "seconds (s)"),
    ("total-time", "seconds (s)"),
+   ("pipeline-peak-rss", "bytes (B)"),
    ("throughput", "constants / second")].lookup slug
 
 /-- Dashboard group order (compile first, then the aiur pipeline, zisk,

--- a/Ix/Cli/BenchPlots.lean
+++ b/Ix/Cli/BenchPlots.lean
@@ -59,15 +59,14 @@ def plotTitle (workload measure : String) : String :=
   | "ix-decompile", "decompile-time"     => "Ix Decompile Time"
   | "ix-decompile", "throughput"         => "Ix Decompile Throughput"
   | "ix-decompile", "peak-rss"           => "Ix Decompile Peak RAM Usage"
-  | "aiur-check-prove", "prove-time"     => "Aiur Prove Time"
-  | "aiur-check-prove", "throughput"     => "Aiur Prove Throughput"
-  | "aiur-check-prove", "peak-rss"       => "Aiur Prove Peak RAM Usage"
-  | "aiur-check-prove", "verify-time"    => "Aiur Verify Time"
-  | "aiur-check-prove", "proof-size"     => "Aiur Proof Size"
-  | "aiur-check-prove", "fft-cost"       => "Aiur FFT Cost"
-  | "aiur-check-execute", "execute-time" => "Aiur Execute Time"
-  | "aiur-check-execute", "throughput"   => "Aiur Execute Throughput"
-  | "aiur-check-execute", "peak-rss"     => "Aiur Execute Peak RAM Usage"
+  | "aiur", "total-time"             => "Aiur Total Time"
+  | "aiur", "stage1-time"            => "Aiur Stage 1 Time"
+  | "aiur", "stage2-time"            => "Aiur Stage 2 Time"
+  | "aiur", "fft-cost"               => "Aiur Stage 1 FFT Cost"
+  | "aiur", "recursive-fft-cost"     => "Aiur Stage 2 FFT Cost"
+  | "aiur", "recursive-verify-time"  => "Aiur Stage 2 Verify Time"
+  | "aiur", "recursive-peak-rss"     => "Aiur Stage 2 Peak RAM Usage"
+  | "aiur", "recursive-proof-size"   => "Aiur Stage 2 Proof Size"
   | "zisk-check-execute", "execute-time" => "Zisk Execute Time"
   | "zisk-check-execute", "throughput"   => "Zisk Execute Throughput"
   | "zisk-check-execute", "peak-rss"     => "Zisk Execute Peak RAM Usage"
@@ -75,36 +74,25 @@ def plotTitle (workload measure : String) : String :=
   | "ooc-check", "check-time"            => "OOC Check Time"
   | "ooc-check", "throughput"            => "OOC Check Throughput"
   | "ooc-check", "peak-rss"              => "OOC Check Peak RAM Usage"
-  | "aiur-recursive", "recursive-execute-time" => "Aiur Recursive Verifier Execute Time"
-  | "aiur-recursive", "recursive-prove-time"   => "Aiur Recursive Verifier Prove Time"
-  | "aiur-recursive", "recursive-verify-time"  => "Aiur Recursive Verifier Verify Time"
-  | "aiur-recursive", "recursive-peak-rss"     => "Aiur Recursive Verifier Peak RAM Usage"
-  | "aiur-recursive", "recursive-proof-size"   => "Aiur Recursive Verifier Proof Size"
-  | "aiur-recursive", "recursive-fft-cost"     => "Aiur Recursive Verifier FFT Cost"
   | w, m => s!"{w}: {m}"
 
-/-- Tracked but not plotted solo. The two aiur runs re-measure each
-    other's deterministic Phase-1 numbers as a redundancy check — one
-    trend line each is enough ("Aiur Execute Time" from the execute run,
-    "Aiur FFT Cost" from the prove run). Zisk `shards` is charted below
+/-- Tracked but not plotted solo. Zisk `shards` is charted below
     over the heavy-tier primaries alone (light constants are pinned at a
     single shard, a flat line at 1), not over the full set here; zisk
     `constants` charts on the input-constants plot below instead of alone.
     `ix-decompile` reuses the compile run's `.ixe`, so its `file-size` /
     `constants` duplicate "Ix Environment Size" / "Ix Input Constants"
     exactly — the decompile run tracks only its own decompile-time /
-    throughput / peak-rss trends. The aiur-recursive run's plain
-    prove-time / proof-size / verify-time / peak-rss measure the INNER
-    IxVM typecheck proof (under recursion-tuned parameters) — tracked for
-    the compare table, but the dashboard trend that matters is the
-    recursion layer's own `recursive-*` series, so the inner metrics
-    aren't plotted. -/
+    throughput / peak-rss trends. The aiur run's stage-1 detail
+    (peak-rss / proof-size / verify-time) is tracked for the compare
+    table, but the dashboard trends that matter are the per-stage wall
+    clocks, the total, and the terminal stage's own detail series — the
+    stage-1 detail isn't plotted (its cost is inside `stage1-time` and
+    the deterministic `fft-cost` trend). -/
 def plotSkips : List (String × String) :=
-  [("aiur-check-prove", "execute-time"), ("aiur-check-execute", "fft-cost"),
-   ("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),
+  [("zisk-check-execute", "shards"), ("zisk-check-execute", "constants"),
    ("ix-decompile", "file-size"), ("ix-decompile", "constants"),
-   ("aiur-recursive", "prove-time"), ("aiur-recursive", "proof-size"),
-   ("aiur-recursive", "verify-time"), ("aiur-recursive", "peak-rss")]
+   ("aiur", "peak-rss"), ("aiur", "proof-size"), ("aiur", "verify-time")]
 
 /-- Canonical units per measure slug, asserted on every sync: bencher
     auto-creates a measure with placeholder units ("Measure (units)") on
@@ -134,13 +122,15 @@ def unitsFor (slug : String) : Option String :=
    ("recursive-peak-rss", "bytes (B)"),
    ("recursive-proof-size", "bytes (B)"),
    ("recursive-fft-cost", "FFTs"),
+   ("stage1-time", "seconds (s)"),
+   ("stage2-time", "seconds (s)"),
+   ("total-time", "seconds (s)"),
    ("throughput", "constants / second")].lookup slug
 
-/-- Dashboard group order (compile first, then aiur prove/execute, zisk,
+/-- Dashboard group order (compile first, then the aiur pipeline, zisk,
     ooc); unranked workloads (a future backend) sort last. -/
 def workloadOrder : List String :=
-  ["ix-compile", "ix-decompile", "aiur-check-prove", "aiur-check-execute",
-   "aiur-recursive", "zisk-check-execute", "ooc-check"]
+  ["ix-compile", "ix-decompile", "aiur", "zisk-check-execute", "ooc-check"]
 
 structure PlotSpec where
   testbed : String
@@ -150,8 +140,8 @@ structure PlotSpec where
 /-- One spec per bench-main testbed: its measure slugs and the benchmark row
     names uploaded there, both from the registry (`BackendSpec.benchmarkNames`,
     keyed off `inputs`) — env-keyed backends (compile, decompile) key one row
-    per compiled env, the per-constant backends one row per primary, ooc adds a
-    whole-env row, and the fixed-config backend lists its configs. Dynamic
+    per compiled env, the per-constant backends one row per primary, and ooc
+    adds a whole-env row. Dynamic
     sub-rows (`<name>/shard-N`) are left out: their multiplicity shifts with the
     shard manifest, and the parent row carries the headline trend. -/
 def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
@@ -159,7 +149,7 @@ def plotSpecs (rows : Array BenchCmd.VectorRow) : Array PlotSpec := Id.run do
   for b in BenchCmd.backendSpecs do
     if b.disabled.isSome then continue
     for (mode, testbed) in b.testbeds do
-      -- On-demand modes (e.g. aiur `recursive`) upload nothing, so there's
+      -- On-demand modes (e.g. aiur `execute`) upload nothing, so there's
       -- nothing to plot — the registry marks them explicitly.
       if b.unscheduled.contains mode then continue
       specs := specs.push
@@ -324,9 +314,8 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut desired : Array DesiredPlot := #[]
   for spec in specs do
     let workload := workloadOf spec.testbed
-    -- A registry testbed bencher hasn't seen yet (its bench-main run isn't
-    -- scheduled — e.g. the aiur `recursive` mode, whose outer prove doesn't
-    -- fit the CI host, so nothing ever uploads to it) has no plots to sync:
+    -- A registry testbed bencher hasn't seen yet (first upload still
+    -- pending after a rename or a new backend) has no plots to sync:
     -- warn and skip it, like a not-yet-uploaded benchmark, instead of
     -- failing the whole run. Picked up on a later sync once data lands.
     let some testbedUuid := findUuid testbeds "slug" spec.testbed
@@ -352,12 +341,12 @@ def runPlotsCmd (p : Cli.Parsed) : IO UInt32 := do
   -- SAME named-constant count for each checked closure (the pre-shard input
   -- set, unaffected by anon-work dedup or shard partitioning), so the count
   -- is shared: sourcing it from both testbeds drew every constant twice.
-  -- aiur-check-prove is the single source (it always uploads `constants`),
+  -- The aiur run is the single source (it always uploads `constants`),
   -- so each primary is one line.
   let overlay : Option DesiredPlot := do
-    let aiurTb ← findUuid testbeds "slug" "aiur-check-prove-x64-32x"
+    let aiurTb ← findUuid testbeds "slug" "aiur-x64-32x"
     let consts ← findUuid measures "slug" "constants"
-    let primaries ← (specs.find? (·.testbed == "aiur-check-prove-x64-32x")).map
+    let primaries ← (specs.find? (·.testbed == "aiur-x64-32x")).map
       (·.benchmarks.filterMap (findUuid benchmarks "name" ·))
     return { title := "Aiur/Zisk Input Constants",
              testbeds := #[aiurTb], benchmarks := primaries,

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -56,8 +56,8 @@ def metricKind (metric : String) : String :=
   if ["peak-rss", "file-size", "proof-size"].contains metric
   then "bytes"
   else if metric.startsWith "phase-" then "seconds"
-  -- Every wall-clock measure is named `<what>-time`, the stage ledger's
-  -- `stage1-time` / `total-time` included.
+  -- Every wall-clock measure is named `<what>-time`, the pipeline
+  -- ledger's `total-time` included.
   else if metric.endsWith "-time" then "seconds"
   else if ["fft-cost", "cycles", "steps", "max-shard-cycles",
            "throughput"].contains metric then "count"

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -827,10 +827,7 @@ def runMatrixCmd (p : Cli.Parsed) : IO UInt32 := do
           && (Ix.Cli.BenchCmd.selectNames rows env b.name mode
               (full := false) (tier := "") (shardOnly := false)).isEmpty then
           continue
-        -- The fixed-config backend's env is only its `.ixe`-restore key,
-        -- not what it measures — keep it out of the label.
-        let label := if b.inputs == .fixedConfigs then s!"{b.name}-{mode}"
-          else s!"{b.name}-{env}-{mode}"
+        let label := s!"{b.name}-{env}-{mode}"
         entries := entries.push <| Json.mkObj
           [("backend", Json.str b.name), ("env", Json.str env),
            ("mode", Json.str mode), ("label", Json.str label),
@@ -868,8 +865,8 @@ def parseError (msg : String) : IO UInt32 := do
     Grammar (an unknown command-line token, or an unknown env in
     BENCH_ENVS, rejects the command — exit 2 and a `parse-error` output):
 
-      !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [aiur-recursive] | all)
-                 [execute | recursive] [fresh] [KEY=VALUE …]
+      !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] | all)
+                 [execute] [fresh] [KEY=VALUE …]
       BENCH_ENVS=InitStd,Mathlib   (case-insensitive, any registry env;
                                     defaults to every env for the
                                     env-keyed backends (compile,
@@ -902,12 +899,10 @@ def parseError (msg : String) : IO UInt32 := do
     command, like a typo'd backend.
 
     The bare `execute` token flips a backend with an execute metrics entry
-    to execute-only — a real switch only for aiur, whose modes store on
-    separate testbeds, so either kind of run finds a cached baseline.
-    `recursive` likewise flips aiur to its recursive mode; that testbed is
-    `unscheduled`, so the run has no bencher baseline (its main side comes
-    from a base-SHA run) and the verifier execute OOMs on the 128 GB CI
-    host — reserved for a bigger manual dispatch.
+    to execute-only — a real switch only for aiur, which it drops from the
+    full proof pipeline to the fast Phase-1-only signal. That testbed is
+    `unscheduled`, so the run has no bencher baseline — its main side
+    comes from a base-SHA run.
 
     The bare `fresh` token makes every run bypass its bencher baseline and
     re-measure the main side with a base-SHA run — for when the published
@@ -933,14 +928,10 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut backends : Array Ix.Cli.BenchCmd.BackendSpec := #[]
   let mut skipped : Array Ix.Cli.BenchCmd.BackendSpec := #[]
   let mut executeFlag := false
-  let mut recursiveFlag := false
   let mut freshFlag := false
   for t in toks.map (·.toLower) do
     if t == "execute" then
       executeFlag := true
-      continue
-    if t == "recursive" then
-      recursiveFlag := true
       continue
     if t == "fresh" then
       freshFlag := true
@@ -955,7 +946,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       return ← parseError s!"unknown token `{t}` in the benchmark command \
         (expected a backend — \
         {", ".intercalate (Ix.Cli.BenchCmd.backendSpecs.map (·.name))} — \
-        or `all` / `execute` / `recursive` / `fresh`)"
+        or `all` / `execute` / `fresh`)"
     for b in requested do
       if b.disabled.isSome then
         if skipped.all (·.name != b.name) then skipped := skipped.push b
@@ -1098,22 +1089,14 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
     else #["InitStd"]
 
   let modeFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>
-    if recursiveFlag && !(b.metricsFor "recursive").isEmpty then "recursive"
-    else if executeFlag && !(b.metricsFor "execute").isEmpty then "execute"
+    if executeFlag && !(b.metricsFor "execute").isEmpty then "execute"
     else b.defaultMode
   let mut entries : Array Json := #[]
   for b in backends do
-    -- The fixed-config backend (`inputs := .fixedConfigs` — aiur-recursive)
-    -- runs a fixed constant list: one run no matter how many envs
-    -- BENCH_ENVS lists. The env kept is the first requested one — its
-    -- compiled `.ixe` is where the run resolves the fixed constants (any
-    -- registry env's closure contains them).
-    let runEnvs := if b.inputs == .fixedConfigs then (envsFor b).take 1
-      else envsFor b
-    for e in runEnvs do
+    for e in envsFor b do
       -- The entry's `--consts` override: the listed names this env owns,
-      -- on the per-constant backends only (env-keyed and fixed-config
-      -- backends measure regardless of constant selection).
+      -- on the per-constant backends only (env-keyed backends measure
+      -- regardless of constant selection).
       let entryConsts :=
         if b.inputs == .perConstant || b.inputs == .perConstantWithEnv then
           ",".intercalate
@@ -1133,7 +1116,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       if acc.contains e then acc else acc.push e
 
   -- Annotate the mode only where a mode CHOICE exists (aiur's
-  -- execute/prove); `ooc=execute` for a single-mode backend is noise.
+  -- prove/execute); `ooc=execute` for a single-mode backend is noise.
   let modes := " ".intercalate
     (backends.map (fun b =>
       if b.testbeds.length > 1 then s!"{b.name}={modeFor b}" else b.name)).toList

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -33,19 +33,32 @@ namespace Ix.Cli.BenchReport
 
 /-! ## Metric formatting -/
 
+/-- Stage qualifiers a pipeline measure carries ahead of its base name:
+    `recursive-` scopes a measure to the recursion stage, `pipeline-` to
+    the whole run. Stripped wherever a measure is interpreted by its base
+    name (formatting kind) or labelled under a heading that already says
+    the stage. -/
+def stagePrefixes : List String := ["recursive-", "pipeline-"]
+
+/-- `metric` with its stage qualifier removed, if it has one. -/
+def dropStagePrefix (metric : String) : String :=
+  match stagePrefixes.find? (fun p => metric.startsWith p) with
+  | some p => (metric.drop p.length).toString
+  | none => metric
+
 /-- Per-metric formatting kind. Metric names are the results-JSON keys the
-    tools emit (see the registry in Ix.Cli.BenchCmd). A `recursive-` metric
-    formats like its inner counterpart (`recursive-peak-rss` like
-    `peak-rss`, …). Unknown metrics fall through to a generic decimal
-    rendering. -/
+    tools emit (see the registry in Ix.Cli.BenchCmd). A stage-qualified
+    metric formats like its base counterpart (`recursive-peak-rss` and
+    `pipeline-peak-rss` like `peak-rss`, …). Unknown metrics fall through
+    to a generic decimal rendering. -/
 def metricKind (metric : String) : String :=
-  let metric := if metric.startsWith "recursive-"
-    then (metric.drop "recursive-".length).toString else metric
+  let metric := dropStagePrefix metric
   if ["peak-rss", "file-size", "proof-size"].contains metric
   then "bytes"
   else if metric.startsWith "phase-" then "seconds"
-  else if ["execute-time", "prove-time", "verify-time", "check-time",
-           "compile-time", "decompile-time"].contains metric then "seconds"
+  -- Every wall-clock measure is named `<what>-time`, the stage ledger's
+  -- `stage1-time` / `total-time` included.
+  else if metric.endsWith "-time" then "seconds"
   else if ["fft-cost", "cycles", "steps", "max-shard-cycles",
            "throughput"].contains metric then "count"
   else if ["constants", "shards"].contains metric then "int"
@@ -173,10 +186,29 @@ def ratio (mainV prV : Float) (metric : String) : Option (Float × String) :=
       | _ => ("more", "fewer")
     some (factor, if grew then words.1 else words.2)
 
+/-- One table of a compare rendering. A single-table backend passes one
+    section with an empty `heading` (the cell title above already names
+    it); a pipeline backend passes one per stage. -/
+structure CompareSection where
+  heading : String := ""
+  metrics : Array String
+
+/-- The stage qualifier shared by every one of a section's measures, if
+    they share one. A stage table's heading already says which stage it
+    is, so its columns read `prove-time`, not `recursive-prove-time`. -/
+def sectionLabelDrop (metrics : Array String) : String :=
+  if metrics.isEmpty then "" else
+  (stagePrefixes.find? fun p => metrics.all (·.startsWith p)).getD ""
+
 structure CompareArgs where
   mainRows : Json
   prRows : Json
-  metrics : Array String
+  /-- The tables to render, in order. -/
+  sections : Array CompareSection
+  /-- Measure the rows sort on, shared by every section so a constant
+      keeps its position across a pipeline's stage tables. Defaults to
+      the first section's first measure. -/
+  sortMetric : String := ""
   threshold : Float
   title : String
   /-- Render the per-constant `phase-<span>` drill-downs (opt-in:
@@ -195,8 +227,12 @@ def renderCompare (a : CompareArgs) : String := Id.run do
   if names.isEmpty then
     return a.title ++ "\n\n_No results were produced (every constant failed, \
       timed out, or was dropped). See the workflow logs._"
-  -- Sort by the primary metric, largest first (n/a rows last).
-  let primary := a.metrics[0]?.getD ""
+  -- Sort by the primary metric, largest first (n/a rows last). Every
+  -- section sorts on the same one, so a pipeline's stage tables list
+  -- their rows in one order and read down the page.
+  let primary := if a.sortMetric.isEmpty
+    then (a.sections[0]?.bind (·.metrics[0]?)).getD ""
+    else a.sortMetric
   let key := fun n => (rowNum a.prRows n primary).orElse
     fun _ => rowNum a.mainRows n primary
   let names := names.qsort fun x y =>
@@ -206,57 +242,71 @@ def renderCompare (a : CompareArgs) : String := Id.run do
     | none, some _ => false
     | none, none => x < y
 
-  let mut head := #[a.rowNoun]
-  for m in a.metrics do
-    head := head ++ #[s!"{metricLabel m} (main)", s!"{metricLabel m} (PR)", "Δ%"]
-  let mut lines := #[
-    "| " ++ " | ".intercalate head.toList ++ " |",
-    "|" ++ "|".intercalate (head.toList.map fun _ => "---") ++ "|"]
-
   let mut failures : Array (String × String) := #[]
-  let mut regressed := 0
-  let mut improved := 0
   for n in names do
-    let mainStatus := rowStatus a.mainRows n
-    let prStatus := rowStatus a.prRows n
-    if mainStatus == "rejected" then failures := failures.push (n, "main")
-    if prStatus == "rejected" then failures := failures.push (n, "PR")
-    let mut rowRegressed := false
-    let mut rowImproved := false
-    let mut cols := #[s!"`{n}`"]
-    for m in a.metrics do
-      let mv := rowNum a.mainRows n m
-      let pv := rowNum a.prRows n m
-      -- An OOM/CRASH row may still carry real partial measurements; render
-      -- those, and the status only for the metrics the kill prevented. OOM
-      -- is a capacity kill; CRASH is a fault in the tool (e.g. a segfault)
-      -- and needs a bug hunt, not a bigger box. A REJECTED row is
-      -- spelled out — the constant was rejected, not benchmarked.
-      let renderSide := fun (status : String) (v : Option Float) =>
-        if status == "rejected" then "❌ failed typecheck"
-        else if status == "oom" && v.isNone then "OOM"
-        else if status == "crash" && v.isNone then "💥 CRASH"
-        else human v m
-      let mut delta := "n/a"
-      if let (some mvv, some pvv) := (mv, pv) then
-        if mvv != 0.0 then
-          let dp := (pvv - mvv) / mvv * 100.0
-          delta := (if dp >= 0.0 then "+" else "") ++ fmtF dp 1 ++ "%"
-          -- Ratio only when it adds signal beyond the percentage.
-          if let some (f, word) := ratio mvv pvv m then
-            if f >= 1.05 then delta := delta ++ s!" ({fmtF f 2}× {word})"
-          let bad := badness dp m
-          if bad > a.threshold then
-            delta := delta ++ " ⚠️"; rowRegressed := true
-          else if bad < -a.threshold then
-            delta := delta ++ " 🟢"; rowImproved := true
-      cols := cols ++ #[renderSide mainStatus mv, renderSide prStatus pv, delta]
-    -- Independent tallies: a row can regress on one metric and improve
-    -- on another (compile-time up, peak-ram down), and the summary must
-    -- not hide either side.
-    if rowRegressed then regressed := regressed + 1
-    if rowImproved then improved := improved + 1
-    lines := lines.push ("| " ++ " | ".intercalate cols.toList ++ " |")
+    if rowStatus a.mainRows n == "rejected" then failures := failures.push (n, "main")
+    if rowStatus a.prRows n == "rejected" then failures := failures.push (n, "PR")
+
+  -- One rendered table per section, plus the names that regressed or
+  -- improved ANYWHERE across them: the summary counts a constant once,
+  -- however many stages moved.
+  let mut blocks : Array (String × Array String) := #[]
+  let mut regressedNames : Array String := #[]
+  let mut improvedNames : Array String := #[]
+  for sec in a.sections do
+    let drop := sectionLabelDrop sec.metrics
+    let label := fun (m : String) =>
+      metricLabel (if drop.isEmpty then m else (m.drop drop.length).toString)
+    let mut head := #[a.rowNoun]
+    for m in sec.metrics do
+      head := head ++ #[s!"{label m} (main)", s!"{label m} (PR)", "Δ%"]
+    let mut lines := #[
+      "| " ++ " | ".intercalate head.toList ++ " |",
+      "|" ++ "|".intercalate (head.toList.map fun _ => "---") ++ "|"]
+    for n in names do
+      let mainStatus := rowStatus a.mainRows n
+      let prStatus := rowStatus a.prRows n
+      let mut rowRegressed := false
+      let mut rowImproved := false
+      let mut cols := #[s!"`{n}`"]
+      for m in sec.metrics do
+        let mv := rowNum a.mainRows n m
+        let pv := rowNum a.prRows n m
+        -- An OOM/CRASH row may still carry real partial measurements; render
+        -- those, and the status only for the metrics the kill prevented. OOM
+        -- is a capacity kill; CRASH is a fault in the tool (e.g. a segfault)
+        -- and needs a bug hunt, not a bigger box. A REJECTED row is
+        -- spelled out — the constant was rejected, not benchmarked.
+        let renderSide := fun (status : String) (v : Option Float) =>
+          if status == "rejected" then "❌ failed typecheck"
+          else if status == "oom" && v.isNone then "OOM"
+          else if status == "crash" && v.isNone then "💥 CRASH"
+          else human v m
+        let mut delta := "n/a"
+        if let (some mvv, some pvv) := (mv, pv) then
+          if mvv != 0.0 then
+            let dp := (pvv - mvv) / mvv * 100.0
+            delta := (if dp >= 0.0 then "+" else "") ++ fmtF dp 1 ++ "%"
+            -- Ratio only when it adds signal beyond the percentage.
+            if let some (f, word) := ratio mvv pvv m then
+              if f >= 1.05 then delta := delta ++ s!" ({fmtF f 2}× {word})"
+            let bad := badness dp m
+            if bad > a.threshold then
+              delta := delta ++ " ⚠️"; rowRegressed := true
+            else if bad < -a.threshold then
+              delta := delta ++ " 🟢"; rowImproved := true
+        cols := cols ++ #[renderSide mainStatus mv, renderSide prStatus pv, delta]
+      -- Independent tallies: a row can regress on one metric and improve
+      -- on another (compile-time up, peak-ram down), and the summary must
+      -- not hide either side.
+      if rowRegressed && !regressedNames.contains n then
+        regressedNames := regressedNames.push n
+      if rowImproved && !improvedNames.contains n then
+        improvedNames := improvedNames.push n
+      lines := lines.push ("| " ++ " | ".intercalate cols.toList ++ " |")
+    blocks := blocks.push (sec.heading, lines)
+  let regressed := regressedNames.size
+  let improved := improvedNames.size
 
   -- Assembly order puts the scannable verdict FIRST and collapses long
   -- tables: a multi-cell PR comment reads as one verdict line per cell,
@@ -283,15 +333,18 @@ def renderCompare (a : CompareArgs) : String := Id.run do
   else if (rowNames a.prRows).isEmpty then
     out := out.push "" |>.push
       "_⚠️ no PR-side results (see the workflow logs)._"
-  if names.size > 5 then
-    out := out ++ #["",
-      s!"<details><summary>comparison table \
-        ({plural names.size a.rowNoun})</summary>", ""]
-      ++ lines ++ #["", "</details>"]
-  else
-    out := out ++ #[""] ++ lines
-  -- Per-phase drill-down (only under `a.phases`): the main table above
-  -- carries every constant's high-level row; below it, each constant with
+  for (heading, lines) in blocks do
+    let caption := if heading.isEmpty then "comparison table" else heading
+    if names.size > 5 then
+      out := out ++ #["",
+        s!"<details><summary>{caption} \
+          ({plural names.size a.rowNoun})</summary>", ""]
+        ++ lines ++ #["", "</details>"]
+    else
+      out := out ++ (if heading.isEmpty then #[""] else #["", s!"#### {heading}", ""])
+        ++ lines
+  -- Per-phase drill-down (only under `a.phases`): the tables above
+  -- carry every constant's high-level row; below it, each constant with
   -- `phase-<span>` fields (aiur witness/commit/quotient breakdowns, zkVM
   -- coarse phases) gets its own collapsed mini-table
   -- (`phase | main | PR | Δ%`), opened as desired.
@@ -550,13 +603,17 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     |>.getD s!"{benchDir}/{params}.prev.json"
   let prPath := (p.flag? "pr").map (·.as! String)
     |>.getD s!"{benchDir}/{params}.json"
-  let metrics :=
-    let flagged := (p.flag? "metric").map (·.as! (Array String)) |>.getD #[]
-    if flagged.isEmpty then
-      (((Ix.Cli.BenchCmd.findBackend backend).map
-        (·.metricsFor mode)).getD []).toArray
-    else flagged
-  if metrics.isEmpty then
+  -- An explicit `--metric` list is always one flat table; otherwise the
+  -- registry decides, splitting a pipeline mode into its stage tables.
+  let spec := Ix.Cli.BenchCmd.findBackend backend
+  let flagged := (p.flag? "metric").map (·.as! (Array String)) |>.getD #[]
+  let sections : Array CompareSection :=
+    if !flagged.isEmpty then #[{ metrics := flagged }]
+    else match (spec.map (·.stagesFor mode)).getD [] with
+      | [] => #[{ metrics := ((spec.map (·.metricsFor mode)).getD []).toArray }]
+      | stages => (stages.map fun (heading, ms) =>
+          ({ heading, metrics := ms.toArray } : CompareSection)).toArray
+  if sections.all (·.metrics.isEmpty) then
     p.printError s!"error: no metrics for {backend}/{mode}; pass --metric or fix backendSpecs"
     return exitUsage
   let threshold := (p.flag? "threshold").map (fun f => (f.as! Nat).toFloat)
@@ -570,10 +627,16 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     else s!"`{backend}` · `{env}`"
   let title := (p.flag? "title").map (·.as! String)
     |>.getD s!"### {cellName} — main from: {mainSrc}"
+  -- A staged mode sorts every table on its LEDGER's headline (the
+  -- closing section's first measure — `total-time`), so the stage tables
+  -- rank constants by what the whole pipeline costs rather than each by
+  -- its own stage.
+  let sortMetric := if sections.size > 1
+    then (sections.back?.bind (·.metrics[0]?)).getD "" else ""
   let mut table := renderCompare {
     mainRows := ← readRows mainPath
     prRows := ← readRows prPath
-    metrics, threshold, title
+    sections, sortMetric, threshold, title
     phases := ((← IO.getEnv "BENCH_PHASES").getD "0") == "1"
     rowNoun :=
       if backend == "compile" then "env"


### PR DESCRIPTION
# CI: the aiur benchmark becomes the full proof pipeline; aiur-recursive absorbed

  CI tracked the pipeline as disjoint benchmarks: `aiur` (stage-1 prove over the
  curated constants, plus a separate execute cell) and `aiur-recursive` (stage 2,
  but only over three fixed constants). Now the aiur benchmark IS the pipeline,
  per constant: every stage plus the total.

  For each constant in the curated Vectors.csv selection, `bench-typecheck
  --recursive` proves the IxVM typecheck (stage 1), then executes and proves the
  in-circuit multi-stark verifier over that fresh proof (stage 2). Rows close
  with a stage ledger — `stage1-time`, `stage2-time` (witness execute + prove
  each), `total-time` — which future stages (KZG) will fold into. `total-time`
  lands last, so it doubles as the completion marker for OOM-kill accounting.
  Both proofs run at **40 FRI queries, log-blowup 2** (50 OOMs the CI hosts).

  Changes:
  
  - Registry: the `aiur` backend's prove mode is now the pipeline, on a fresh
    testbed (`aiur-x64-32x`); `aiur-recursive` and its fixed-config machinery
    (`recursiveConstants`) are deleted. Thresholds carried over; headline
    metrics = the ledger. The Phase-1-only `execute` mode stays as an
    unscheduled local mode.
  - `!benchmark`: the `recursive` token is gone (prove IS the pipeline).
  - Plots and the threshold-reset workload lists synced.

  Verified: build green, `ci matrix`/`ci parse` exercised, and a smoke run of
  `Nat.add_comm` through the pipeline sums the ledger exactly.

  Note: `aiur-x64-32x` is a fresh testbed — the first bench-main run on main
  seeds its baseline. Its numbers are not comparable to the old
  `aiur-check-prove` series (standalone stage 1 at 100 queries).

