### PR TITLE
# Fix v4.33 fallout in the ignored kernel suites: Prop-below call-site surgery + egress hints channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,20 @@ jobs:
 
   rust-test:
     runs-on: ubuntu-latest
+    # Portable codegen for the one job on the GitHub-hosted fleet.
+    # `.cargo/config.toml` sets `-Ctarget-cpu=native` (authoritative in CI
+    # since #575), but `ubuntu-latest` runners are heterogeneous
+    # microarchitectures sharing one cargo cache: a proc-macro dylib or test
+    # binary compiled `native` on one runner SIGILLs when a later run lands
+    # on a runner without those ISA extensions (clippy-driver died with
+    # `signal: 4, SIGILL` checking `aiur` off a cached tracing-attributes).
+    # x86-64-v3 (AVX2) is the documented baseline for GitHub-hosted x64
+    # runners, and RUSTFLAGS participates in the cache key, so this also
+    # re-keys away from any native-built cache entries. The warp jobs keep
+    # `native`: the bench flow reuses their artifacts and records CPU
+    # provenance for exactly that reason (#575).
+    env:
+      RUSTFLAGS: -Ctarget-cpu=x86-64-v3
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-rust-toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,21 +92,7 @@ jobs:
         run: lake test --wfail -- --ignored ixvm
 
   rust-test:
-    runs-on: ubuntu-latest
-    # Portable codegen for the one job on the GitHub-hosted fleet.
-    # `.cargo/config.toml` sets `-Ctarget-cpu=native` (authoritative in CI
-    # since #575), but `ubuntu-latest` runners are heterogeneous
-    # microarchitectures sharing one cargo cache: a proc-macro dylib or test
-    # binary compiled `native` on one runner SIGILLs when a later run lands
-    # on a runner without those ISA extensions (clippy-driver died with
-    # `signal: 4, SIGILL` checking `aiur` off a cached tracing-attributes).
-    # x86-64-v3 (AVX2) is the documented baseline for GitHub-hosted x64
-    # runners, and RUSTFLAGS participates in the cache key, so this also
-    # re-keys away from any native-built cache entries. The warp jobs keep
-    # `native`: the bench flow reuses their artifacts and records CPU
-    # provenance for exactly that reason (#575).
-    env:
-      RUSTFLAGS: -Ctarget-cpu=x86-64-v3
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-rust-toolchain

--- a/Ix/AuxGen/CompileAux.lean
+++ b/Ix/AuxGen/CompileAux.lean
@@ -1033,7 +1033,7 @@ blocks claim one source-indexed aux name")
 '{breconName.pretty}' — two blocks claim one source-indexed aux name")
             brecPlans := brecPlans.insert breconName newPlan
         if let some belowName := recNameToBelowName name then
-          if (← liftM (lookupConst? belowName : CompileM _)).isSome then
+          if let some belowCi ← liftM (lookupConst? belowName : CompileM _) then
             let newPlan := BRecOnCallSitePlan.fromRecPlan plan
             if let some existing :=
                 cenvGlobal.belowCallSitePlans.get? belowName then
@@ -1041,6 +1041,30 @@ blocks claim one source-indexed aux name")
                 throw (.invalidMutualBlock
                   s!"conflicting below call-site plans for \
 '{belowName.pretty}' — two blocks claim one source-indexed aux name")
+            -- Prop-level (IndPredBelow) `.below` is an INDUCTIVE, so user
+            -- code can also reference its constructors and its `.casesOn`
+            -- wrapper — both start with the below params (parent params +
+            -- parent motives) and need the same motive permutation.
+            -- Registered under their own names in the same map; the apply
+            -- site discriminates the telescope shape via
+            -- `belowPlanKeyIsHead` (compile.rs family registration).
+            -- `X.below.rec` is deliberately not registered (only
+            -- regenerated wrappers reference it, and those skip surgery
+            -- via the aux-regen guard).
+            let mut familyNames : Array Name := #[]
+            if let .inductInfo bv := belowCi then
+              familyNames := bv.ctors
+              let casesName := Name.mkStr belowName "casesOn"
+              if (← liftM (lookupConst? casesName : CompileM _)).isSome then
+                familyNames := familyNames.push casesName
+            for member in familyNames do
+              if let some existing :=
+                  cenvGlobal.belowCallSitePlans.get? member then
+                if existing != newPlan then
+                  throw (.invalidMutualBlock
+                    s!"conflicting below call-site plans for \
+'{member.pretty}' — two blocks claim one source-indexed aux name")
+              belowPlans := belowPlans.insert member newPlan
             belowPlans := belowPlans.insert belowName newPlan
 
   return (auxLayout, plans, brecPlans, belowPlans)

--- a/Ix/CallSitePlan.lean
+++ b/Ix/CallSitePlan.lean
@@ -154,4 +154,17 @@ def isIdentity (plan : BRecOnCallSitePlan) : Bool :=
 
 end BRecOnCallSitePlan
 
