### PR TITLE
fix(ci): preserve native Rust codegen

### DIFF
--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -1,0 +1,17 @@
+name: Set up Rust toolchain
+description: >-
+  Install Rust and cache Cargo artifacts without exporting RUSTFLAGS, leaving
+  each workspace's .cargo/config.toml authoritative.
+
+inputs:
+  cache-workspaces:
+    description: Cargo workspaces to cache
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+        cache-workspaces: ${{ inputs.cache-workspaces }}

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v7
       # Rust toolchain + cargo cache, so the cargo step inside `lake build`
       # does not recompile the Plonky3/multi-stark dependencies every run.
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # Log the build CPU so a benchmark shift can be traced to a host change.
       - name: Log build CPU
         run: |
@@ -265,7 +265,7 @@ jobs:
       # binaries only. (Restore an install-sp1 step here when sp1 is
       # re-enabled in the registry.)
       - if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: ${{ matrix.params.backend }}
       - name: Install Zisk

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -162,7 +162,7 @@ jobs:
           path: ~/.local/bin
           key: bench-bins-${{ inputs.head-sha }}
       - if: steps.bins.outputs.cache-hit != 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust-toolchain
       # `.cargo/config.toml` sets `-Ctarget-cpu=native`; log the build CPU so a
       # benchmark shift can be traced to an instruction-set change.
       - name: Log build CPU
@@ -441,7 +441,7 @@ jobs:
       # and system deps (the shared composite install actions).
       - name: Set up zkVM Rust toolchain
         if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: ${{ matrix.params.backend }}
       # sp1 is disabled in the registry (execute too slow for CI);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       - uses: leanprover/lean-action@v1
         with:
           build-args: "--wfail -v"
@@ -71,7 +71,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # `./.lake`, not `.lake`: the cache path is hashed into the entry's
       # version, and lean-action saves under `./.lake`, so a bare `.lake` here
       # computes a different version and the restore misses despite the key
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       - uses: taiki-e/install-action@nextest
       # Install Lean for rust-bindgen step
       - uses: leanprover/lean-action@v1
@@ -144,7 +144,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: sp1
       - uses: ./.github/actions/install-sp1
@@ -183,7 +183,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: zisk
       # Proving key ON (the default): the execute step's `client.setup()` loads

--- a/.github/workflows/ignored.yml
+++ b/.github/workflows/ignored.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-32x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # Only restore the cache, since `ci.yml` will save the test binary to the cache first
       - uses: actions/cache/restore@v6
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # Only restore the cache, since `ci.yml` will save the test binary to the cache first
       - uses: actions/cache/restore@v6
         with:
@@ -83,7 +83,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       - uses: actions/cache@v6
         with:
           path: ./.lake


### PR DESCRIPTION
The `setup-rust-toolchain` action clobbers RUSTFLAGS per https://github.com/actions-rust-lang/setup-rust-toolchain#rustflags, so AVX-512 was getting disabled in CI. This PR restores native codegen via an empty `rustflags` input to the setup action, and centralizes it in a reusable action to make maintenance easier.