### PR TITLE
 perf: decompile Pass-2 restructure + compile hot-path batch (post-#572 perf pass)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ panic = "abort"
 
 [profile.release]
 panic = "abort"
+# Cross-crate inlining across the ixon/compile/ffi boundary — the hot
+# loops (blake3 digests, subterm sharing, serialization) span crates.
+# "thin" keeps build times tolerable vs "fat" for near-equal wins.
+lto = "thin"
 
 [workspace.package]
 version = "0.1.0"

--- a/Ix/AuxGen/Kernel.lean
+++ b/Ix/AuxGen/Kernel.lean
@@ -137,6 +137,15 @@ partial def kunivToLevel (u : MKUniv) (paramNames : Array Name) : Level :=
 structure AuxKernelCtx where
   tcState : Ix.Tc.TcState .meta
   ingressCache : Std.HashMap (Address × Address) MKExpr := {}
+  /-- Mirrors Rust `KernelCtx.aux_ingress_seen`: ids whose
+      `ingressAuxGenDep` dispatch already ran against this kenv. The
+      dispatch is deterministic per constant kind, so a seen id is at
+      final kenv fidelity and the ingress walkers skip re-expanding its
+      reference closure. Keyed by resolved id (not bare name) so an
+      address shifted by later aux registration reads as unseen. Lives
+      as long as the kenv (this ctx never clears — see the Pass-2
+      driver's KENV_CLEAR note). -/
+  auxIngressSeen : Std.HashSet MKId := {}
 
 /-- Fresh bridge context: empty Meta kenv, canonical prim addresses with
     no resolver (prim KIds get synthetic display names; the accelerations
@@ -343,7 +352,7 @@ def ensurePreludeInKenvOf (maps : AddrMaps) : KBridgeM Unit := do
     deps surface as `unknownConst` at TC time and are faulted in).
     Mirrors Rust `ensure_in_kenv_of_inner_env` (expr_utils.rs:1944). -/
 partial def ensureInKenvOfInner (name : Name) (maps : AddrMaps)
-    (replaceAxioStub : Bool) : KBridgeM Unit := do
+    (replaceAxioStub : Bool) (stubProofValues : Bool) : KBridgeM Unit := do
   let addr := maps.resolve name
   let zid : MKId := ⟨addr, name⟩
 
@@ -380,15 +389,26 @@ partial def ensureInKenvOfInner (name : Name) (maps : AddrMaps)
   | .thmInfo d =>
     let lp := d.cnst.levelParams
     let ty ← leanExprToKexpr d.cnst.type lp maps
-    let val ← leanExprToKexpr d.value lp maps
-    kenvInsert zid (.defn name lp .thm .safe .opaque
-      (UInt64.ofNat lp.size) ty val #[] zid)
+    -- Prewarm callers stub the proof (type-only `.axio`, the exact
+    -- fidelity `ingressTypeStub` gives thms) — kernel TC never unfolds
+    -- theorem values (proof irrelevance). Mirrors the Rust
+    -- `stub_proof_values` branch.
+    if stubProofValues then
+      kenvInsert zid (.axio name lp false (UInt64.ofNat lp.size) ty)
+    else
+      let val ← leanExprToKexpr d.value lp maps
+      kenvInsert zid (.defn name lp .thm .safe .opaque
+        (UInt64.ofNat lp.size) ty val #[] zid)
   | .opaqueInfo d =>
     let lp := d.cnst.levelParams
     let ty ← leanExprToKexpr d.cnst.type lp maps
-    let val ← leanExprToKexpr d.value lp maps
-    kenvInsert zid (.defn name lp .opaq .safe .opaque
-      (UInt64.ofNat lp.size) ty val #[] zid)
+    -- Same as the thm arm: opaque values are opaque to defeq.
+    if stubProofValues then
+      kenvInsert zid (.axio name lp false (UInt64.ofNat lp.size) ty)
+    else
+      let val ← leanExprToKexpr d.value lp maps
+      kenvInsert zid (.defn name lp .opaq .safe .opaque
+        (UInt64.ofNat lp.size) ty val #[] zid)
   | .axiomInfo a =>
     let lp := a.cnst.levelParams
     let ty ← leanExprToKexpr a.cnst.type lp maps
@@ -399,19 +419,25 @@ partial def ensureInKenvOfInner (name : Name) (maps : AddrMaps)
     kenvInsert zid (.quot name lp (quotKindOfLean q.kind) (UInt64.ofNat lp.size) ty)
   | .ctorInfo ctor =>
     -- Constructors ingress via their parent (the one downstream walk).
-    ensureInKenvOfInner ctor.induct maps replaceAxioStub
+    ensureInKenvOfInner ctor.induct maps replaceAxioStub stubProofValues
   | .recInfo _ =>
     -- Recursors are kernel-generated, never ingressed from Lean.
     pure ()
 
 /-- Mirrors Rust `ensure_in_kenv_of` (expr_utils.rs:2162). -/
 def ensureInKenvOf (name : Name) (maps : AddrMaps) : KBridgeM Unit :=
-  ensureInKenvOfInner name maps false
+  ensureInKenvOfInner name maps false false
 
 /-- Stub-upgrading variant (Rust `ensure_full_in_kenv_of`,
     expr_utils.rs:2174). -/
 def ensureFullInKenvOf (name : Name) (maps : AddrMaps) : KBridgeM Unit :=
-  ensureInKenvOfInner name maps true
+  ensureInKenvOfInner name maps true false
+
+/-- Bulk pre-warm variant (Rust `ensure_in_kenv_of_prewarm`): theorem /
+    opaque values ingress as type-only stubs — sufficient for kernel TC
+    and the dominant share of Pass-2 kenv memory otherwise. -/
+def ensureInKenvOfPrewarm (name : Name) (maps : AddrMaps) : KBridgeM Unit :=
+  ensureInKenvOfInner name maps false true
 
 /-! ## Open-term conversion (FVar context) -/
 

--- a/Ix/AuxGen/Recursor.lean
+++ b/Ix/AuxGen/Recursor.lean
@@ -1391,13 +1391,19 @@ failure here surfaces as a hard error, never a silent fallback. -/
 
     Collect all constant names referenced in an expression, appended onto
     `out` (a work queue, NOT a set — dedup happens at the consumer's
-    `seen`). Explicit stack, matching the Rust traversal order. -/
+    `seen`). Explicit stack, matching the Rust traversal order, with a
+    digest-keyed visited set so structurally shared subterms are walked
+    once (DAG cost, not unshared-tree cost). -/
 def collectConstRefs (expr : Expr) (out : Array Name) : Array Name := Id.run do
   let mut out := out
+  let mut visited : Std.HashSet Address := {}
   let mut stack : Array Expr := #[expr]
   repeat
     if let some e := stack.back? then
       stack := stack.pop
+      if visited.contains e.getHash then
+        continue
+      visited := visited.insert e.getHash
       match e with
       | .const n _ _ => out := out.push n
       | .app f a _ =>
@@ -1473,24 +1479,37 @@ def ingressAuxGenDep (name : Name) (ci : ConstantInfo) (maps : AddrMaps)
     ingressTypeStub name v.cnst.type v.cnst.levelParams maps
     return collectConstRefs v.cnst.type queue
 
+/-- Mirrors Rust `drain_ingress_queue` (recursor.rs).
+
+    Drain a worklist of names through `ingressAuxGenDep`, deduplicated
+    against the kenv-lifetime `auxIngressSeen` (resolved-id-keyed — see
+    the `AuxKernelCtx` field docs) instead of a per-call set: the
+    dispatch is deterministic per constant kind, so a seen id is already
+    at final kenv fidelity and re-expanding its closure would be pure
+    cost. -/
+def drainIngressQueue (queue₀ : Array Name) (maps : AddrMaps) :
+    KBridgeM Unit := do
+  let mut queue := queue₀
+  repeat
+    let some name := queue.back? | break
+    queue := queue.pop
+    let zid : MKId := ⟨maps.resolve name, name⟩
+    if (← get).auxIngressSeen.contains zid then
+      continue
+    modify fun kctx =>
+      { kctx with auxIngressSeen := kctx.auxIngressSeen.insert zid }
+    if let some ci ← lookupConst? name then
+      queue ← ingressAuxGenDep name ci maps queue
+  return ()
+
 /-- Mirrors Rust `ingress_target_type_deps` (recursor.rs:2548).
 
     Ingress constants referenced by an inductive target type with enough
     fidelity for WHNF (target aliases like `Set α := α → Prop` must
     unfold). -/
 def ingressTargetTypeDeps (targetTy : Expr) (maps : AddrMaps) :
-    KBridgeM Unit := do
-  let mut seen : Std.HashSet Name := {}
-  let mut queue : Array Name := collectConstRefs targetTy #[]
-  repeat
-    let some name := queue.back? | break
-    queue := queue.pop
-    if seen.contains name then
-      continue
-    seen := seen.insert name
-    if let some ci ← lookupConst? name then
-      queue ← ingressAuxGenDep name ci maps queue
-  return ()
+    KBridgeM Unit :=
+  drainIngressQueue (collectConstRefs targetTy #[]) maps
 
 /-- Mirrors Rust `ingress_field_deps` (recursor.rs:2572).
 
@@ -1501,19 +1520,10 @@ def ingressTargetTypeDeps (targetTy : Expr) (maps : AddrMaps) :
     otherwise). -/
 def ingressFieldDeps (cls : FlatInfo) (_lvlParams : Array Name)
     (maps : AddrMaps) : KBridgeM Unit := do
-  let mut seen : Std.HashSet Name := {}
   let mut queue : Array Name := #[]
   for ctor in cls.ctors do
     queue := collectConstRefs ctor.cnst.type queue
-  repeat
-    let some name := queue.back? | break
-    queue := queue.pop
-    if seen.contains name then
-      continue
-    seen := seen.insert name
-    let some ci ← lookupConst? name | continue
-    queue ← ingressAuxGenDep name ci maps queue
-  return ()
+  drainIngressQueue queue maps
 
 /-- Mirrors Rust `peek_result_sort` (recursor.rs:2732).
 

--- a/Ix/DecompileDriver.lean
+++ b/Ix/DecompileDriver.lean
@@ -1044,7 +1044,7 @@ def decompileEnvPass2 (ixonEnv : Ixon.Env)
             stack := stack.push r
     match runK ctx st blockKey (fun maps => do
         for n in toIngress do
-          Ix.AuxGen.ensureInKenvOf n maps) with
+          Ix.AuxGen.ensureInKenvOfPrewarm n maps) with
     | .ok (_, kctx') => st := { st with kctx := kctx' }
     | .error e =>
       let errs := st.errors.push (blockKey, s!"block ingress: {e}")
@@ -1153,7 +1153,7 @@ def decompileEnvPass2Parallel (ixonEnv : Ixon.Env)
             stack := stack.push r
     match runK ctx st blockKey (fun maps => do
         for n in toIngress do
-          Ix.AuxGen.ensureInKenvOf n maps) with
+          Ix.AuxGen.ensureInKenvOfPrewarm n maps) with
     | .ok (_, kctx') => st := { st with kctx := kctx' }
     | .error e =>
       st := { st with

--- a/crates/compile/src/compile.rs
+++ b/crates/compile/src/compile.rs
@@ -103,6 +103,17 @@ pub struct KernelCtx {
   /// addresses that may shift as alpha-collapse reassigns addresses over
   /// the course of compilation.
   pub kenv: ix_kernel::env::KEnv<ix_kernel::mode::Meta>,
+  /// Ids whose `ingress_aux_gen_dep` dispatch has already run against
+  /// `kenv`. The dispatch is a deterministic function of the constant's
+  /// kind, so once an id is here its kenv entry is at final fidelity and
+  /// the walkers skip re-expanding its whole reference closure (that
+  /// re-expansion was Θ(blocks × closure) when the set lived per call).
+  /// Keyed by resolved `KId` — not bare `Name` — so an address shifted
+  /// by later aux registration reads as unseen and re-ingresses under
+  /// the new id, exactly as the per-call sets healed it. Must be cleared
+  /// together with `kenv` (the entries it vouches for die with it).
+  pub aux_ingress_seen:
+    rustc_hash::FxHashSet<ix_kernel::id::KId<ix_kernel::mode::Meta>>,
 }
 
 impl Default for KernelCtx {
@@ -113,7 +124,10 @@ impl Default for KernelCtx {
 
 impl KernelCtx {
   pub fn new() -> Self {
-    KernelCtx { kenv: ix_kernel::env::KEnv::new() }
+    KernelCtx {
+      kenv: ix_kernel::env::KEnv::new(),
+      aux_ingress_seen: rustc_hash::FxHashSet::default(),
+    }
   }
 }
 
@@ -1987,7 +2001,7 @@ struct SharingResult {
 /// This is the theoretical size if each unique subterm were stored once in a content-addressed store.
 /// Each unique expression = 32-byte key + value (with 32-byte hash references for children/externals).
 fn compute_hash_consed_size(
-  info_map: &std::collections::HashMap<blake3::Hash, sharing::SubtermInfo>,
+  info_map: &FxHashMap<blake3::Hash, sharing::SubtermInfo>,
 ) -> usize {
   info_map.values().map(|info| info.hash_consed_size).sum()
 }
@@ -2353,6 +2367,7 @@ enum MutConstKind {
 pub fn compile_definition(
   def: &Def,
   mut_ctx: &MutCtx,
+  ctx_addrs: &[Address],
   cache: &mut BlockCache,
   stt: &CompileState,
 ) -> Result<(Definition, ConstantMeta), CompileError> {
@@ -2382,8 +2397,7 @@ pub fn compile_definition(
     univ_params.iter().map(|n| compile_name(n, stt)).collect();
   let all_addrs: Vec<Address> =
     def.all.iter().map(|n| compile_name(n, stt)).collect();
-  let ctx_addrs: Vec<Address> =
-    ctx_to_all(mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
+  let ctx_addrs: Vec<Address> = ctx_addrs.to_vec();
 
   let data = Definition {
     kind: def.kind,
@@ -2430,6 +2444,7 @@ fn compile_recursor_rule(
 pub fn compile_recursor(
   rec: &Rec,
   mut_ctx: &MutCtx,
+  ctx_addrs: &[Address],
   cache: &mut BlockCache,
   stt: &CompileState,
 ) -> Result<(Recursor, ConstantMeta), CompileError> {
@@ -2486,8 +2501,7 @@ pub fn compile_recursor(
 
   let all_addrs: Vec<Address> =
     rec.all.iter().map(|n| compile_name(n, stt)).collect();
-  let ctx_addrs: Vec<Address> =
-    ctx_to_all(mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
+  let ctx_addrs: Vec<Address> = ctx_addrs.to_vec();
 
   let mut meta = ConstantMeta::new(ConstantMetaInfo::Rec {
     name: name_addr,
@@ -2571,6 +2585,7 @@ fn compile_constructor(
 pub fn compile_inductive(
   ind: &Ind,
   mut_ctx: &MutCtx,
+  ctx_addrs: &[Address],
   cache: &mut BlockCache,
   stt: &CompileState,
 ) -> Result<(Inductive, ConstantMeta, Vec<ConstantMeta>), CompileError> {
@@ -2625,8 +2640,7 @@ pub fn compile_inductive(
 
   let all_addrs: Vec<Address> =
     ind.ind.all.iter().map(|n| compile_name(n, stt)).collect();
-  let ctx_addrs: Vec<Address> =
-    ctx_to_all(mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
+  let ctx_addrs: Vec<Address> = ctx_addrs.to_vec();
 
   let mut meta = ConstantMeta::new(ConstantMetaInfo::Indc {
     name: name_addr,
@@ -3679,7 +3693,10 @@ fn compile_const_inner(
       stt,
       "compile_single_def",
     )?;
-    let (data, meta) = compile_definition(def, &mut_ctx, cache, stt)?;
+    let ctx_addrs: Vec<Address> =
+      ctx_to_all(&mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
+    let (data, meta) =
+      compile_definition(def, &mut_ctx, &ctx_addrs, cache, stt)?;
     let _t_compile = _t0.elapsed();
     let n_unique_exprs = cache.exprs.len();
     let refs: Vec<Address> = cache.refs.iter().cloned().collect();
@@ -3834,7 +3851,10 @@ fn compile_const_inner(
           exprs.push((&rule.rhs, val.cnst.level_params.as_slice()));
         }
         preseed_expr_tables(&exprs, &mut_ctx, cache, stt, "compile_recursor")?;
-        let (data, meta) = compile_recursor(val, &mut_ctx, cache, stt)?;
+        let ctx_addrs: Vec<Address> =
+          ctx_to_all(&mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
+        let (data, meta) =
+          compile_recursor(val, &mut_ctx, &ctx_addrs, cache, stt)?;
         let refs: Vec<Address> = cache.refs.iter().cloned().collect();
         let univs: Vec<Arc<Univ>> = cache.univs.iter().cloned().collect();
         let result = apply_sharing_to_recursor_with_stats(data, refs, univs);
@@ -3942,9 +3962,13 @@ fn compile_mutual(
   }
   preseed_expr_tables(&exprs, &mut_ctx, cache, stt, "compile_mutual")?;
 
-  // Compile each constant
+  // Compile each constant. The block-context address list is identical
+  // for every member (a deterministic function of `mut_ctx`), so it is
+  // computed once here instead of sorted+re-interned per member.
   let mut ixon_mutuals = Vec::new();
   let mut all_metas: FxHashMap<Name, ConstantMeta> = FxHashMap::default();
+  let ctx_addrs: Vec<Address> =
+    ctx_to_all(&mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
 
   for class in &sorted_classes {
     // Only push one representative per equivalence class into ixon_mutuals,
@@ -3954,7 +3978,8 @@ fn compile_mutual(
     for cnst in class {
       match cnst {
         MutConst::Defn(def) => {
-          let (data, meta) = compile_definition(def, &mut_ctx, cache, stt)?;
+          let (data, meta) =
+            compile_definition(def, &mut_ctx, &ctx_addrs, cache, stt)?;
           if !representative_pushed {
             ixon_mutuals.push(IxonMutConst::Defn(data));
             representative_pushed = true;
@@ -3963,7 +3988,7 @@ fn compile_mutual(
         },
         MutConst::Indc(ind) => {
           let (data, meta, ctor_metas_vec) =
-            compile_inductive(ind, &mut_ctx, cache, stt)?;
+            compile_inductive(ind, &mut_ctx, &ctx_addrs, cache, stt)?;
           if !representative_pushed {
             ixon_mutuals.push(IxonMutConst::Indc(data));
             representative_pushed = true;
@@ -3975,7 +4000,8 @@ fn compile_mutual(
           all_metas.insert(ind.ind.cnst.name.clone(), meta);
         },
         MutConst::Recr(rec) => {
-          let (data, meta) = compile_recursor(rec, &mut_ctx, cache, stt)?;
+          let (data, meta) =
+            compile_recursor(rec, &mut_ctx, &ctx_addrs, cache, stt)?;
           if !representative_pushed {
             ixon_mutuals.push(IxonMutConst::Recr(data));
             representative_pushed = true;
@@ -4034,7 +4060,9 @@ fn compile_mutual(
       for class in &sorted_classes {
         for cnst in class {
           let n = cnst.name();
-          let meta = all_metas.get(&n).cloned().unwrap_or_default();
+          // `remove`, not `get().cloned()`: each name is consumed exactly
+          // once, and ConstantMeta is an arena-sized deep clone.
+          let meta = all_metas.remove(&n).unwrap_or_default();
           stt.env.register_name(n.clone(), Named::new(addr.clone(), meta));
           stt.name_to_addr.insert(n.clone(), addr.clone());
         }
@@ -4043,7 +4071,7 @@ fn compile_mutual(
       for class in &sorted_classes {
         for cnst in class {
           let n = cnst.name();
-          let meta = all_metas.get(&n).cloned().unwrap_or_default();
+          let meta = all_metas.remove(&n).unwrap_or_default();
           stt.promote_aux(&n, addr.clone(), meta)?;
         }
       }
@@ -4087,7 +4115,9 @@ fn compile_mutual(
   for class in &sorted_classes {
     for cnst in class {
       let n = cnst.name();
-      let meta = all_metas.get(&n).cloned().unwrap_or_default();
+      // `remove`: consumed once per name (either the register_name arm
+      // or the promote_aux arm below), so no deep clone is needed.
+      let meta = all_metas.remove(&n).unwrap_or_default();
 
       let proj = match cnst {
         MutConst::Defn(_) => defn_proj_constant(idx, block_addr.clone()),
@@ -4099,10 +4129,9 @@ fn compile_mutual(
           let proj_addr = Address::hash(&proj_bytes);
           if aux {
             stt.env.store_const(proj_addr.clone(), indc_proj);
-            stt.env.register_name(
-              n.clone(),
-              Named::new(proj_addr.clone(), meta.clone()),
-            );
+            stt
+              .env
+              .register_name(n.clone(), Named::new(proj_addr.clone(), meta));
             stt.name_to_addr.insert(n.clone(), proj_addr.clone());
           } else {
             stt.promote_aux(&n, proj_addr, meta)?;
@@ -4111,7 +4140,7 @@ fn compile_mutual(
           // Constructor projections
           for (cidx, ctor) in ind.ctors.iter().enumerate() {
             let ctor_meta =
-              all_metas.get(&ctor.cnst.name).cloned().unwrap_or_default();
+              all_metas.remove(&ctor.cnst.name).unwrap_or_default();
             let ctor_proj =
               ctor_proj_constant(idx, cidx as u64, block_addr.clone());
             let mut ctor_bytes = Vec::new();
@@ -4121,7 +4150,7 @@ fn compile_mutual(
               stt.env.store_const(ctor_addr.clone(), ctor_proj);
               stt.env.register_name(
                 ctor.cnst.name.clone(),
-                Named::new(ctor_addr.clone(), ctor_meta.clone()),
+                Named::new(ctor_addr.clone(), ctor_meta),
               );
               stt.name_to_addr.insert(ctor.cnst.name.clone(), ctor_addr);
             } else {
@@ -4139,10 +4168,7 @@ fn compile_mutual(
       let proj_addr = Address::hash(&proj_bytes);
       if aux {
         stt.env.store_const(proj_addr.clone(), proj);
-        stt.env.register_name(
-          n.clone(),
-          Named::new(proj_addr.clone(), meta.clone()),
-        );
+        stt.env.register_name(n.clone(), Named::new(proj_addr.clone(), meta));
         stt.name_to_addr.insert(n.clone(), proj_addr);
       } else {
         stt.promote_aux(&n, proj_addr, meta)?;

--- a/crates/compile/src/compile/aux_gen/expr_utils.rs
+++ b/crates/compile/src/compile/aux_gen/expr_utils.rs
@@ -1969,6 +1969,7 @@ fn ensure_in_kenv_of_inner_env(
   stt: &crate::compile::CompileState,
   kenv: &mut ix_kernel::env::KEnv<Meta>,
   replace_axio_stub: bool,
+  stub_proof_values: bool,
 ) {
   use ix_common::env::{ConstantInfo as LCI, DefinitionSafety};
   use ix_kernel::constant::KConst;
@@ -2083,6 +2084,25 @@ fn ensure_in_kenv_of_inner_env(
     LCI::ThmInfo(d) => {
       let lp = &d.cnst.level_params;
       let ty = to_z(&d.cnst.typ, lp, kenv);
+      // Prewarm callers stub the proof: theorem values are never
+      // delta-unfolded by kernel TC (Prop defeq short-circuits on proof
+      // irrelevance), so the aux_gen phases only ever read the TYPE —
+      // the same fidelity `ingress_type_stub` gives thms it discovers
+      // itself. Full ingestion of every walked proof term was the
+      // dominant share of Pass-2 kenv RSS.
+      if stub_proof_values {
+        kenv.insert(
+          zid.clone(),
+          KConst::Axio {
+            name: name.clone(),
+            level_params: lp.clone(),
+            is_unsafe: false,
+            lvls: lp.len() as u64,
+            ty,
+          },
+        );
+        return;
+      }
       let val = to_z(&d.value, lp, kenv);
       kenv.insert(
         zid.clone(),
@@ -2103,6 +2123,21 @@ fn ensure_in_kenv_of_inner_env(
     LCI::OpaqueInfo(d) => {
       let lp = &d.cnst.level_params;
       let ty = to_z(&d.cnst.typ, lp, kenv);
+      // Same as the ThmInfo arm: opaque values are opaque to kernel
+      // defeq by definition, so prewarm callers keep the type only.
+      if stub_proof_values {
+        kenv.insert(
+          zid.clone(),
+          KConst::Axio {
+            name: name.clone(),
+            level_params: lp.clone(),
+            is_unsafe: false,
+            lvls: lp.len() as u64,
+            ty,
+          },
+        );
+        return;
+      }
       let val = to_z(&d.value, lp, kenv);
       kenv.insert(
         zid.clone(),
@@ -2156,6 +2191,7 @@ fn ensure_in_kenv_of_inner_env(
         stt,
         kenv,
         replace_axio_stub,
+        stub_proof_values,
       );
     },
     LCI::RecInfo(_) => {
@@ -2178,6 +2214,7 @@ fn ensure_in_kenv_of_inner(
     stt,
     &mut kctx.kenv,
     replace_axio_stub,
+    false,
   );
 }
 
@@ -2188,6 +2225,22 @@ pub fn ensure_in_kenv_of(
   kctx: &mut crate::compile::KernelCtx,
 ) {
   ensure_in_kenv_of_inner(name, lean_env, stt, kctx, false);
+}
+
+/// [`ensure_in_kenv_of`] for bulk pre-warm walks (decompile Pass 2's
+/// ingress BFS): theorem/opaque VALUES are replaced by type-only `Axio`
+/// stubs — the exact fidelity `ingress_type_stub` gives thms the
+/// gen-phase walkers discover themselves, and sufficient for kernel TC
+/// (proof irrelevance; opaque values are never unfolded). Everything
+/// else ingresses exactly as [`ensure_in_kenv_of`]. Cuts the dominant
+/// share of Pass-2 kenv RSS, which is what forced the periodic clears.
+pub fn ensure_in_kenv_of_prewarm(
+  name: &Name,
+  lean_env: &ix_common::env::Env,
+  stt: &crate::compile::CompileState,
+  kctx: &mut crate::compile::KernelCtx,
+) {
+  ensure_in_kenv_of_inner_env(name, lean_env, stt, &mut kctx.kenv, false, true);
 }
 
 /// Like [`ensure_in_kenv_of`], but upgrades an existing type-only `Axio`
@@ -2208,7 +2261,7 @@ fn ensure_full_in_tc_env(
   stt: &crate::compile::CompileState,
   kenv: &mut ix_kernel::env::KEnv<Meta>,
 ) {
-  ensure_in_kenv_of_inner_env(name, lean_env, stt, kenv, true);
+  ensure_in_kenv_of_inner_env(name, lean_env, stt, kenv, true, false);
 }
 
 /// Convenience wrapper: ingress into the **original** kenv (`stt.kctx`).

--- a/crates/compile/src/compile/aux_gen/recursor.rs
+++ b/crates/compile/src/compile/aux_gen/recursor.rs
@@ -2583,18 +2583,9 @@ fn ingress_target_type_deps(
   stt: &crate::compile::CompileState,
   kctx: &mut crate::compile::KernelCtx,
 ) {
-  let mut seen = rustc_hash::FxHashSet::default();
   let mut queue = Vec::new();
   collect_const_refs(target_ty, &mut queue);
-
-  while let Some(name) = queue.pop() {
-    if !seen.insert(name.clone()) {
-      continue;
-    }
-    if let Some(ci) = lean_env.get(&name) {
-      ingress_aux_gen_dep(&name, &ci, lean_env, stt, kctx, &mut queue);
-    }
-  }
+  drain_ingress_queue(&mut queue, lean_env, stt, kctx);
 }
 
 /// Walk field domains of constructors and ingress any referenced constants
@@ -2608,22 +2599,46 @@ fn ingress_field_deps(
   stt: &crate::compile::CompileState,
   kctx: &mut crate::compile::KernelCtx,
 ) {
-  let mut seen = rustc_hash::FxHashSet::default();
   let mut queue: Vec<Name> = Vec::new();
 
   // Collect all Const references from constructor types.
   for ctor in &class.ctors {
     collect_const_refs(&ctor.cnst.typ, &mut queue);
   }
+  drain_ingress_queue(&mut queue, lean_env, stt, kctx);
+}
 
+/// Drain a worklist of names through `ingress_aux_gen_dep`, deduplicated
+/// against `kctx.aux_ingress_seen` (kenv-lifetime, resolved-id-keyed —
+/// see the field docs) instead of a per-call set: the dispatch is
+/// deterministic per constant kind, so a seen id is already at final
+/// kenv fidelity and re-expanding its closure would be pure cost.
+fn drain_ingress_queue(
+  queue: &mut Vec<Name>,
+  lean_env: &LeanEnv,
+  stt: &crate::compile::CompileState,
+  kctx: &mut crate::compile::KernelCtx,
+) {
+  use ix_kernel::id::KId;
+  use ix_kernel::ingress::resolve_lean_name_addr;
+  use ix_kernel::mode::Meta;
+
+  let mut seen = std::mem::take(&mut kctx.aux_ingress_seen);
   while let Some(name) = queue.pop() {
-    if !seen.insert(name.clone()) {
+    let addr = resolve_lean_name_addr(
+      &name,
+      Some(&stt.name_to_addr),
+      Some(&stt.aux_name_to_addr),
+    );
+    let zid: KId<Meta> = KId::new(addr, name.clone());
+    if !seen.insert(zid) {
       continue;
     }
-
-    let Some(ci) = lean_env.get(&name) else { continue };
-    ingress_aux_gen_dep(&name, &ci, lean_env, stt, kctx, &mut queue);
+    if let Some(ci) = lean_env.get(&name) {
+      ingress_aux_gen_dep(&name, &ci, lean_env, stt, kctx, queue);
+    }
   }
+  kctx.aux_ingress_seen = seen;
 }
 
 fn ingress_aux_gen_dep(
@@ -2722,10 +2737,19 @@ fn ingress_type_stub(
 }
 
 /// Collect all constant names referenced in a LeanExpr.
-/// Uses an explicit stack to avoid stack overflow on deeply nested expressions.
+/// Uses an explicit stack to avoid stack overflow on deeply nested
+/// expressions, and a digest-keyed visited set so structurally shared
+/// subterms are walked once (DAG cost) instead of once per occurrence
+/// (unshared-tree cost — exponential on the eta-expanded structure
+/// types this pass sees constantly).
 fn collect_const_refs(expr: &LeanExpr, out: &mut Vec<Name>) {
+  let mut visited: rustc_hash::FxHashSet<&LeanExpr> =
+    rustc_hash::FxHashSet::default();
   let mut stack: Vec<&LeanExpr> = vec![expr];
   while let Some(e) = stack.pop() {
+    if !visited.insert(e) {
+      continue;
+    }
     match e.as_data() {
       ExprData::Const(n, _, _) => out.push(n.clone()),
       ExprData::App(f, a, _) => {

--- a/crates/compile/src/compile/env.rs
+++ b/crates/compile/src/compile/env.rs
@@ -11,10 +11,11 @@
 //! (`decode_env_lazy` in the ffi crate) rather than as a whole-env
 //! owned copy, accumulator constants and named metadata live as their
 //! serialized bytes rather than ~20×-larger structured forms, worker
-//! kernel envs clear periodically, the setup passes share one
-//! whole-env decode, and the `.ixe` streams to disk from Rust rather
-//! than crossing the FFI as an env-sized ByteArray. All of it is
-//! always on, and every mode produces a bit-identical `.ixe`.
+//! kernel contexts are fresh per block (canonicity §10.5), the setup
+//! passes share one whole-env decode, and the `.ixe` streams to disk
+//! from Rust rather than crossing the FFI as an env-sized ByteArray.
+//! All of it is always on, and every mode produces a bit-identical
+//! `.ixe`.
 //!
 //! Three knobs:
 //! - `IX_COMPILE_WORKERS=N` — scheduler worker count (default: all
@@ -58,9 +59,12 @@ use ixon::CompileError;
 // ===========================================================================
 
 /// Enable progress output. Quiet by default; set `IX_VERBOSE=1` to see
-/// per-phase timings and scheduler progress.
-static IX_VERBOSE: LazyLock<bool> =
-  LazyLock::new(|| std::env::var("IX_VERBOSE").is_ok());
+/// per-phase timings and scheduler progress. `IX_COMPILE_DBG=1` (the
+/// Lean driver's phase-attribution knob) is accepted as an alias so one
+/// flag lights up both sides of the pipeline.
+static IX_VERBOSE: LazyLock<bool> = LazyLock::new(|| {
+  std::env::var("IX_VERBOSE").is_ok() || std::env::var("IX_COMPILE_DBG").is_ok()
+});
 
 /// Log every block start + finish. Set `IX_LOG_BLOCKS=1` for deep debugging.
 /// Very verbose — only useful when you need to pin a panic to a specific block.
@@ -149,8 +153,9 @@ pub fn compile_env_with_options(
   let graph = scan.graph;
   if *IX_VERBOSE {
     eprintln!(
-      "[compile_env] setup 1/7 setup_scan (graph+ground+groups): {:.2}s",
-      phase_start.elapsed().as_secs_f32()
+      "[compile_env] setup 1/7 setup_scan (graph+ground+groups): {:.2}s{}",
+      phase_start.elapsed().as_secs_f32(),
+      crate::diag::rss_log_suffix(),
     );
   }
 
@@ -164,8 +169,9 @@ pub fn compile_env_with_options(
     proliferate_ungrounded(scan.immediate_ungrounded, &graph.in_refs);
   if *IX_VERBOSE {
     eprintln!(
-      "[compile_env] setup 2/7 proliferate_ungrounded: {:.2}s",
-      phase_start.elapsed().as_secs_f32()
+      "[compile_env] setup 2/7 proliferate_ungrounded: {:.2}s{}",
+      phase_start.elapsed().as_secs_f32(),
+      crate::diag::rss_log_suffix(),
     );
   }
   // Pin the highest-in-degree constants in the lazy env: the ref
@@ -223,9 +229,10 @@ pub fn compile_env_with_options(
   let condensed = compute_sccs(&grounded_out_refs);
   if *IX_VERBOSE {
     eprintln!(
-      "[compile_env] setup 3/7 compute_sccs ({} blocks): {:.2}s",
+      "[compile_env] setup 3/7 compute_sccs ({} blocks): {:.2}s{}",
       condensed.blocks.len(),
-      phase_start.elapsed().as_secs_f32()
+      phase_start.elapsed().as_secs_f32(),
+      crate::diag::rss_log_suffix(),
     );
   }
 
@@ -283,8 +290,9 @@ pub fn compile_env_with_options(
   precompile_aux_gen_prereqs(&condensed, lean_env, &stt)?;
   if *IX_VERBOSE {
     eprintln!(
-      "[compile_env] setup 5/7 precompile_aux_gen_prereqs: {:.2}s",
-      phase_start.elapsed().as_secs_f32()
+      "[compile_env] setup 5/7 precompile_aux_gen_prereqs: {:.2}s{}",
+      phase_start.elapsed().as_secs_f32(),
+      crate::diag::rss_log_suffix(),
     );
   }
 
@@ -366,9 +374,10 @@ pub fn compile_env_with_options(
   }
   if *IX_VERBOSE {
     eprintln!(
-      "[compile_env] setup 7/7 ready_queue init: {:.2}s (total pre-scheduler: {:.2}s)",
+      "[compile_env] setup 7/7 ready_queue init: {:.2}s (total pre-scheduler: {:.2}s){}",
       phase_start.elapsed().as_secs_f32(),
       setup_start.elapsed().as_secs_f32(),
+      crate::diag::rss_log_suffix(),
     );
   }
 
@@ -505,7 +514,8 @@ pub fn compile_env_with_options(
           // print "stalled" ticks less often so the log doesn't churn.
           if changed || done == 0 {
             eprintln!(
-              "[compile_env] {done}/{total} ({pct:.1}%) · {elapsed:.0}s{eta}{suffix}"
+              "[compile_env] {done}/{total} ({pct:.1}%) · {elapsed:.0}s{eta}{suffix}{}",
+              crate::diag::rss_log_suffix(),
             );
           } else {
             eprintln!(
@@ -935,9 +945,10 @@ pub fn compile_env_with_options(
   if *IX_VERBOSE {
     let scheduler_elapsed = compile_start.elapsed().as_secs_f64();
     eprintln!(
-      "[compile_env] scheduler drained: {}/{} blocks in {scheduler_elapsed:.1}s",
+      "[compile_env] scheduler drained: {}/{} blocks in {scheduler_elapsed:.1}s{}",
       completed.load(AtomicOrdering::SeqCst),
       total_blocks,
+      crate::diag::rss_log_suffix(),
     );
   }
 
@@ -977,12 +988,13 @@ pub fn compile_env_with_options(
     let total_elapsed = compile_start.elapsed().as_secs_f64();
     eprintln!(
       "[compile_env] complete in {total_elapsed:.1}s · \
-       env: {} consts, {} named, {} names, {} blobs, {} comms",
+       env: {} consts, {} named, {} names, {} blobs, {} comms{}",
       stt.env.const_count(),
       stt.env.named_count(),
       stt.env.name_count(),
       stt.env.blob_count(),
       stt.env.comm_count(),
+      crate::diag::rss_log_suffix(),
     );
   }
 

--- a/crates/compile/src/compile/mutual.rs
+++ b/crates/compile/src/compile/mutual.rs
@@ -26,7 +26,7 @@ use crate::compile::{
   compile_inductive, compile_mutual_block, compile_name, compile_recursor,
   preseed_expr_tables, sort_consts,
 };
-use crate::mutual::{Def, Ind, MutConst};
+use crate::mutual::{Def, Ind, MutConst, ctx_to_all};
 use ix_common::address::Address;
 use ix_common::env::{
   ConstantInfo as LeanConstantInfo, ConstantVal, ConstructorVal,
@@ -145,16 +145,20 @@ pub fn compile_aux_block_with_rename(
   }
   preseed_expr_tables(&exprs, &mut_ctx, &mut cache, stt, "compile_aux_block")?;
 
-  // Compile each representative per class.
+  // Compile each representative per class. The block-context address
+  // list is identical for every member — computed once, not per member.
   let mut ixon_mutuals = Vec::new();
   let mut all_metas: FxHashMap<Name, ConstantMeta> = FxHashMap::default();
+  let ctx_addrs: Vec<Address> =
+    ctx_to_all(&mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
 
   for class in &sorted_classes {
     let mut rep_pushed = false;
     for cnst in class {
       match cnst {
         MutConst::Recr(rec) => {
-          let (data, meta) = compile_recursor(rec, &mut_ctx, &mut cache, stt)?;
+          let (data, meta) =
+            compile_recursor(rec, &mut_ctx, &ctx_addrs, &mut cache, stt)?;
           if !rep_pushed {
             ixon_mutuals.push(IxonMutConst::Recr(data));
             rep_pushed = true;
@@ -163,7 +167,7 @@ pub fn compile_aux_block_with_rename(
         },
         MutConst::Defn(def) => {
           let (data, meta) =
-            compile_definition(def, &mut_ctx, &mut cache, stt)?;
+            compile_definition(def, &mut_ctx, &ctx_addrs, &mut cache, stt)?;
           if !rep_pushed {
             ixon_mutuals.push(IxonMutConst::Defn(data));
             rep_pushed = true;
@@ -172,7 +176,7 @@ pub fn compile_aux_block_with_rename(
         },
         MutConst::Indc(ind) => {
           let (data, meta, ctor_metas) =
-            compile_inductive(ind, &mut_ctx, &mut cache, stt)?;
+            compile_inductive(ind, &mut_ctx, &ctx_addrs, &mut cache, stt)?;
           if !rep_pushed {
             ixon_mutuals.push(IxonMutConst::Indc(data));
             rep_pushed = true;

--- a/crates/compile/src/decompile.rs
+++ b/crates/compile/src/decompile.rs
@@ -5,8 +5,11 @@
 //!
 //! `IX_DECOMPILE_KENV_CLEAR_ENTRIES=N` controls how many dependency names
 //! Pass 2 tracks before clearing its shared kernel environment. The default
-//! is 131072; `0` disables clearing. Raising the limit spends memory to avoid
-//! rebuilding dependency closures after a full kernel-cache clear.
+//! is 1048576; `0` disables clearing. The reference lists discovered by the
+//! ingress BFS are memoized for the whole run (they don't change when the
+//! kenv clears), so a post-clear re-walk re-ingresses constants but does
+//! not re-decode or re-walk their bodies — the limit is primarily a peak-RAM
+//! bound, no longer a wall-clock cliff.
 
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_precision_loss)]
@@ -45,6 +48,7 @@ use ixon::{
 use crate::{
   compile::CompileState,
   compile::aux_gen::nested::compute_lean_ind_flags,
+  diag::rss_log_suffix,
   mutual::{Def, Ind, MutConst as LeanMutConst, MutCtx, all_to_ctx},
 };
 use dashmap::DashMap;
@@ -52,7 +56,11 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
 
-const DEFAULT_DECOMPILE_KENV_CLEAR_ENTRIES: usize = 131_072;
+// Pre-warm now stubs theorem/opaque proof values (`ensure_in_kenv_of_prewarm`),
+// which were the dominant share of per-entry kenv RSS — so the same RAM
+// envelope covers ~8× the entry count and clears become a rare backstop
+// (FLT-scale closures no longer cross the limit at all).
+const DEFAULT_DECOMPILE_KENV_CLEAR_ENTRIES: usize = 1_048_576;
 
 fn decompile_kenv_clear_entries_from(raw: Option<&str>) -> Option<usize> {
   match raw {
@@ -2826,7 +2834,7 @@ fn roundtrip_block(
 ) -> Result<FxHashMap<Name, LeanConstantInfo>, DecompileError> {
   use crate::compile::{
     BlockCache as CompileBlockCache, collect_mut_const_exprs,
-    compile_definition, compile_inductive, compile_mutual_block,
+    compile_definition, compile_inductive, compile_mutual_block, compile_name,
     compile_recursor, preseed_expr_tables, sort_consts,
   };
   use crate::mutual::ctx_to_all;
@@ -2877,6 +2885,8 @@ fn roundtrip_block(
   let mut name_to_class: FxHashMap<Name, usize> = FxHashMap::default();
   let mut all_metas: FxHashMap<Name, ConstantMeta> = FxHashMap::default();
   let mut ixon_mutuals: Vec<MutConst> = Vec::new();
+  let ctx_addrs: Vec<Address> =
+    ctx_to_all(&mut_ctx).iter().map(|n| compile_name(n, stt)).collect();
 
   for (class_idx, class) in sorted_classes.iter().enumerate() {
     let mut rep_pushed = false;
@@ -2884,15 +2894,14 @@ fn roundtrip_block(
       name_to_class.insert(cnst.name(), class_idx);
       match cnst {
         LeanMutConst::Recr(rec) => {
-          let (data, meta) = compile_recursor(rec, &mut_ctx, &mut cache, stt)
-            .map_err(|e| {
-            DecompileError::BadConstantFormat {
-              msg: format!(
-                "roundtrip compile_rec {}: {e}",
-                rec.cnst.name.pretty()
-              ),
-            }
-          })?;
+          let (data, meta) =
+            compile_recursor(rec, &mut_ctx, &ctx_addrs, &mut cache, stt)
+              .map_err(|e| DecompileError::BadConstantFormat {
+                msg: format!(
+                  "roundtrip compile_rec {}: {e}",
+                  rec.cnst.name.pretty()
+                ),
+              })?;
           if !rep_pushed {
             ixon_mutuals.push(MutConst::Recr(data));
             rep_pushed = true;
@@ -2900,10 +2909,14 @@ fn roundtrip_block(
           all_metas.insert(rec.cnst.name.clone(), meta);
         },
         LeanMutConst::Defn(def) => {
-          let (data, meta) = compile_definition(def, &mut_ctx, &mut cache, stt)
-            .map_err(|e| DecompileError::BadConstantFormat {
-              msg: format!("roundtrip compile_def {}: {e}", def.name.pretty()),
-            })?;
+          let (data, meta) =
+            compile_definition(def, &mut_ctx, &ctx_addrs, &mut cache, stt)
+              .map_err(|e| DecompileError::BadConstantFormat {
+                msg: format!(
+                  "roundtrip compile_def {}: {e}",
+                  def.name.pretty()
+                ),
+              })?;
           if !rep_pushed {
             ixon_mutuals.push(MutConst::Defn(data));
             rep_pushed = true;
@@ -2912,14 +2925,13 @@ fn roundtrip_block(
         },
         LeanMutConst::Indc(ind) => {
           let (data, meta, ctor_metas) =
-            compile_inductive(ind, &mut_ctx, &mut cache, stt).map_err(|e| {
-              DecompileError::BadConstantFormat {
+            compile_inductive(ind, &mut_ctx, &ctx_addrs, &mut cache, stt)
+              .map_err(|e| DecompileError::BadConstantFormat {
                 msg: format!(
                   "roundtrip compile_indc {}: {e}",
                   ind.ind.cnst.name.pretty()
                 ),
-              }
-            })?;
+              })?;
           if !rep_pushed {
             ixon_mutuals.push(MutConst::Indc(data));
             rep_pushed = true;
@@ -3163,11 +3175,11 @@ fn roundtrip_block(
             );
             let compiled = preseeded.and_then(|()| match &omc {
               LeanMutConst::Defn(d) => {
-                compile_definition(d, &mut_ctx, &mut pcache, stt)
+                compile_definition(d, &mut_ctx, &ctx_addrs, &mut pcache, stt)
                   .map(|(data, _)| MutConst::Defn(data))
               },
               LeanMutConst::Recr(r) => {
-                compile_recursor(r, &mut_ctx, &mut pcache, stt)
+                compile_recursor(r, &mut_ctx, &ctx_addrs, &mut pcache, stt)
                   .map(|(data, _)| MutConst::Recr(data))
               },
               LeanMutConst::Indc(_) => unreachable!("probe is Defn/Recr only"),
@@ -3907,36 +3919,6 @@ struct StoredPlanBlock {
   class_names: Vec<Vec<Name>>,
   aux_layout: Option<ixon::env::AuxLayout>,
   flat_names: Vec<Name>,
-}
-
-/// ` · rss X.X GiB (anon Y.Y, file Z.Z)` sampled from
-/// `/proc/self/status`, appended to phase logs. Anon can only leave RAM
-/// via swap; file RSS is reclaimable page cache — the split shows which
-/// memory-reduction lever applies. Empty when procfs is unavailable.
-fn rss_log_suffix() -> String {
-  let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
-    return String::new();
-  };
-  let field_kb = |name: &str| -> Option<u64> {
-    status
-      .lines()
-      .find(|l| l.starts_with(name))
-      .and_then(|l| l.split_whitespace().nth(1))
-      .and_then(|v| v.parse().ok())
-  };
-  let gib_tenths = |kb: u64| -> (u64, u64) {
-    let tenths = kb * 10 / (1024 * 1024);
-    (tenths / 10, tenths % 10)
-  };
-  match (field_kb("VmRSS:"), field_kb("RssAnon:"), field_kb("RssFile:")) {
-    (Some(rss), Some(anon), Some(file)) => {
-      let (r, rt) = gib_tenths(rss);
-      let (a, at) = gib_tenths(anon);
-      let (f, ft) = gib_tenths(file);
-      format!(" · rss {r}.{rt} GiB (anon {a}.{at}, file {f}.{ft})")
-    },
-    _ => String::new(),
-  }
 }
 
 /// One `Muts`-tagged Named entry, pre-resolved for plan lookups.
@@ -5317,38 +5299,46 @@ pub fn decompile_env(
     rss_log_suffix(),
   );
 
-  // Pass 1.5: Lean-faithful inductive flags
+  // Pass 1.5: Lean-faithful inductive flags. Scoped so `lean_env` — a
+  // full structured copy of the environment used only by
+  // `compute_lean_ind_flags` — drops here instead of living to the end
+  // of the function: Pass 2 already holds `dstt.env` plus its own
+  // `work_env` snapshot, and a third whole-env copy is pure peak RSS.
   let t_p1_5 = std::time::Instant::now();
-  let lean_env: ix_common::env::Env =
-    dstt.env.iter().map(|e| (e.key().clone(), e.value().clone())).collect();
-  let mut groups: FxHashMap<Name, Vec<Name>> = FxHashMap::default();
-  for entry in dstt.env.iter() {
-    if let LeanConstantInfo::InductInfo(v) = entry.value()
-      && let Some(first) = v.all.first()
-    {
-      groups.entry(first.clone()).or_insert_with(|| v.all.clone());
-    }
-  }
-  for (key, all) in &groups {
-    let flags = compute_lean_ind_flags(all, &lean_env).map_err(|e| {
-      DecompileError::BadConstantFormat {
-        msg: format!("ind-flags fixup for block '{}': {e}", key.pretty()),
-      }
-    })?;
-    for member in all {
-      if let Some(mut entry) = dstt.env.get_mut(member)
-        && let LeanConstantInfo::InductInfo(v) = entry.value_mut()
+  let n_ind_groups = {
+    let lean_env: ix_common::env::Env =
+      dstt.env.iter().map(|e| (e.key().clone(), e.value().clone())).collect();
+    let mut groups: FxHashMap<Name, Vec<Name>> = FxHashMap::default();
+    for entry in dstt.env.iter() {
+      if let LeanConstantInfo::InductInfo(v) = entry.value()
+        && let Some(first) = v.all.first()
       {
-        v.num_nested = Nat::from(flags.num_nested);
-        v.is_rec = flags.is_rec;
-        v.is_reflexive = flags.is_reflexive;
+        groups.entry(first.clone()).or_insert_with(|| v.all.clone());
       }
     }
-  }
+    for (key, all) in &groups {
+      let flags = compute_lean_ind_flags(all, &lean_env).map_err(|e| {
+        DecompileError::BadConstantFormat {
+          msg: format!("ind-flags fixup for block '{}': {e}", key.pretty()),
+        }
+      })?;
+      for member in all {
+        if let Some(mut entry) = dstt.env.get_mut(member)
+          && let LeanConstantInfo::InductInfo(v) = entry.value_mut()
+        {
+          v.num_nested = Nat::from(flags.num_nested);
+          v.is_rec = flags.is_rec;
+          v.is_reflexive = flags.is_reflexive;
+        }
+      }
+    }
+    groups.len()
+  };
   eprintln!(
-    "[decompile] Pass 1.5 done in {:.2}s ({} constants in dstt.env)",
+    "[decompile] Pass 1.5 done in {:.2}s ({} inductive groups){}",
     t_p1_5.elapsed().as_secs_f32(),
-    groups.len(),
+    n_ind_groups,
+    rss_log_suffix(),
   );
 
   // Pass 2: Regenerate aux_gen constants for mutual inductive blocks.
@@ -5453,6 +5443,18 @@ pub fn decompile_env(
   // for every block (still O(n) across all blocks combined).
   let mut ingressed: FxHashSet<Name> = FxHashSet::default();
 
+  // Run-scoped memo of each walked constant's reference list. `ingressed`
+  // doubles as the kenv-content tracker, so a kenv clear must wipe it —
+  // but the reference graph itself never changes, so the refs survive the
+  // clear here. Post-clear re-walks then cost hash probes instead of
+  // re-decoding and re-walking every constant in the closure (the
+  // Θ(N²/L) term that made the clear threshold a wall-clock cliff).
+  // Names absent from `work_env` at walk time are deliberately NOT
+  // memoized: aux constants enter `work_env` only when their block
+  // regenerates them, so an early miss must stay a live probe rather
+  // than a frozen empty entry.
+  let mut refs_memo: FxHashMap<Name, Vec<Name>> = FxHashMap::default();
+
   // Size trigger for the kenv clear at the bottom of the block loop.
   // A full clear makes later blocks re-walk their whole ingress
   // closures, so the threshold must sit above the kenv working set of
@@ -5499,13 +5501,22 @@ pub fn decompile_env(
       if !ingressed.insert(name.clone()) {
         continue;
       }
-      expr_utils::ensure_in_kenv_of(&name, &work_env, stt, &mut kctx);
-      if let Some(ci) = work_env.get(&name) {
-        for ref_name in get_constant_info_references(&ci) {
-          if !ingressed.contains(&ref_name) {
-            stack.push(ref_name);
+      expr_utils::ensure_in_kenv_of_prewarm(&name, &work_env, stt, &mut kctx);
+      if let Some(refs) = refs_memo.get(&name) {
+        for ref_name in refs {
+          if !ingressed.contains(ref_name) {
+            stack.push(ref_name.clone());
           }
         }
+      } else if let Some(ci) = work_env.get(&name) {
+        let refs: Vec<Name> =
+          get_constant_info_references(&ci).into_iter().collect();
+        for ref_name in &refs {
+          if !ingressed.contains(ref_name) {
+            stack.push(ref_name.clone());
+          }
+        }
+        refs_memo.insert(name, refs);
       }
     }
     let t_after_ingress = std::time::Instant::now();
@@ -5586,6 +5597,7 @@ pub fn decompile_env(
     // few re-ingress walks for a bounded working set.
     if kenv_clear_entries.is_some_and(|limit| ingressed.len() > limit) {
       kctx.kenv.clear_releasing_memory();
+      kctx.aux_ingress_seen.clear();
       ingressed.clear();
       kenv_clears += 1;
       expr_utils::ensure_prelude_in_kenv_of(stt, &mut kctx);

--- a/crates/compile/src/diag.rs
+++ b/crates/compile/src/diag.rs
@@ -1,0 +1,31 @@
+//! Shared diagnostics helpers for phase logging.
+
+/// ` · rss X.X GiB (anon Y.Y, file Z.Z)` sampled from
+/// `/proc/self/status`, appended to phase logs. Anon can only leave RAM
+/// via swap; file RSS is reclaimable page cache — the split shows which
+/// memory-reduction lever applies. Empty when procfs is unavailable.
+pub fn rss_log_suffix() -> String {
+  let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+    return String::new();
+  };
+  let field_kb = |name: &str| -> Option<u64> {
+    status
+      .lines()
+      .find(|l| l.starts_with(name))
+      .and_then(|l| l.split_whitespace().nth(1))
+      .and_then(|v| v.parse().ok())
+  };
+  let gib_tenths = |kb: u64| -> (u64, u64) {
+    let tenths = kb * 10 / (1024 * 1024);
+    (tenths / 10, tenths % 10)
+  };
+  match (field_kb("VmRSS:"), field_kb("RssAnon:"), field_kb("RssFile:")) {
+    (Some(rss), Some(anon), Some(file)) => {
+      let (r, rt) = gib_tenths(rss);
+      let (a, at) = gib_tenths(anon);
+      let (f, ft) = gib_tenths(file);
+      format!(" · rss {r}.{rt} GiB (anon {a}.{at}, file {f}.{ft})")
+    },
+    _ => String::new(),
+  }
+}

--- a/crates/compile/src/graph.rs
+++ b/crates/compile/src/graph.rs
@@ -199,80 +199,92 @@ pub fn build_ref_graph(env: &Env) -> RefGraph {
 }
 
 pub fn get_constant_info_references(constant_info: &ConstantInfo) -> NameSet {
-  let cache = &mut FxHashMap::default();
+  let mut acc = NameSet::default();
+  let mut visited: FxHashSet<&Expr> = FxHashSet::default();
   match constant_info {
-    ConstantInfo::AxiomInfo(val) => get_expr_references(&val.cnst.typ, cache),
-    ConstantInfo::DefnInfo(val) => merge_name_sets(
-      get_expr_references(&val.cnst.typ, cache),
-      get_expr_references(&val.value, cache),
-    ),
-    ConstantInfo::ThmInfo(val) => merge_name_sets(
-      get_expr_references(&val.cnst.typ, cache),
-      get_expr_references(&val.value, cache),
-    ),
-    ConstantInfo::OpaqueInfo(val) => merge_name_sets(
-      get_expr_references(&val.cnst.typ, cache),
-      get_expr_references(&val.value, cache),
-    ),
-    ConstantInfo::QuotInfo(val) => get_expr_references(&val.cnst.typ, cache),
+    ConstantInfo::AxiomInfo(val) => {
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+    },
+    ConstantInfo::DefnInfo(val) => {
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+      collect_expr_references(&val.value, &mut visited, &mut acc);
+    },
+    ConstantInfo::ThmInfo(val) => {
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+      collect_expr_references(&val.value, &mut visited, &mut acc);
+    },
+    ConstantInfo::OpaqueInfo(val) => {
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+      collect_expr_references(&val.value, &mut visited, &mut acc);
+    },
+    ConstantInfo::QuotInfo(val) => {
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+    },
     ConstantInfo::InductInfo(val) => {
-      let name_set = get_expr_references(&val.cnst.typ, cache);
-      let ctors_name_set = val.ctors.iter().cloned().collect();
-      merge_name_sets(name_set, ctors_name_set)
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+      acc.extend(val.ctors.iter().cloned());
     },
     ConstantInfo::CtorInfo(val) => {
-      let mut name_set = get_expr_references(&val.cnst.typ, cache);
-      name_set.insert(val.induct.clone());
-      name_set
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+      acc.insert(val.induct.clone());
     },
     ConstantInfo::RecInfo(val) => {
-      let name_set = get_expr_references(&val.cnst.typ, cache);
-      val.rules.iter().fold(name_set, |mut acc, rule| {
+      collect_expr_references(&val.cnst.typ, &mut visited, &mut acc);
+      for rule in &val.rules {
         acc.insert(rule.ctor.clone());
-        merge_name_sets(acc, get_expr_references(&rule.rhs, cache))
-      })
+        collect_expr_references(&rule.rhs, &mut visited, &mut acc);
+      }
     },
   }
+  acc
 }
 
-fn get_expr_references<'a>(
+/// Iterative DAG walk pushing every `Const`/`Proj` head into one shared
+/// accumulator. `visited` keys on `Expr`'s digest-backed `Hash`/`Eq`
+/// (Arc pointer fast path), so each distinct subterm — structurally
+/// shared or not — is expanded once, exactly the dedup the old
+/// per-constant memo provided. Θ(n + r) total: the old walk returned a
+/// fresh `NameSet` per node and merged/cloned it into every parent
+/// (Θ(n·r) allocations on ref-heavy constants). This feeds both
+/// compile's `setup_scan` and decompile's Pass-2 ingress BFS. The
+/// accumulated set is value-identical to the old result; no downstream
+/// consumer reads set iteration order into output bytes (SCC members
+/// and serialized sections are canonically re-sorted).
+fn collect_expr_references<'a>(
   expr: &'a Expr,
-  cache: &mut FxHashMap<&'a Expr, NameSet>,
-) -> NameSet {
-  if let Some(cached) = cache.get(expr) {
-    return cached.clone();
+  visited: &mut FxHashSet<&'a Expr>,
+  acc: &mut NameSet,
+) {
+  let mut stack: Vec<&'a Expr> = vec![expr];
+  while let Some(e) = stack.pop() {
+    if !visited.insert(e) {
+      continue;
+    }
+    match e.as_data() {
+      ExprData::Const(name, ..) => {
+        acc.insert(name.clone());
+      },
+      ExprData::App(f, a, _) => {
+        stack.push(f);
+        stack.push(a);
+      },
+      ExprData::Lam(_, typ, body, ..) | ExprData::ForallE(_, typ, body, ..) => {
+        stack.push(typ);
+        stack.push(body);
+      },
+      ExprData::LetE(_, typ, value, body, ..) => {
+        stack.push(typ);
+        stack.push(value);
+        stack.push(body);
+      },
+      ExprData::Mdata(_, inner, _) => stack.push(inner),
+      ExprData::Proj(type_name, _, inner, _) => {
+        acc.insert(type_name.clone());
+        stack.push(inner);
+      },
+      _ => {},
+    }
   }
-  let name_set = match expr.as_data() {
-    ExprData::Const(name, ..) => NameSet::from_iter([name.clone()]),
-    ExprData::App(f, a, _) => {
-      let f_name_set = get_expr_references(f, cache);
-      let a_name_set = get_expr_references(a, cache);
-      merge_name_sets(f_name_set, a_name_set)
-    },
-    ExprData::Lam(_, typ, body, ..) | ExprData::ForallE(_, typ, body, ..) => {
-      let typ_name_set = get_expr_references(typ, cache);
-      let body_name_set = get_expr_references(body, cache);
-      merge_name_sets(typ_name_set, body_name_set)
-    },
-    ExprData::LetE(_, typ, value, body, ..) => {
-      let typ_name_set = get_expr_references(typ, cache);
-      let value_name_set = get_expr_references(value, cache);
-      let body_name_set = get_expr_references(body, cache);
-      merge_name_sets(
-        typ_name_set,
-        merge_name_sets(value_name_set, body_name_set),
-      )
-    },
-    ExprData::Mdata(_, expr, _) => get_expr_references(expr, cache),
-    ExprData::Proj(type_name, _, expr, _) => {
-      let mut name_set = get_expr_references(expr, cache);
-      name_set.insert(type_name.clone());
-      name_set
-    },
-    _ => NameSet::default(),
-  };
-  cache.insert(expr, name_set.clone());
-  name_set
 }
 
 #[cfg(test)]

--- a/crates/compile/src/lib.rs
+++ b/crates/compile/src/lib.rs
@@ -4,6 +4,7 @@ pub mod compile;
 pub mod condense;
 pub mod congruence;
 pub mod decompile;
+pub mod diag;
 pub mod graph;
 pub mod ground;
 pub mod kernel_egress;

--- a/crates/ffi/src/compile.rs
+++ b/crates/ffi/src/compile.rs
@@ -333,11 +333,16 @@ pub extern "C" fn rs_compile_env(
 
   // Canonical consts merkle root — equals the serialized header root
   // when a file is written; still reported on a fail-closed abort so
-  // callers can record what the complete-subset content was.
+  // callers can record what the complete-subset content was. Computed
+  // once here (parallel sort + tree) and handed to the writer — the
+  // sort and the ~2·N-node tree used to run twice per compile.
   let mut const_addrs: Vec<Address> =
     compile_stt.env.consts.iter().map(|e| e.key().clone()).collect();
-  const_addrs.sort_unstable();
-  let root = ixon::merkle::merkle_root_canonical(&const_addrs)
+  {
+    use rayon::prelude::*;
+    const_addrs.par_sort_unstable();
+  }
+  let root = ixon::merkle::merkle_root_canonical_sorted(&const_addrs)
     .unwrap_or_else(ixon::merkle::zero_address);
   let named_count = compile_stt.env.named.len() as u64;
   let unique_anon = const_addrs.len() as u64;
@@ -352,14 +357,15 @@ pub extern "C" fn rs_compile_env(
       s.push(".tmp");
       std::path::PathBuf::from(s)
     };
-    let written = match compile_stt.env.put_file(&tmp) {
-      Ok(n) => n,
-      Err(e) => {
-        std::fs::remove_file(&tmp).ok();
-        let msg = format!("rs_compile_env: serialization failed: {e}");
-        return LeanIOResult::error_string(&msg);
-      },
-    };
+    let written =
+      match compile_stt.env.put_file_with_header(&tmp, &const_addrs, &root) {
+        Ok(n) => n,
+        Err(e) => {
+          std::fs::remove_file(&tmp).ok();
+          let msg = format!("rs_compile_env: serialization failed: {e}");
+          return LeanIOResult::error_string(&msg);
+        },
+      };
     if let Err(e) = std::fs::rename(&tmp, &path) {
       std::fs::remove_file(&tmp).ok();
       let msg = format!(
@@ -1579,6 +1585,7 @@ pub extern "C" fn rs_decompile_env(
 ) -> LeanIOResult<LeanOwned> {
   let path = path.as_str().to_string();
 
+  let t_read = std::time::Instant::now();
   let bytes = match std::fs::read(&path) {
     Ok(b) => b,
     Err(e) => {
@@ -1592,6 +1599,8 @@ pub extern "C" fn rs_decompile_env(
   // form costs a large multiple of its encoding — enough to dominate
   // the decompile's peak RSS on the biggest envs. One load path at
   // every scale also keeps the bench rows comparable across envs.
+  let t_parse = std::time::Instant::now();
+  let read_secs = (t_parse - t_read).as_secs_f32();
   let mut slice: &[u8] = &bytes;
   let env = match ixon::env::Env::get_demoted_named(&mut slice) {
     Ok(env) => env,
@@ -1601,6 +1610,11 @@ pub extern "C" fn rs_decompile_env(
       ));
     },
   };
+  eprintln!(
+    "[decompile] env read in {read_secs:.2}s, parsed in {:.2}s{}",
+    t_parse.elapsed().as_secs_f32(),
+    ix_compile::diag::rss_log_suffix(),
+  );
 
   // The env owns its bytes after parsing; release the file buffer
   // before the decompile allocates next to it.
@@ -1643,7 +1657,14 @@ pub extern "C" fn rs_decompile_env(
       ));
     },
   };
-  LeanIOResult::ok(LeanOwned::from_nat_u64(dstt.env.len() as u64))
+  let n = dstt.env.len() as u64;
+  // One-shot CLI entry (`ix decompile` only — the import path uses
+  // `rs_decompile_env_consts`): skip the destructors like
+  // `rs_compile_env` does; dropping ~30 GiB of DashMaps costs seconds
+  // and the OS reclaims at exit.
+  std::mem::forget(dstt);
+  std::mem::forget(stt);
+  LeanIOResult::ok(LeanOwned::from_nat_u64(n))
 }
 
 /// Decompile a serialized `.ixe` env and materialize constants as real

--- a/crates/ixon/src/merkle.rs
+++ b/crates/ixon/src/merkle.rs
@@ -107,6 +107,39 @@ pub fn merkle_root_canonical(leaves: &[Address]) -> Option<Address> {
   Some(level.into_iter().next().unwrap())
 }
 
+/// Host-side variant of [`merkle_root_canonical`] for callers that
+/// already hold lex-sorted, deduplicated leaves (e.g. the serializers'
+/// const table — map keys are unique by construction and sorted right
+/// before this call). Skips the clone + re-sort + dedup and hashes
+/// leaves and levels in parallel; the pairing is positional, so the
+/// root is bit-identical to [`merkle_root_canonical`] on the same set.
+#[cfg(not(target_arch = "riscv64"))]
+pub fn merkle_root_canonical_sorted(
+  sorted_unique: &[Address],
+) -> Option<Address> {
+  use rayon::prelude::*;
+  debug_assert!(
+    sorted_unique.windows(2).all(|w| w[0] < w[1]),
+    "merkle_root_canonical_sorted: leaves must be sorted and unique"
+  );
+  if sorted_unique.is_empty() {
+    return None;
+  }
+  if sorted_unique.len() == 1 {
+    return Some(leaf_hash(&sorted_unique[0]));
+  }
+  let mut level: Vec<Address> =
+    sorted_unique.par_iter().map(leaf_hash).collect();
+  let zero = zero_address();
+  while level.len() > 1 {
+    level = level
+      .par_chunks(2)
+      .map(|pair| node_hash(&pair[0], pair.get(1).unwrap_or(&zero)))
+      .collect();
+  }
+  Some(level.into_iter().next().unwrap())
+}
+
 // ---------------------------------------------------------------------------
 // Free-form composition
 // ---------------------------------------------------------------------------

--- a/crates/ixon/src/serialize.rs
+++ b/crates/ixon/src/serialize.rs
@@ -1474,6 +1474,8 @@ impl<'a> NamedMetaCursor<'a> {
 
 use super::comm::Comm;
 use super::env::{Env, LazyConstSlice, LazyIndex, LazyNamed};
+#[cfg(not(target_arch = "riscv64"))]
+use super::merkle::merkle_root_canonical_sorted;
 use super::merkle::{merkle_root_canonical, zero_address};
 
 impl Env {
@@ -1505,9 +1507,11 @@ impl Env {
     #[cfg(not(target_arch = "riscv64"))]
     use rayon::slice::ParallelSliceMut;
 
-    // Chatty per-section logging, off unless IX_VERBOSE=1, so we can
-    // diagnose serialization stalls on huge envs (Mathlib: ~1M consts).
-    let verbose = std::env::var("IX_VERBOSE").is_ok();
+    // Chatty per-section logging, off unless IX_VERBOSE=1 (or its
+    // pipeline-wide alias IX_COMPILE_DBG), so we can diagnose
+    // serialization stalls on huge envs (Mathlib: ~1M consts).
+    let verbose = std::env::var("IX_VERBOSE").is_ok()
+      || std::env::var("IX_COMPILE_DBG").is_ok();
     let overall_start = std::time::Instant::now();
 
     // Header: Tag4 with flag=0xE, size=VERSION (format version)
@@ -1529,6 +1533,12 @@ impl Env {
     const_addrs.par_sort_unstable();
     #[cfg(target_arch = "riscv64")]
     const_addrs.sort_unstable();
+    // Keys are unique (map) and just sorted — the `_sorted` variant
+    // skips the internal clone+re-sort and hashes levels in parallel.
+    #[cfg(not(target_arch = "riscv64"))]
+    let root =
+      merkle_root_canonical_sorted(&const_addrs).unwrap_or_else(zero_address);
+    #[cfg(target_arch = "riscv64")]
     let root = merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
     put_address(&root, buf);
 
@@ -1819,7 +1829,39 @@ impl Env {
   #[cfg(not(target_arch = "riscv64"))]
   pub fn put_file(&self, path: &std::path::Path) -> Result<u64, String> {
     use rayon::prelude::*;
+    let mut const_addrs: Vec<Address> =
+      self.consts.iter().map(|e| e.key().clone()).collect();
+    const_addrs.par_sort_unstable();
+    let root =
+      merkle_root_canonical_sorted(&const_addrs).unwrap_or_else(zero_address);
+    self.put_file_with_header(path, &const_addrs, &root)
+  }
+
+  /// [`Env::put_file`] with the sorted const-address table and its
+  /// merkle root supplied by the caller. `rs_compile_env` needs the
+  /// root even on a fail-closed abort where no file is written, so it
+  /// computes both up front and hands them in here — previously the
+  /// table was collected+sorted and the ~2·N-node tree hashed twice
+  /// per compile. `const_addrs` MUST be exactly
+  /// `self.consts` keys lex-sorted, and `root` their canonical merkle
+  /// root; debug builds assert the former.
+  #[cfg(not(target_arch = "riscv64"))]
+  pub fn put_file_with_header(
+    &self,
+    path: &std::path::Path,
+    const_addrs: &[Address],
+    root: &Address,
+  ) -> Result<u64, String> {
+    use rayon::prelude::*;
     use std::io::Write;
+    debug_assert_eq!(const_addrs.len(), self.consts.len());
+    // Per-section timing, mirroring `Env::put`'s logging (same knobs).
+    // `put_file` is the production writer, so stalls here are otherwise
+    // invisible — one opaque gap between "compile done" and the row.
+    let verbose = std::env::var("IX_VERBOSE").is_ok()
+      || std::env::var("IX_COMPILE_DBG").is_ok();
+    let overall_start = std::time::Instant::now();
+    let mut sec_start = std::time::Instant::now();
     let file = std::fs::File::create(path)
       .map_err(|e| format!("Env::put_file: create {}: {e}", path.display()))?;
     let mut w = std::io::BufWriter::with_capacity(8 * 1024 * 1024, file);
@@ -1838,14 +1880,18 @@ impl Env {
       };
     }
 
-    // Header: Tag4 (flag=0xE, size=VERSION) + canonical merkle root
-    // over consts.keys().
+    // Header: Tag4 (flag=0xE, size=VERSION) + the caller-supplied
+    // canonical merkle root over consts.keys().
     Tag4::new(Self::FLAG, Self::VERSION).put(&mut buf);
-    let mut const_addrs: Vec<Address> =
-      self.consts.iter().map(|e| e.key().clone()).collect();
-    const_addrs.par_sort_unstable();
-    let root = merkle_root_canonical(&const_addrs).unwrap_or_else(zero_address);
-    put_address(&root, &mut buf);
+    put_address(root, &mut buf);
+    if verbose {
+      eprintln!(
+        "[Env::put_file] header written ({} consts) in {:.1}s",
+        const_addrs.len(),
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
+    }
 
     // Bundle header fields: distinguished root + assumed-present list
     // (mirrors `Env::put`, including the writer-side main sanity check).
@@ -1880,11 +1926,19 @@ impl Env {
         emit!();
       }
     }
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 1/6 blobs done in {:.1}s ({written} bytes \
+         written)",
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
+    }
 
     // Section 2: Consts — the dominant bytes; raw_bytes stream straight
     // through with no intermediate copy of the constant bodies
     put_u64(const_addrs.len() as u64, &mut buf);
-    for addr in &const_addrs {
+    for addr in const_addrs {
       if let Some(entry) = self.consts.get(addr) {
         put_address(addr, &mut buf);
         let bytes = entry.value().raw_bytes();
@@ -1894,6 +1948,14 @@ impl Env {
           .map_err(|e| format!("Env::put_file: write const: {e}"))?;
         written += bytes.len() as u64;
       }
+    }
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 2/6 consts done in {:.1}s ({written} bytes \
+         written)",
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
     }
     // Section 3: anon_hints — the canonical hint channel, serialized
     // straight from the map as delta-coded §2 ranks + fused hints
@@ -1916,10 +1978,29 @@ impl Env {
       prev = rank + 1;
       emit!();
     }
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 3/6 anon_hints done in {:.1}s ({written} \
+         bytes written)",
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
+    }
 
     // Section 4: Names (topologically sorted; builds the name index the
-    // Named section encodes through).
+    // Named section encodes through). The topo sort is single-threaded
+    // over every name component — timed separately from the writes so
+    // its share is visible (see `topological_sort_names`).
     let sorted_names = topological_sort_names(&self.names);
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 4/6 names: topo sort of {} entries in \
+         {:.1}s",
+        sorted_names.len(),
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
+    }
     let mut name_index: NameIndex = NameIndex::new();
     put_u64(sorted_names.len() as u64, &mut buf);
     for (i, (addr, name)) in sorted_names.iter().enumerate() {
@@ -1927,6 +2008,14 @@ impl Env {
       put_address(addr, &mut buf);
       put_name_component(name, &mut buf);
       emit!();
+    }
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 4/6 names done in {:.1}s ({written} bytes \
+         written)",
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
     }
 
     // Section 5: Named — the largest per-entry section, and the only
@@ -1960,7 +2049,7 @@ impl Env {
             put_named_indexed(
               entry.value(),
               &name_index,
-              &const_addrs,
+              const_addrs,
               &mut scratch,
               &mut b,
             )?;
@@ -1972,6 +2061,14 @@ impl Env {
         w.write_all(b).map_err(|e| format!("Env::put_file: write: {e}"))?;
         written += b.len() as u64;
       }
+    }
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 5/6 named done in {:.1}s ({written} bytes \
+         written)",
+        sec_start.elapsed().as_secs_f64(),
+      );
+      sec_start = std::time::Instant::now();
     }
     // Section 6: Comms
     let mut comm_addrs: Vec<Address> =
@@ -1988,6 +2085,14 @@ impl Env {
 
     emit!();
     w.flush().map_err(|e| format!("Env::put_file: flush: {e}"))?;
+    if verbose {
+      eprintln!(
+        "[Env::put_file] section 6/6 comms done in {:.1}s · ALL DONE: \
+         {written} bytes in {:.1}s",
+        sec_start.elapsed().as_secs_f64(),
+        overall_start.elapsed().as_secs_f64(),
+      );
+    }
     Ok(written)
   }
 

--- a/crates/ixon/src/sharing.rs
+++ b/crates/ixon/src/sharing.rs
@@ -9,7 +9,6 @@
 #![allow(clippy::cast_possible_wrap)]
 #![allow(clippy::match_same_arms)]
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use indexmap::IndexSet;
@@ -222,11 +221,11 @@ pub fn analyze_block(
   exprs: &[Arc<Expr>],
   track_hash_consed_size: bool,
 ) -> (
-  HashMap<blake3::Hash, SubtermInfo>,
+  FxHashMap<blake3::Hash, SubtermInfo>,
   FxHashMap<*const Expr, blake3::Hash>,
   Vec<blake3::Hash>,
 ) {
-  let mut info_map: HashMap<blake3::Hash, SubtermInfo> = HashMap::new();
+  let mut info_map: FxHashMap<blake3::Hash, SubtermInfo> = FxHashMap::default();
   let mut ptr_to_hash: FxHashMap<*const Expr, blake3::Hash> =
     FxHashMap::default();
   let mut hash_buf: Vec<u8> = Vec::with_capacity(128);
@@ -341,7 +340,7 @@ pub fn hash_expr(expr: &Arc<Expr>) -> blake3::Hash {
 /// CRITICAL: Keys are sorted by hash bytes for deterministic output.
 /// This ensures Lean and Rust produce the same topological order.
 pub fn topological_sort(
-  info_map: &HashMap<blake3::Hash, SubtermInfo>,
+  info_map: &FxHashMap<blake3::Hash, SubtermInfo>,
 ) -> Vec<blake3::Hash> {
   #[derive(Clone, Copy, PartialEq, Eq)]
   enum VisitState {
@@ -349,13 +348,13 @@ pub fn topological_sort(
     Done,
   }
 
-  let mut state: HashMap<blake3::Hash, VisitState> = HashMap::new();
+  let mut state: FxHashMap<blake3::Hash, VisitState> = FxHashMap::default();
   let mut result: Vec<blake3::Hash> = Vec::new();
 
   fn visit(
     hash: blake3::Hash,
-    info_map: &HashMap<blake3::Hash, SubtermInfo>,
-    state: &mut HashMap<blake3::Hash, VisitState>,
+    info_map: &FxHashMap<blake3::Hash, SubtermInfo>,
+    state: &mut FxHashMap<blake3::Hash, VisitState>,
     result: &mut Vec<blake3::Hash>,
   ) {
     match state.get(&hash) {
@@ -390,10 +389,10 @@ pub fn topological_sort(
 /// Compute effective sizes for all subterms in topological order.
 /// Returns a map from hash to effective size (total serialized bytes).
 pub fn compute_effective_sizes(
-  info_map: &HashMap<blake3::Hash, SubtermInfo>,
+  info_map: &FxHashMap<blake3::Hash, SubtermInfo>,
   topo_order: &[blake3::Hash],
-) -> HashMap<blake3::Hash, usize> {
-  let mut sizes: HashMap<blake3::Hash, usize> = HashMap::new();
+) -> FxHashMap<blake3::Hash, usize> {
+  let mut sizes: FxHashMap<blake3::Hash, usize> = FxHashMap::default();
 
   for hash in topo_order {
     if let Some(info) = info_map.get(hash) {
@@ -412,14 +411,14 @@ pub fn compute_effective_sizes(
 /// Returns a summary of why sharing may not be effective.
 #[allow(dead_code)]
 pub fn analyze_sharing_stats(
-  info_map: &HashMap<blake3::Hash, SubtermInfo>,
+  info_map: &FxHashMap<blake3::Hash, SubtermInfo>,
   topo_order: &[blake3::Hash],
 ) -> SharingStats {
   let effective_sizes = compute_effective_sizes(info_map, topo_order);
 
   let total_subterms = info_map.len();
-  let mut usage_distribution: HashMap<usize, usize> = HashMap::new();
-  let mut size_distribution: HashMap<usize, usize> = HashMap::new();
+  let mut usage_distribution: FxHashMap<usize, usize> = FxHashMap::default();
+  let mut size_distribution: FxHashMap<usize, usize> = FxHashMap::default();
   let mut total_usage: usize = 0;
   let mut unique_subterms = 0;
   let mut shared_subterms = 0;
@@ -514,8 +513,8 @@ pub struct SharingStats {
   pub candidates_usage_ge_2: usize,
   pub candidates_positive_potential: usize,
   pub actually_shared: usize,
-  pub usage_distribution: HashMap<usize, usize>,
-  pub size_distribution: HashMap<usize, usize>,
+  pub usage_distribution: FxHashMap<usize, usize>,
+  pub size_distribution: FxHashMap<usize, usize>,
 }
 
 impl std::fmt::Display for SharingStats {
@@ -576,7 +575,7 @@ impl std::fmt::Display for SharingStats {
 ///
 /// Optimized from O(k×n) to O(n log n) by pre-sorting candidates.
 pub fn decide_sharing(
-  info_map: &HashMap<blake3::Hash, SubtermInfo>,
+  info_map: &FxHashMap<blake3::Hash, SubtermInfo>,
   topo_order: &[blake3::Hash],
 ) -> IndexSet<blake3::Hash> {
   let effective_sizes = compute_effective_sizes(info_map, topo_order);
@@ -633,7 +632,7 @@ pub fn build_sharing_vec(
   exprs: &[Arc<Expr>],
   shared_hashes: &IndexSet<blake3::Hash>,
   ptr_to_hash: &FxHashMap<*const Expr, blake3::Hash>,
-  info_map: &HashMap<blake3::Hash, SubtermInfo>,
+  info_map: &FxHashMap<blake3::Hash, SubtermInfo>,
   topo_order: &[blake3::Hash],
 ) -> (Vec<Arc<Expr>>, Vec<Arc<Expr>>) {
   // CRITICAL: Re-sort shared_hashes in topological order (leaves first).
@@ -646,7 +645,7 @@ pub fn build_sharing_vec(
   // Build sharing vector incrementally to avoid forward references.
   // When building sharing[i], only Share(j) for j < i is allowed.
   let mut sharing_vec: Vec<Arc<Expr>> = Vec::with_capacity(shared_hashes.len());
-  let mut hash_to_idx: HashMap<blake3::Hash, u64> = HashMap::new();
+  let mut hash_to_idx: FxHashMap<blake3::Hash, u64> = FxHashMap::default();
   let mut cache: FxHashMap<*const Expr, Arc<Expr>> = FxHashMap::default();
 
   for h in &shared_in_topo_order {
@@ -695,7 +694,7 @@ enum RewriteFrame<'a> {
 /// Uses iterative traversal with caching to handle deep trees and Arc sharing.
 fn rewrite_expr(
   expr: &Arc<Expr>,
-  hash_to_idx: &HashMap<blake3::Hash, u64>,
+  hash_to_idx: &FxHashMap<blake3::Hash, u64>,
   ptr_to_hash: &FxHashMap<*const Expr, blake3::Hash>,
   cache: &mut FxHashMap<*const Expr, Arc<Expr>>,
 ) -> Arc<Expr> {


### PR DESCRIPTION
Performance pass over the decompile and compile pipelines, following up on the post-#572 benchmark reports (FLT decompile +114% time / +110% RAM was the headline regression). Three commits on main (post-#578): thin LTO, Rust-side phase/RSS instrumentation, and the algorithmic batch. **Serialized bytes are unchanged everywhere** — verified end-to-end at Mathlib scale (see Validation).

## Headline numbers (Mathlib, 736,624 consts, 32-core / 124 GiB box)

**Decompile** (`ix decompile compilemathlib.ixe`, CI-comparable: local baseline 151.2 s ≈ CI's 152.5 s row):

| | before | after | Δ |
|---|---|---|---|
| Pass 2 ingress | 18.8 s | **6.0 s** | −68 % |
| Pass 2 gen | 75.9 s | **62.2 s** | −18 % |
| **wall total** | **151.2 s** | **120.9 s** | **−20 %** |
| peak RSS | 34.8 GiB | **30.5 GiB** | −4.3 GiB |
| constrained run (65536-entry clear knob, 7 clears) | 228.0 s | **136.1 s** | −40 % |
| cost per kenv clear | ~10 s | ~1.9 s | −81 % |

The constrained row is the FLT mechanism reproduced locally: FLT's dependency closure crosses the old default kenv-clear threshold, so its CI row was paying a full closure re-walk on every clear. That cliff is now flattened three ways (a clear-surviving refs memo + cheap re-ensure + a threshold FLT never reaches), so the FLT row should recover most of the regression **plus** RAM.

**Compile** (`ix compile CompileMathlib.lean`, A/B on this branch's base vs tip, byte-identical outputs):

| | base | perf | Δ |
|---|---|---|---|
| setup_scan | 11.1 s | 9.2 s | −17 % |
| scheduler | 32.8 s | 30.0 s | −8.5 % |
| **compile+serialize+write** | **59.5 s** | **55.0 s** | **−7.6 %** |

## What changed

### Decompile Pass 2

- **`get_constant_info_references` rewritten** as a single-accumulator iterative DAG walk (visited set keyed on `Expr`'s digest-backed `Hash`/`Eq`) instead of materializing+merging+cloning a `NameSet` per expression node. Feeds both compile's `setup_scan` and decompile's Pass-2 ingress BFS. Result sets are value-identical; no consumer reads set iteration order into bytes (SCC members and every serialized section re-sort canonically).
- **Ingress BFS refs memo survives kenv clears**: the BFS's `ingressed` set doubles as the kenv-content tracker, so the periodic kenv clear wiped the only BFS memo and every clear re-walked the whole closure — a Θ(N²/L) term, and the mechanism behind FLT's +114 %. The discovered reference lists now survive clears (the reference graph doesn't change when the kenv does); names absent from `work_env` stay unmemoized so late-appearing aux constants are re-probed live.
- **Aux ingress walker dedup moves into `KernelCtx`**: `ingress_target_type_deps` / `ingress_field_deps` kept a per-call `seen`, re-expanding the full reference closure for every block (Θ(blocks × closure)). The set is now kenv-lifetime (`aux_ingress_seen`), keyed by **resolved id** — not bare name — so an address shifted by later aux registration reads as unseen and re-ingresses under the new id, exactly as the per-call sets healed it. Fresh-per-block in compile (§10.5 unchanged); cleared with the kenv in decompile. `collect_const_refs` additionally gains a digest-keyed visited set (shared subterms walked once, not once per occurrence). Measured: Pass-2 gen −18 %.
- **Pre-warm ingests proofs as type-only stubs**: the Pass-2 BFS ingested theorem/opaque constants with full proof terms (~47 KB/name measured) while the gen-phase walkers deliberately use type-only stubs for the same kinds. The new `ensure_in_kenv_of_prewarm` ingests thm/opaque as type-only `Axio` stubs — sufficient for kernel TC (proof irrelevance; opaque never unfolds) and the exact fidelity `ingress_type_stub` already gives. With per-entry kenv cost collapsed, the clear default rises 131072 → 1048576 and becomes a rare backstop; the `IX_DECOMPILE_KENV_CLEAR_ENTRIES` knob semantics are unchanged. Validated by a full-Mathlib decompile with **0 aux_gen errors** across 6,598 regenerated blocks (plus the congruence checks).
- Free wins: `lean_env` (a third whole-env copy) drops after Pass 1.5 instead of living to end of `decompile_env`; `rs_decompile_env` skips the ~30 GiB destructor churn on exit (one-shot CLI, mirroring `rs_compile_env`) and reports read/parse spans — the pre-Pass-1 `.ixe` parse is ~37 s of the wall and is now visible (largest remaining chunk; future target).

Lean mirrors land in the same commit: `AuxKernelCtx.auxIngressSeen` + `drainIngressQueue` + `collectConstRefs` visited set + `ensureInKenvOfPrewarm` wired into both Pass-2 driver variants (`Ix/AuxGen/Kernel.lean`, `Ix/AuxGen/Recursor.lean`, `Ix/DecompileDriver.lean`).

### Compile

- **Digest-keyed maps drop SipHash**: every blake3-digest-keyed map in `ixon/sharing.rs` moves from `std::HashMap` to `FxHashMap` (keys are already uniform digests; every order-sensitive consumer re-sorts).
- **Merkle root computed once, in parallel**: new host-only `merkle_root_canonical_sorted` (parallel leaf/level hashing for callers holding sorted unique leaves, bit-identical root). `rs_compile_env` computes the const table + root **once** and hands both to the new `put_file_with_header`; previously the par-sort and the ~2·N-node tree ran twice per compile.
- **Block-context addresses hoisted**: `compile_definition/inductive/recursor` take the block-context address list as a parameter, computed once per block (was: full ctx sort + re-intern per member, O(M² log M) per block).
- **Metadata moves instead of cloning**: mutual-path `ConstantMeta` moves out of `all_metas` via `remove` instead of two deep clones per constant.
- **Instrumentation**: `IX_COMPILE_DBG=1` now lights the Rust side too (scheduler phases with RSS attribution, `Env::put_file` per-section timers — the §4 serial name topo-sort is timed separately and shows 1.9 s at Mathlib scale, the next serializer target).
- **Thin LTO** on the release profile (no embedded guest builds in this workspace; external guest builds use their own profiles).

## Validation

- **Whole-Mathlib byte identity**: `ix compile` of `CompileMathlib.lean` on this branch's pre-perf base vs tip → `cmp` **identical** (3,326,436,547 bytes).
- **Whole-Mathlib decompile**: 0 aux_gen errors, 0 congruence failures (default and constrained-knob runs).
- `--ignored` parity gates: **validate-aux** (3,699 matches / 0 mismatches), **aux-gen-diff** (plain-defn mismatches 0), **decompile-diff** (plain fidelity + callsite replay PASS; Pass-2 plan parity 300/300; aux-fidelity PASS) — these cover the Lean mirror changes.
- `cargo test --workspace --release`: 1,256 passed / 0 failed (incl. `put_file_matches_put` for the `put_file_with_header` split).
- `lake test`: 2,668 checks, exit 0.
- `cargo clippy --workspace --release --all-targets` clean; `cargo fmt --check` clean.

## Explicitly not touched

Fresh-per-block `KernelCtx` in the compile scheduler (§10.5 determinism), wire format (no `Env::VERSION` change), DEMOTE/EAGER defaults, and the Lean drivers' performance (mirrors are behavior-parity only, per BENCHMARKS.md ground rules).

Follow-up targets surfaced by the new instrumentation (measured, not yet done): the ~37 s decompile pre-phase (`.ixe` parse — per-member Muts block re-parsing lives there), the §4 name topo-sort in the serializer (1.9 s serial), and the prove-side items from the benchmark digest (targeted hint-row promotion, FFT pin re-baseline, sequencing the two ixvm test envs).