+/-- Whether a `belowCallSitePlans` key is the `.below`/`.below_N` HEAD
+    (telescope `params, motives, indices, major` — surgery requires the
+    full floor) as opposed to a Prop-below FAMILY member (a `.below`
+    constructor or `.below.casesOn`, whose telescope starts with the
+    below params — parent params then parent motives — and has no
+    major-premise floor: a field-less below ctor is fully applied at
+    exactly params+motives). Mirrors Rust `below_plan_key_is_head`
+    (surgery.rs). -/
+def belowPlanKeyIsHead (name : Name) : Bool :=
+  match name with
+  | .str _ s _ => s == "below" || s.startsWith "below_"
+  | _ => false
+
 end Ix.AuxGen

--- a/Ix/CompileM.lean
+++ b/Ix/CompileM.lean
@@ -73,9 +73,17 @@ structure CompileEnv where
       Shares the motive permutation with `.rec`, but `.brecOn` places
       indices+major before the handler binders. -/
   brecOnCallSitePlans : Std.HashMap Name Ix.AuxGen.BRecOnCallSitePlan := {}
-  /-- Per-`.below` surgery plans (Rust `stt.below_call_site_plans`).
-      `.below` has the motive-only telescope `params, motives, indices,
-      major`. -/
+  /-- Per-`.below`-family surgery plans (Rust
+      `stt.below_call_site_plans`). A `X.below`/`X.below_N` HEAD has the
+      motive-only telescope `params, motives, indices, major`. For
+      Prop-level (IndPredBelow) families the map also carries the rest
+      of the family's user-visible surface under their own names — the
+      `.below` constructors and the `.below.casesOn` wrapper, whose
+      telescopes start with the below inductive's parameters (parent
+      params, then parent motives) and have NO major-premise floor
+      (a field-less below ctor is fully applied at exactly
+      params+motives). The apply site discriminates the two shapes via
+      `Ix.AuxGen.belowPlanKeyIsHead`. -/
   belowCallSitePlans : Std.HashMap Name Ix.AuxGen.BRecOnCallSitePlan := {}
   /-- Persistent set of names compiled by aux-gen (Rust
       `stt.aux_gen_extra_names`); merged from block tails by the driver
@@ -853,9 +861,13 @@ partial def compileAppSpine (e : Expr) : CompileM (Ixon.Expr × UInt64) := do
               return ← compileRecCallSite name lvls plan headExpr args
       if let some plan := cenv.belowCallSitePlans.get? name then
         if !plan.isIdentity then
-          let fixedTailLen := plan.nIndices + 1 -- indices + major
-          let expectedTotal :=
-            plan.nParams + plan.nSourceMotives + fixedTailLen
+          -- `.below`/`.below_N` HEADS need the indices+major floor; a
+          -- Prop-below FAMILY member (ctor / `.below.casesOn`) has no
+          -- floor — a field-less below ctor is fully applied at exactly
+          -- params+motives (compile.rs below-family branch).
+          let isHead := Ix.AuxGen.belowPlanKeyIsHead name
+          let expectedTotal := plan.nParams + plan.nSourceMotives
+            + (if isHead then plan.nIndices + 1 else 0)
           if args.size >= expectedTotal then
             return ← compileBelowCallSite name plan headExpr args
       if let some plan := cenv.brecOnCallSitePlans.get? name then
@@ -1095,20 +1107,22 @@ partial def compileHeadRewriteCallSite (name : Name) (lvls : Array Level)
   let headForCanon := Expr.mkConst name targetLevels
   buildCallSite nameAddr headForCanon canonicalArgs collapsedArgs entries true
 
-/-- `.below` call-site surgery (compile.rs:1163-1263): telescope is
-    `params, motives, indices, major` — motive keep/reorder mirrors the
-    recursor plan; everything after the motives is kept identically. -/
+/-- `.below`-family call-site surgery (compile.rs below-family branch).
+    HEAD telescope is `params, motives, indices, major`; a Prop-below
+    FAMILY member (ctor / `.below.casesOn`) starts with the below params
+    (parent params, then parent motives). In both shapes everything
+    after the motive segment is kept identically, so one identity tail
+    covers indices+major, ctor fields, and casesOn
+    target-motive+indices+major+minors alike — the caller enforces the
+    per-shape application floor. -/
 partial def compileBelowCallSite (name : Name)
     (plan : Ix.AuxGen.BRecOnCallSitePlan) (headExpr : Expr)
     (args : Array Expr) : CompileM (Ixon.Expr × UInt64) := do
-  let fixedTailLen := plan.nIndices + 1 -- indices + major
-  let expectedTotal := plan.nParams + plan.nSourceMotives + fixedTailLen
   compileName name
   let nameAddr := name.getHash
   let params := args.extract 0 plan.nParams
   let motives := args.extract plan.nParams (plan.nParams + plan.nSourceMotives)
-  let fixedTail := args.extract (plan.nParams + plan.nSourceMotives) expectedTotal
-  let extraTail := args.extract expectedTotal args.size
+  let tail := args.extract (plan.nParams + plan.nSourceMotives) args.size
 
   let nCanonMotives := plan.nCanonicalMotives
   let mut canonicalArgs : Array (Nat × Expr) := #[]
@@ -1129,15 +1143,10 @@ partial def compileBelowCallSite (name : Name)
       entries := entries.push (.collapsed collapsedArgs.size.toUInt64 0)
       collapsedArgs := collapsedArgs.push motive
 
