### PR TITLE
ci: `!benchmark` fixes

### DIFF
--- a/.github/actions/log-cpu/action.yml
+++ b/.github/actions/log-cpu/action.yml
@@ -1,7 +1,8 @@
 name: Log CPU information
 description: >-
   Log a benchmark host's CPU and effective cgroup allocation, optionally
-  recording the report or printing the report carried with native binaries.
+  recording the report, printing native-binary build provenance, and warning
+  when the build and measurement CPUs differ.
 
 inputs:
   label:
@@ -13,6 +14,13 @@ inputs:
     required: false
   provenance-file:
     description: Optional native-binary build-host report to print
+    required: false
+  provenance-label:
+    description: Subject named in provenance mismatch warnings
+    required: false
+    default: Native benchmark binaries
+  warning-file:
+    description: Optional Markdown file to which provenance warnings are appended
     required: false
   log-current:
     description: Whether to log the current host
@@ -27,9 +35,12 @@ runs:
         CPU_LABEL: ${{ inputs.label }}
         CPU_OUTPUT_FILE: ${{ inputs.output-file }}
         CPU_PROVENANCE_FILE: ${{ inputs.provenance-file }}
+        CPU_PROVENANCE_LABEL: ${{ inputs.provenance-label }}
+        CPU_WARNING_FILE: ${{ inputs.warning-file }}
         LOG_CURRENT_CPU: ${{ inputs.log-current }}
       run: |
         set -euo pipefail
