### PR TITLE
chore: Fix bench CI

### DIFF
--- a/.github/actions/setup-rust-toolchain/action.yml
+++ b/.github/actions/setup-rust-toolchain/action.yml
@@ -1,7 +1,7 @@
 name: Set up Rust toolchain
 description: >-
-  Install Rust and cache Cargo artifacts without exporting RUSTFLAGS, leaving
-  each workspace's .cargo/config.toml authoritative.
+  Install Rust on Warp Linux x64 and cache Cargo artifacts without exporting
+  RUSTFLAGS, leaving each workspace's .cargo/config.toml authoritative.
 
 inputs:
   cache-workspaces:
@@ -11,7 +11,22 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Require Warp Linux x64 runner
+      shell: bash
+      env:
+        IX_RUNNER_NAME: ${{ runner.name }}
+        IX_RUNNER_OS: ${{ runner.os }}
+        IX_RUNNER_ARCH: ${{ runner.arch }}
+      run: |
+        if [[ "$IX_RUNNER_NAME" != warp-* || "$IX_RUNNER_OS" != Linux || "$IX_RUNNER_ARCH" != X64 ]]; then
+          echo "::error::setup-rust-toolchain requires a Warp Linux x64 runner; got name=$IX_RUNNER_NAME os=$IX_RUNNER_OS arch=$IX_RUNNER_ARCH"
+          exit 1
+        fi
+
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         rustflags: ""
+        # `target/` may contain host-executed native code. Every caller runs
+        # within the Warp x64 compatibility domain.
+        cache-key: warp-x64
         cache-workspaces: ${{ inputs.cache-workspaces }}

--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -81,9 +81,9 @@ jobs:
   # job; only the benchmark job waits on it.
   plan:
     needs: build
-    # `ci matrix` only runs Lean code (the AVX-512 parts of the binary are
-    # never executed here), so a cheap non-warp host is fine.
-    runs-on: ubuntu-latest
+    # Native target features may occur anywhere in `ix`, including this
+    # registry-only subcommand, so keep it on the Warp x64 runner fleet.
+    runs-on: warp-ubuntu-latest-x64-8x
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -894,9 +894,9 @@ jobs:
     # Assemble even when benchmark runs failed — the tables carry the ❌
     # rows. Only the build job must have succeeded (it made the binaries).
     if: always() && needs.build.result == 'success'
-    # `bench report` only runs Lean code (the AVX-512 parts of the binary
-    # are never executed here), so a cheap non-warp host is fine.
-    runs-on: ubuntu-latest
+    # The report command uses the build job's native `ix`, so keep it on the
+    # Warp x64 runner fleet; report assembly does not need benchmark-scale RAM.
+    runs-on: warp-ubuntu-latest-x64-8x
     permissions:
       contents: read
     steps:

--- a/.github/workflows/bencher-plots.yml
+++ b/.github/workflows/bencher-plots.yml
@@ -24,9 +24,9 @@ permissions:
 
 jobs:
   sync-plots:
-    # `bench plots` is a pure-Lean subcommand and the rest is bencher API
-    # calls — cheap host is fine (same rationale as bench-main's plan job).
-    runs-on: ubuntu-latest
+    # The restored `ix` uses native target features selected on the benchmark
+    # build runner, even though this subcommand itself is pure Lean.
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v7
       # The staged binaries from bench-main's build job: this main tip's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: lake test --wfail -- --ignored ixvm
 
   rust-test:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-rust-toolchain


### PR DESCRIPTION
Fixes a benchmarking abort from #575 ([workflow log](https://github.com/argumentcomputer/ix/actions/runs/32319937991/job/96280604589)) due to running AVX-512 binaries compiled by Warpbuild on `ubuntu-latest` (which doesn't support the same set of AVX instructions). Instead we now use Warpbuild runners for all bench jobs, varying machine type by workload