-  let fixedTailCanonBase := plan.nParams + nCanonMotives
-  for (t, i) in fixedTail.zipIdx do
-    canonicalArgs := canonicalArgs.push (fixedTailCanonBase + i, t)
-    entries := entries.push (.kept (fixedTailCanonBase + i).toUInt64 0)
-
-  let extraTailCanonBase := fixedTailCanonBase + fixedTailLen
-  for (t, i) in extraTail.zipIdx do
-    canonicalArgs := canonicalArgs.push (extraTailCanonBase + i, t)
-    entries := entries.push (.kept (extraTailCanonBase + i).toUInt64 0)
+  let tailCanonBase := plan.nParams + nCanonMotives
+  for (t, i) in tail.zipIdx do
+    canonicalArgs := canonicalArgs.push (tailCanonBase + i, t)
+    entries := entries.push (.kept (tailCanonBase + i).toUInt64 0)
 
   let sortedCanon := (sortByCanonIdx canonicalArgs).map (·.2)
   buildCallSite nameAddr headExpr sortedCanon collapsedArgs entries false

--- a/Ix/DecompileDriver.lean
+++ b/Ix/DecompileDriver.lean
@@ -373,6 +373,41 @@ def installDecompileCallSitePlans
         if auxMemberNames.contains belowName
             || decompiledView.contains belowName then
           let newPlan := Ix.AuxGen.BRecOnCallSitePlan.fromRecPlan plan
+          -- Prop-level (IndPredBelow) `.below` families additionally
+          -- expose constructors and a `.casesOn` wrapper to user code —
+          -- mirror the compile side's family registration (same map;
+          -- the apply site discriminates the telescope shape via
+          -- `belowPlanKeyIsHead`). The below inductive itself is
+          -- regenerated later, so its ctor names are derived from the
+          -- PARENT inductive's ctors via the same suffix transplant
+          -- `buildBelowIndcCtor` uses. Prop-ness is signalled by the
+          -- presence of a `.below.rec` aux member (Type-level `.below`
+          -- is a definition and has no recursor).
+          let isPropBelow :=
+            auxMemberNames.contains (Ix.Name.mkStr belowName "rec")
+          let parentName? : Option Ix.Name := match belowName with
+            | .str p _ _ => some p
+            | _ => none
+          let familyNames : Array Ix.Name := Id.run do
+            let some parentName := parentName? | return #[]
+            let some (.inductInfo pv) := decompiledView.get? parentName
+              | return #[]
+            let mut out : Array Ix.Name := pv.ctors.map fun ctorName =>
+              let suffix := (Ix.AuxGen.nameStripPrefix ctorName parentName).getD
+                (Ix.AuxGen.nameComponents ctorName)
+              Ix.AuxGen.nameAppendComponents belowName suffix
+            out := out.push (Ix.Name.mkStr belowName "casesOn")
+            return out
+          if isPropBelow then
+            for member in familyNames do
+              match belowPlans.get? member with
+              | some existing =>
+                if existing != newPlan then
+                  throw s!"conflicting below call-site plans for \
+'{member.pretty}' across stored blocks"
+              | none =>
+                belowPlans := belowPlans.insert member newPlan
+                newBelow := newBelow.push (member, newPlan)
           match belowPlans.get? belowName with
           | some existing =>
             if existing != newPlan then

--- a/Tests/Ix/Kernel/CheckEnv.lean
+++ b/Tests/Ix/Kernel/CheckEnv.lean
@@ -138,6 +138,15 @@ def testRustCheckEnv : TestSeq :=
     check proceeds, so a hang is recognisable by a missing terminator
     after `[i/N] name ...` — look for the last printed name. -/
 def focusConsts : Array Lean.Name := #[
+  -- 2026-08-19 (v4.33 bump fallout): Prop-mutual IndPredBelow matchers.
+  -- The `match_2` matchers mention `OddP.below`/`EvenP.below` applied to
+  -- the parent family's motives, so they pin the below inductive's
+  -- parameter order against Lean's authored order (see #571).
+  Lean.mkPrivateNameCore `Tests.Ix.Compile.Mutual
+    `Tests.Ix.Compile.Mutual.BelowPredicate.oddp_nonneg.match_2,
+  Lean.mkPrivateNameCore `Tests.Ix.Compile.Mutual
+    `Tests.Ix.Compile.Mutual.BelowPredicate.evenp_nonneg.match_2,
+
   -- Current Nat-conformance follow-up residue from 2026-04-30.
   `Lean.Grind.Fin.instPowFinCoOfNatIntCast,
   `Fin.pred_one,

--- a/Tests/Main.lean
+++ b/Tests/Main.lean
@@ -256,6 +256,30 @@ def ignoredRunners (env : Lean.Environment) : List (String × IO UInt32) := [
 ]
 
 def main (args : List String) : IO UInt32 := do
