### PR TITLE
ci: Fix Zisk build

### DIFF
--- a/.github/actions/install-zisk/action.yml
+++ b/.github/actions/install-zisk/action.yml
@@ -63,24 +63,33 @@ runs:
     - name: Install Zisk toolchain (ziskup)
       shell: bash
       run: |
-        # ziskup's internal `cargo-zisk toolchain install` fetches the Zisk
-        # Rust toolchain from 0xPolygonHermez/rust `releases/latest`, which
-        # breaks whenever upstream publishes a release tag before uploading
-        # its assets. Tolerate that one failure (it is ziskup's last material
-        # step under --nokey) and redo the toolchain install; the follow-up
+        # Both pins track the argumentcomputer/zisk fork the guests build
+        # against (`blake3-precompile-1.0.0-alpha`) and must move with it.
+        #
+        # cargo-zisk 1.0.0-alpha matches the fork's `zisk-sdk` / `ziskos` and the
+        # proving key restored below. Unpinned, ziskup takes the newest release,
+        # whose `cargo-zisk toolchain install` also stopped honoring
+        # `releases/latest` in favor of the highest tag of a tracked major.
+        #
+        # zisk-0.5.1 is the last Rust toolchain whose `riscv64ima-zisk-zkvm-elf`
+        # target spec embeds the guest memory-layout linker script
+        # (`link_script: Some(LINKER_SCRIPT)`), which defines `_global_pointer`,
+        # `_init_stack_top` and the `_kernel_heap_*` symbols that `ziskos::_start`
+        # references. zisk-1.0.0 dropped it; upstream instead ships the script in
+        # `ziskbuild` and passes it as `-C link-arg=-T`, machinery that landed in
+        # zisk 1.1.0-alpha and so is absent from the 1.0.0-alpha fork. Any newer
+        # toolchain therefore fails the guest link with those symbols undefined.
+        # Unpin only alongside a fork rebase that carries ziskbuild's script.
+        #
+        # ziskup ends by running `cargo-zisk toolchain install` itself, which
+        # breaks whenever upstream publishes a release tag before uploading its
+        # assets. Tolerate that one failure (it is ziskup's last material step
+        # under --nokey) and redo the toolchain install pinned; the follow-up
         # command still fails the job if ziskup died earlier (no cargo-zisk
-        # binary) or the download itself breaks. Latest is deliberate: the
-        # guests rely on the linker script embedded in current toolchain
-        # builds (the zisk-1.0.0 artifact predates its restoration).
+        # binary) or the download itself breaks.
         curl -L https://raw.githubusercontent.com/0xPolygonHermez/zisk/main/ziskup/install.sh \
-          | bash -s -- --cpu --nokey -y --prefix "$HOME/.zisk" || true
-        # No --toolchain-version pin: the zisk-1.0.0 toolchain artifact
-        # predates the restoration of the embedded guest linker script, and
-        # the newer builds (rustc 1.94-dev, 2026-07+) carry it. Latest is
-        # what dev boxes run; the guests' build.rs probes the installed
-        # toolchain either way, so an older artifact still links via the
-        # vendored zisk.ld.
-        "$HOME/.zisk/bin/cargo-zisk" toolchain install
+          | bash -s -- --cpu --nokey -y --prefix "$HOME/.zisk" --version 1.0.0-alpha || true
+        "$HOME/.zisk/bin/cargo-zisk" toolchain install --toolchain-version zisk-0.5.1
         echo "$HOME/.zisk/bin" >> "$GITHUB_PATH"
     # Pre-build the proofman C++ sys crate ALONE so its build script runs
     # exactly once before any parallel zisk-host build. zisk-host pulls


### PR DESCRIPTION
The Zisk toolchain was updated yesterday to v1.1.0-alpha, which broke the `ziskup` installer since we are pinned to 1.0.0-alpha. Pinning the toolchain fixes the build.