### PR TITLE
Prop-mutual `.below` families — canonical rec order + casesOn regeneration

### DIFF
--- a/Ix/AuxGen/CompileAux.lean
+++ b/Ix/AuxGen/CompileAux.lean
@@ -557,7 +557,53 @@ def compileBelowRecursors (belowIndcs : Array MutConst) (maps : AddrMaps)
     belowRecs := belowRecs.push (.recr rv)
 
   if !belowRecs.isEmpty then
-    compileAuxBlock belowRecs maps
+    -- The below-rec block's storage order must align with the below
+    -- inductive block's member order (`classes`), exactly like the main
+    -- recursor block: the kernel's `populate_recursor_rules_from_block`
+    -- pairs `rec_block[i]` with `flat[i]` positionally (canonicity
+    -- §6.2). Without a class-order key, `sortConsts` picks its own
+    -- structural permutation of the recursors, which can diverge from
+    -- the inductive block's order (Prop-valued mutual predicate
+    -- families: HaskellSpec `dict`). Mirrors mutual.rs
+    -- `compile_below_recursors`.
+    let mut nameToPos : Std.HashMap Name UInt64 := {}
+    for (cls, pos) in classes.zipIdx do
+      for memberName in cls do
+        nameToPos := nameToPos.insert (Name.mkStr memberName "rec")
+          (UInt64.ofNat pos)
+    let keyMap := nameToPos
+    let classOrderKey : MutConst → UInt64 := fun c =>
+      (keyMap.get? c.name).getD u64Max
+    compileAuxBlockWithRename belowRecs maps none (some classOrderKey)
+
+  -- Regenerate `.below.casesOn` against the canonical below-recs
+  -- (mirrors mutual.rs `compile_below_recursors`). Lean authors
+  -- `X.below.casesOn` with motives in LEAN's member order; the recs
+  -- above carry the canonical motive layout, so the Lean-authored
+  -- wrapper is ill-typed in the compiled env. Regenerate from the
+  -- canonical rec and register here so the ordinary compile of the
+  -- Lean value is skipped.
+  let mut belowCases : Array MutConst := #[]
+  for (recName, recVal) in recs do
+    let indName? := match recName with
+      | .str parent "rec" _ => some parent
+      | _ => none
+    if let some indName := indName? then
+      let casesOnName := Name.mkStr indName "casesOn"
+      if (← liftM (lookupConst? casesOnName : CompileM _)).isSome then
+        if let some d ←
+            liftM (generateCasesOn casesOnName recVal : CompileM _) then
+          belowCases := belowCases.push (.defn {
+            name := d.name
+            levelParams := d.levelParams
+            type := d.typ
+            kind := .defn
+            value := d.value
+            hints := .abbrev
+            safety := defSafety d.isUnsafe
+            all := #[] })
+  if !belowCases.isEmpty then
+    compileAuxBlock belowCases maps
 
 /-! ## generateAndCompileAuxRecursors (mutual.rs:511) -/
 

--- a/Ix/CallSiteSurgery.lean
+++ b/Ix/CallSiteSurgery.lean
@@ -79,7 +79,17 @@ def classifyAuxGen (name : Name) : Option (AuxKind × Name) :=
     else if s1 == "recOn" || s1.startsWith "recOn_" then
       some (.recOnAux, p1)
     else if s1 == "casesOn" || s1.startsWith "casesOn_" then
-      some (.casesOnAux, p1)
+      -- X.casesOn / X.casesOn_N or X.below.casesOn. The below wrapper
+      -- roots under the FAMILY (like `X.below.rec` above) so it joins
+      -- the family block's aux members and the decompiler's Phase 3b
+      -- can regenerate it against the canonical below-rec.
+      match p1 with
+      | .str gp ps _ =>
+        if ps == "below" || ps.startsWith "below_" then
+          some (.casesOnAux, gp)
+        else
+          some (.casesOnAux, p1)
+      | _ => some (.casesOnAux, p1)
     else if s1 == "below" || s1.startsWith "below_" then
       some (.below, p1)
     else if s1 == "brecOn" || s1.startsWith "brecOn_" then

--- a/Ix/DecompileDriver.lean
+++ b/Ix/DecompileDriver.lean
@@ -646,6 +646,16 @@ def decompileBlockAuxGen (ctx : Pass2Ctx) (st₀ : Pass2St)
       (kind : Ix.AuxGen.AuxKind)
       (gen : Pass2St → Ix.Name → Ix.RecursorVal →
         Except String (Option Ix.AuxGen.AuxDef))
+      -- Rec resolver: Phase 1b/1c resolve `<parent>.rec` from the work
+      -- env / dstt; Phase 3b resolves from the freshly GENERATED
+      -- below-recs (their roundtripped forms only land after Phase 3,
+      -- and the Rust mirror likewise feeds the generated `RecursorVal`).
+      (recOf : Pass2St → Ix.Name → Option Ix.RecursorVal :=
+        fun st recName => match st.workEnv.get? recName with
+          | some (.recInfo rv) => some rv
+          | _ => match st.dstt.get? recName with
+            | some (.recInfo rv) => some rv
+            | _ => none)
       : Pass2St × Std.HashMap Ix.Name Ix.ConstantInfo := Id.run do
     let mut st := st₀
     let mut newGen : Std.HashMap Ix.Name Ix.ConstantInfo := {}
@@ -656,12 +666,7 @@ def decompileBlockAuxGen (ctx : Pass2Ctx) (st₀ : Pass2St)
         | _ => none
       let some indName := indName? | continue
       let recName := Ix.Name.mkStr indName "rec"
-      let recVal? : Option Ix.RecursorVal := match st.workEnv.get? recName with
-        | some (.recInfo rv) => some rv
-        | _ => match st.dstt.get? recName with
-          | some (.recInfo rv) => some rv
-          | _ => none
-      let some recVal := recVal? | continue
+      let some recVal := recOf st recName | continue
       let mut auxDefOpt : Option Ix.AuxGen.AuxDef := none
       match gen st wName recVal with
       | .ok d => auxDefOpt := d
@@ -816,6 +821,18 @@ def decompileBlockAuxGen (ctx : Pass2Ctx) (st₀ : Pass2St)
               | none =>
                 st := stPut st n (.recInfo rv)
               st := recordErr st n e
+        -- Phase 3b: regenerate `.below.casesOn` from the canonical
+        -- below-recs — deferred from Phase 1b, where these members skip
+        -- silently because `X.below.rec` does not exist until this
+        -- phase regenerates it. The resolver feeds the GENERATED rec
+        -- (not the roundtripped one), exactly like the Rust mirror.
+        -- Runs regardless of the roundtrip outcome above.
+        let (st', gen) := wrapPhase st generatedConsts .casesOnAux
+          (fun stCur n rv => runC ctx stCur n (Ix.AuxGen.generateCasesOn n rv))
+          (recOf := fun _ n =>
+            (belowRecs.find? (fun p => p.1 == n)).map (·.2))
+        st := st'
+        generatedConsts := gen.fold (fun m k v => m.insert k v) generatedConsts
       | .error e =>
         st := recordErr st lo s!"aux_gen below.rec failed for {lo.pretty}: {e}"
 

--- a/Tests/Ix/Compile/Mutual.lean
+++ b/Tests/Ix/Compile/Mutual.lean
@@ -624,4 +624,33 @@ end ThreeMember
 
 end AuxOwnership
 
+-- Prop-valued mutual inductive predicates whose `.below` auxiliaries form
+-- a generated mutual-inductive family (IndPredBelow) — the HaskellSpec
+-- `dict`/`pat`/`type` shape. The mutual theorems by structural
+-- pattern-matching force Lean to generate `EvenP.below`/`OddP.below`
+-- (plus `.below.casesOn`, defined via `.below.rec`), exercising:
+-- (a) the below-rec block's class-order key — its storage order must
+--     follow the below inductive block (canonicity §6.2), and
+-- (b) the `.below.casesOn` regeneration against the canonical below-rec
+--     (compile + decompile Phase 3b; Lean's authored wrapper applies
+--     motives in Lean's member order and would be ill-typed against the
+--     canonical rec).
+namespace BelowPredicate
+mutual
+  public inductive EvenP : Nat → Prop where
+    | zero : EvenP 0
+    | succ : {n : Nat} → OddP n → EvenP (n + 1)
+  public inductive OddP : Nat → Prop where
+    | succ : {n : Nat} → EvenP n → OddP (n + 1)
+end
+
+mutual
+  public theorem evenp_nonneg : {n : Nat} → EvenP n → 0 ≤ n
+    | _, .zero => Nat.le_refl 0
+    | _, .succ h => Nat.le_trans (oddp_nonneg h) (Nat.le_succ _)
+  public theorem oddp_nonneg : {n : Nat} → OddP n → 0 ≤ n
+    | _, .succ h => Nat.le_trans (evenp_nonneg h) (Nat.le_succ _)
+end
+end BelowPredicate
+
 end Tests.Ix.Compile.Mutual

--- a/crates/compile/src/compile/mutual.rs
+++ b/crates/compile/src/compile/mutual.rs
@@ -1217,12 +1217,75 @@ fn compile_below_recursors(
     stt,
     kctx,
   )?;
-  for (_, rec) in recs {
-    below_recs.push(MutConst::Recr(rec));
+  for (_, rec) in &recs {
+    below_recs.push(MutConst::Recr(rec.clone()));
   }
 
   if !below_recs.is_empty() {
-    compile_aux_block(&below_recs, lean_env, stt, kctx)?;
+    // The below-rec block's storage order must align with the below
+    // inductive block's member order (`classes`), exactly like the main
+    // recursor block above: the kernel's
+    // `populate_recursor_rules_from_block` pairs `rec_block[i]` with
+    // `flat[i]` positionally (canonicity §6.2). Without a class-order
+    // key, `sort_consts` picks its own structural permutation of the
+    // recursors, which can diverge from the inductive block's order —
+    // sibling below-recursors first differ at index/motive shape while
+    // sibling below-inductives first differ at ctor content (seen on
+    // Prop-valued mutual predicate families: HaskellSpec `dict`).
+    let mut name_to_pos: FxHashMap<Name, u64> = FxHashMap::default();
+    for (pos, class) in classes.iter().enumerate() {
+      for member_name in class {
+        let rec_name = Name::str(member_name.clone(), "rec".to_string());
+        name_to_pos.insert(rec_name, pos as u64);
+      }
+    }
+    let class_order_key = |c: &MutConst| -> u64 {
+      name_to_pos.get(&c.name()).copied().unwrap_or(u64::MAX)
+    };
+    compile_aux_block_with_rename(
+      &below_recs,
+      lean_env,
+      stt,
+      kctx,
+      None,
+      Some(&class_order_key),
+    )?;
+  }
+
+  // Regenerate `.below.casesOn` against the canonical below-recs. Lean
+  // authors `X.below.casesOn` for every below inductive, and its value
+  // applies `X.below.rec` with motives in LEAN's member order — but the
+  // block above regenerated those recs with the canonical motive layout,
+  // so the Lean-authored wrapper is ill-typed in the compiled env
+  // (kernel: AppTypeMismatch on the motive arguments). Mirror the main
+  // family's Phase-2b: regenerate each casesOn from its canonical rec
+  // and register it here so the ordinary compile of the Lean value is
+  // skipped (aux registrations suppress it, like every other patch).
+  let mut below_cases: Vec<MutConst> = Vec::new();
+  for (rec_name, rec_val) in &recs {
+    let ind_name = match rec_name.as_data() {
+      ix_common::env::NameData::Str(parent, _, _) => parent.clone(),
+      _ => continue,
+    };
+    let cases_on_name = Name::str(ind_name, "casesOn".to_string());
+    if lean_env.get(&cases_on_name).is_some()
+      && let Some(d) =
+        aux_gen::cases_on::generate_cases_on(&cases_on_name, rec_val, lean_env)
+    {
+      below_cases.push(MutConst::Defn(Def {
+        name: d.name.clone(),
+        level_params: d.level_params.clone(),
+        typ: d.typ.clone(),
+        kind: DefKind::Definition,
+        value: d.value.clone(),
+        hints: ReducibilityHints::Abbrev,
+        safety: def_safety(d.is_unsafe),
+        all: vec![],
+      }));
+    }
+  }
+  if !below_cases.is_empty() {
+    compile_aux_block(&below_cases, lean_env, stt, kctx)?;
   }
   Ok(())
 }

--- a/crates/compile/src/decompile.rs
+++ b/crates/compile/src/decompile.rs
@@ -2267,7 +2267,23 @@ fn classify_aux_gen(name: &Name) -> Option<(AuxKind, Name)> {
     },
     s if s == "recOn" || s.starts_with("recOn_") => Some((AuxKind::RecOn, p1)),
     s if s == "casesOn" || s.starts_with("casesOn_") => {
-      Some((AuxKind::CasesOn, p1))
+      // X.casesOn / X.casesOn_N or X.below.casesOn. The below wrapper
+      // roots under the FAMILY (like `X.below.rec` above) so it joins
+      // the family block's aux_members and Phase 3b can regenerate it
+      // against the canonical below-rec; rooting it at `X.below` would
+      // group it under an aux block that never runs aux-gen phases,
+      // dropping it from the decompiled env entirely.
+      if let Some(ps) = p1.last_str()
+        && (ps == "below" || ps.starts_with("below_"))
+      {
+        let root = match p1.as_data() {
+          NameData::Str(gp, _, _) => gp.clone(),
+          _ => return None,
+        };
+        Some((AuxKind::CasesOn, root))
+      } else {
+        Some((AuxKind::CasesOn, p1))
+      }
     },
     s if s == "below" || s.starts_with("below_") => Some((AuxKind::Below, p1)),
     s if s == "brecOn" || s.starts_with("brecOn_") => {
@@ -4261,6 +4277,93 @@ fn recover_aux_from_original(
   true
 }
 
+/// Regenerate one `.casesOn` definition from its (already regenerated)
+/// canonical recursor and roundtrip it into `dstt`. Shared by Phase 1b
+/// (family casesOn — the rec is available up front) and Phase 3b
+/// (`.below.casesOn` — its rec only exists once Phase 3 has generated
+/// the below-rec block).
+#[allow(clippy::too_many_arguments)]
+fn regen_one_cases_on(
+  co_name: &Name,
+  rec_val: &RecursorVal,
+  gen_env: &LeanEnv,
+  generated_consts: &mut FxHashMap<Name, LeanConstantInfo>,
+  orig_env: Option<&LeanEnv>,
+  stt: &CompileState,
+  dstt: &DecompileState,
+  aux_gen_errors: &mut Vec<(Name, DecompileError)>,
+) {
+  use crate::compile::aux_gen::cases_on::generate_cases_on;
+  if let Some(aux_def) = generate_cases_on(co_name, rec_val, gen_env) {
+    // Lean marks `.casesOn` unsafe iff the parent `.rec` is unsafe
+    // (an unsafe recursor transitively forces every wrapper around it).
+    let safety = if rec_val.is_unsafe {
+      DefinitionSafety::Unsafe
+    } else {
+      DefinitionSafety::Safe
+    };
+    let as_defn = LeanConstantInfo::DefnInfo(DefinitionVal {
+      cnst: ConstantVal {
+        name: aux_def.name.clone(),
+        level_params: aux_def.level_params.clone(),
+        typ: aux_def.typ.clone(),
+      },
+      value: aux_def.value.clone(),
+      hints: ReducibilityHints::Abbrev,
+      safety,
+      all: vec![aux_def.name.clone()],
+    });
+    generated_consts.insert(aux_def.name.clone(), as_defn);
+
+    let mc = LeanMutConst::Defn(Def {
+      name: aux_def.name.clone(),
+      level_params: aux_def.level_params.clone(),
+      typ: aux_def.typ.clone(),
+      kind: DefKind::Definition,
+      value: aux_def.value.clone(),
+      hints: ReducibilityHints::Abbrev,
+      safety,
+      // Lean emits `.casesOn` / `.recOn` as standalone `defnDecl`s
+      // (`refs/lean4/src/Lean/Elab/Inductive.lean:mkCasesOn` et al.),
+      // each with `all = [self]`. `Named.original.0` captured that
+      // exact shape; regenerating with `all = []` here makes the
+      // Phase-A block hash match but leaves the Lean-level `all`
+      // blank, so Phase B's `ConstantInfo::get_hash()` diverges
+      // (type + value match but `all` differs). See
+      // `docs/ix_canonicity.md` §9.2.
+      all: vec![aux_def.name.clone()],
+    });
+    match roundtrip_block(&[mc], generated_consts, orig_env, stt, dstt) {
+      Ok(roundtripped) if !roundtripped.is_empty() => {
+        for (n, ci) in roundtripped {
+          dstt.insert_interned(n, ci);
+        }
+      },
+      Ok(_) => {
+        // Empty roundtrip result: prefer the source-faithful original
+        // pair; fall back to the regenerated form otherwise.
+        if !recover_aux_from_original(&aux_def.name, stt, dstt)
+          && let Some(ci) = generated_consts.get(&aux_def.name)
+        {
+          dstt.insert_interned(aux_def.name.clone(), ci.clone());
+        }
+      },
+      Err(e) => {
+        // Recovery keeps the Lean-facing env populated for diagnosis,
+        // but the failure is always recorded — post-preseed, the
+        // roundtrip is byte-exact corpus-wide, so any error here is
+        // a regression.
+        if !recover_aux_from_original(&aux_def.name, stt, dstt)
+          && let Some(ci) = generated_consts.get(&aux_def.name)
+        {
+          dstt.insert_interned(aux_def.name.clone(), ci.clone());
+        }
+        aux_gen_errors.push((aux_def.name.clone(), e));
+      },
+    }
+  }
+}
+
 fn decompile_block_aux_gen(
   all_names: &[Name],
   aux_members: &[(AuxKind, Name)],
@@ -4273,7 +4376,6 @@ fn decompile_block_aux_gen(
   use crate::compile::aux_gen::{
     below::{BelowConstant, generate_below_constants},
     brecon::generate_brecon_constants,
-    cases_on::generate_cases_on,
     expr_utils, populate_canon_kenv_with_below,
     recursor::generate_canonical_recursors_with_overlay,
   };
@@ -4487,74 +4589,16 @@ fn decompile_block_aux_gen(
           }
         },
       };
-      if let Some(aux_def) = generate_cases_on(co_name, &rec_val, env) {
-        // Lean marks `.casesOn` unsafe iff the parent `.rec` is unsafe
-        // (an unsafe recursor transitively forces every wrapper around it).
-        let safety = if rec_val.is_unsafe {
-          DefinitionSafety::Unsafe
-        } else {
-          DefinitionSafety::Safe
-        };
-        let as_defn = LeanConstantInfo::DefnInfo(DefinitionVal {
-          cnst: ConstantVal {
-            name: aux_def.name.clone(),
-            level_params: aux_def.level_params.clone(),
-            typ: aux_def.typ.clone(),
-          },
-          value: aux_def.value.clone(),
-          hints: ReducibilityHints::Abbrev,
-          safety,
-          all: vec![aux_def.name.clone()],
-        });
-        generated_consts.insert(aux_def.name.clone(), as_defn);
-
-        let mc = LeanMutConst::Defn(Def {
-          name: aux_def.name.clone(),
-          level_params: aux_def.level_params.clone(),
-          typ: aux_def.typ.clone(),
-          kind: DefKind::Definition,
-          value: aux_def.value.clone(),
-          hints: ReducibilityHints::Abbrev,
-          safety,
-          // Lean emits `.casesOn` / `.recOn` as standalone `defnDecl`s
-          // (`refs/lean4/src/Lean/Elab/Inductive.lean:mkCasesOn` et al.),
-          // each with `all = [self]`. `Named.original.0` captured that
-          // exact shape; regenerating with `all = []` here makes the
-          // Phase-A block hash match but leaves the Lean-level `all`
-          // blank, so Phase B's `ConstantInfo::get_hash()` diverges
-          // (type + value match but `all` differs). See
-          // `docs/ix_canonicity.md` §9.2.
-          all: vec![aux_def.name.clone()],
-        });
-        match roundtrip_block(&[mc], &generated_consts, orig_env, stt, dstt) {
-          Ok(roundtripped) if !roundtripped.is_empty() => {
-            for (n, ci) in roundtripped {
-              dstt.insert_interned(n, ci);
-            }
-          },
-          Ok(_) => {
-            // Empty roundtrip result: prefer the source-faithful original
-            // pair; fall back to the regenerated form otherwise.
-            if !recover_aux_from_original(&aux_def.name, stt, dstt)
-              && let Some(ci) = generated_consts.get(&aux_def.name)
-            {
-              dstt.insert_interned(aux_def.name.clone(), ci.clone());
-            }
-          },
-          Err(e) => {
-            // Recovery keeps the Lean-facing env populated for diagnosis,
-            // but the failure is always recorded — post-preseed, the
-            // roundtrip is byte-exact corpus-wide, so any error here is
-            // a regression.
-            if !recover_aux_from_original(&aux_def.name, stt, dstt)
-              && let Some(ci) = generated_consts.get(&aux_def.name)
-            {
-              dstt.insert_interned(aux_def.name.clone(), ci.clone());
-            }
-            aux_gen_errors.push((aux_def.name.clone(), e));
-          },
-        }
-      }
+      regen_one_cases_on(
+        co_name,
+        &rec_val,
+        env,
+        &mut generated_consts,
+        orig_env,
+        stt,
+        dstt,
+        &mut aux_gen_errors,
+      );
     }
   }
 
@@ -4943,6 +4987,40 @@ fn decompile_block_aux_gen(
                 }
               }
             },