+  -- Special case: namespace-filtered kernel ixon roundtrip diagnostic.
+  -- `kernel-roundtrip-ns=Nat.le` runs the same pipeline as the
+  -- `kernel-ixon-roundtrip` suite (compile → ingress → egress →
+  -- decompile → hash-compare) but only on the transitive closure of the
+  -- constants matching the given name prefixes (comma-separated), so a
+  -- single-family regression can be bisected in seconds instead of a
+  -- full-env pass.
+  if let some arg := args.find? (·.startsWith "kernel-roundtrip-ns=") then
+    let prefixes := (arg.drop "kernel-roundtrip-ns=".length).toString.splitOn ","
+      |>.filterMap fun s => if s.isEmpty then none else some s.toName
+    let env ← get_env!
+    let seeds := env.constants.toList.filterMap fun (n, _) =>
+      if prefixes.any (·.isPrefixOf n) then some n else none
+    let closed := collectDeps env seeds
+    IO.println s!"[kernel-roundtrip-ns] {seeds.length} seeds, {closed.length} constants in closure"
+    let errors ← Tests.Ix.Kernel.Roundtrip.rsKernelRoundtripFFI closed
+    if errors.isEmpty then
+      IO.println "[kernel-roundtrip-ns] OK: roundtrip clean"
+      return 0
+    IO.println s!"[kernel-roundtrip-ns] {errors.size} errors:"
+    for msg in errors[:min 50 errors.size] do
+      IO.println s!"  {msg}"
+    return 1
+
   -- Special case: rust-compile diagnostic (full env)
   if args.contains "rust-compile" then
     let env ← get_env!