+        export LC_ALL=C
 
         resolve_path() {
           if [[ "$1" == \~/* ]]; then
@@ -38,6 +49,12 @@ runs:
             printf '%s\n' "$1"
           fi
         }
+
+        model_name() {
+          awk -F ': *' '/^Model name:/ { print $2; exit }' "$@"
+        }
+
+        current_cpu_model=$(lscpu | model_name)
 
         cpu_report() {
           echo "Context: $CPU_LABEL"
@@ -78,4 +95,20 @@ runs:
             echo "::warning::Binary build CPU provenance is unavailable (the cache may predate CPU reports)"
           fi
           echo "::endgroup::"
+
+          provenance_model=$(model_name "$provenance_file" 2>/dev/null || true)
+          warning=""
+          if [ -z "$provenance_model" ] || [ -z "$current_cpu_model" ]; then
+            warning=$(printf '**CPU provenance unavailable for %s:** one report has no CPU model, so native-code compatibility cannot be checked.' "$CPU_PROVENANCE_LABEL")
+          elif [ "$provenance_model" != "$current_cpu_model" ]; then
+            warning=$(printf "**CPU model mismatch for %s:** built on \`%s\`; measured on \`%s\`. Native Rust code uses \`-Ctarget-cpu=native\`." "$CPU_PROVENANCE_LABEL" "$provenance_model" "$current_cpu_model")
+          fi
+          if [ -n "$warning" ]; then
+            echo "::warning::$warning"
+            if [ -n "$CPU_WARNING_FILE" ]; then
+              warning_file=$(resolve_path "$CPU_WARNING_FILE")
+              mkdir -p "$(dirname "$warning_file")"
+              printf '%s\n' "- $warning" >> "$warning_file"
+            fi
+          fi
         fi

--- a/.github/actions/log-cpu/action.yml
+++ b/.github/actions/log-cpu/action.yml
@@ -1,0 +1,81 @@
+name: Log CPU information
+description: >-
+  Log a benchmark host's CPU and effective cgroup allocation, optionally
+  recording the report or printing the report carried with native binaries.
+
+inputs:
+  label:
+    description: Heading and context stored in a newly recorded CPU report
+    required: false
+    default: CPU information
+  output-file:
+    description: Optional path at which to record the current host report
+    required: false
+  provenance-file:
+    description: Optional native-binary build-host report to print
+    required: false
+  log-current:
+    description: Whether to log the current host
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        CPU_LABEL: ${{ inputs.label }}
+        CPU_OUTPUT_FILE: ${{ inputs.output-file }}
+        CPU_PROVENANCE_FILE: ${{ inputs.provenance-file }}
+        LOG_CURRENT_CPU: ${{ inputs.log-current }}
+      run: |
+        set -euo pipefail
+
+        resolve_path() {
+          if [[ "$1" == \~/* ]]; then
+            printf '%s/%s\n' "$HOME" "${1:2}"
+          else
+            printf '%s\n' "$1"
+          fi
+        }
+
+        cpu_report() {
+          echo "Context: $CPU_LABEL"
+          echo "Runner: ${RUNNER_NAME:-unknown} (${RUNNER_OS:-unknown}/${RUNNER_ARCH:-unknown})"
+          echo "Kernel: $(uname -srvm)"
+          echo "nproc: $(nproc)"
+          if [ -r /sys/fs/cgroup/cpu.max ]; then
+            echo "cgroup cpu.max: $(< /sys/fs/cgroup/cpu.max)"
+          fi
+          if [ -r /sys/fs/cgroup/cpuset.cpus.effective ]; then
+            echo "cgroup cpuset.cpus.effective: $(< /sys/fs/cgroup/cpuset.cpus.effective)"
+          fi
+          grep -m1 '^Cpus_allowed_list:' /proc/self/status || true
+          lscpu
+          flags=$({ grep -m1 -oE 'avx2|avx512[a-z0-9_]*' /proc/cpuinfo || true; } \
+            | sort -u | tr '\n' ' ')
+          echo "AVX flags: ${flags:-absent}"
+        }
+
+        if [ "$LOG_CURRENT_CPU" = true ]; then
+          echo "::group::$CPU_LABEL"
+          if [ -n "$CPU_OUTPUT_FILE" ]; then
+            output_file=$(resolve_path "$CPU_OUTPUT_FILE")
+            mkdir -p "$(dirname "$output_file")"
+            cpu_report | tee "$output_file"
+          else
+            cpu_report
+          fi
+          echo "::endgroup::"
+        fi
+
+        if [ -n "$CPU_PROVENANCE_FILE" ]; then
+          provenance_file=$(resolve_path "$CPU_PROVENANCE_FILE")
+          echo "::group::Native benchmark binary build CPU"
+          if [ -s "$provenance_file" ]; then
+            cat "$provenance_file"
+          else
+            echo "::warning::Binary build CPU provenance is unavailable (the cache may predate CPU reports)"
+          fi
+          echo "::endgroup::"
+        fi

--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -1,0 +1,17 @@
+name: Set up Rust toolchain
+description: >-
+  Install Rust and cache Cargo artifacts without exporting RUSTFLAGS, leaving
+  each workspace's .cargo/config.toml authoritative.
+
+inputs:
+  cache-workspaces:
+    description: Cargo workspaces to cache
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
+        cache-workspaces: ${{ inputs.cache-workspaces }}

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -208,18 +208,25 @@ jobs:
       - if: steps.gates.outputs.zkvm == 'true'
         name: Cut closure shards for heavy primaries
         run: ix bench shard --env ${{ matrix.env }} --ixe ${{ matrix.env }}.ixe
-      # Cache the `.ixe` (plus the shard directory when the step above ran)
-      # for the benchmark job. For an env only decompile consumes, the
-      # `zkshards-*` directory doesn't exist and simply isn't stored.
-      # IMPORTANT: every restore of this key must list the same paths —
-      # actions/cache versions the entry by its path list.
+      # Cache the `.ixe` for the benchmark job. IMPORTANT: every restore of
+      # this key must list the same paths — actions/cache versions the
+      # entry by its path list, so a mismatched list is unreachable
+      # whatever the key. Keeping this entry to one path lets bench-pr's
+      # base-side restore fall back to that workflow's compile-job key (a
+      # stacked PR's base is a PR head, which never passes through here).
       - if: steps.gates.outputs.consumed == 'true'
         uses: actions/cache/save@v6
         with:
-          path: |
-            ${{ matrix.env }}.ixe
-            zkshards-${{ matrix.env }}
+          path: ${{ matrix.env }}.ixe
           key: bench-ixe-${{ github.sha }}-${{ matrix.env }}
+      # Shards get their own entry rather than riding the `.ixe`: only the
+      # zkVM envs have any, so bundling them would put a directory that
+      # usually doesn't exist into every `.ixe` restore's path list.
+      - if: steps.gates.outputs.zkvm == 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: zkshards-${{ matrix.env }}
+          key: bench-shards-${{ github.sha }}-${{ matrix.env }}
       # Upload the compile metrics. Testbed, workload, and threshold flags
       # all come from the registry (the reasoning behind each bound lives
       # next to `thresholds` in Ix/Cli/BenchCmd.lean).
@@ -297,16 +304,21 @@ jobs:
           auto-config: false
           build: false
           use-github-cache: false
-      # Pull the `.ixe` (+ any pre-cut closure shards) the compile job
-      # built — do NOT recompile here. (The path list must match the
-      # compile job's save exactly.)
+      # Pull the `.ixe` the compile job built — do NOT recompile here.
+      # (The path list must match the compile job's save exactly.)
       - uses: actions/cache/restore@v6
         with:
-          path: |
-            ${{ matrix.params.env }}.ixe
-            zkshards-${{ matrix.params.env }}
+          path: ${{ matrix.params.env }}.ixe
           key: bench-ixe-${{ github.sha }}-${{ matrix.params.env }}
           fail-on-cache-miss: true
+      # The pre-cut closure shards, for the backends that have any. Not
+      # fail-on-cache-miss: cutting them in the compile job is an
+      # optimisation, and `ix bench run` still cuts lazily without them.
+      - if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
+        uses: actions/cache/restore@v6
+        with:
+          path: zkshards-${{ matrix.params.env }}
+          key: bench-shards-${{ github.sha }}-${{ matrix.params.env }}
       # If the kernel rejects a constant, `ix bench run` exits 3 and this
       # step fails — that is a correctness regression, not a benchmark
       # blip. The completed rows are already on disk for the upload below.

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -46,15 +46,17 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-32x
     steps:
       - uses: actions/checkout@v7
+      # Native codegen fixes the available instructions at build time. Carry
+      # this report with the binaries so every later measurement records both
+      # the build host and its own run host.
+      - name: Log build CPU
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Benchmark binary build CPU
+          output-file: ${{ runner.temp }}/benchmark-build-cpu.txt
       # Rust toolchain + cargo cache, so the cargo step inside `lake build`
       # does not recompile the Plonky3/multi-stark dependencies every run.
       - uses: ./.github/actions/setup-rust-toolchain
-      # Log the build CPU so a benchmark shift can be traced to a host change.
-      - name: Log build CPU
-        run: |
-          lscpu
-          flags=$(grep -m1 -oE 'avx2|avx512[a-z0-9_]*' /proc/cpuinfo | sort -u | tr '\n' ' ')
-          echo "AVX flags: ${flags:-absent}"
       - uses: leanprover/lean-action@v1
         with:
           auto-config: false
@@ -65,6 +67,7 @@ jobs:
           echo | lake run install            # copies ix -> ~/.local/bin/ix
           lake build bench-typecheck bench-recursive-verifier
           cp .lake/build/bin/bench-typecheck .lake/build/bin/bench-recursive-verifier ~/.local/bin/
+          cp "${{ runner.temp }}/benchmark-build-cpu.txt" ~/.local/bin/
           chmod +x ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier
       - uses: actions/cache/save@v6
         with:
@@ -138,6 +141,11 @@ jobs:
         with:
           path: ~/.local/bin
           key: bench-bins-${{ github.sha }}
+      - name: Log compile CPU
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Compile measurement CPU
+          provenance-file: ~/.local/bin/benchmark-build-cpu.txt
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       # FC's library env lives in a sibling `${COMPILE_DIR}FC` package dir, so
       # point COMPILE_DIR there for the FC matrix job.
@@ -261,6 +269,15 @@ jobs:
         params: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/cache/restore@v6
+        with:
+          path: ~/.local/bin
+          key: bench-bins-${{ github.sha }}
+      - name: Log run CPU
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Benchmark measurement CPU
+          provenance-file: ~/.local/bin/benchmark-build-cpu.txt
       # The zkVM runs build their Rust host in-run; the rest run staged
       # binaries only. (Restore an install-sp1 step here when sp1 is
       # re-enabled in the registry.)
@@ -271,10 +288,6 @@ jobs:
       - name: Install Zisk
         if: matrix.params.backend == 'zisk'
         uses: ./.github/actions/install-zisk
-      - uses: actions/cache/restore@v6
-        with:
-          path: ~/.local/bin
-          key: bench-bins-${{ github.sha }}
       - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       # Provision the toolchain so the staged binaries find libleanshared
       # (no package build). use-github-cache off: nothing to cache here, and

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v7
       # Rust toolchain + cargo cache, so the cargo step inside `lake build`
       # does not recompile the Plonky3/multi-stark dependencies every run.
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # Log the build CPU so a benchmark shift can be traced to a host change.
       - name: Log build CPU
         run: |
@@ -265,7 +265,7 @@ jobs:
       # binaries only. (Restore an install-sp1 step here when sp1 is
       # re-enabled in the registry.)
       - if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: ${{ matrix.params.backend }}
       - name: Install Zisk

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -197,19 +197,30 @@ jobs:
       - if: steps.parse.outputs.fresh == '1' && steps.bins.outputs.cache-hit == 'true'
         uses: ./.github/actions/setup-rust-toolchain
       # `.cargo/config.toml` sets `-Ctarget-cpu=native`; log the build CPU so a
-      # benchmark shift can be traced to an instruction-set change.
+      # benchmark shift can be traced to the host that selected the native
+      # instruction set. The report travels with the binaries below.
       - name: Log build CPU
         if: steps.parse.outputs.fresh == '1' || steps.bins.outputs.cache-hit != 'true'
-        run: |
-          lscpu
-          flags=$(grep -m1 -oE 'avx2|avx512[a-z0-9_]*' /proc/cpuinfo | sort -u | tr '\n' ' ')
-          echo "AVX flags: ${flags:-absent}"
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Benchmark binary build CPU
+          output-file: ${{ runner.temp }}/benchmark-build-cpu.txt
       - name: Build benchmark binaries
         if: steps.parse.outputs.fresh == '1' || steps.bins.outputs.cache-hit != 'true'
         run: |
           lake build ix bench-typecheck bench-recursive-verifier
           cp .lake/build/bin/ix .lake/build/bin/bench-typecheck .lake/build/bin/bench-recursive-verifier ~/.local/bin/
+          cp "${{ runner.temp }}/benchmark-build-cpu.txt" ~/.local/bin/
           chmod +x ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier
+      # Cache entries are immutable and may lack optional provenance. Keep the
+      # run artifact's shape stable and state explicitly when its build host is
+      # unknown.
+      - name: Ensure build CPU provenance
+        run: |
+          if [ ! -s "$HOME/.local/bin/benchmark-build-cpu.txt" ]; then
+            echo "Benchmark binary build CPU unavailable: cache predates CPU provenance." \
+              > "$HOME/.local/bin/benchmark-build-cpu.txt"
+          fi
       - if: steps.parse.outputs.fresh != '1' && steps.bins.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
@@ -218,7 +229,7 @@ jobs:
       - name: Package run binaries
         run: >-
           tar -C "$HOME/.local/bin" -cf benchmark-binaries.tar
-          ix bench-typecheck bench-recursive-verifier
+          ix bench-typecheck bench-recursive-verifier benchmark-build-cpu.txt
       - name: Upload run binaries
         uses: actions/upload-artifact@v7
         with:
@@ -358,6 +369,12 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           tar -C "$HOME/.local/bin" -xf benchmark-binaries.tar
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Log compile CPU
+        if: steps.compile-source.outputs.rebuild == 'true'
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Compile measurement CPU
+          provenance-file: ~/.local/bin/benchmark-build-cpu.txt
       # Pointed at the Benchmarks/Compile subpackage (same toolchain as
       # the root): mathlib is a dependency only there, so the mathlib
       # cache fetch has to run from that directory.
@@ -465,6 +482,11 @@ jobs:
           mkdir -p .lake/build/bin
           tar -C .lake/build/bin -xf benchmark-binaries.tar
           echo "$PWD/.lake/build/bin" >> "$GITHUB_PATH"
+      - name: Log run CPU
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Benchmark job CPU
+          provenance-file: .lake/build/bin/benchmark-build-cpu.txt
       # Toolchain only (no package build, no mathlib cache): the restored
       # binaries need the toolchain's libleanshared to run. This job never
       # compiles an env — the `.ixe` and compile row come from the compile
@@ -652,12 +674,25 @@ jobs:
             if [ "$BENV" != Mathlib ] || [ "${{ steps.base-ixe.outputs.cache-hit }}" = true ]; then
               mkdir -p base/.lake/build/bin
               mv ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier base/.lake/build/bin/ 2>/dev/null || true
+              mv ~/.local/bin/benchmark-build-cpu.txt base/.lake/build/bin/ 2>/dev/null || true
               [ -x base/.lake/build/bin/ix ] && [ -x base/.lake/build/bin/bench-typecheck ] \
                 && [ -x base/.lake/build/bin/bench-recursive-verifier ] && cached=true
             fi
           fi
           echo "cached=$cached" >> "$GITHUB_OUTPUT"
           echo "base binaries: $([ "$cached" = true ] && echo restored from cache || echo building from source)"
+      - name: Log cached base binary build CPU
+        if: steps.decide.outputs.run-base == 'true' && steps.base-src.outputs.cached == 'true'
+        uses: ./.github/actions/log-cpu
+        with:
+          log-current: "false"
+          provenance-file: base/.lake/build/bin/benchmark-build-cpu.txt
+      - name: Log base build CPU
+        if: steps.decide.outputs.run-base == 'true' && steps.base-src.outputs.cached != 'true'
+        uses: ./.github/actions/log-cpu
+        with:
+          label: Base benchmark binary build CPU
+          output-file: base/.lake/build/bin/benchmark-build-cpu.txt
       - name: Build base (ix, bench-typecheck, bench-recursive-verifier)
         if: steps.decide.outputs.run-base == 'true' && steps.base-src.outputs.cached != 'true'
         uses: leanprover/lean-action@v1

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,5 +1,7 @@
 # `!benchmark` PR command: run the curated constant set (Benchmarks/Vectors.csv)
-# through chosen prover backend(s) and post a main-vs-PR comparison table.
+# through chosen prover backend(s) and post a base-vs-PR comparison table.
+# The base is the PR's own base branch — main for an unstacked PR, the
+# parent PR's head for a stacked one — and the report is labelled with it.
 #
 #   !benchmark ([aiur] [zisk] [sp1] [ooc] [compile] [decompile] | all) [execute]
 #     (sp1 is disabled in the registry (Ix/Cli/BenchCmd.lean) — the parser skips it
@@ -18,9 +20,14 @@
 #   BENCH_PHASES=1                 # add per-constant phase drill-downs to the comment
 #   RUST_LOG=info                  # passthrough env (allowlisted)
 #   IX_COMPILE_EAGER=1             # compile-knob passthrough (also IX_COMPILE_DEMOTE /
-#                                  # IX_COMPILE_WORKERS); reaches the measured `ix
-#                                  # compile` and keys its caches, so a knob run gets
-#                                  # its own row instead of the default run's
+#                                  # IX_COMPILE_WORKERS): RAM/speed knobs for the
+#                                  # measured `ix compile`. Every setting emits a
+#                                  # bit-identical `.ixe`, so they move the compile
+#                                  # backend's own numbers and nothing downstream.
+#                                  # The `.ixe` and compile-row caches are keyed by
+#                                  # SHA alone, so a knob run on a commit already
+#                                  # benchmarked replays the cached row instead of
+#                                  # recompiling unless it also requests `fresh`
 #   IX_DECOMPILE_KENV_CLEAR_ENTRIES=0
 #                                  # decompile Pass 2 cache limit; 0 disables clearing
 #                                  # (default: 131072)
@@ -37,7 +44,7 @@
 #     default set is what one host can finish. BENCH_FULL=1 and
 #     BENCH_CONSTS still override. The bare `execute`
 #     token switches it to the fast Phase-1-only mode (witness
-#     generation; no bencher baseline exists for that, so the main side
+#     generation; no bencher baseline exists for that, so the base side
 #     comes from a base-SHA run).
 #   - zisk / sp1 / ooc: `execute`.
 #   - compile: `ix compile <env>.lean` → `<env>.ixe`.
@@ -52,7 +59,7 @@
 # to bencher, so the canonical baseline is never touched.
 #
 # For each matrix entry the job runs `ix bench run` twice: once on the PR
-# checkout, once for the main side. The main side comes from bencher.dev
+# checkout, once for the base side. The base side comes from bencher.dev
 # (`ix bench fetch-main`) only on FULL coverage (and, for ooc, a cached
 # attribution CSV); anything less — base SHA not uploaded, partial
 # coverage, an ooc attribution cache miss, or `fresh` — triggers a full
@@ -77,6 +84,12 @@ on:
       base-sha:
         description: Full base SHA to compare against
         required: true
+      base-ref:
+        description: >-
+          Base branch name, for labelling the base side of the report.
+          Defaults to the base SHA when unset, which is what a manual
+          dispatch comparing two loose commits wants.
+        required: false
       head-sha:
         description: Full head SHA to benchmark
         required: true
@@ -120,6 +133,7 @@ jobs:
             --ref "${{ github.event.repository.default_branch }}" \
             -f pr="${{ github.event.issue.number }}" \
             -f base-sha="${{ steps.comment-branch.outputs.base_sha }}" \
+            -f base-ref="${{ steps.comment-branch.outputs.base_ref }}" \
             -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
             -f comment-body="$COMMENT_BODY"
 
@@ -325,14 +339,12 @@ jobs:
           # The job runs PR code; never leave the token in .git.
           persist-credentials: false
       # Apply the allowlisted KEY=VALUE lines from the !benchmark comment,
-      # so IX_COMPILE_* knobs reach the measured compile. Also written to
-      # a file so the cache keys below can hash it: a run with different
-      # knobs must not reuse or overwrite the default run's published
-      # .ixe and row.
+      # so IX_COMPILE_* knobs reach the measured compile. Delivered via an
+      # env var, not inline `${{ }}` — inlining would risk shell injection.
       - name: Apply passthrough env
         env:
           PTENV: ${{ needs.build.outputs.passthrough-env }}
-        run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' | tee ptenv.txt >> "$GITHUB_ENV"
+        run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' >> "$GITHUB_ENV"
       # A normal run can seed its run-scoped artifact from persistent caches.
       # `fresh` skips both restores, so the decision below requires a compile.
       - name: Restore published .ixe
@@ -340,15 +352,19 @@ jobs:
         id: pr-ixe
         uses: actions/cache/restore@v6
         with:
+          # actions/cache derives an entry's version from its path list, so
+          # the list is effectively part of the key: this one path matches
+          # bench-main's compile-job save, which lets a stacked PR's base
+          # run reach either producer's entry from one restore.
           path: ${{ matrix.env }}.ixe
-          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
+          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}
       - name: Restore published compile row
         if: needs.build.outputs.fresh != '1'
         id: pr-row
         uses: actions/cache/restore@v6
         with:
           path: compile.json
-          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
+          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
       - name: Select compile source
         id: compile-source
         run: |
@@ -401,8 +417,10 @@ jobs:
         if: needs.build.outputs.fresh != '1' && steps.pr-ixe.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
+          # Path lists are version-significant — keep this identical to the
+          # restore above and to bench-main's save.
           path: ${{ matrix.env }}.ixe
-          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
+          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}
       # Publish the measured row too: the compile backend's benchmark run
       # reuses it as its PR side (same runner class, binaries, command).
       - name: Publish compile row
@@ -410,7 +428,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: compile.json
-          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
+          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
       - name: Upload run environment
         uses: actions/upload-artifact@v7
         with:
@@ -446,6 +464,7 @@ jobs:
       CONSTS: ${{ matrix.params.consts }}
       LABEL: ${{ matrix.params.label }}
       BASE_SHA: ${{ inputs.base-sha }}
+      BASE_REF: ${{ inputs.base-ref }}
       HEAD_SHA: ${{ inputs.head-sha }}
       SHARD: ${{ needs.build.outputs.shard }}
       FULL: ${{ needs.build.outputs.full }}
@@ -466,7 +485,7 @@ jobs:
       - name: Apply passthrough env
         env:
           PTENV: ${{ needs.build.outputs.passthrough-env }}
-        run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' | tee ptenv.txt >> "$GITHUB_ENV"
+        run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' >> "$GITHUB_ENV"
       # Place this run's PR binaries into the PR tree's own bin dir.
       # `ix bench run` looks for the measured tools in <repo>/.lake/build/bin
       # before PATH, so keeping them in-tree separates the PR side from the
@@ -521,7 +540,7 @@ jobs:
       # ---------- PR side ----------
       # The PR side runs first: `ix bench run` selects its constants from
       # Vectors.csv, and pr.json's row names become the canonical name
-      # list this run measures — the main-side fetch below asks bencher
+      # list this run measures — the base-side fetch below asks bencher
       # for exactly those names.
       - name: Run backend on PR → pr.json
         id: pr-run
@@ -550,7 +569,7 @@ jobs:
           ix bench run --backend "$BACKEND" --env "$BENV" --mode "$MODE" \
             --ixe "$BENV.ixe" --out "$GITHUB_WORKSPACE/pr.json" $flags
 
-      # ---------- main side ----------
+      # ---------- base side ----------
       # Try bencher.dev first (bench-main.yml uploads main's numbers).
       # fetch-main's exit codes matter:
       #   3     = transient (base SHA not uploaded yet) — fall back to
@@ -566,7 +585,7 @@ jobs:
         id: bencher
         run: |
           # `fresh` skips bencher entirely — same as a full miss: no
-          # main.json, so the base run below supplies the whole main side.
+          # main.json, so the base run below supplies the whole base side.
           if [ "$FRESH" = 1 ]; then
             echo "source=base run @ ${BASE_SHA::7} (fresh — bencher bypassed)" >> "$GITHUB_OUTPUT"
             echo "run-base=true" >> "$GITHUB_OUTPUT"
@@ -596,12 +615,12 @@ jobs:
                echo "run-base=true" >> "$GITHUB_OUTPUT" ;;
             *) echo "::error::fetch-main: permanent config error (exit $rc) — check backendSpecs testbeds vs bench-main.yml"; exit "$rc" ;;
           esac
-      # Main-side attribution CSV for the ooc drill-down: bench-main cached
+      # Base-side attribution CSV for the ooc drill-down: bench-main cached
       # the base SHA's CSV by (SHA, cell) — bencher itself stores metric
       # rows only. Restored BEFORE the base-run decision so a miss can
       # force one (ooc's base run is the cheapest backend; a re-run beats
       # a silently absent drill-down).
-      - name: Restore main-side attribution CSV (ooc)
+      - name: Restore base-side attribution CSV (ooc)
         id: perconst
         if: matrix.params.backend == 'ooc' && env.FRESH != '1'
         continue-on-error: true
@@ -646,18 +665,31 @@ jobs:
         with:
           path: ~/.local/bin
           key: bench-bins-${{ env.BASE_SHA }}
-      - name: Restore base .ixe (bench-main compile cache)
+      # Two producers compile the env at a given SHA: bench-main for main
+      # commits, this workflow's compile job for PR heads. A stacked PR's
+      # base is the latter, so both keys are tried from one step. This works
+      # because both producers save the same single path; actions/cache
+      # versions an entry by its paths. restore-keys matches by prefix, so
+      # no registry env name may be a prefix of another.
+      - name: Restore base .ixe (bench-main or bench-pr compile cache)
         if: steps.decide.outputs.run-base == 'true' && env.FRESH != '1'
         id: base-ixe
         uses: actions/cache/restore@v6
         with:
-          # Path list must match bench-main's compile-job save (actions/cache
-          # versions entries by path list); the key suffix is the env name
-          # (bench-main's matrix.env).
-          path: |
-            ${{ matrix.params.env }}.ixe
-            zkshards-${{ matrix.params.env }}
+          path: ${{ matrix.params.env }}.ixe
           key: bench-ixe-${{ env.BASE_SHA }}-${{ matrix.params.env }}
+          restore-keys: |
+            bench-pr-ixe-${{ env.BASE_SHA }}-${{ matrix.params.env }}
+      # Shards live in their own entry and only exist for the zkVM
+      # backends; without them `ix bench run` cuts them itself.
+      - name: Restore base closure shards
+        if: >-
+          steps.decide.outputs.run-base == 'true' && env.FRESH != '1' &&
+          (matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1')
+        uses: actions/cache/restore@v6
+        with:
+          path: zkshards-${{ matrix.params.env }}
+          key: bench-shards-${{ env.BASE_SHA }}-${{ matrix.params.env }}
       # Cached base binaries are only usable when both `lean-toolchain`
       # files match, and — for Mathlib — only when the `.ixe` also
       # restored (otherwise the base side would need mathlib oleans that
@@ -668,10 +700,17 @@ jobs:
         if: steps.decide.outputs.run-base == 'true'
         id: base-src
         run: |
+          # `cache-hit` is true only for the primary key; a stacked-base
+          # entry arrives via restore-keys. `cache-matched-key` covers both.
+          ixe=false
+          if [ -n "${{ steps.base-ixe.outputs.cache-matched-key }}" ]; then
+            ixe=true
+          fi
+          echo "ixe=$ixe" >> "$GITHUB_OUTPUT"
           cached=false
           if [ "${{ steps.base-bins.outputs.cache-hit }}" = true ] \
              && cmp -s lean-toolchain base/lean-toolchain; then
-            if [ "$BENV" != Mathlib ] || [ "${{ steps.base-ixe.outputs.cache-hit }}" = true ]; then
+            if [ "$BENV" != Mathlib ] || [ "$ixe" = true ]; then
               mkdir -p base/.lake/build/bin
               mv ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier base/.lake/build/bin/ 2>/dev/null || true
               mv ~/.local/bin/benchmark-build-cpu.txt base/.lake/build/bin/ 2>/dev/null || true
@@ -680,6 +719,7 @@ jobs:
             fi
           fi
           echo "cached=$cached" >> "$GITHUB_OUTPUT"
+          echo "base .ixe: $([ "$ixe" = true ] && echo restored from cache || echo compiling in the base run)"
           echo "base binaries: $([ "$cached" = true ] && echo restored from cache || echo building from source)"
       - name: Log cached base binary build CPU
         if: steps.decide.outputs.run-base == 'true' && steps.base-src.outputs.cached == 'true'
@@ -720,7 +760,7 @@ jobs:
       # The PR's `ix bench` drives the base run (--repo base); the MEASURED
       # tools come from base/.lake/build/bin. If the PR changed the
       # benchmark CLIs themselves, the base tools may reject the new flags
-      # and every constant drops — the compare then shows a loud "main
+      # and every constant drops — the compare then shows a loud "base
       # produced no results" note instead of a silent all-n/a table.
       #
       # Partial bencher miss: run just the uncovered names (via --consts).
@@ -730,10 +770,10 @@ jobs:
       - name: Run backend on base → merge into main.json
         if: steps.decide.outputs.run-base == 'true'
         run: |
-          if [ "${{ steps.base-ixe.outputs.cache-hit }}" = true ]; then
+          if [ "${{ steps.base-src.outputs.ixe }}" = true ]; then
             mv "${{ matrix.params.env }}.ixe" "base/${{ matrix.params.env }}.ixe"
-            # bench-main's pre-cut closure shards ride the same cache entry;
-            # in place, `ix bench run` skips re-cutting them for the base tree.
+            # Shards, when restored above: in place, `ix bench run` skips
+            # re-cutting them for the base tree.
             mv "zkshards-${{ matrix.params.env }}" "base/zkshards-${{ matrix.params.env }}" 2>/dev/null || true
           fi
           if [ "$BACKEND" = zisk ]; then
@@ -772,7 +812,7 @@ jobs:
               mv "$GITHUB_WORKSPACE/base.json" "$GITHUB_WORKSPACE/main.json"
             fi
             # The ooc run writes a per-constant attribution CSV next to its
-            # results file; carry it to main.json's side so `ix bench
+            # results file; carry it to the base-side main.json so `ix bench
             # compare` finds the pair and renders the drill-down (bencher
             # cannot supply it — it stores metric rows only).
             if [ -f "$GITHUB_WORKSPACE/base.json.perconst.csv" ]; then
@@ -784,7 +824,7 @@ jobs:
       # ---------- compare ----------
       # A base-run-produced attribution CSV (moved to main.json's side in
       # the merge step) wins; the cached one only fills the gap.
-      - name: Place main-side attribution CSV
+      - name: Place base-side attribution CSV
         if: matrix.params.backend == 'ooc'
         run: |
           if [ ! -f "$GITHUB_WORKSPACE/main.json.perconst.csv" ] \
@@ -796,8 +836,9 @@ jobs:
           mkdir -p out
           ix bench compare \
             --backend "$BACKEND" --env "$BENV" --mode "$MODE" \
-            --main "$GITHUB_WORKSPACE/main.json" --pr "$GITHUB_WORKSPACE/pr.json" \
-            --main-source "${{ steps.decide.outputs.source }}" \
+            --base "$GITHUB_WORKSPACE/main.json" --pr "$GITHUB_WORKSPACE/pr.json" \
+            --base-source "${{ steps.decide.outputs.source }}" \
+            --base-label "${BASE_REF:-${BASE_SHA::7}}" \
             --out "out/table-$LABEL.md"
           cat "out/table-$LABEL.md"
 
@@ -861,11 +902,14 @@ jobs:
         env:
           SUMMARY: ${{ needs.build.outputs.config-summary }}
           HEAD_SHA: ${{ inputs.head-sha }}
+          BASE_SHA: ${{ inputs.base-sha }}
+          BASE_REF: ${{ inputs.base-ref }}
         run: |
           mkdir -p tables   # absent when no run uploaded a table
           ix bench report \
             --tables tables --summary "$SUMMARY" \
             --head "$HEAD_SHA" \
+            --base-label "${BASE_REF:-${BASE_SHA::7}}" \
             --repo-url "${{ github.server_url }}/${{ github.repository }}" \
             --run-id "${{ github.run_id }}" --out comment-body.md
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -42,9 +42,14 @@
 #   - zisk / sp1 / ooc: `execute`.
 #   - compile: `ix compile <env>.lean` → `<env>.ixe`.
 #   - decompile: `ix decompile` over the compile run's fresh `.ixe`.
-# The bare `fresh` token skips the bencher fetch and re-measures the main
-# side with a local base-SHA run. Nothing in this workflow uploads to
-# bencher, so the canonical baseline is never touched.
+# The bare `fresh` token skips the bencher fetch and prevents persistent
+# cached binaries, `.ixe` files, and compile rows from reaching measured jobs.
+# A cached head `ix` may bootstrap the canonical command parser, but the full
+# bundle is rebuilt before it is published. Both measured source trees are
+# rebuilt, while Cargo and package dependency caches remain available. Files
+# passed between jobs are run-scoped artifacts, so only products generated
+# during this workflow run reach a benchmark. Nothing in this workflow uploads
+# to bencher, so the canonical baseline is never touched.
 #
 # For each matrix entry the job runs `ix bench run` twice: once on the PR
 # checkout, once for the main side. The main side comes from bencher.dev
@@ -118,15 +123,17 @@ jobs:
             -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
             -f comment-body="$COMMENT_BODY"
 
-  # Build the PR's `ix`, `bench-typecheck`, and `bench-recursive-verifier`
-  # once, cache them by head SHA, and let every other job restore them.
-  # Re-running !benchmark on the same commit skips the build entirely.
+  # Select or build the PR's `ix`, `bench-typecheck`, and
+  # `bench-recursive-verifier` once, then publish them as a run-scoped
+  # artifact for every later job. Normal runs may select a persistent
+  # head-SHA cache. A cached `ix` may bootstrap command parsing, but `fresh`
+  # replaces the full bundle before it is published to benchmark jobs.
   # Built on a warp runner like bench-main's binaries, so both sides share
   # the same instruction set (AVX-512) — and every job that runs these
   # binaries must be a warp host too, or a plain GitHub host crashes with
   # an illegal instruction. The job ends by parsing the !benchmark command
-  # with the freshly built `ix bench ci parse`: the registry lives in
-  # Lean, so the matrix can only be computed after the build.
+  # with the selected `ix bench ci parse`: the registry lives in Lean, so
+  # the matrix can only be computed after a binary is available.
   build:
     if: github.event_name == 'workflow_dispatch'
     runs-on: warp-ubuntu-latest-x64-32x
@@ -161,36 +168,23 @@ jobs:
         with:
           path: ~/.local/bin
           key: bench-bins-${{ inputs.head-sha }}
+      # A cache miss needs an `ix` before the command can be parsed. The
+      # remaining binaries are built after parsing, when `fresh` is known.
       - if: steps.bins.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-rust-toolchain
-      # `.cargo/config.toml` sets `-Ctarget-cpu=native`; log the build CPU so a
-      # benchmark shift can be traced to an instruction-set change.
-      - name: Log build CPU
-        if: steps.bins.outputs.cache-hit != 'true'
-        run: |
-          lscpu
-          flags=$(grep -m1 -oE 'avx2|avx512[a-z0-9_]*' /proc/cpuinfo | sort -u | tr '\n' ' ')
-          echo "AVX flags: ${flags:-absent}"
-      # One lean-action for both paths: cache miss → build the binaries;
-      # cache hit → provision the toolchain only (the restored `ix` still
-      # needs libleanshared to run the parse step below).
+      # A persistent hit still needs the matching toolchain for libleanshared.
       - uses: leanprover/lean-action@v1
         with:
           auto-config: false
           build: ${{ steps.bins.outputs.cache-hit != 'true' }}
-          build-args: "ix bench-typecheck bench-recursive-verifier"
+          build-args: ix
           use-github-cache: false
       - if: steps.bins.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.local/bin
-          cp .lake/build/bin/ix .lake/build/bin/bench-typecheck .lake/build/bin/bench-recursive-verifier ~/.local/bin/
-          chmod +x ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier
-      - if: steps.bins.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6
-        with:
-          path: ~/.local/bin
-          key: bench-bins-${{ inputs.head-sha }}
-      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+          cp .lake/build/bin/ix ~/.local/bin/
+          chmod +x ~/.local/bin/ix
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       # Parse the !benchmark command from an env var (never
       # inline-interpolated); unknown tokens fall off the allowlist.
       - name: Parse command
@@ -198,6 +192,41 @@ jobs:
         env:
           COMMENT_BODY: ${{ inputs.comment-body }}
         run: ix bench ci parse
+      # On a cache hit, `ix` above is a control-plane bootstrap only. A fresh
+      # run replaces it before the bundle can reach any measured job.
+      - if: steps.parse.outputs.fresh == '1' && steps.bins.outputs.cache-hit == 'true'
+        uses: ./.github/actions/setup-rust-toolchain
+      # `.cargo/config.toml` sets `-Ctarget-cpu=native`; log the build CPU so a
+      # benchmark shift can be traced to an instruction-set change.
+      - name: Log build CPU
+        if: steps.parse.outputs.fresh == '1' || steps.bins.outputs.cache-hit != 'true'
+        run: |
+          lscpu
+          flags=$(grep -m1 -oE 'avx2|avx512[a-z0-9_]*' /proc/cpuinfo | sort -u | tr '\n' ' ')
+          echo "AVX flags: ${flags:-absent}"
+      - name: Build benchmark binaries
+        if: steps.parse.outputs.fresh == '1' || steps.bins.outputs.cache-hit != 'true'
+        run: |
+          lake build ix bench-typecheck bench-recursive-verifier
+          cp .lake/build/bin/ix .lake/build/bin/bench-typecheck .lake/build/bin/bench-recursive-verifier ~/.local/bin/
+          chmod +x ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier
+      - if: steps.parse.outputs.fresh != '1' && steps.bins.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.local/bin
+          key: bench-bins-${{ inputs.head-sha }}
+      - name: Package run binaries
+        run: >-
+          tar -C "$HOME/.local/bin" -cf benchmark-binaries.tar
+          ix bench-typecheck bench-recursive-verifier
+      - name: Upload run binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-binaries
+          path: benchmark-binaries.tar
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
 
   # Post the initial PR comment as soon as the command is parsed: an
   # error message if the parse/build failed, otherwise a "running…"
@@ -263,9 +292,10 @@ jobs:
           body-path: comment-body.md
 
   # One measured `ix compile` per requested env, before the benchmark
-  # runs. It publishes the `.ixe` the other runs restore (so they never
-  # race to compile it themselves), and its results row doubles as the
-  # compile backend's PR side — requesting compile never compiles twice.
+  # runs. It publishes the `.ixe` and compile row as one run-scoped artifact
+  # so later jobs cannot accidentally select a persistent entry themselves.
+  # Normal runs may seed that artifact from the head-SHA caches; `fresh`
+  # always compiles it in this job.
   compile:
     name: compile-${{ matrix.env }}
     needs: build
@@ -292,29 +322,47 @@ jobs:
         env:
           PTENV: ${{ needs.build.outputs.passthrough-env }}
         run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' | tee ptenv.txt >> "$GITHUB_ENV"
-      # If !benchmark already ran on this commit with the same config, the
-      # .ixe is already published and this whole job short-circuits.
-      - name: Check for published .ixe
+      # A normal run can seed its run-scoped artifact from persistent caches.
+      # `fresh` skips both restores, so the decision below requires a compile.
+      - name: Restore published .ixe
+        if: needs.build.outputs.fresh != '1'
         id: pr-ixe
         uses: actions/cache/restore@v6
         with:
           path: ${{ matrix.env }}.ixe
           key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
-          lookup-only: true
-      - name: Restore PR binaries
-        if: steps.pr-ixe.outputs.cache-hit != 'true'
+      - name: Restore published compile row
+        if: needs.build.outputs.fresh != '1'
+        id: pr-row
         uses: actions/cache/restore@v6
         with:
-          path: ~/.local/bin
-          key: bench-bins-${{ inputs.head-sha }}
-          fail-on-cache-miss: true
-      - if: steps.pr-ixe.outputs.cache-hit != 'true'
-        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          path: compile.json
+          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
+      - name: Select compile source
+        id: compile-source
+        run: |
+          if [ "${{ steps.pr-ixe.outputs.cache-hit }}" = true ] \
+             && [ "${{ steps.pr-row.outputs.cache-hit }}" = true ]; then
+            echo "rebuild=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "rebuild=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Download run binaries
+        if: steps.compile-source.outputs.rebuild == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: benchmark-binaries
+      - name: Unpack run binaries
+        if: steps.compile-source.outputs.rebuild == 'true'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tar -C "$HOME/.local/bin" -xf benchmark-binaries.tar
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       # Pointed at the Benchmarks/Compile subpackage (same toolchain as
       # the root): mathlib is a dependency only there, so the mathlib
       # cache fetch has to run from that directory.
       - name: Provision Lean toolchain
-        if: steps.pr-ixe.outputs.cache-hit != 'true'
+        if: steps.compile-source.outputs.rebuild == 'true'
         uses: leanprover/lean-action@v1
         with:
           lake-package-directory: Benchmarks/Compile
@@ -326,14 +374,14 @@ jobs:
       # The measured compile resolves the env's imports from these oleans;
       # bench-main builds the same target before its measured compile.
       - name: Build env oleans
-        if: steps.pr-ixe.outputs.cache-hit != 'true'
+        if: steps.compile-source.outputs.rebuild == 'true'
         working-directory: Benchmarks/Compile
         run: lake build Compile${{ matrix.env }}
       - name: Compile ${{ matrix.env }}.ixe
-        if: steps.pr-ixe.outputs.cache-hit != 'true'
+        if: steps.compile-source.outputs.rebuild == 'true'
         run: ix bench run --backend compile --env ${{ matrix.env }} --out compile.json
       - name: Publish .ixe
-        if: steps.pr-ixe.outputs.cache-hit != 'true'
+        if: needs.build.outputs.fresh != '1' && steps.pr-ixe.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: ${{ matrix.env }}.ixe
@@ -341,11 +389,21 @@ jobs:
       # Publish the measured row too: the compile backend's benchmark run
       # reuses it as its PR side (same runner class, binaries, command).
       - name: Publish compile row
-        if: steps.pr-ixe.outputs.cache-hit != 'true'
+        if: needs.build.outputs.fresh != '1' && steps.pr-row.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: compile.json
           key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}-${{ hashFiles('ptenv.txt') }}
+      - name: Upload run environment
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-env-${{ matrix.env }}
+          path: |
+            ${{ matrix.env }}.ixe
+            compile.json
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
 
   benchmark:
     # Explicit name — the default would append every matrix value; the
@@ -392,28 +450,25 @@ jobs:
         env:
           PTENV: ${{ needs.build.outputs.passthrough-env }}
         run: printf '%s\n' "$PTENV" | sed '/^[[:space:]]*$/d' | tee ptenv.txt >> "$GITHUB_ENV"
-      # Restore the PR binaries into the PR tree's own bin dir.
+      # Place this run's PR binaries into the PR tree's own bin dir.
       # `ix bench run` looks for the measured tools in <repo>/.lake/build/bin
       # before PATH, so keeping them in-tree separates the PR side from the
       # base side (whose binaries land in base/.lake/build/bin, and whose
       # cache restore reuses ~/.local/bin). The PR's `ix bench` drives BOTH
       # sides; `--repo` picks whose tools get measured.
-      - name: Restore PR binaries
-        uses: actions/cache/restore@v6
+      - name: Download run binaries
+        uses: actions/download-artifact@v8
         with:
-          path: ~/.local/bin
-          key: bench-bins-${{ env.HEAD_SHA }}
-          fail-on-cache-miss: true
-      - run: |
+          name: benchmark-binaries
+      - name: Place PR binaries
+        run: |
           mkdir -p .lake/build/bin
-          mv ~/.local/bin/ix ~/.local/bin/bench-typecheck ~/.local/bin/bench-recursive-verifier .lake/build/bin/
+          tar -C .lake/build/bin -xf benchmark-binaries.tar
           echo "$PWD/.lake/build/bin" >> "$GITHUB_PATH"
       # Toolchain only (no package build, no mathlib cache): the restored
       # binaries need the toolchain's libleanshared to run. This job never
       # compiles an env — the `.ixe` and compile row come from the compile
-      # job, published moments ago in this same workflow run, so a cache
-      # miss below is an infrastructure failure, not something to
-      # recompile around.
+      # job's run-scoped artifact.
       - name: Provision Lean toolchain
         uses: leanprover/lean-action@v1
         with:
@@ -421,22 +476,10 @@ jobs:
           auto-config: false
           build: false
           use-github-cache: false
-      # The compiled env is the same for every run of this PR commit; the
-      # compile job published it and runs pass it via `--ixe`.
-      - name: Restore PR .ixe
-        uses: actions/cache/restore@v6
+      - name: Download run environment
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ matrix.params.env }}.ixe
-          key: bench-pr-ixe-${{ env.HEAD_SHA }}-${{ matrix.params.env }}-${{ hashFiles('ptenv.txt') }}
-          fail-on-cache-miss: true
-      # Compile runs reuse the compile job's measured row as their PR side.
-      - name: Restore compile row
-        if: matrix.params.backend == 'compile'
-        uses: actions/cache/restore@v6
-        with:
-          path: compile.json
-          key: bench-pr-row-${{ env.HEAD_SHA }}-${{ matrix.params.env }}-${{ hashFiles('ptenv.txt') }}
-          fail-on-cache-miss: true
+          name: benchmark-env-${{ matrix.params.env }}
       # zkVM runs additionally need the Rust toolchain + the backend's toolchain
       # and system deps (the shared composite install actions).
       - name: Set up zkVM Rust toolchain
@@ -538,7 +581,7 @@ jobs:
       # a silently absent drill-down).
       - name: Restore main-side attribution CSV (ooc)
         id: perconst
-        if: matrix.params.backend == 'ooc'
+        if: matrix.params.backend == 'ooc' && env.FRESH != '1'
         continue-on-error: true
         uses: actions/cache/restore@v6
         with:
@@ -569,21 +612,20 @@ jobs:
           ref: ${{ env.BASE_SHA }}
           path: base
           persist-credentials: false
-      # bench-main already cached the base SHA's binaries and `.ixe` when
-      # that commit was pushed to main — restore both before paying for a
-      # from-scratch base build. (The bench-bins-<sha> keys have two
-      # producers: bench-main's build job for main commits, and this
-      # workflow's build job for PR heads — a stacked-PR base hits the
-      # latter.)
+      # A normal base rerun can restore the products bench-main cached when
+      # that SHA reached main. `fresh` skips both restores. The
+      # bench-bins-<sha> keys have two producers: bench-main's build job for
+      # main commits, and this workflow's build job for PR heads (so a
+      # stacked-PR base can hit the latter).
       - name: Restore base binaries (bench-bins cache)
-        if: steps.decide.outputs.run-base == 'true'
+        if: steps.decide.outputs.run-base == 'true' && env.FRESH != '1'
         id: base-bins
         uses: actions/cache/restore@v6
         with:
           path: ~/.local/bin
           key: bench-bins-${{ env.BASE_SHA }}
       - name: Restore base .ixe (bench-main compile cache)
-        if: steps.decide.outputs.run-base == 'true'
+        if: steps.decide.outputs.run-base == 'true' && env.FRESH != '1'
         id: base-ixe
         uses: actions/cache/restore@v6
         with:
@@ -759,12 +801,15 @@ jobs:
         with:
           ref: ${{ inputs.head-sha }}
           persist-credentials: false
-      - uses: actions/cache/restore@v6
+      - name: Download run binaries
+        uses: actions/download-artifact@v8
         with:
-          path: ~/.local/bin
-          key: bench-bins-${{ inputs.head-sha }}
-          fail-on-cache-miss: true
-      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+          name: benchmark-binaries
+      - name: Unpack run binaries
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          tar -C "$HOME/.local/bin" -xf benchmark-binaries.tar
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       # Provision the toolchain so `ix` finds libleanshared (no package build).
       - uses: leanprover/lean-action@v1
         with:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -363,7 +363,9 @@ jobs:
         id: pr-row
         uses: actions/cache/restore@v6
         with:
-          path: compile.json
+          path: |
+            compile.json
+            compile-cpu-warnings.md
           key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
       - name: Select compile source
         id: compile-source
@@ -382,6 +384,7 @@ jobs:
       - name: Unpack run binaries
         if: steps.compile-source.outputs.rebuild == 'true'
         run: |
+          rm -f compile-cpu-warnings.md
           mkdir -p "$HOME/.local/bin"
           tar -C "$HOME/.local/bin" -xf benchmark-binaries.tar
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -391,6 +394,8 @@ jobs:
         with:
           label: Compile measurement CPU
           provenance-file: ~/.local/bin/benchmark-build-cpu.txt
+          provenance-label: PR benchmark binaries during compile
+          warning-file: compile-cpu-warnings.md
       # Pointed at the Benchmarks/Compile subpackage (same toolchain as
       # the root): mathlib is a dependency only there, so the mathlib
       # cache fetch has to run from that directory.
@@ -427,7 +432,9 @@ jobs:
         if: needs.build.outputs.fresh != '1' && steps.pr-row.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
-          path: compile.json
+          path: |
+            compile.json
+            compile-cpu-warnings.md
           key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
       - name: Upload run environment
         uses: actions/upload-artifact@v7
@@ -436,6 +443,7 @@ jobs:
           path: |
             ${{ matrix.env }}.ixe
             compile.json
+            compile-cpu-warnings.md
           if-no-files-found: error
           retention-days: 1
           overwrite: true
@@ -506,6 +514,8 @@ jobs:
         with:
           label: Benchmark job CPU
           provenance-file: .lake/build/bin/benchmark-build-cpu.txt
+          provenance-label: PR benchmark binaries in this job
+          warning-file: cpu-warnings.md
       # Toolchain only (no package build, no mathlib cache): the restored
       # binaries need the toolchain's libleanshared to run. This job never
       # compiles an env — the `.ixe` and compile row come from the compile
@@ -727,6 +737,8 @@ jobs:
         with:
           log-current: "false"
           provenance-file: base/.lake/build/bin/benchmark-build-cpu.txt
+          provenance-label: Cached base benchmark binaries
+          warning-file: cpu-warnings.md
       - name: Log base build CPU
         if: steps.decide.outputs.run-base == 'true' && steps.base-src.outputs.cached != 'true'
         uses: ./.github/actions/log-cpu
@@ -834,11 +846,15 @@ jobs:
       - name: Build comparison table
         run: |
           mkdir -p out
+          if [ "$BACKEND" = compile ] && [ -s compile-cpu-warnings.md ]; then
+            cat compile-cpu-warnings.md >> cpu-warnings.md
+          fi
           ix bench compare \
             --backend "$BACKEND" --env "$BENV" --mode "$MODE" \
             --base "$GITHUB_WORKSPACE/main.json" --pr "$GITHUB_WORKSPACE/pr.json" \
             --base-source "${{ steps.decide.outputs.source }}" \
             --base-label "${BASE_REF:-${BASE_SHA::7}}" \
+            --warning-file "$GITHUB_WORKSPACE/cpu-warnings.md" \
             --out "out/table-$LABEL.md"
           cat "out/table-$LABEL.md"
 

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -162,7 +162,7 @@ jobs:
           path: ~/.local/bin
           key: bench-bins-${{ inputs.head-sha }}
       - if: steps.bins.outputs.cache-hit != 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust-toolchain
       # `.cargo/config.toml` sets `-Ctarget-cpu=native`; log the build CPU so a
       # benchmark shift can be traced to an instruction-set change.
       - name: Log build CPU
@@ -441,7 +441,7 @@ jobs:
       # and system deps (the shared composite install actions).
       - name: Set up zkVM Rust toolchain
         if: matrix.params.backend == 'zisk' || matrix.params.backend == 'sp1'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: ${{ matrix.params.backend }}
       # sp1 is disabled in the registry (execute too slow for CI);

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -69,8 +69,10 @@
 # access (anti-poisoning; no token permission can override it), so cache
 # saves would all fail. The issue_comment run therefore only checks the
 # commenter is an org MEMBER/OWNER and re-dispatches this same file as
-# workflow_dispatch, which is allowed to save caches. Manual dispatch
-# needs repo write access.
+# workflow_dispatch, which is allowed to save caches. The relay rejects fork
+# PRs before dispatch so only repository writers can supply code to that cache
+# scope. Manual dispatch already requires repo write access and may
+# intentionally compare loose commits.
 name: Benchmark pull requests
 
 on:
@@ -127,11 +129,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          head_repo=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.repo.full_name')
+          if [ "$head_repo" != "$GITHUB_REPOSITORY" ]; then
+            echo "::error::Comment-triggered benchmarks require a same-repository PR head"
+            exit 1
+          fi
           gh workflow run bench-pr.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "${{ github.event.repository.default_branch }}" \
-            -f pr="${{ github.event.issue.number }}" \
+            -f pr="$PR_NUMBER" \
             -f base-sha="${{ steps.comment-branch.outputs.base_sha }}" \
             -f base-ref="${{ steps.comment-branch.outputs.base_ref }}" \
             -f head-sha="${{ steps.comment-branch.outputs.head_sha }}" \
@@ -152,6 +160,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: warp-ubuntu-latest-x64-32x
     outputs:
+      revision: ${{ steps.target.outputs.revision }}
       matrix: ${{ steps.parse.outputs.matrix }}
       envs: ${{ steps.parse.outputs.envs }}
       shard: ${{ steps.parse.outputs.shard }}
@@ -163,25 +172,27 @@ jobs:
       # rejected; the failure comment quotes it.
       parse-error: ${{ steps.parse.outputs.parse-error }}
     steps:
-      # Everything downstream needs this job, so malformed inputs die here
-      # (the checkout would take a bare "main" or a short SHA otherwise).
+      # The relay admits only same-repository heads; manual dispatch requires
+      # repo write access. Emit the validated full SHA once for every checkout.
       - name: Validate SHAs
+        id: target
         env:
           BASE: ${{ inputs.base-sha }}
           HEAD: ${{ inputs.head-sha }}
         run: |
           [[ "$BASE" =~ ^[0-9a-f]{40}$ && "$HEAD" =~ ^[0-9a-f]{40}$ ]] \
             || { echo "base-sha/head-sha must be full 40-hex SHAs" >&2; exit 1; }
+          echo "revision=$HEAD" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.head-sha }}
+          ref: ${{ steps.target.outputs.revision }}
           # The job builds and runs PR code; never leave the token in .git.
           persist-credentials: false
       - id: bins
         uses: actions/cache/restore@v6
         with:
           path: ~/.local/bin
-          key: bench-bins-${{ inputs.head-sha }}
+          key: bench-bins-${{ steps.target.outputs.revision }}
       # A cache miss needs an `ix` before the command can be parsed. The
       # remaining binaries are built after parsing, when `fresh` is known.
       - if: steps.bins.outputs.cache-hit != 'true'
@@ -239,7 +250,7 @@ jobs:
         uses: actions/cache/save@v6
         with:
           path: ~/.local/bin
-          key: bench-bins-${{ inputs.head-sha }}
+          key: bench-bins-${{ steps.target.outputs.revision }}
       - name: Package run binaries
         run: >-
           tar -C "$HOME/.local/bin" -cf benchmark-binaries.tar
@@ -276,7 +287,7 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           PARSE_ERROR: ${{ needs.build.outputs.parse-error }}
           SUMMARY: ${{ needs.build.outputs.config-summary }}
-          HEAD_SHA: ${{ inputs.head-sha }}
+          HEAD_SHA: ${{ needs.build.outputs.revision }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           if [ "$BUILD_RESULT" != success ]; then
@@ -335,7 +346,7 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.head-sha }}
+          ref: ${{ needs.build.outputs.revision }}
           # The job runs PR code; never leave the token in .git.
           persist-credentials: false
       # Apply the allowlisted KEY=VALUE lines from the !benchmark comment,
@@ -357,7 +368,7 @@ jobs:
           # bench-main's compile-job save, which lets a stacked PR's base
           # run reach either producer's entry from one restore.
           path: ${{ matrix.env }}.ixe
-          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-ixe-${{ needs.build.outputs.revision }}-${{ matrix.env }}
       - name: Restore published compile row
         if: needs.build.outputs.fresh != '1'
         id: pr-row
@@ -366,7 +377,7 @@ jobs:
           path: |
             compile.json
             compile-cpu-warnings.md
-          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-row-${{ needs.build.outputs.revision }}-${{ matrix.env }}
       - name: Select compile source
         id: compile-source
         run: |
@@ -425,7 +436,7 @@ jobs:
           # Path lists are version-significant — keep this identical to the
           # restore above and to bench-main's save.
           path: ${{ matrix.env }}.ixe
-          key: bench-pr-ixe-${{ inputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-ixe-${{ needs.build.outputs.revision }}-${{ matrix.env }}
       # Publish the measured row too: the compile backend's benchmark run
       # reuses it as its PR side (same runner class, binaries, command).
       - name: Publish compile row
@@ -435,7 +446,7 @@ jobs:
           path: |
             compile.json
             compile-cpu-warnings.md
-          key: bench-pr-row-${{ inputs.head-sha }}-${{ matrix.env }}
+          key: bench-pr-row-${{ needs.build.outputs.revision }}-${{ matrix.env }}
       - name: Upload run environment
         uses: actions/upload-artifact@v7
         with:
@@ -473,7 +484,7 @@ jobs:
       LABEL: ${{ matrix.params.label }}
       BASE_SHA: ${{ inputs.base-sha }}
       BASE_REF: ${{ inputs.base-ref }}
-      HEAD_SHA: ${{ inputs.head-sha }}
+      HEAD_SHA: ${{ needs.build.outputs.revision }}
       SHARD: ${{ needs.build.outputs.shard }}
       FULL: ${{ needs.build.outputs.full }}
       FRESH: ${{ needs.build.outputs.fresh }}
@@ -891,7 +902,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.head-sha }}
+          ref: ${{ needs.build.outputs.revision }}
           persist-credentials: false
       - name: Download run binaries
         uses: actions/download-artifact@v8
@@ -917,7 +928,7 @@ jobs:
       - name: Build comment body
         env:
           SUMMARY: ${{ needs.build.outputs.config-summary }}
-          HEAD_SHA: ${{ inputs.head-sha }}
+          HEAD_SHA: ${{ needs.build.outputs.revision }}
           BASE_SHA: ${{ inputs.base-sha }}
           BASE_REF: ${{ inputs.base-ref }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       - uses: leanprover/lean-action@v1
         with:
           build-args: "--wfail -v"
@@ -71,7 +71,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # `./.lake`, not `.lake`: the cache path is hashed into the entry's
       # version, and lean-action saves under `./.lake`, so a bare `.lake` here
       # computes a different version and the restore misses despite the key
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       - uses: taiki-e/install-action@nextest
       # Install Lean for rust-bindgen step
       - uses: leanprover/lean-action@v1
@@ -144,7 +144,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: sp1
       - uses: ./.github/actions/install-sp1
@@ -183,7 +183,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
         with:
           cache-workspaces: zisk
       # Proving key ON (the default): the execute step's `client.setup()` loads

--- a/.github/workflows/ignored.yml
+++ b/.github/workflows/ignored.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-32x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # Only restore the cache, since `ci.yml` will save the test binary to the cache first
       - uses: actions/cache/restore@v6
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       # Only restore the cache, since `ci.yml` will save the test binary to the cache first
       - uses: actions/cache/restore@v6
         with:
@@ -83,7 +83,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-16x
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: ./.github/actions/setup-rust-toolchain
       - uses: actions/cache@v6
         with:
           path: ./.lake

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -2,7 +2,7 @@
   `ix bench` reporting subcommands — everything between the results rows
   JSON (`Ix.Benchmark.Results`) and a human or bencher.dev:
 
-    compare     two rows files → a Markdown main-vs-PR table. With no
+    compare     two rows files → a Markdown base-vs-PR table. With no
                 explicit inputs, compares the parameter combination's local baseline against
                 its previous run (`.lake/benches/<params>.json` vs `.prev.json`), so
                 a bare local rerun reports its own delta.
@@ -220,6 +220,10 @@ structure CompareArgs where
       env-keyed), `env/constant` on ooc (which mixes an env row with
       per-constant rows). -/
   rowNoun : String := "constant"
+  /-- What to call the base side in headers and notes. `!benchmark`
+      compares against the PR's own base branch, which is only `main` for
+      an unstacked PR; a manual dispatch can name any two SHAs. -/
+  baseLabel : String := "main"
 
 def renderCompare (a : CompareArgs) : String := Id.run do
   let names := (rowNames a.mainRows ++ rowNames a.prRows).foldl
@@ -244,7 +248,8 @@ def renderCompare (a : CompareArgs) : String := Id.run do
 
   let mut failures : Array (String × String) := #[]
   for n in names do
-    if rowStatus a.mainRows n == "rejected" then failures := failures.push (n, "main")
+    if rowStatus a.mainRows n == "rejected" then
+      failures := failures.push (n, a.baseLabel)
     if rowStatus a.prRows n == "rejected" then failures := failures.push (n, "PR")
 
   -- One rendered table per section, plus the names that regressed or
@@ -259,7 +264,7 @@ def renderCompare (a : CompareArgs) : String := Id.run do
       metricLabel (if drop.isEmpty then m else (m.drop drop.length).toString)
     let mut head := #[a.rowNoun]
     for m in sec.metrics do
-      head := head ++ #[s!"{label m} (main)", s!"{label m} (PR)", "Δ%"]
+      head := head ++ #[s!"{label m} ({a.baseLabel})", s!"{label m} (PR)", "Δ%"]
     let mut lines := #[
       "| " ++ " | ".intercalate head.toList ++ " |",
       "|" ++ "|".intercalate (head.toList.map fun _ => "---") ++ "|"]
@@ -329,7 +334,7 @@ def renderCompare (a : CompareArgs) : String := Id.run do
   -- of leaving a silent all-n/a column; the workflow logs carry the why.
   if (rowNames a.mainRows).isEmpty then
     out := out.push "" |>.push
-      "_⚠️ no main-side results (base run failed — see the workflow logs)._"
+      s!"_⚠️ no {a.baseLabel}-side results (base run failed — see the workflow logs)._"
   else if (rowNames a.prRows).isEmpty then
     out := out.push "" |>.push
       "_⚠️ no PR-side results (see the workflow logs)._"
@@ -347,7 +352,7 @@ def renderCompare (a : CompareArgs) : String := Id.run do
   -- carry every constant's high-level row; below it, each constant with
   -- `phase-<span>` fields (aiur witness/commit/quotient breakdowns, zkVM
   -- coarse phases) gets its own collapsed mini-table
-  -- (`phase | main | PR | Δ%`), opened as desired.
+  -- (`phase | base | PR | Δ%`), opened as desired.
   let mut detail : Array String := #[]
   if a.phases then
     for n in names do
@@ -356,7 +361,8 @@ def renderCompare (a : CompareArgs) : String := Id.run do
       if keys.isEmpty then continue
       detail := detail.push "" |>.push "<details>"
         |>.push s!"<summary><code>{n}</code></summary>" |>.push ""
-        |>.push "| phase | main | PR | Δ% |" |>.push "|---|---|---|---|"
+        |>.push s!"| phase | {a.baseLabel} | PR | Δ% |"
+        |>.push "|---|---|---|---|"
       for k in keys.qsort (· < ·) do
         let mv := rowNum a.mainRows n k
         let pv := rowNum a.prRows n k
@@ -499,7 +505,7 @@ private def moverDriver (m pr : PerConstEntry) : String :=
     Movers split into two classes with different evidence quality:
 
     - **cost movers** — the predicted cost moved: |Δcost| ≥ `costFloorRel`
-      of the constant's main-side cost, OR ≥ `costFloorAbs` outright (so a
+      of the constant's base-side cost, OR ≥ `costFloorAbs` outright (so a
       big constant moving a lot of real cost at a small percentage still
       enters). Ranked by percent change — pathologies first. The op
       counters are far more stable than wall time but NOT bit-deterministic
@@ -513,7 +519,8 @@ private def moverDriver (m pr : PerConstEntry) : String :=
       but cost did not. On an A/A run this is pure scheduling/cache noise;
       on an A/B it can also be allocator or locality effects a counter
       can't see. Reported second, clearly labeled. -/
-def renderPerConstMovers (mainCsv prCsv : String) (topN : Nat := 10)
+def renderPerConstMovers (mainCsv prCsv : String) (baseLabel : String := "main")
+    (topN : Nat := 10)
     (floorMs : Float := 10.0) (floorRel : Float := 0.03)
     (costFloorRel : Float := 0.15) (costFloorAbs : Float := 1e9) :
     IO String := do
@@ -571,7 +578,7 @@ def renderPerConstMovers (mainCsv prCsv : String) (topN : Nat := 10)
     if rows.isEmpty then ""
     else Id.run do
       let mut s := s!"**{title}**\n\n\
-        | constant | main | PR | Δtime | Δcost (Zisk) | driver |\n\
+        | constant | {baseLabel} | PR | Δtime | Δcost (Zisk) | driver |\n\
         |---|---|---|---|---|---|\n"
       for (name, m, p, _) in rows do
         let dcost := fmtDeltaCell m.cost p.cost "cycles"
@@ -599,7 +606,7 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   -- Explicit paths win; otherwise the local baseline pair, so a bare
   -- `ix bench compare --backend …` after two runs reports the local delta.
   let benchDir ← Ix.Cli.BenchCmd.benchOutputDir
-  let mainPath := (p.flag? "main").map (·.as! String)
+  let mainPath := (p.flag? "base").map (·.as! String)
     |>.getD s!"{benchDir}/{params}.prev.json"
   let prPath := (p.flag? "pr").map (·.as! String)
     |>.getD s!"{benchDir}/{params}.json"
@@ -618,7 +625,8 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     return exitUsage
   let threshold := (p.flag? "threshold").map (fun f => (f.as! Nat).toFloat)
     |>.getD 3.0
-  let mainSrc := (p.flag? "main-source").map (·.as! String) |>.getD mainPath
+  let mainSrc := (p.flag? "base-source").map (·.as! String) |>.getD mainPath
+  let baseLabel := (p.flag? "base-label").map (·.as! String) |>.getD "main"
   -- Name the mode only where a mode choice exists (aiur); a single-mode
   -- backend's `· execute` is registry plumbing, not information.
   let cellName :=
@@ -626,7 +634,7 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     then s!"`{backend}` · `{env}` · `{mode}`"
     else s!"`{backend}` · `{env}`"
   let title := (p.flag? "title").map (·.as! String)
-    |>.getD s!"### {cellName} — main from: {mainSrc}"
+    |>.getD s!"### {cellName} — {baseLabel} from: {mainSrc}"
   -- A staged mode sorts every table on its LEDGER's headline (the
   -- closing section's first measure — `total-time`), so the stage tables
   -- rank constants by what the whole pipeline costs rather than each by
@@ -636,7 +644,7 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   let mut table := renderCompare {
     mainRows := ← readRows mainPath
     prRows := ← readRows prPath
-    sections, sortMetric, threshold, title
+    sections, sortMetric, threshold, title, baseLabel
     phases := ((← IO.getEnv "BENCH_PHASES").getD "0") == "1"
     rowNoun :=
       if backend == "compile" then "env"
@@ -651,7 +659,7 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
   if (← System.FilePath.pathExists ⟨mainAttrib⟩)
     && (← System.FilePath.pathExists ⟨prAttrib⟩)
   then
-    table := table ++ "\n\n" ++ (← renderPerConstMovers mainAttrib prAttrib)
+    table := table ++ "\n\n" ++ (← renderPerConstMovers mainAttrib prAttrib baseLabel)
   match p.flag? "out" with
   | some f => IO.FS.writeFile (f.as! String) (table ++ "\n")
   | none => IO.println table
@@ -670,9 +678,10 @@ def runReportCmd (p : Cli.Parsed) : IO UInt32 := do
   let repoUrl := (p.flag? "repo-url").map (·.as! String) |>.getD ""
   let runId := (p.flag? "run-id").map (·.as! String) |>.getD ""
   let summary := (p.flag? "summary").map (·.as! String) |>.getD ""
+  let baseLabel := (p.flag? "base-label").map (·.as! String) |>.getD "main"
   let commit := if head.isEmpty then ""
-    else if repoUrl.isEmpty then s!" — main vs `{head.take 7}`"
-    else s!" — main vs [`{head.take 7}`]({repoUrl}/commit/{head})"
+    else if repoUrl.isEmpty then s!" — {baseLabel} vs `{head.take 7}`"
+    else s!" — {baseLabel} vs [`{head.take 7}`]({repoUrl}/commit/{head})"
   let mut parts := #[s!"## `!benchmark`{commit}", "", summary, ""]
   let entries := (← System.FilePath.readDir tablesDir).map (·.path.toString)
   let tables := (entries.filter fun p =>
@@ -952,9 +961,9 @@ def parseError (msg : String) : IO UInt32 := do
                                     (passthrough; BENCH_PHASES=1 adds the
                                     per-constant phase drill-downs to the
                                     comment; the IX_COMPILE_* knobs reach
-                                    the measured `ix compile` and key its
-                                    caches, so knob runs don't reuse a
-                                    default run's published row)
+                                    the measured `ix compile`, but emit the
+                                    same `.ixe`; caches are SHA-keyed, so add
+                                    `fresh` to remeasure a knob on one SHA)
 
     The KEY=VALUE config may sit on its own lines below the command (the
     comment form) or inline on the command line, whitespace-separated
@@ -965,7 +974,7 @@ def parseError (msg : String) : IO UInt32 := do
     The bare `execute` token flips a backend with an execute metrics entry
     to execute-only — a real switch only for aiur, which it drops from the
     full proof pipeline to the fast Phase-1-only signal. That testbed is
-    `unscheduled`, so the run has no bencher baseline — its main side
+    `unscheduled`, so the run has no bencher baseline — its base side
     comes from a base-SHA run.
 
     The bare `fresh` token makes every run bypass its bencher baseline and
@@ -1226,18 +1235,19 @@ end Ix.Cli.BenchReport
 open Ix.Cli.BenchReport in
 def benchCompareCmd : Cli.Cmd := `[Cli|
   "compare" VIA runCompareCmd;
-  "Render a Markdown main-vs-PR table from two results rows files. Defaults to the parameter combination's local baseline pair (<BENCH_OUTPUT_DIR or .lake/benches>/<params>{.prev,}.json), so a bare rerun compares against the previous local run."
+  "Render a Markdown base-vs-PR table from two results rows files. Defaults to the parameter combination's local baseline pair (<BENCH_OUTPUT_DIR or .lake/benches>/<params>{.prev,}.json), so a bare rerun compares against the previous local run."
 
   FLAGS:
     backend       : String; "Run backend (metrics come from the registry)"
     env           : String; "Run env (default: InitStd)"
     mode          : String; "Run mode (default: the backend's default_mode)"
-    main          : String; "Main-side rows JSON (default: the run baseline .prev.json)"
+    base          : String; "Base-side rows JSON (default: the run baseline .prev.json)"
     pr            : String; "PR-side rows JSON (default: the run baseline .json)"
     metric        : Array String; "Metric column(s), overriding the registry"
     threshold     : Nat;    "Flag |Δ| above this percentage (default: 3)"
     title         : String; "Table title (default: derived from the run)"
-    "main-source" : String; "Where the main side came from, for the title"
+    "base-source" : String; "Where the base side came from, for the title"
+    "base-label"  : String; "Name the base side in headers (default: main)"
     out           : String; "Write the table here instead of stdout"
 ]
 
@@ -1250,6 +1260,7 @@ def benchReportCmd : Cli.Cmd := `[Cli|
     tables     : String; "Directory of table-*.md files (default: tables)"
     summary    : String; "Summary line for the header"
     head       : String; "Commit SHA to title the report with"
+    "base-label" : String; "Name the base side in the header (default: main)"
     "repo-url" : String; "Repository URL, enabling commit/logs links"
     "run-id"   : String; "Workflow run id for the logs link"
     out        : String; "Also write the report here (always printed)"

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -969,10 +969,13 @@ def parseError (msg : String) : IO UInt32 := do
     comes from a base-SHA run.
 
     The bare `fresh` token makes every run bypass its bencher baseline and
-    re-measure the main side with a base-SHA run — for when the published
-    baseline is suspect (corrupted upload, stale toolchain). The comparison
-    prints in the comment only; PR runs never upload to bencher, so the
-    canonical baseline is untouched. -/
+    keeps persistent cached benchmark binaries, compiled `.ixe` files, and
+    compile rows out of measured jobs. A cached head `ix` may bootstrap this
+    canonical parser, but the workflow replaces the full binary bundle before
+    publishing it. Both measured source trees are rebuilt, and run-scoped
+    artifacts carry their products between jobs. Dependency caches remain
+    enabled. The comparison prints in the comment only; PR runs never upload
+    to bencher, so the canonical baseline is untouched. -/
 def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   let body ← match p.flag? "comment" with
     | some f => pure (f.as! String)
@@ -1191,7 +1194,8 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
   if !consts.isEmpty then
     summary := summary ++ s!" · consts: `{",".intercalate consts.toList}`"
   if freshFlag then
-    summary := summary ++ " · baseline: `fresh` (base-SHA run, bencher bypassed)"
+    summary := summary ++
+      " · baseline: `fresh` (benchmark products rebuilt, base-SHA run, bencher bypassed)"
   for b in skipped do
     summary := summary ++
       s!" · skipped `{b.name}` ({b.disabled.getD "disabled in the registry"})"

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -660,6 +660,12 @@ def runCompareCmd (p : Cli.Parsed) : IO UInt32 := do
     && (← System.FilePath.pathExists ⟨prAttrib⟩)
   then
     table := table ++ "\n\n" ++ (← renderPerConstMovers mainAttrib prAttrib baseLabel)
+  if let some path := (p.flag? "warning-file").map (·.as! String) then
+    if ← System.FilePath.pathExists ⟨path⟩ then
+      let warning := (← IO.FS.readFile path).trimAscii.toString
+      if !warning.isEmpty then
+        let lines := (warning.splitOn "\n").map fun line => "> " ++ line
+        table := "> [!WARNING]\n" ++ "\n".intercalate lines ++ "\n\n" ++ table
   match p.flag? "out" with
   | some f => IO.FS.writeFile (f.as! String) (table ++ "\n")
   | none => IO.println table
@@ -1248,6 +1254,7 @@ def benchCompareCmd : Cli.Cmd := `[Cli|
     title         : String; "Table title (default: derived from the run)"
     "base-source" : String; "Where the base side came from, for the title"
     "base-label"  : String; "Name the base side in headers (default: main)"
+    "warning-file" : String; "Markdown warning file to prepend when present"
     out           : String; "Write the table here instead of stdout"
 ]
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -6,10 +6,10 @@ thin wrapper: the same `ix bench run` you type in a terminal is what both
 workflows execute, so every CI number is reproducible on your machine.
 
 - **`!benchmark` PR comment** (`.github/workflows/bench-pr.yml`) — on demand,
-  posts a **main-vs-PR** comparison table on the pull request. main's numbers
-  come from bencher.dev (`ix bench fetch-main`); the PR side is measured
-  fresh. When bencher can't supply the base SHA (not ingested yet, or the PR
-  adds new constants), the workflow measures the gap on a base checkout.
+  posts a **base-vs-PR** comparison table on the pull request. The base is the
+  PR's actual target branch. Its numbers come from bencher.dev (`ix bench
+  fetch-main`) when that SHA was ingested on main; otherwise the workflow
+  measures them on a checkout of the base SHA.
 - **Bencher.dev** (`.github/workflows/bench-main.yml`) — on every push to
   `main`, tracks each measure over time at <https://bencher.dev> (project
   `ix`), the canonical store the PR path reads from.
@@ -43,7 +43,7 @@ row** — an empty or quietly-partial cell can't be green.
 |---|---|
 | `run`        | run one cell: select names, ensure the `.ixe`, spawn the tool under the RAM watchdog (one process per constant on aiur/zkVM), fold each spawn's span window into its row, gate on the rows |
 | `shard`      | pre-cut the closure-shard artifacts for the env's heavy-tier constants (`ix shard extract` → `ix profile` → `ix shard`) |
-| `compare`    | two rows files → Markdown main-vs-PR table (thresholds, ratios, OOM/❌ rows; per-constant phase drop-downs under `BENCH_PHASES=1`) |
+| `compare`    | two rows files → Markdown base-vs-PR table (thresholds, ratios, OOM/❌ rows; per-constant phase drop-downs under `BENCH_PHASES=1`) |
 | `bmf`        | rows → Bencher Metric Format (non-`ok` rows dropped) |
 | `fetch-main` | pull a base SHA's rows from bencher.dev (exit 3 = transient, fall back to a local base run; exit 2 = config error, fail loudly) |
 | `report`     | assemble per-cell tables into one Markdown report (CI posts it as the PR comment) |
@@ -76,7 +76,7 @@ ix bench run --backend aiur --env InitStd --mode prove \
 ix bench fetch-main --sha $(git merge-base origin/main HEAD) \
   --backend aiur --mode prove --consts Nat.add_comm --out main.json
 ix bench compare --backend aiur --env InitStd --mode prove \
-  --main main.json --pr .lake/benches/aiur-InitStd-prove.json
+  --base main.json --pr .lake/benches/aiur-InitStd-prove.json
 
 # The recursion cell — fixed IxVM statements (Nat.add_comm,
 # Array.extract_append), resolved in the env's .ixe:
@@ -204,6 +204,11 @@ single-line form for `bench-pr.yml`'s manual workflow_dispatch, whose
 input box can't hold newlines:
 `!benchmark aiur execute BENCH_ENVS=InitStd,Mathlib BENCH_FULL=1`.
 
+The `IX_COMPILE_*` settings change compile-time RAM and speed but produce a
+bit-identical `.ixe`, so normal `.ixe` and compile-row caches are keyed only by
+commit and env. Add `fresh` when remeasuring a compile knob on an already
+benchmarked commit.
+
 Parsed by `ix bench ci parse` in the PR build job, right after the `ix`
 binary exists — the registry lives in Lean, so nothing pre-build reads it
 (and no Python remains). Mode defaults per backend from the registry; the
@@ -223,7 +228,8 @@ untouched.
 
 **bench-main.yml**: `build` (compile `ix` + `bench-typecheck` once, cache by
 SHA) → `plan` (`ix bench ci matrix` → job matrices) + `compile` (per env:
-`ix bench run --backend compile`, cache the `.ixe` + pre-cut zisk shards) →
+`ix bench run --backend compile`, cache the `.ixe` and pre-cut zisk shards
+separately) →
 `aiur` (execute + prove cells) / `zkvm-execute` / `ooc-check` (each: restore caches, one
 `ix bench run … --ixe`, `ix bench bmf`, upload via
 `.github/actions/bencher-track`) / `aiur-recursive` (same shape — it
@@ -249,7 +255,8 @@ auto-creates measures with placeholder units on first upload).
 then `ix bench ci parse`) → `compile` (one measured `ix compile` per env,
 publishing a run-scoped `.ixe` + row artifact) → `benchmark` matrix (per cell:
 download only those run artifacts; run the PR side; fetch main's numbers,
-with a targeted base-checkout run covering only what bencher lacked;
+with a base-checkout run covering what bencher lacked (including every
+non-`main` base, whose `.ixe` can be restored from its earlier PR run);
 `ix bench compare` → table artifact) → `assemble` (`ix bench report` builds
 the comment body, unprivileged) → `comment` (posts it — the only job with a
 write token, running no PR code). Normal runs may seed the run artifacts from
@@ -270,8 +277,6 @@ build CPU.
   execute-only.
 - **sp1** — disabled in the registry (execute too slow per push);
   re-enable it there and it returns to the matrices and the parser.
-- **Non-`main` base branches** — `fetch-main` queries `branch=main`; a PR
-  against another base always pays the local base run.
 - **aiur recursive over the full selection in CI** — the `aiur-recursive`
   cell tracks IxVM recursion on its two fixed constants, but the full
   `Vectors.csv` fan-out of `bench-typecheck --recursive` is too heavy for

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -256,6 +256,14 @@ write token, running no PR code). Normal runs may seed the run artifacts from
 persistent head/base-SHA caches. `fresh` bypasses those caches and rebuilds
 the measured products while retaining dependency caches.
 
+Every job that creates a timing row logs its CPU model, instruction set,
+effective CPU count, affinity, and cgroup allocation. Because the benchmark
+binaries use native codegen, their build jobs also record the build CPU and
+carry that report inside the binary cache or run artifact; measurement jobs
+print it next to their own host report. A cache entry created before this
+provenance was introduced remains usable and is reported as having an unknown
+build CPU.
+
 ## Not yet covered
 
 - **zkVM prove** — the hosts prove, but CI has no GPU runner; cells are

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -269,7 +269,10 @@ binaries use native codegen, their build jobs also record the build CPU and
 carry that report inside the binary cache or run artifact; measurement jobs
 print it next to their own host report. A cache entry created before this
 provenance was introduced remains usable and is reported as having an unknown
-build CPU.
+build CPU. The exact `lscpu` model name is compared; a difference (or missing
+build provenance) is rendered as a warning in that cell's PR comment table.
+This is diagnostic only: the CPU model does not participate in cache keys, and
+only an explicit `fresh` request bypasses the measured-product caches.
 
 ## Not yet covered
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -210,10 +210,14 @@ binary exists — the registry lives in Lean, so nothing pre-build reads it
 bare `execute` token flips `aiur` to Phase-1 only, and `recursive` to its
 recursive mode (unscheduled testbed, so no bencher baseline; OOMs the
 standard CI host — meant for a bigger manual dispatch). The bare `fresh`
-token makes every cell bypass its bencher baseline and re-measure the main
-side with a base-SHA run — for when the published baseline is suspect. PR
-runs never upload to bencher, so the comparison prints in the comment and
-the canonical baseline is untouched.
+token makes every cell bypass its bencher baseline and keeps persistent cached
+benchmark binaries, compiled `.ixe` files, and compile rows out of measured
+jobs. A cached head `ix` may bootstrap the canonical command parser, but the
+workflow replaces the full binary bundle before publishing it. Both the PR and
+base products are rebuilt; run-scoped artifacts carry them between jobs. Cargo
+and package dependency caches remain enabled. PR runs never upload to bencher,
+so the comparison prints in the comment and the canonical baseline is
+untouched.
 
 ## CI shape
 
@@ -241,15 +245,16 @@ The sync also asserts every measure's canonical units (bencher
 auto-creates measures with placeholder units on first upload).
 
 **bench-pr.yml**: `setup` (authorize the comment, resolve base/head SHAs) →
-`build` (PR binaries, cached by head SHA; ends with `ix bench ci parse` —
-the matrix can only exist once `ix` does) → `compile` (one measured
-`ix compile` per env: publishes the `.ixe` the prover cells restore AND
-the row the compile cell reuses as its PR side) → `benchmark` matrix (per cell:
-PR-side `ix bench run`; `ix bench fetch-main` for main's numbers, with a
-targeted base-checkout run covering only what bencher lacked;
+`build` (select or build the PR binaries, publish a run-scoped artifact,
+then `ix bench ci parse`) → `compile` (one measured `ix compile` per env,
+publishing a run-scoped `.ixe` + row artifact) → `benchmark` matrix (per cell:
+download only those run artifacts; run the PR side; fetch main's numbers,
+with a targeted base-checkout run covering only what bencher lacked;
 `ix bench compare` → table artifact) → `assemble` (`ix bench report` builds
 the comment body, unprivileged) → `comment` (posts it — the only job with a
-write token, running no PR code).
+write token, running no PR code). Normal runs may seed the run artifacts from
+persistent head/base-SHA caches. `fresh` bypasses those caches and rebuilds
+the measured products while retaining dependency caches.
 
 ## Not yet covered
 


### PR DESCRIPTION
- Properly sets `rustflags` in CI, respecting `.cargo/config.toml` and thus ensuring AVX-512 codegen on supported machines
- Checks every bench runner supports AVX-512 instructions. If two benchmark runners have different CPU models, the PR comment prints a warning for visibility. In this case the user can then re-run the benchmark with the `fresh` argument
- Ignores all cached `ix` binaries and `.ixe` environments when `fresh` is passed to `!benchmark`, so a toolchain bump PR can correctly measure across versions
- Correctly labels the base commit in the benchmark comment output, so non-main base branches are supported