+          }
+
+          // Phase 3b: Regenerate `.below.casesOn` from the canonical
+          // below-recs — deferred from Phase 1b, where these members
+          // skip silently because `X.below.rec` does not exist until
+          // this phase regenerates it. Mirrors compile-side
+          // `compile_below_recursors`: the Lean-authored wrapper
+          // applies motives in Lean's member order, so it must be
+          // regenerated against the canonical rec. Runs regardless of
+          // the roundtrip outcome above (compile likewise always
+          // compiles the regenerated casesOn after the rec block).
+          for (kind, co_name) in aux_members {
+            if *kind != AuxKind::CasesOn {
+              continue;
+            }
+            let parent = match co_name.as_data() {
+              ix_common::env::NameData::Str(p, _, _) => p.clone(),
+              _ => continue,
+            };
+            let rec_name = Name::str(parent, "rec".to_string());
+            if let Some((_, rv)) =
+              below_recs.iter().find(|(n, _)| *n == rec_name)
+            {
+              regen_one_cases_on(
+                co_name,
+                rv,
+                &below_env,
+                &mut generated_consts,
+                orig_env,
+                stt,
+                dstt,
+                &mut aux_gen_errors,
+              );
+            }
           }
         },
         Err(e) => {

--- a/crates/kernel/src/inductive.rs
+++ b/crates/kernel/src/inductive.rs
@@ -1584,7 +1584,7 @@ impl<M: KernelMode> TypeChecker<'_, M> {
     });
 
     if dump_canonical {
-      log::info!(
+      eprintln!(
         "[canonical_aux_order.dump] all0={:?} n_aux={} n_block_params={}",
         all0_name.map(Name::pretty),
         pairs.len(),
@@ -1592,7 +1592,7 @@ impl<M: KernelMode> TypeChecker<'_, M> {
       );
       for (i, (kid, kconst)) in pairs.iter().enumerate() {
         let seed = aux_seed_names.get(i).cloned().unwrap_or_else(Name::anon);
-        log::info!(
+        eprintln!(
           "  pre-sort[{}] addr={} seed={} member_id_addr={}",
           i,
           &kid.addr.hex()[..8],
@@ -1600,12 +1600,12 @@ impl<M: KernelMode> TypeChecker<'_, M> {
           &aux[i].id.addr.hex()[..8]
         );
         if let KConst::Indc { ty, ctors, .. } = kconst {
-          log::info!("    indc.ty={ty}");
+          eprintln!("    indc.ty={ty}");
           for (ci, ctor_kid) in ctors.iter().enumerate() {
             if let Some(KConst::Ctor { ty, .. }) =
               all_ctor_lookup.get(&ctor_kid.addr)
             {
-              log::info!("    ctor[{ci}].ty={ty}");
+              eprintln!("    ctor[{ci}].ty={ty}");
             }
           }
         }
@@ -1624,10 +1624,10 @@ impl<M: KernelMode> TypeChecker<'_, M> {
     )?;
 
     if dump_canonical {
-      log::info!("[canonical_aux_order.dump] post-sort classes:");
+      eprintln!("[canonical_aux_order.dump] post-sort classes:");
       for (ci, class) in classes.iter().enumerate() {
         for (mi, (kid, _)) in class.iter().enumerate() {
-          log::info!("  class[{ci}][{mi}] addr={}", &kid.addr.hex()[..8]);
+          eprintln!("  class[{ci}][{mi}] addr={}", &kid.addr.hex()[..8]);
         }
       }
     }
@@ -1686,7 +1686,7 @@ impl<M: KernelMode> TypeChecker<'_, M> {
     if !self.recursor_dump_matches_block(block_id, flat) {
       return;
     }
-    log::info!(
+    eprintln!(
       "[recursor.dump] {label} flat aux order for {block_id}: originals={} aux={}",
       n_originals,
       flat.len().saturating_sub(n_originals)
@@ -1694,11 +1694,9 @@ impl<M: KernelMode> TypeChecker<'_, M> {
     for (aux_i, member) in flat.iter().skip(n_originals).enumerate() {
       let spec =
         member.spec_params.iter().map(|e| format!("{e}")).collect::<Vec<_>>();
-      log::info!(
+      eprintln!(
         "  aux[{aux_i:2}] id={} own_params={} indices={} spec={spec:?}",
-        member.id,
-        member.own_params,
-        member.n_indices
+        member.id, member.own_params, member.n_indices
       );
     }
   }
@@ -1809,18 +1807,18 @@ impl<M: KernelMode> TypeChecker<'_, M> {
     failed_gen_major: Option<&KExpr<M>>,
     failed_stored_major: Option<&KExpr<M>>,
   ) {
-    log::info!(
+    eprintln!(
       "[recursor.align] FAIL ind_block={ind_block_id} rec_block={rec_block_id} \
 peers={} flat={} rec_ids={} failed_gi={failed_gi}",
       generated_snapshot.len(),
       flat.len(),
       rec_ids.len()
     );
-    log::info!(
+    eprintln!(
       "  failed gen major: {}",
       Self::major_domain_signature_text(failed_gen_major)
     );
-    log::info!(
+    eprintln!(
       "  failed stored major: {}",
       Self::major_domain_signature_text(failed_stored_major)
     );
@@ -1860,18 +1858,18 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
         _ => None,
       };
       let mark = if gi == failed_gi { "!!" } else { "  " };
-      log::info!(
+      eprintln!(
         "  {mark} peer[{gi:2}] flat.id={} target={}… aux={} ind={}…",
         flat[gi].id,
         &target_addr.hex()[..8],
         flat[gi].is_aux,
         &gen_rec.ind_addr.hex()[..8]
       );
-      log::info!(
+      eprintln!(
         "       gen   : {}",
         Self::major_domain_signature_text(gen_major.as_ref())
       );
-      log::info!(
+      eprintln!(
         "       sto   : {} (rid={})",
         Self::major_domain_signature_text(stored_major.as_ref()),
         rid
@@ -1890,9 +1888,9 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
       return Ok(false);
     }
     if depth > 80 {
-      log::info!("[rule rhs diff] first diff {path}: recursion limit");
-      log::info!("  gen: {lhs}");
-      log::info!("  sto: {rhs}");
+      eprintln!("[rule rhs diff] first diff {path}: recursion limit");
+      eprintln!("  gen: {lhs}");
+      eprintln!("  sto: {rhs}");
       return Ok(true);
     }
 
@@ -1908,9 +1906,9 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
         ExprData::All(_, _, rty, rbody, _),
       ) => {
         if !self.is_def_eq(lty, rty)? {
-          log::info!("[rule rhs diff] first diff {path}.dom");
-          log::info!("  gen: {lty}");
-          log::info!("  sto: {rty}");
+          eprintln!("[rule rhs diff] first diff {path}.dom");
+          eprintln!("  gen: {lty}");
+          eprintln!("  sto: {rty}");
           return Ok(true);
         }
         let saved = self.lctx.len();
@@ -1938,9 +1936,9 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
         self.dump_rule_rhs_first_diff(la, ra, &format!("{path}.arg"), depth + 1)
       },
       _ => {
-        log::info!("[rule rhs diff] first diff {path}");
-        log::info!("  gen: {lw}");
-        log::info!("  sto: {rw}");
+        eprintln!("[rule rhs diff] first diff {path}");
+        eprintln!("  gen: {lw}");
+        eprintln!("  sto: {rw}");
         Ok(true)
       },
     }
@@ -2829,7 +2827,7 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
         block_first_id.as_ref(),
       )?;
       if self.recursor_dump_matches_block(block_id, &flat) {
-        log::info!("[recursor.dump] canonical_order={canonical_order:?}");
+        eprintln!("[recursor.dump] canonical_order={canonical_order:?}");
       }
       // Apply the permutation produced by sort_consts: each canonical
       // class index k maps to one representative aux from the original
@@ -2942,7 +2940,7 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
         "generated recursor params + motives + minors",
         &[n_params, n_motives, n_minors],
       )?;
-      log::info!(
+      eprintln!(
         "[recursor.dump] generated recursors for {block_id}: count={} prefix_skip={prefix_skip}",
         generated.len()
       );
@@ -2952,7 +2950,7 @@ peers={} flat={} rec_ids={} failed_gi={failed_gi}",
           prefix_skip,
           &g.ind_addr,
         )?;
-        log::info!(
+        eprintln!(
           "  gen[{gi:2}] ind_addr={} {}",
           &g.ind_addr.hex()[..8],
           Self::major_domain_signature_text(major.as_ref())
@@ -4904,17 +4902,15 @@ re-run with `IX_RECURSOR_DUMP={}` for the full breakdown.",
       .or_else(|| generated.iter().position(|g| g.ind_addr == ind_id.addr));
 
     if self.recursor_dump_matches_id(id) {
-      log::info!(
+      eprintln!(
         "[recursor.dump] check {} rec_block={} resolved_block={} stored_pos={stored_pos:?} selected_idx={selected_idx:?}",
-        id,
-        rec_block,
-        resolved_block
+        id, rec_block, resolved_block
       );
-      log::info!(
+      eprintln!(
         "[recursor.dump] stored major: {}",
         Self::major_domain_signature_text(stored_major.as_ref())
       );
-      log::info!("[recursor.dump] signature_matches={signature_matches:?}");
+      eprintln!("[recursor.dump] signature_matches={signature_matches:?}");
       for (gi, g) in generated.iter().enumerate() {
         if g.ind_addr != ind_id.addr {
           continue;
@@ -4924,7 +4920,7 @@ re-run with `IX_RECURSOR_DUMP={}` for the full breakdown.",
           prefix_skip,
           &g.ind_addr,
         )?;
-        log::info!(
+        eprintln!(
           "  cand[{gi:2}] {}",
           Self::major_domain_signature_text(major.as_ref())
         );
@@ -4990,11 +4986,11 @@ re-run with `IX_RECURSOR_DUMP={}` for the full breakdown.",
                     } else {
                       "idx/major"
                     };
-                    log::info!(
+                    eprintln!(
                       "[type diff] binder {bi} ({label}) DIFFERS (p={params} m={motives} min={minors})"
                     );
-                    log::info!("  gen: {gd}");
-                    log::info!("  sto: {sd}");
+                    eprintln!("  gen: {gd}");
+                    eprintln!("  sto: {sd}");
                     break;
                   }
                   let _ = self.push_fvar_decl_anon(gd.clone());
@@ -5003,9 +4999,9 @@ re-run with `IX_RECURSOR_DUMP={}` for the full breakdown.",
                   bi += 1;
                 },
                 _ => {
-                  log::info!("[type diff] return differs at {bi}");
-                  log::info!("  gen: {gc}");
-                  log::info!("  sto: {sc}");
+                  eprintln!("[type diff] return differs at {bi}");
+                  eprintln!("  gen: {gc}");
+                  eprintln!("  sto: {sc}");
                   break;
                 },
               }
@@ -5081,12 +5077,12 @@ re-run with `IX_RECURSOR_DUMP={}` for the full breakdown.",
                 "rhs",
                 0,
               );
-              log::info!(
+              eprintln!(
                 "[rule rhs diff] rule {ri} RHS mismatch (fields={})",
                 gen_rule.fields
               );
-              log::info!("  gen: {}", gen_rule.rhs);
-              log::info!("  sto: {}", stored_rule.rhs);
+              eprintln!("  gen: {}", gen_rule.rhs);
+              eprintln!("  sto: {}", stored_rule.rhs);
             }
             return Err(TcError::Other(format!(
               "check_recursor: rule {ri} RHS mismatch"


### PR DESCRIPTION
Fixes the known-open finding from the mega-PR's real-library benchmark:
`ix check-rs` rejected 25 constants of HaskellSpec's env — every
`.below` auxiliary of its Prop-valued *mutual* inductive predicates
(dict/pat/type/bind/exp/gde… families; `main` rejected a strict
superset of 37 before the aux-alias fix). After this branch the
HaskellSpec env and the whole CatalogReal catalog kernel-check clean.

## Two root causes, both compile-side

**1. The below-rec block ignored §6.2.** Prop-mutual predicates get an
IndPredBelow-generated *mutual-inductive* `.below` family, and its
recursor block was compiled through the keyless `compile_aux_block` —
so `sort_consts` picked its own structural permutation. Sibling
below-*recursors* first differ at index/motive shape while sibling
below-*inductives* first differ at ctor content, so the two blocks'
canonical orders can diverge — and the kernel's
`populate_recursor_rules_from_block` pairs `rec_block[i]` with
`flat[i]` positionally (canonicity §6.2, verified loudly). The main
recursor block already passes a class-order key for exactly this
reason; the below-rec block now does too.

**2. Lean's authored `X.below.casesOn` dies once the rec is
canonical.** Its value applies `X.below.rec` with motives in *Lean's*
member order; ix regenerates that rec with the canonical motive
layout, so the authored wrapper becomes genuinely ill-typed in the
compiled env (the AppTypeMismatch and both universe-param-count
rejections). Ordinary families never hit this because ix regenerates
their `casesOn` from the canonical rec (Phase 1b/2b); the below path
now does the same.

**Decompile had to learn the new shape:** `classify_aux_gen` rooted
`X.below.casesOn` at `X.below` — an aux inductive, not a family — so
the member joined no processed block and silently vanished from
decompiled envs; it now roots at the family like `X.below.rec`. And
since the wrapper's rec only exists after the below-rec phase, its
regeneration is deferred to a new Phase 3b fed by the *generated*
`RecursorVal`s (the Lean driver's `wrapPhase` gains a rec-resolver
parameter; the Rust side factors Phase 1b's body into
`regen_one_cases_on`).

## Commits

1. **kernel: emit gated canonicity/recursor dumps on stderr** — the
   `IX_RECURSOR_DUMP` / alignment-failure / rule-diff dumps logged via
   the `log` facade with no backend installed in the CLI; every
   breakdown the kernel's own error hints point at was silently
   dropped. Now stderr, like the compile-side mirror dumps.
2. **compile: align the below-rec block with its inductive block;
   regenerate below.casesOn** (mutual.rs + AuxGen/CompileAux.lean).
3. **decompile: regenerate below.casesOn against the canonical
   below-rec (Phase 3b)** (decompile.rs + DecompileDriver.lean +
   CallSiteSurgery.lean classifier).
4. **tests: `BelowPredicate` corpus fixture** — EvenP/OddP mutual Prop
   predicates + mutual theorems by structural pattern-matching (the
   IndPredBelow trigger), permanently swept by validate-aux /
   aux-gen-diff / decompile-diff and the C5 qualified corpus.

## Verification

| gate | result |
|---|---|
| HaskellSpec standalone (`CompileHS.lean`) | 25 rejections → **64,051/64,051 kernel-clean** |
| CatalogReal (`ix catalog --audit` + `check-rs`) | **208,583/208,583**, audit still green (19,584 address-preserving), root `957e5f8cfc35…` |
| full `lake test` | 2,670 pass (fixture included) |
| `validate-aux` | 0 failures |
| `aux-gen-diff` | Rust and Lean drivers byte-identical (6,247,773 B), serial + parallel |
| `decompile-diff` | all gates PASS (300 plans; aux-family recovers the 19 dropped below-casesOn) |
| mathlib Rust compile | 736,624 consts → **3,155,811,864 B**, `ix validate` **0 failures** |
| mathlib ALIGNED (`compile-lean @16 --rust-check`) | **byte-identical with Rust**, and `cmp`-identical with the on-disk artifact |
| mathlib `validate-lean` (5-phase, @8) | phases 1–4 PASS (phase 1 reproduces the canonical bytes; phase 4 zero findings, `skippedAux` +99 = the below-casesOn constants now on the aux track); phase 5 decompile in flight at PR time |

## ⚠️ Canonical bytes move (+249,024 at mathlib scale)

`X.below.casesOn` storage changes from standalone authored defs to
regenerated aux-block members across every Prop-below family
(`Nat.le`, `Relation.TransGen`, `Acc`, `List.Perm`, …). Same wire
format, different compiler output — all artifacts regenerate.
**Open decision:** bump `Env::VERSION` to 2 per the policy sentence
("any change to serialized bytes bumps VERSION"), or fold into the
still-unreleased v1 from the base PR. One-integer change either way
(serialize.rs + Ix/Ixon.lean + docs/Ixon.md).

## Downstream

TruthMinesLib should re-pin past this branch's merge (not just the
base PR): HaskellSpec is one of their 81 libraries, and their
kernel-check gates over any catalog containing it hit exactly the 25
pre-fix rejections.