--- a/crates/compile/src/compile.rs
+++ b/crates/compile/src/compile.rs
@@ -166,8 +166,23 @@ pub struct CompileState {
   /// `.rec`, but `.brecOn` places indices+major before the handler binders,
   /// so the telescope has to be rewritten by a separate layout rule.
   pub brec_on_call_site_plans: DashMap<Name, surgery::BRecOnCallSitePlan>,
-  /// Per-`.below` surgery plans. `.below` has the motive-only telescope
-  /// `params, motives, indices, major`.
+  /// Per-`.below`-family surgery plans. A `X.below`/`X.below_N` HEAD has
+  /// the motive-only telescope `params, motives, indices, major`. For
+  /// Prop-level (IndPredBelow) families the map also carries the rest of
+  /// the family's user-visible surface under their own names — the
+  /// `.below` constructors (`X.below.succ`, …) and the `.below.casesOn`
+  /// wrapper. Those telescopes start with the below inductive's
+  /// parameters (parent params, then parent motives), so the same motive
+  /// permutation applies to `[n_params, n_params + n_source_motives)`
+  /// and everything after (ctor fields / casesOn
+  /// target-motive+indices+major+minors) rides along kept-identity —
+  /// but with NO major-premise floor: a field-less below ctor
+  /// (`EvenP.below.zero`) is fully applied at exactly params+motives.
+  /// The apply site discriminates the two telescope shapes by the key's
+  /// last component (`below`/`below_N` = head, anything else = family
+  /// member); `X.below.rec` is deliberately NOT registered (nothing
+  /// user-visible references it — only regenerated wrappers, which skip
+  /// surgery via the aux-regen guard).
   pub below_call_site_plans: DashMap<Name, surgery::BRecOnCallSitePlan>,
   /// Per-block nested-auxiliary layout (permutation + source ctor
   /// counts) for each source `InductiveVal.all[0]` name. Used by:
@@ -1275,9 +1290,22 @@ pub fn compile_expr(
                 if let Some(plan) = stt.below_call_site_plans.get(name)
                   && !plan.is_identity()
                 {
-                  let fixed_tail_len = plan.n_indices + 1; // indices + major
-                  let expected_total =
-                    plan.n_params + plan.n_source_motives + fixed_tail_len;
+                  // The map covers the whole below family (see the field
+                  // docs). A `.below`/`.below_N` HEAD has the telescope
+                  // `params, motives, indices, major` and surgery needs
+                  // the full floor; a Prop-below FAMILY member (ctor /
+                  // `.below.casesOn`) starts with the below params —
+                  // parent params then parent motives — and has NO
+                  // major-premise floor (a field-less below ctor is
+                  // fully applied at exactly params+motives). In both
+                  // shapes everything after the motive segment is kept
+                  // in place, so one identity tail covers indices+major,
+                  // ctor fields, and casesOn target-motive+indices+
+                  // major+minors alike.
+                  let is_head = surgery::below_plan_key_is_head(name);
+                  let expected_total = plan.n_params
+                    + plan.n_source_motives
+                    + if is_head { plan.n_indices + 1 } else { 0 };
                   if args.len() >= expected_total {
                     let name_addr = compile_name(name, stt);
                     let args_owned: Vec<LeanExpr> =
@@ -1285,17 +1313,13 @@ pub fn compile_expr(
                     let params = &args_owned[..plan.n_params];
                     let motives = &args_owned
                       [plan.n_params..plan.n_params + plan.n_source_motives];
-                    let fixed_tail = &args_owned
-                      [plan.n_params + plan.n_source_motives..expected_total];
-                    let extra_tail = &args_owned[expected_total..];
+                    let tail =
+                      &args_owned[plan.n_params + plan.n_source_motives..];
 
                     let n_canon_motives = plan.n_canonical_motives();
                     let mut canonical_args: Vec<(usize, LeanExpr)> =
                       Vec::with_capacity(
-                        plan.n_params
-                          + n_canon_motives
-                          + fixed_tail.len()
-                          + extra_tail.len(),
+                        plan.n_params + n_canon_motives + tail.len(),
                       );
                     let mut collapsed_args: Vec<LeanExpr> = Vec::new();
                     let mut entries: Vec<CallSiteEntry> = Vec::new();
@@ -1328,23 +1352,11 @@ pub fn compile_expr(
                       }
                     }
 
-                    let fixed_tail_canon_base = plan.n_params + n_canon_motives;
-                    for (i, t) in fixed_tail.iter().enumerate() {
-                      canonical_args
-                        .push((fixed_tail_canon_base + i, t.clone()));
+                    let tail_canon_base = plan.n_params + n_canon_motives;
+                    for (i, t) in tail.iter().enumerate() {
+                      canonical_args.push((tail_canon_base + i, t.clone()));
                       entries.push(CallSiteEntry::Kept {
-                        canon_idx: (fixed_tail_canon_base + i) as u64,
-                        meta: 0,
-                      });
-                    }
-
-                    let extra_tail_canon_base =
-                      fixed_tail_canon_base + fixed_tail_len;
-                    for (i, t) in extra_tail.iter().enumerate() {
-                      canonical_args
-                        .push((extra_tail_canon_base + i, t.clone()));
-                      entries.push(CallSiteEntry::Kept {
-                        canon_idx: (extra_tail_canon_base + i) as u64,
+                        canon_idx: (tail_canon_base + i) as u64,
                         meta: 0,
                       });
                     }
@@ -4340,7 +4352,7 @@ fn compile_mutual(
             stt.brec_on_call_site_plans.insert(brecon_name, new_plan);
           }
           if let Some(below_name) = surgery::rec_name_to_below_name(&name)
-            && lean_env.get(&below_name).is_some()
+            && let Some(below_ci) = lean_env.get(&below_name)
           {
             let new_plan = surgery::BRecOnCallSitePlan::from_rec_plan(&plan);
             if stt
@@ -4355,6 +4367,40 @@ fn compile_mutual(
                   below_name.pretty(),
                 ),
               });
+            }
+            // Prop-level (IndPredBelow) `.below` is an INDUCTIVE, so user
+            // code can also reference its constructors and its
+            // `.casesOn` wrapper — both start with the below params
+            // (parent params + parent motives) and need the same motive
+            // permutation. Registered under their own names in the same
+            // map; the apply site discriminates the telescope shape via
+            // `below_plan_key_is_head`. `X.below.rec` is deliberately
+            // not registered (only regenerated wrappers reference it,
+            // and those skip surgery via the aux-regen guard).
+            let mut family_names: Vec<Name> = Vec::new();
+            if let LeanConstantInfo::InductInfo(bv) = &*below_ci {
+              family_names.extend(bv.ctors.iter().cloned());
+              let cases_name =
+                Name::str(below_name.clone(), "casesOn".to_string());
+              if lean_env.get(&cases_name).is_some() {
+                family_names.push(cases_name);
+              }
+            }
+            for member in family_names {
+              if stt
+                .below_call_site_plans
+                .get(&member)
+                .is_some_and(|existing| *existing != new_plan)
+              {
+                return Err(CompileError::InvalidMutualBlock {
+                  reason: format!(
+                    "conflicting below call-site plans for '{}' — two \
+                     blocks claim one source-indexed aux name",
+                    member.pretty(),
+                  ),
+                });
+              }
+              stt.below_call_site_plans.insert(member, new_plan.clone());
             }
             stt.below_call_site_plans.insert(below_name, new_plan);
           }

--- a/crates/compile/src/compile/surgery.rs
+++ b/crates/compile/src/compile/surgery.rs
@@ -198,6 +198,18 @@ pub fn rec_name_to_below_name(name: &Name) -> Option<Name> {
   }
 }
 
+/// Whether a `below_call_site_plans` key is the `.below`/`.below_N` HEAD
+/// (telescope `params, motives, indices, major` — surgery requires the
+/// full floor) as opposed to a Prop-below FAMILY member (a `.below`
+/// constructor or `.below.casesOn`, whose telescope starts with the
+/// below params — parent params then parent motives — and has no
+/// major-premise floor: a field-less below ctor is fully applied at
+/// exactly params+motives).
+pub fn below_plan_key_is_head(name: &Name) -> bool {
+  matches!(name.as_data(), NameData::Str(_, s, _)
+    if s == "below" || s.starts_with("below_"))
+}
+
 // ===========================================================================
 // Telescope utilities
 // ===========================================================================

--- a/crates/compile/src/decompile.rs
+++ b/crates/compile/src/decompile.rs
@@ -4246,10 +4246,8 @@ fn install_decompile_call_site_plans(
           family_names
             .push(Name::str(below_name.clone(), "casesOn".to_string()));
           for member in family_names {
-            let existing_differs = stt
-              .below_call_site_plans
-              .get(&member)
-              .map(|e| *e != new_plan);
+            let existing_differs =
+              stt.below_call_site_plans.get(&member).map(|e| *e != new_plan);
             match existing_differs {
               Some(true) => {
                 return Err(DecompileError::BadConstantFormat {

--- a/crates/compile/src/decompile.rs
+++ b/crates/compile/src/decompile.rs
@@ -4209,6 +4209,64 @@ fn install_decompile_call_site_plans(
           || env.contains_key(&below_name))
       {
         let new_plan = surgery::BRecOnCallSitePlan::from_rec_plan(&plan);
+        // Prop-level (IndPredBelow) `.below` families additionally expose
+        // constructors and a `.casesOn` wrapper to user code — mirror the
+        // compile side's family registration (same map; the apply site
+        // discriminates the telescope shape via
+        // `below_plan_key_is_head`). The below inductive itself is
+        // regenerated later (Phase 3), so at install time its ctor names
+        // are derived from the PARENT inductive's ctors via the same
+        // suffix transplant `build_below_indc_ctor` uses. Prop-ness is
+        // signalled by the presence of a `.below.rec` aux member
+        // (Type-level `.below` is a definition and has no recursor).
+        let is_prop_below = aux_members.iter().any(|(k, n)| {
+          *k == AuxKind::BelowRec
+            && matches!(n.as_data(),
+              ix_common::env::NameData::Str(p, _, _) if *p == below_name)
+        });
+        let parent_name = match below_name.as_data() {
+          ix_common::env::NameData::Str(p, _, _) => Some(p.clone()),
+          _ => None,
+        };
+        if is_prop_below
+          && let Some(parent_name) = parent_name
+          && let Some(parent_ci) = env.get(&parent_name)
+          && let LeanConstantInfo::InductInfo(pv) = &*parent_ci
+        {
+          let mut family_names: Vec<Name> = pv
+            .ctors
+            .iter()
+            .map(|ctor_name| {
+              let suffix = ctor_name
+                .strip_prefix(&parent_name)
+                .unwrap_or_else(|| ctor_name.components());
+              below_name.append_components(&suffix)
+            })
+            .collect();
+          family_names
+            .push(Name::str(below_name.clone(), "casesOn".to_string()));
+          for member in family_names {
+            let existing_differs = stt
+              .below_call_site_plans
+              .get(&member)
+              .map(|e| *e != new_plan);
+            match existing_differs {
+              Some(true) => {
+                return Err(DecompileError::BadConstantFormat {
+                  msg: format!(
+                    "conflicting below call-site plans for '{}' across \
+                     stored blocks",
+                    member.pretty(),
+                  ),
+                });
+              },
+              Some(false) => {},
+              None => {
+                stt.below_call_site_plans.insert(member, new_plan.clone());
+              },
+            }
+          }
+        }
         let existing_differs =
           stt.below_call_site_plans.get(&below_name).map(|e| *e != new_plan);
         match existing_differs {

--- a/crates/compile/src/kernel_egress.rs
+++ b/crates/compile/src/kernel_egress.rs
@@ -862,14 +862,23 @@ fn build_mut_const(
 }
 
 /// Build a fresh `Named` entry for a reconstructed constant, preserving
-/// the original's `meta` and `original` (aux_gen regeneration hint) fields
-/// but with an updated `addr`.
+/// the original's `meta`, `hints`, and `original` (aux_gen regeneration
+/// hint) fields but with an updated `addr`.
 ///
 /// Decompile's Pass 2 relies on `named.has_original()` to decide which
 /// entries are aux_gen-regenerated — we MUST copy that field over, or
 /// otherwise every `.brecOn*` / `.below` / `.brecOn_N.eq` gets dropped.
+///
+/// The per-name `hints` channel must survive too: decompile reconstructs
+/// `DefinitionVal.hints` from `Named.hints` (absent → `Opaque`), and the
+/// aux-regen roundtrip validates the decompiled constant's Lean-level
+/// hash — which includes hints — against the source env. Dropping the
+/// channel here made every regenerated `.casesOn`/`.recOn`/`.below`/
+/// `.brecOn` fail that validation (`Opaque` vs `Abbrev`) on the kernel
+/// egress leg, discarding the metadata-restored form.
 fn rebuild_named(addr: Address, original: &Named) -> Named {
   let mut named = Named::new(addr, (*original.meta()).clone());
+  named.set_hints(original.hints());
   if let Some((orig_addr, orig_meta)) = original.original() {
     named.set_original(orig_addr, (*orig_meta).clone());
   }

--- a/crates/kernel/src/infer.rs
+++ b/crates/kernel/src/infer.rs
@@ -152,33 +152,39 @@ impl<M: KernelMode> TypeChecker<'_, M> {
               // error — what's useful here is the post-whnf forms and
               // whether they converge under `is_def_eq`'s lazy unfold
               // strategy.
+              //
+              // stderr, not the log facade: no log backend is installed
+              // in the CLI or test binaries, so `log::info!` dumps are
+              // silently dropped (same fix as the inductive.rs
+              // canonicity dumps).
               let a_whnf = self.whnf(&a_ty);
               let d_whnf = self.whnf(&dom);
               let depth = crate::env_var("IX_APP_DIFF_DEPTH")
                 .ok()
                 .and_then(|s| s.parse::<usize>().ok())
                 .unwrap_or(2);
-              log::info!(
-                "[app diff] AppTypeMismatch at depth={}",
-                self.ctx.len()
+              eprintln!(
+                "[app diff] AppTypeMismatch at depth={} in {}",
+                self.ctx.len(),
+                self.debug_label.as_deref().unwrap_or("<unknown>")
               );
-              log::info!("  f:          {}", compact_expr(f));
-              log::info!("  a:          {}", compact_expr(a));
-              log::info!("  a_ty:       {}", compact_expr_deep(&a_ty, depth));
-              log::info!("  dom:        {}", compact_expr_deep(&dom, depth));
-              log::info!("  a_ty data:  {:?}", a_ty.data());
-              log::info!("  dom data:   {:?}", dom.data());
+              eprintln!("  f:          {}", compact_expr(f));
+              eprintln!("  a:          {}", compact_expr(a));
+              eprintln!("  a_ty:       {}", compact_expr_deep(&a_ty, depth));
+              eprintln!("  dom:        {}", compact_expr_deep(&dom, depth));
+              eprintln!("  a_ty data:  {:?}", a_ty.data());
+              eprintln!("  dom data:   {:?}", dom.data());
               match &a_whnf {
                 Ok(w) => {
-                  log::info!("  a_ty whnf:  {}", compact_expr_deep(w, depth))
+                  eprintln!("  a_ty whnf:  {}", compact_expr_deep(w, depth))
                 },
-                Err(e) => log::info!("  a_ty whnf:  ERR {e}"),
+                Err(e) => eprintln!("  a_ty whnf:  ERR {e}"),
               }
               match &d_whnf {
                 Ok(w) => {
-                  log::info!("  dom  whnf:  {}", compact_expr_deep(w, depth))
+                  eprintln!("  dom  whnf:  {}", compact_expr_deep(w, depth))
                 },
-                Err(e) => log::info!("  dom  whnf:  ERR {e}"),
+                Err(e) => eprintln!("  dom  whnf:  ERR {e}"),
               }
             }
             return Err(TcError::AppTypeMismatch {


### PR DESCRIPTION
Fixes the two failures in the post-v4.33 (#572) ignored sweep:

```
kernel-check-env       × Kernel check failed with 2 failure(s)
kernel-ixon-roundtrip  × 50 roundtrip mismatches
```

Both are latent bugs that the toolchain bump exposed, not regressions in #572
itself. Neither suite runs in PR CI (`--ignored`), so they surfaced only on a
local sweep.

## Bug 1 — Prop-mutual `.below` families: ctors and `below.casesOn` had no call-site surgery (`kernel-check-env`)

The two failing constants were the `_private.…BelowPredicate.{oddp,evenp}_nonneg.match_2`
matchers from #571's Prop-mutual fixture, rejected by the kernel with
`AppTypeMismatch at depth=0`.

**Mechanism.** On a Prop-valued *mutual* inductive-predicate family,
IndPredBelow's `.below` is itself a mutual inductive whose parameters are the
parent params followed by the parent **motives — in Lean's source member
order**. Our canonical below family is generated from the canonical parent
recursor, so its motive-parameter order follows `sort_consts`' canonical class
order instead. The two orders coincided for `EvenP`/`OddP` until the v4.33
content hashes flipped the structural sort to `(OddP, EvenP)`:

```
[compile.sort_consts] iter 1 → classes:      # BelowPredicate parent block
  c[0][0] …BelowPredicate.OddP
  c[1][0] …BelowPredicate.EvenP
```

User references to `X.below` **heads** are already reconciled by
`below_call_site_plans`, and `X.brecOn` by its derived plans. But a Prop-level
below family exposes two more user-referencable surfaces with the same leading
`params, motives` telescope, and neither had a plan:

- the **below constructors** (`OddP.below.succ`, `EvenP.below.zero`, …), and
- the regenerated **`X.below.casesOn`** wrapper.

Matchers compiled by structural recursion over the predicates reference both
with source-order motives. `IX_APP_DIFF` (see Bug 3) showed the kernel's
canonical `OddP.below.succ` receiving the EvenP motive where it expects OddP's:

```
f:    OddP.below.succ
a_ty: forall (n : Nat), EvenP n -> Prop     # what the matcher passes (source order)
dom:  forall (n : Nat), OddP  n -> Prop     # what the canonical ctor expects
```

**Fix.** Register the same derived `BRecOnCallSitePlan` under each below-ctor
name and the `.below.casesOn` name (Prop families only — Type-level `.below`
is a definition with neither), in the existing `below_call_site_plans` map.
The apply site discriminates the two telescope shapes by the key's last
component (`below`/`below_N` = head, which keeps its indices+major application
floor; anything else = family member, with **no** floor, since a field-less
below ctor like `EvenP.below.zero` is fully applied at exactly
params+motives). In both shapes everything after the motive segment is kept in
place, so the below branch now emits one identity tail — byte-identical
entries to the old fixed/extra split for heads. `X.below.rec` is deliberately
not registered: only regenerated wrappers reference it, and those skip surgery
via the aux-regen guard.

Mirrored in lockstep across the Rust and pure-Lean compilers (apply branch,
compile-side registration, decompile-side plan install — the latter derives
the ctor names from the parent inductive via the same suffix transplant
`buildBelowIndcCtor` uses, since the below inductive is not yet regenerated at
install time). CallSite metadata makes the rewrite self-describing, so the
decompiler restores the source-order spelling with no changes.

This keeps the canonicity architecture as documented (§9.3/§17.2: canonical
bytes are hash-sorted; the Lean-facing view is restored via surgery metadata),
rather than source-ordering the below generation — the alternative considered
and rejected because it would re-introduce source-order dependence into
canonical content.

## Bug 2 — `ixon_egress` dropped the per-name `hints` channel (`kernel-ixon-roundtrip`)

The reported "50 mismatches" is `compare_envs`' error cap, not the total; all
were `X.below.casesOn` of inductive *predicates* (`Nat.le`, `List.Forall₂`,
`Std.DHashMap.Raw.WF`, …) whose IH binder decompiled as a bare `ih` where
v4.33's IndPredBelow now writes hygienic `ih._@.<module>.<hash>._hygCtx._hyg.N`
names.

**Mechanism.** `kernel_egress.rs::rebuild_named` copied a `Named` entry's
`meta` and `original` fields but dropped **`hints`**. Decompile reconstructs
`DefinitionVal.hints` from that per-name channel (absent → `Opaque`), and
`roundtrip_block` Phase B validates each decompiled aux constant's Lean-level
hash — which includes hints — against the source env. On the kernel egress leg
every regenerated `.casesOn`/`.recOn`/`.below`/`.brecOn` therefore failed that
validation (`Opaque` vs `Abbrev`; 4,846 spurious Pass-2 errors on a full env),
recovery's own hash check failed the same way, and the **raw generated** form
shipped in place of the metadata-restored one.

That substitution was invisible while raw regeneration was name-faithful. It
became visible once two things landed on top of it: #571's Phase-3b
`below.casesOn` regeneration (whose below-rec input is regenerated in the
decompile work env, where the original below ctors are not yet present, so the
IH binder name falls back to a bare `ih`), and v4.33's `_hygCtx` hygienic
binder names, which made the fallback diverge from the original for every
inductive predicate's `below.casesOn`.

**Fix.** One line: carry `hints` through `rebuild_named` (plus the doc
comment). Phase B's metadata restoration now lands, which also shields the
Lean-facing env from any future generation-side binder-name drift.

## Bug 3 — the kernel's `[app diff]` dump was silently dropped

`IX_APP_DIFF`'s AppTypeMismatch trace logged through the `log` facade, but no
log backend is installed in the CLI or test binaries — the same failure mode
#571's first patch fixed for the inductive.rs canonicity dumps. Emitted on
stderr now, with the failing constant's debug label in the header. (This dump
is how Bug 1 was diagnosed.)

## Tests / tooling

- `focusConsts` gains the two BelowPredicate `match_2` matchers, so
  `kernel-check-const` reproduces this regression class in ~10s
  (`IX_KERNEL_FOCUS_CONST=match_2 lake test -- kernel-check-const --ignored`).
- `Tests/Main.lean` gains a `kernel-roundtrip-ns=<prefixes>` special arg
  mirroring `rust-compile`: the same compile → ingress → egress → decompile →
  hash-compare pipeline as `kernel-ixon-roundtrip`, but over the transitive
  closure of the name-prefix-matched constants only.
  `kernel-roundtrip-ns=Nat.le` reproduced Bug 2 on a 98-constant closure in
  40 ms.

## Verification

- `kernel-check-env`: **219,554/219,554 passed** (was 219,549/219,551)
- `kernel-ixon-roundtrip`: **169,194 constants verified, 0 errors** (the old
  run stopped at the 50-error cap partway through the env); Pass-2
  `aux_gen diff` errors: **4,846 → 0**
- `validate-aux`: 0 failures; `aux-gen-diff`: all gates PASS (Lean/Rust
  byte-identical, incl. plans + parallel driver gates); `decompile-diff`: all
  gates PASS incl. callsite-replay
- Full sweep `lake test -- --ignored
  --exclude=tc-pins,tc-accel-diff,tc-anon-diff,tc-init,tc-tutorial,tc-roundtrip,lean4lean`
  → exit 0

## Non-blocking observations

- The `[compile_env] block FAILED inductBadNonSort*/inductTooFewParams/r6Host.mk`
  stderr lines during the sweep are expected kernel-tutorial noise
  (intentionally-bad fixtures being rejected). However, `r6Host` is now
  rejected at *compile* time (`missing constant: r6Host.rec_1` — the fixture
  env lacks the nested-aux recursor a real Lean env would carry) rather than
  by the kernel positivity descent it was written to exercise. Follow-up: give
  the fixture a dummy `rec_1` so the R6 descent path is exercised again.
- `X.below.rec` heads and partial applications of below-family constants below
  the params+motives floor remain outside surgery's reach, matching the
  existing `below`/`brecOn` head behavior — such call sites fail loudly in the
  kernel check rather than silently miscompiling.
  
  ## Also in this PR

- `style: rustfmt` — one over-split chain in the new plan-registration code.
- `ci: portable codegen for the GitHub-hosted rust-test job` — the lint job's
  clippy failure was not a lint: since #575 made `.cargo/config.toml`'s
  `-Ctarget-cpu=native` authoritative in CI, the one job on the heterogeneous
  `ubuntu-latest` fleet could execute native-built cached artifacts (e.g. a
  `tracing-attributes` proc-macro dylib inside `clippy-driver`) on a runner
  without the builder's ISA extensions → SIGILL; `nextest --run-ignored all`
  had the same runtime exposure. Pin that job to `-Ctarget-cpu=x86-64-v3`
  (the GitHub-hosted AVX2 baseline) — RUSTFLAGS is in the rust-cache key, so
  this also re-keys away from poisoned caches. Warp jobs keep `native` per
  #575's bench design. Affects every PR's CI, so this hunk can be
  cherry-picked to main independently if preferred.
