### PR TITLE
feat: Parallel Aiur execution over env shards

### DIFF
--- a/.github/workflows/bench-main.yml
+++ b/.github/workflows/bench-main.yml
@@ -133,6 +133,10 @@ jobs:
         include:
           - { env: InitStd }
           - { env: Lean }
+          # Init+Std+Lean+Batteries: the aiur-sharded-env (whole-env Aiur
+          # execution) benchmark's fast tier. Batteries builds from the
+          # shared Compile package; no mathlib cache needed.
+          - { env: ISLB }
           - { env: Mathlib, mathlib: true }
           - { env: FLT, cache_pkg: flt, mathlib: true }
           # - { env: FC, cache_pkg: formal_conjectures, mathlib: true }

--- a/.github/workflows/bencher-thresholds-reset.yml
+++ b/.github/workflows/bencher-thresholds-reset.yml
@@ -44,7 +44,7 @@ on:
         # GitHub requires literal choice options, so this list stays static:
         # keep it (and the jobs' valid= lists below) in sync with the
         # backend testbeds in Ix/Cli/BenchCmd.lean (backendSpecs).
-        options: [ix-compile, ix-decompile, aiur, zisk-check-execute, sp1-check-execute, ooc-check, all]
+        options: [ix-compile, ix-decompile, aiur, aiur-sharded-env-check, zisk-check-execute, sp1-check-execute, ooc-check, all]
       sha:
         description: "Commit to anchor to (default: HEAD)"
         required: false
@@ -77,7 +77,7 @@ jobs:
           # (backendSpecs) minus the runner-arch suffix. Static because this
           # job runs on a cheap runner with no built `ix`; keep in sync when
           # adding a backend.
-          valid="aiur ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
+          valid="aiur aiur-sharded-env-check ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
           if [ "$EVENT" = workflow_dispatch ]; then
             # Reset the chosen workload(s) at the given commit; no PR scan.
             sha="${INPUT_SHA:-$HEAD_SHA}"
@@ -133,7 +133,7 @@ jobs:
           # which the merge job expands into every workload). Same static
           # list as the reset job; keep both in sync with backendSpecs in
           # Ix/Cli/BenchCmd.lean.
-          valid="aiur ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
+          valid="aiur aiur-sharded-env-check ix-compile ix-decompile ooc-check sp1-check-execute zisk-check-execute"
           accepted="$valid all"
           # Parse the workload token(s) after the command, lowercased.
           workloads=$(printf '%s' "$BODY" \

--- a/Benchmarks/Compile/CompileISLB.lean
+++ b/Benchmarks/Compile/CompileISLB.lean
@@ -1,0 +1,2 @@
+import Lean
+import Batteries

--- a/Benchmarks/Compile/lakefile.toml
+++ b/Benchmarks/Compile/lakefile.toml
@@ -18,6 +18,9 @@ name = "CompileMathlib"
 name = "CompileBatteries"
 
 [[lean_lib]]
+name = "CompileISLB"
+
+[[lean_lib]]
 name = "CompileRedStep"
 
 [[lean_lib]]

--- a/Ix/Aiur/Protocol.lean
+++ b/Ix/Aiur/Protocol.lean
@@ -191,6 +191,35 @@ opaque verify : @& AiurSystem →
 
 end AiurSystem
 
+namespace Bytecode.Toplevel
+
+@[extern "rs_aiur_toplevel_shard_check_batch"]
+private opaque shardCheckBatchWithEnv' : @& Bytecode.Toplevel →
+  @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray → Bool → @& Nat →
+  @& CommitmentParameters → @& FriParameters →
+    Except String (Array (String × Nat))
+
+/-- Check EVERY shard of a partition in one call: rayon over the shard
+    list with true work-stealing (no chunk barriers), each shard
+    through the exact single-shard machinery over its own private
+    record and witness io. `shardsBlob` encodes, per shard, a 4-byte LE
+    owned-constant count followed by that many 32-byte addresses.
+    Returns one `(error, peakBytes)` pair per shard in shard order:
+    empty error = clean, and `peakBytes` is the analytic prover RAM
+    peak ([`AiurSystem::peak_prove_bytes`] Rust-side) of the shard's
+    executed record — the split/merge input (0 on failure).
+    `jobs = 0` uses rayon's default pool width. -/
+def shardCheckBatchWithEnv (toplevel : @& Bytecode.Toplevel)
+  (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle)
+  (shardsBlob : ByteArray) (useBytecode : Bool := false) (jobs : Nat := 0)
+  (commitmentParameters : CommitmentParameters := defaultCommitmentParameters)
+  (friParameters : FriParameters := defaultFriParameters)
+  : Except String (Array (String × Nat)) :=
+  shardCheckBatchWithEnv' toplevel funIdx envHandle shardsBlob useBytecode
+    jobs commitmentParameters friParameters
+
+end Bytecode.Toplevel
+
 /-- One-shot variant of `AiurSystem.circuitShapes` for flows that never
 build an `AiurSystem` (the `ix check` statistics): Rust builds the system,
 extracts the shapes, and drops it. -/

--- a/Ix/Aiur/Protocol.lean
+++ b/Ix/Aiur/Protocol.lean
@@ -208,7 +208,11 @@ private opaque shardCheckBatchWithEnv' : @& Bytecode.Toplevel →
     empty error = clean, and `peakBytes` is the analytic prover RAM
     peak ([`AiurSystem::peak_prove_bytes`] Rust-side) of the shard's
     executed record — the split/merge input (0 on failure).
-    `jobs = 0` uses rayon's default pool width. -/
+    `jobs = 0` uses rayon's default pool width (all cores): peak RSS
+    is bounded by the Rust-side RAM gate (a byte-weighted admission
+    semaphore over estimated per-shard execution RSS vs available
+    system RAM), not by thread count — pass `jobs` only to narrow
+    CPU use. -/
 def shardCheckBatchWithEnv (toplevel : @& Bytecode.Toplevel)
   (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle)
   (shardsBlob : ByteArray) (useBytecode : Bool := false) (jobs : Nat := 0)

--- a/Ix/Aiur/Semantics/BytecodeFfi.lean
+++ b/Ix/Aiur/Semantics/BytecodeFfi.lean
@@ -196,6 +196,26 @@ def checkAddrWithEnv (toplevel : @& Bytecode.Toplevel)
   (checkAddrWithEnv' toplevel funIdx envHandle addrBytes useBytecode).map
     fun r => (r.output, .ofArrays r.ioData r.ioMap, r.queryCounts)
 
+@[extern "rs_aiur_toplevel_check_addrs_with_env"]
+private opaque checkAddrsWithEnv' : @& Bytecode.Toplevel →
+  @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray → Bool → @& Nat →
+    Except String (Array (String × String))
+
+/-- Batch PARALLEL check of many full-closure claims: `addrsBlob` is
+    the concatenation of 32-byte addresses, and Rust checks them on a
+    rayon pool of `jobs` threads (0 = rayon default) — each claim
+    through the exact single-claim machinery over task-private data
+    (own witness io, own query record), nothing shared between tasks
+    but the read-only toplevel and env. Returns the FAILURES as
+    `(addrHex, error)` pairs; empty means all passed. Per-claim
+    outputs/records are not returned — use `checkAddrWithEnv` for a
+    single claim's full result. -/
+def checkAddrsWithEnv (toplevel : @& Bytecode.Toplevel)
+  (funIdx : @& Bytecode.FunIdx) (envHandle : @& EnvHandle)
+  (addrsBlob : ByteArray) (useBytecode : Bool := false) (jobs : Nat := 0)
+  : Except String (Array (String × String)) :=
+  checkAddrsWithEnv' toplevel funIdx envHandle addrsBlob useBytecode jobs
+
 @[extern "rs_aiur_toplevel_shard_check_with_env"]
 private opaque shardCheckWithEnv' : @& Bytecode.Toplevel →
   @& Bytecode.FunIdx → @& EnvHandle → @& ByteArray → Bool →

--- a/Ix/Aiur/Statistics.lean
+++ b/Ix/Aiur/Statistics.lean
@@ -53,6 +53,19 @@ structure ExecutionStats where
   totalCacheHits : Nat
   deriving Inhabited
 
+/-- Coarse PROVER RAM projection for a record with these circuit
+    heights: the committed trace bytes over the LDE domain,
+    `Σ nextPowerOfTwo(height) · committedWidth · 8 · 2^logBlowup`, with empty
+    circuits contributing nothing (the prover deactivates them). A
+    surrogate for relative shard sizing — how many shards must split
+    (over a prover budget) or could merge (far under it) — not an
+    exact allocator-level peak. -/
+def ExecutionStats.projectedProverBytes (stats : ExecutionStats)
+    (logBlowup : Nat := defaultCommitmentParameters.logBlowup) : Nat :=
+  stats.circuits.foldl (init := 0) fun acc c =>
+    if c.height == 0 then acc
+    else acc + Nat.nextPowerOfTwo c.height * c.width * 8 * (2 ^ logBlowup)
+
 /-- Continuous transform-size surrogate: `0` at `0` (an empty circuit is
 deactivated by the prover), else `x·log2(max(x, 2))` — the clamp keeps a
 height-1 transform nonzero. -/

--- a/Ix/Cli/BenchCmd.lean
+++ b/Ix/Cli/BenchCmd.lean
@@ -97,6 +97,10 @@ structure EnvSpec where
 def envSpecs : List EnvSpec := [
   { name := "InitStd", module := "Benchmarks/Compile/CompileInitStd.lean" },
   { name := "Lean",    module := "Benchmarks/Compile/CompileLean.lean" },
+  -- Init+Std+Lean+Batteries as ONE env: the whole-env Aiur execution
+  -- benchmark's fast tier (the union deduplicates — Lean already
+  -- carries Init and Std).
+  { name := "ISLB",    module := "Benchmarks/Compile/CompileISLB.lean" },
   { name := "Mathlib", module := "Benchmarks/Compile/CompileMathlib.lean" },
   { name := "FLT",     module := "Benchmarks/Compile/CompileFLT.lean" }
 ]
@@ -156,6 +160,11 @@ structure BackendSpec where
   defaultMode : String
   /-- The inputs (envs and row names) this backend's runs fan over. -/
   inputs : BenchInputs
+  /-- For a `perEnv` backend: restrict the fan-out to these registry env
+      names instead of every compiled env (`none` = all). Ignored for
+      the per-constant backends, whose env set comes from `Vectors.csv`
+      row selection. -/
+  envs : Option (List String) := none
   /-- `some reason` ⇒ `parse` skips the backend with the note in the
       config summary. -/
   disabled : Option String := none
@@ -264,6 +273,26 @@ def backendSpecs : List BackendSpec := [
                    ("fri-verifier-proof-size", "0.05", "_"),
                    ("ixvm-verify-time", "0.10", "_"),
                    ("fri-verifier-verify-time", "0.10", "_")] },
+  -- aiur-sharded-env: whole-env Aiur execution — the sharded feeder pipeline
+  -- end-to-end at env scale, one row per env. Shards the `.ixe` for the
+  -- runner's RAM (`ix shard --max-ram 100`: naive sizing → ~3.5 GB
+  -- execution RSS per shard on a 128 GB runner), then one gated
+  -- full-width rayon batch (`ix check --ixe --ixes`) over the whole
+  -- manifest — the byte-weighted RamGate, not a thread cap, bounds peak
+  -- RSS, so the same entry is correct on any runner class. ISLB only
+  -- for now (~10 min/run); add "FLT" / "Mathlib" to `envs` for the
+  -- env-scale tiers (~30-45 min each on the 32x runner) when their
+  -- per-push cost is warranted. `shards` is deterministic per
+  -- (env bytes, budget) and only drops on a real compression win →
+  -- upper-only pin.
+  { name := "aiur-sharded-env", defaultMode := "execute", inputs := .perEnv,
+    envs := some ["ISLB"],
+    testbeds := [("execute", "aiur-sharded-env-check-x64-32x")],
+    metrics := [("execute", ["check-time", "throughput", "peak-rss",
+                             "constants", "shards"])],
+    thresholds := [("constants", "0", "0"), ("shards", "0", "_"),
+                   ("check-time", "0.10", "_"), ("throughput", "_", "0.10"),
+                   ("peak-rss", "0.10", "_")] },
   { name := "zisk", defaultMode := "execute", inputs := .perConstant,
     testbeds := [("execute", "zisk-check-execute-x64-32x")],
     metrics := [("execute", ["execute-time", "throughput", "peak-rss",
@@ -319,6 +348,10 @@ def backendSpecs : List BackendSpec := [
   -- CONSUMER — it reuses the compile run's fresh `.ixe` rather than
   -- producing one.
   { name := "decompile", defaultMode := "execute", inputs := .perEnv,
+    -- Pinned to the pre-ISLB env set: ISLB exists for the aiur-sharded-env
+    -- whole-env execution benchmark, and its content is Lean +
+    -- Batteries — a decompile row would mostly re-measure Lean's.
+    envs := some ["InitStd", "Lean", "Mathlib", "FLT"],
     testbeds := [("execute", "ix-decompile-x64-32x")],
     metrics := [("execute", ["decompile-time", "throughput", "peak-rss",
                              "file-size", "constants"])],
@@ -376,7 +409,9 @@ def BackendSpec.scheduledModes (b : BackendSpec) : List String :=
 def BackendSpec.envNames (b : BackendSpec) : List String :=
   let names := envSpecs.map (·.name)
   match b.inputs with
-  | .perEnv => names
+  | .perEnv => match b.envs with
+    | some restricted => names.filter restricted.contains
+    | none => names
   | .perConstant | .perConstantWithEnv =>
     names.filter fun env =>
       b.scheduledModes.any fun m =>
@@ -391,7 +426,7 @@ def BackendSpec.envNames (b : BackendSpec) : List String :=
 def BackendSpec.benchmarkNames (b : BackendSpec) (mode : String) :
     Array String := Id.run do
   match b.inputs with
-  | .perEnv => return (envSpecs.map (·.name)).toArray
+  | .perEnv => return b.envNames.toArray
   | .perConstant | .perConstantWithEnv =>
     let mut ns : Array String := #[]
     for env in b.envNames do
@@ -721,6 +756,27 @@ def runBenchRunCmd (p : Cli.Parsed) : IO UInt32 := do
         #["check-rs", ixe, "--anon", "--consts-file", namesFile, "--json", out]
       if exit != 0 && exit != exitRejected then
         IO.eprintln s!"[bench] per-constant checks failed (exit {exit})"
+  | "aiur-sharded-env" =>
+    -- Whole-env sharded Aiur execution: shard the env for the runner's
+    -- RAM (naive `--max-ram 100` sizing → ~3.5 GB execution RSS per
+    -- shard), then ONE gated full-width rayon batch over the manifest —
+    -- the RamGate bounds peak RSS, so no `--jobs` is passed. The check
+    -- writes the env-keyed row itself (`--json`): check-time,
+    -- throughput, peak-rss, constants, shards. The shard step is
+    -- deterministic setup, not part of the measured window.
+    let ixe ← ensureIxe repo info ((p.flag? "ixe").map (·.as! String))
+    let ix ← resolveBin repo "ix"
+    let manifest := s!"{env}-exec.ixes"
+    let exit ← runGuarded watchdog ceilingGb ix
+      #["shard", ixe, "--max-ram", "100", "--out", manifest]
+    if exit != 0 then
+      IO.eprintln s!"[bench] ix shard failed (exit {exit})"
+      return 1
+    let exit ← runGuarded watchdog ceilingGb ix
+      #["check", "--ixe", ixe, "--ixes", manifest,
+        "--json", out, "--json-name", info.name]
+    if exit != 0 && exit != exitRejected then
+      IO.eprintln s!"[bench] whole-env aiur check failed (exit {exit})"
   | "lean4lean" =>
     -- The reference Lean4-in-Lean4 kernel checks the env's library from
     -- its oleans, so no `.ixe` is resolved. The tool takes the same
@@ -847,7 +903,7 @@ def benchRunCmd : Cli.Cmd := `[Cli|
   "Execute one benchmark run (backend × env × mode), writing benchmark results JSON. Exits 0 on success (rows saved as the local baseline), 3 when the kernel rejected any constant, 1 when no rows were produced."
 
   FLAGS:
-    backend      : String; "aiur | zisk | sp1 | ooc | lean4lean | compile | decompile"
+    backend      : String; "aiur | aiur-sharded-env | zisk | sp1 | ooc | lean4lean | compile | decompile"
     env          : String; "Benchmark env from the registry (default: InitStd)"
     mode         : String; "prove | execute (default: the backend's defaultMode)"
     out          : String; "Benchmark results JSON output path (default: bench.json)"

--- a/Ix/Cli/BenchReport.lean
+++ b/Ix/Cli/BenchReport.lean
@@ -1134,8 +1134,9 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
     (fun e => constsByEnv.any (·.1 == e))).toArray
 
   -- Env defaults, per backend, when BENCH_ENVS is absent: the env-keyed
-  -- backends (`inputs := .perEnv` — compile, decompile) cover their full
-  -- registry env set — their row IS the env, so a compiler PR sees every
+  -- backends (`inputs := .perEnv` — compile, decompile, aiur-sharded-env) cover
+  -- their registry env set (the full set, or the spec's `envs`
+  -- restriction) — their row IS the env, so a compiler PR sees every
   -- env's delta without asking — while the per-constant backends default
   -- to the light InitStd (a Mathlib prove is too heavy for an unasked-for
   -- default). An explicit BENCH_ENVS applies to every requested backend —
@@ -1148,7 +1149,7 @@ def runParseCmd (p : Cli.Parsed) : IO UInt32 := do
       constEnvs
     else if !envs.isEmpty then envs
     else if b.inputs == .perEnv then
-      (Ix.Cli.BenchCmd.envSpecs.map (·.name)).toArray
+      (b.envs.getD (Ix.Cli.BenchCmd.envSpecs.map (·.name))).toArray
     else #["InitStd"]
 
   let modeFor := fun (b : Ix.Cli.BenchCmd.BackendSpec) =>

--- a/Ix/Cli/CheckCmd.lean
+++ b/Ix/Cli/CheckCmd.lean
@@ -616,41 +616,17 @@ def shardsCover (ixonEnv : Ixon.Env) (shards : Array (Array Address)) : IO Bool 
     IO.println s!"[shards] OK: partition covers all {ixonEnv.consts.size} consts, disjoint"
   pure ok
 
-/-- IxVM-native check over EVERY shard. Builds the `EnvHandle` ONCE
-    and shares it across every shard's FFI call (no per-shard
-    re-mmap). Coverage-gates the manifest before running any shard —
-    exit 0 has to mean "every env const was checked by some shard",
-    same soundness contract as `runShardCheckAll`. -/
-def runShardManifestAllNative (manifestPath ixePath : String) (jobs? : Option Nat)
-    (compiled : Aiur.CompiledToplevel) (printStats : Bool)
-    (statsOut : Option String) (useBytecode : Bool) : IO UInt32 := do
-  match (← loadEnvAndShards manifestPath ixePath) with
-  | .error e => IO.eprintln e; return 1
-  | .ok (ixonEnv, shards) =>
-    if !(← shardsCover ixonEnv shards) then return 1
-    let envHandle ← match Aiur.EnvHandle.fromIxe ixePath with
-      | .error e => IO.eprintln s!"EnvHandle.fromIxe {ixePath}: {e}"; return 1
-      | .ok h => pure h
-    let shapes := Aiur.circuitShapes compiled.bytecode
-      Aiur.defaultCommitmentParameters Aiur.defaultFriParameters
-    let maxJobs := max 1 (jobs?.getD shards.size)
-    let mut rc : UInt32 := 0
-    for chunk in (shards.mapIdx (fun k b => (b, k))).toList.toChunks maxJobs do
-      let tasks ← chunk.mapM fun (blocks, k) =>
-        IO.asTask (prio := .dedicated)
-          (runShardOwnedNative envHandle compiled printStats statsOut useBytecode shapes ixonEnv blocks k)
-      for t in tasks do
-        match t.get with
-        | .ok r => if r != 0 then rc := 1
-        | .error e => IO.eprintln s!"shard check task failed: {e}"; rc := 1
-    pure rc
-
-/-- Whole-partition check as ONE Rust rayon batch (work-stealing across
-    shards, no chunk barriers), against per-shard Lean tasks in
-    `runShardManifestAllNative`. Each shard runs the identical
-    single-shard machinery over its own record; per shard the analytic
-    prover RAM peak of the executed record is reported — the input to
-    split (over a prover budget) / merge (far under it) decisions. -/
+/-- Whole-partition check as ONE Rust rayon batch: work-stealing across
+    shards, no chunk barriers (measured 2.3–2.5x faster than the
+    per-shard Lean-task scheduler it replaced, whose chunk-of-N full
+    barrier idled workers on each wave's slowest shard). Each shard
+    runs the identical single-shard machinery over its own record; per
+    shard the analytic prover RAM peak of the executed record is
+    reported — the input to split (over a prover budget) / merge (far
+    under it) decisions. Builds the `EnvHandle` ONCE, shared by every
+    shard. Coverage-gates the manifest before running any shard — exit
+    0 has to mean "every env const was checked by some shard", same
+    soundness contract as `runShardCheckAll`. -/
 def runShardBatchNative (manifestPath ixePath : String) (jobs? : Option Nat)
     (compiled : Aiur.CompiledToplevel) (useBytecode : Bool) : IO UInt32 := do
   match (← loadEnvAndShards manifestPath ixePath) with
@@ -662,9 +638,22 @@ def runShardBatchNative (manifestPath ixePath : String) (jobs? : Option Nat)
       | .ok h => pure h
     let funIdx := compiled.getFuncIdx `verify_claim |>.get!
     let jobs := jobs?.getD 0
+    -- Assign every const to its shard in ONE env pass. Calling
+    -- `ownedConstsForBlocks` per shard rescans all consts each time —
+    -- at env scale (241 shards × 688k consts) that is ~30 min of setup.
+    -- Each shard's array keeps env-iteration order, identical to what
+    -- the per-shard filter produces, so claim digests are unchanged.
+    let mut blockToShard : Std.HashMap Address Nat := {}
+    for (blocks, k) in shards.mapIdx (fun k b => (b, k)) do
+      for blk in blocks do blockToShard := blockToShard.insert blk k
+    let mut ownedPerShard : Array (Array Address) := Array.replicate shards.size #[]
+    for (addr, lc) in ixonEnv.consts do
+      let some c := lc.get? | continue
+      match blockToShard.get? (blockAddrOf addr c) with
+      | some k => ownedPerShard := ownedPerShard.modify k (·.push addr)
+      | none => pure ()
     let mut blob := ByteArray.empty
-    for blocks in shards do
-      let owned := ownedConstsForBlocks ixonEnv blocks
+    for owned in ownedPerShard do
       let n := owned.size.toUInt32
       blob := blob.push n.toUInt8
       blob := blob.push (n >>> 8).toUInt8
@@ -805,11 +794,8 @@ def runCheckCmd (p : Cli.Parsed) : IO UInt32 := do
       let compiled ← match toplevel.compile with
         | .error e => IO.eprintln s!"Compilation failed: {e}"; return 1
         | .ok c => pure c
-      if p.hasFlag "batch" then
-        return (← runShardBatchNative manifest ixe
-          ((p.flag? "jobs").map (·.as! Nat)) compiled useBytecode)
-      return (← runShardManifestAllNative manifest ixe
-        ((p.flag? "jobs").map (·.as! Nat)) compiled printStats statsOut useBytecode)
+      return (← runShardBatchNative manifest ixe
+        ((p.flag? "jobs").map (·.as! Nat)) compiled useBytecode)
   | _, _, _ =>
     -- `--jobs N` (N ≠ 1) with an `--ixe` env and no `--claim` takes the
     -- parallel batch path: one FFI call, rayon over the target list,
@@ -842,7 +828,6 @@ def checkCmd : Cli.Cmd := `[Cli|
     "ixes"      : String;   "Path to a `.ixes` shard manifest (with --ixe). With --shard K: check the constants owned by shard K (ingress their closure, skip the frontier). Without --shard: check every shard of the partition concurrently, after a coverage check."
     "shard"     : Nat;      "0-based shard index K (with --ixe + --ixes): check the constants owned by shard K of the manifest's partition."
     "jobs"      : Nat;      "Parallelism. With --ixes (no --shard): max shards checked concurrently (default: all at once). With --ixe alone and N ≠ 1: check the targeted constants on N Rust threads (0 = all cores), each claim over its own private record — peak RAM is bounded by N in-flight claim closures."
-    "batch";                "With --ixes (no --shard): run the whole partition as ONE Rust rayon batch — work-stealing across shards, no chunk barriers — instead of per-shard Lean tasks. Each shard still executes sequentially over its own record; prints every shard's projected prover RAM peak (the analytic model) for split/merge decisions. --jobs bounds the pool (0 = all cores)."
 
   ARGS:
     ...names : String; "Fully-qualified Lean.Name(s) to check. With none, iterate every named constant in the env (sorted)."

--- a/Ix/Cli/CheckCmd.lean
+++ b/Ix/Cli/CheckCmd.lean
@@ -128,6 +128,69 @@ inductive Target where
   | shard (owned : Array Address)
   | leanW (w : IxVM.ClaimHarness.ClaimWitness)
 
+/-- Batch PARALLEL check over one `.ixe`: resolve the targets (explicit
+    names, or every named constant when `names` is empty), hand the
+    address list to Rust in one call (`checkAddrsWithEnv`), and let a
+    rayon pool of `jobs` threads check them — each claim through the
+    exact single-claim machinery over task-private data (its own
+    witness io and query record), nothing shared between tasks but the
+    read-only toplevel and env. Failures come back as batch indices
+    and resolve to labels here. -/
+def runBatchCheck (ixePath : String) (names : List String) (jobs : Nat)
+    (toplevel : Aiur.Source.Toplevel) (useBytecode : Bool) : IO UInt32 := do
+  let compiled : Aiur.CompiledToplevel ← match toplevel.compile with
+    | .error e => IO.eprintln s!"Compilation failed: {e}"; return 1
+    | .ok c => pure c
+  let envHandle ← match Aiur.EnvHandle.fromIxe ixePath with
+    | .error e => IO.eprintln s!"EnvHandle.fromIxe {ixePath}: {e}"; return 1
+    | .ok h => pure h
+  let bytes ← IO.FS.readBinFile ixePath
+  let ixonEnv ← match Ixon.deEnvAnon bytes with
+    | .error e => IO.eprintln s!"Failed to deserialize {ixePath}: {e}"; return 1
+    | .ok env => pure env
+  IO.println s!"Loaded {ixePath}: {ixonEnv.namedCount} named, \
+    {ixonEnv.constCount} consts, {ixonEnv.blobCount} blobs"
+  -- Unresolved names are recorded and reported with the check
+  -- failures rather than aborting: the batch is inherently
+  -- keep-going (every target's result comes back), so resolution
+  -- failures get the same treatment.
+  let mut targets : Array (String × Address) := #[]
+  let mut unresolved : Array String := #[]
+  if names.isEmpty then
+    let sorted := ixonEnv.named.toArray.qsort
+      (fun a b => toString a.1 < toString b.1)
+    for (ixName, named) in sorted do
+      targets := targets.push (toString (ixNameToLeanName ixName), named.addr)
+  else
+    for arg in names do
+      match resolveIxeAddr ixonEnv arg with
+      | none =>
+        IO.eprintln s!"{arg} not found in {ixePath}"
+        unresolved := unresolved.push arg
+      | some addr => targets := targets.push (arg, addr)
+  let funIdx := compiled.getFuncIdx `verify_claim |>.get!
+  let mut blob := ByteArray.empty
+  for (_, a) in targets do blob := blob ++ a.hash
+  IO.println s!"Typechecking {targets.size} constant(s), {jobs} thread(s)"
+  (← IO.getStdout).flush
+  match compiled.bytecode.checkAddrsWithEnv funIdx envHandle blob
+      useBytecode jobs with
+  | .error e => IO.eprintln s!"batch check: {e}"; return 1
+  | .ok failures =>
+    if failures.isEmpty && unresolved.isEmpty then
+      IO.println s!"All {targets.size} constant(s) passed"
+      return 0
+    for (idxStr, err) in failures do
+      let label := match idxStr.toNat? with
+        | some i =>
+          if h : i < targets.size then targets[i].1 else s!"index {idxStr}"
+        | none => s!"index {idxStr}"
+      IO.eprintln s!"{label}: IxVM-native Aiur execution error: {err}"
+    IO.eprintln
+      s!"{failures.size} of {targets.size} checked constant(s) FAILED\
+        {if unresolved.isEmpty then "" else s!", {unresolved.size} unresolved"}"
+    return 1
+
 /-- Run a single check claim through the codegen'd IxVM Rust kernel.
     The `envHandle?` is `none` only for `.leanW` targets (`--interp`
     fallback); the addr/shard arms require it. -/
@@ -684,7 +747,20 @@ def runCheckCmd (p : Cli.Parsed) : IO UInt32 := do
       return (← runShardManifestAllNative manifest ixe
         ((p.flag? "jobs").map (·.as! Nat)) compiled printStats statsOut useBytecode)
   | _, _, _ =>
-    forEachClaim ixePath claimHex names keepGoing "check" interpSource runOne
+    -- `--jobs N` (N ≠ 1) with an `--ixe` env and no `--claim` takes the
+    -- parallel batch path: one FFI call, rayon over the target list,
+    -- each claim checked over task-private data. `--jobs 1` (or no
+    -- flag) keeps the sequential per-claim loop unchanged.
+    match (p.flag? "jobs").map (·.as! Nat), ixePath with
+    | some jobs, some ixe =>
+      if jobs != 1 && !interpSource && claimHex.isNone then
+        runBatchCheck ixe names jobs toplevel useBytecode
+      else
+        forEachClaim ixePath claimHex names keepGoing "check" interpSource
+          runOne
+    | _, _ =>
+      forEachClaim ixePath claimHex names keepGoing "check" interpSource
+        runOne
 
 end Ix.Cli.CheckCmd
 
@@ -701,7 +777,7 @@ def checkCmd : Cli.Cmd := `[Cli|
     "stats-out" : String;   "Redirect the per-circuit statistics dump to this file (only used when exactly one constant is targeted)."
     "ixes"      : String;   "Path to a `.ixes` shard manifest (with --ixe). With --shard K: check the constants owned by shard K (ingress their closure, skip the frontier). Without --shard: check every shard of the partition concurrently, after a coverage check."
     "shard"     : Nat;      "0-based shard index K (with --ixe + --ixes): check the constants owned by shard K of the manifest's partition."
-    "jobs"      : Nat;      "Max shards to check concurrently when checking a whole partition (--ixes without --shard). Default: all at once. Lower it to bound peak RAM — each in-flight shard re-ingests its closure into its own IO buffer."
+    "jobs"      : Nat;      "Parallelism. With --ixes (no --shard): max shards checked concurrently (default: all at once). With --ixe alone and N ≠ 1: check the targeted constants on N Rust threads (0 = all cores), each claim over its own private record — peak RAM is bounded by N in-flight claim closures."
 
   ARGS:
     ...names : String; "Fully-qualified Lean.Name(s) to check. With none, iterate every named constant in the env (sorted)."

--- a/Ix/Cli/CheckCmd.lean
+++ b/Ix/Cli/CheckCmd.lean
@@ -515,6 +515,7 @@ def runShardOwned (ixonEnv : Ixon.Env) (blocks : Array Address) (shardK : Nat)
     one env parse. -/
 def runShardOwnedNative (envHandle : Aiur.EnvHandle) (compiled : Aiur.CompiledToplevel)
     (printStats : Bool) (statsOut : Option String) (useBytecode : Bool)
+    (shapes : Array Aiur.CircuitShape)
     (ixonEnv : Ixon.Env) (blocks : Array Address) (shardK : Nat) : IO UInt32 := do
   let owned := ownedConstsForBlocks ixonEnv blocks
   IO.println s!"[shard] shard {shardK}: {blocks.size} owned blocks → \
@@ -531,6 +532,13 @@ def runShardOwnedNative (envHandle : Aiur.EnvHandle) (compiled : Aiur.CompiledTo
     IO.eprintln s!"{label}: IxVM-native shard check error: {e}"
     return 1
   | .ok (_output, _ioBuffer, queryCounts) =>
+    -- Prover RAM projection from this shard's executed heights: the
+    -- input to split/merge decisions against a prover budget.
+    let stats := Aiur.computeStats compiled queryCounts shapes
+    let bytes := stats.projectedProverBytes
+    let gib := Float.ofNat bytes / 1073741824.0
+    IO.println s!"[shard {shardK}] projected prover RAM: \
+      {gib} GiB (padded committed traces × blowup)"
     if printStats then emitStats compiled queryCounts statsOut
     pure 0
 
@@ -556,7 +564,9 @@ def runShardCheckManifestNative (manifestPath ixePath : String) (shardK : Nat)
       let envHandle ← match Aiur.EnvHandle.fromIxe ixePath with
         | .error e => IO.eprintln s!"EnvHandle.fromIxe {ixePath}: {e}"; return 1
         | .ok h => pure h
-      runShardOwnedNative envHandle compiled printStats statsOut useBytecode ixonEnv blocks shardK
+      let shapes := Aiur.circuitShapes compiled.bytecode
+        Aiur.defaultCommitmentParameters Aiur.defaultFriParameters
+      runShardOwnedNative envHandle compiled printStats statsOut useBytecode shapes ixonEnv blocks shardK
 
 /-- Coverage check over already-loaded env + shards: every constant's
     check-schedule block is owned by **exactly one** shard. That is the whole
@@ -621,17 +631,68 @@ def runShardManifestAllNative (manifestPath ixePath : String) (jobs? : Option Na
     let envHandle ← match Aiur.EnvHandle.fromIxe ixePath with
       | .error e => IO.eprintln s!"EnvHandle.fromIxe {ixePath}: {e}"; return 1
       | .ok h => pure h
+    let shapes := Aiur.circuitShapes compiled.bytecode
+      Aiur.defaultCommitmentParameters Aiur.defaultFriParameters
     let maxJobs := max 1 (jobs?.getD shards.size)
     let mut rc : UInt32 := 0
     for chunk in (shards.mapIdx (fun k b => (b, k))).toList.toChunks maxJobs do
       let tasks ← chunk.mapM fun (blocks, k) =>
         IO.asTask (prio := .dedicated)
-          (runShardOwnedNative envHandle compiled printStats statsOut useBytecode ixonEnv blocks k)
+          (runShardOwnedNative envHandle compiled printStats statsOut useBytecode shapes ixonEnv blocks k)
       for t in tasks do
         match t.get with
         | .ok r => if r != 0 then rc := 1
         | .error e => IO.eprintln s!"shard check task failed: {e}"; rc := 1
     pure rc
+
+/-- Whole-partition check as ONE Rust rayon batch (work-stealing across
+    shards, no chunk barriers), against per-shard Lean tasks in
+    `runShardManifestAllNative`. Each shard runs the identical
+    single-shard machinery over its own record; per shard the analytic
+    prover RAM peak of the executed record is reported — the input to
+    split (over a prover budget) / merge (far under it) decisions. -/
+def runShardBatchNative (manifestPath ixePath : String) (jobs? : Option Nat)
+    (compiled : Aiur.CompiledToplevel) (useBytecode : Bool) : IO UInt32 := do
+  match (← loadEnvAndShards manifestPath ixePath) with
+  | .error e => IO.eprintln e; return 1
+  | .ok (ixonEnv, shards) =>
+    if !(← shardsCover ixonEnv shards) then return 1
+    let envHandle ← match Aiur.EnvHandle.fromIxe ixePath with
+      | .error e => IO.eprintln s!"EnvHandle.fromIxe {ixePath}: {e}"; return 1
+      | .ok h => pure h
+    let funIdx := compiled.getFuncIdx `verify_claim |>.get!
+    let jobs := jobs?.getD 0
+    let mut blob := ByteArray.empty
+    for blocks in shards do
+      let owned := ownedConstsForBlocks ixonEnv blocks
+      let n := owned.size.toUInt32
+      blob := blob.push n.toUInt8
+      blob := blob.push (n >>> 8).toUInt8
+      blob := blob.push (n >>> 16).toUInt8
+      blob := blob.push (n >>> 24).toUInt8
+      for a in owned do blob := blob ++ a.hash
+    IO.println s!"Typechecking {shards.size} shard(s) in one rayon \
+      batch, {jobs} thread(s) (0 = all)"
+    (← IO.getStdout).flush
+    match compiled.bytecode.shardCheckBatchWithEnv funIdx envHandle blob
+        useBytecode jobs Aiur.defaultCommitmentParameters
+        Aiur.defaultFriParameters with
+    | .error e => IO.eprintln s!"shard batch: {e}"; return 1
+    | .ok results =>
+      let mut failures : Nat := 0
+      for k in [:results.size] do
+        let (err, peak) := results[k]!
+        if err.isEmpty then
+          let gib := Float.ofNat peak / 1073741824.0
+          IO.println s!"[shard {k}] ok, projected prover peak {gib} GiB"
+        else
+          IO.eprintln s!"[shard {k}] FAILED: {err}"
+          failures := failures + 1
+      if failures == 0 then
+        IO.println s!"All {results.size} shard(s) passed"
+        return 0
+      IO.eprintln s!"{failures} of {results.size} shard(s) FAILED"
+      return 1
 
 /-- Run the shard operation over EVERY shard — the whole-partition behavior of
     `--ixes` with no `--shard` (used by `prove`). Loads the env once. Returns 1
@@ -744,6 +805,9 @@ def runCheckCmd (p : Cli.Parsed) : IO UInt32 := do
       let compiled ← match toplevel.compile with
         | .error e => IO.eprintln s!"Compilation failed: {e}"; return 1
         | .ok c => pure c
+      if p.hasFlag "batch" then
+        return (← runShardBatchNative manifest ixe
+          ((p.flag? "jobs").map (·.as! Nat)) compiled useBytecode)
       return (← runShardManifestAllNative manifest ixe
         ((p.flag? "jobs").map (·.as! Nat)) compiled printStats statsOut useBytecode)
   | _, _, _ =>
@@ -778,6 +842,7 @@ def checkCmd : Cli.Cmd := `[Cli|
     "ixes"      : String;   "Path to a `.ixes` shard manifest (with --ixe). With --shard K: check the constants owned by shard K (ingress their closure, skip the frontier). Without --shard: check every shard of the partition concurrently, after a coverage check."
     "shard"     : Nat;      "0-based shard index K (with --ixe + --ixes): check the constants owned by shard K of the manifest's partition."
     "jobs"      : Nat;      "Parallelism. With --ixes (no --shard): max shards checked concurrently (default: all at once). With --ixe alone and N ≠ 1: check the targeted constants on N Rust threads (0 = all cores), each claim over its own private record — peak RAM is bounded by N in-flight claim closures."
+    "batch";                "With --ixes (no --shard): run the whole partition as ONE Rust rayon batch — work-stealing across shards, no chunk barriers — instead of per-shard Lean tasks. Each shard still executes sequentially over its own record; prints every shard's projected prover RAM peak (the analytic model) for split/merge decisions. --jobs bounds the pool (0 = all cores)."
 
   ARGS:
     ...names : String; "Fully-qualified Lean.Name(s) to check. With none, iterate every named constant in the env (sorted)."

--- a/Ix/Cli/CheckCmd.lean
+++ b/Ix/Cli/CheckCmd.lean
@@ -33,6 +33,8 @@ public import Ix.Ixon
 public import Ix.Meta
 public import Ix.Store
 public import Ix.Cli.NameResolve
+public import Ix.Benchmark.Results
+public import Ix.TracingTexray
 
 public section
 
@@ -628,7 +630,12 @@ def shardsCover (ixonEnv : Ixon.Env) (shards : Array (Array Address)) : IO Bool 
     0 has to mean "every env const was checked by some shard", same
     soundness contract as `runShardCheckAll`. -/
 def runShardBatchNative (manifestPath ixePath : String) (jobs? : Option Nat)
-    (compiled : Aiur.CompiledToplevel) (useBytecode : Bool) : IO UInt32 := do
+    (compiled : Aiur.CompiledToplevel) (useBytecode : Bool)
+    (json? : Option (String × String) := none) : IO UInt32 := do
+  -- The row's peak-rss needs the process-tree RSS sampler running
+  -- (`peakTreeRssBytes` reports 0 otherwise); started before the env
+  -- load so the peak covers the whole run, like `check-rs`.
+  if json?.isSome then TracingTexray.startSampler
   match (← loadEnvAndShards manifestPath ixePath) with
   | .error e => IO.eprintln e; return 1
   | .ok (ixonEnv, shards) =>
@@ -663,11 +670,14 @@ def runShardBatchNative (manifestPath ixePath : String) (jobs? : Option Nat)
     IO.println s!"Typechecking {shards.size} shard(s) in one rayon \
       batch, {jobs} thread(s) (0 = all)"
     (← IO.getStdout).flush
+    let totalConsts := ownedPerShard.foldl (· + ·.size) 0
+    let start ← IO.monoMsNow
     match compiled.bytecode.shardCheckBatchWithEnv funIdx envHandle blob
         useBytecode jobs Aiur.defaultCommitmentParameters
         Aiur.defaultFriParameters with
     | .error e => IO.eprintln s!"shard batch: {e}"; return 1
     | .ok results =>
+      let elapsedMs := (← IO.monoMsNow) - start
       let mut failures : Nat := 0
       for k in [:results.size] do
         let (err, peak) := results[k]!
@@ -677,11 +687,29 @@ def runShardBatchNative (manifestPath ixePath : String) (jobs? : Option Nat)
         else
           IO.eprintln s!"[shard {k}] FAILED: {err}"
           failures := failures + 1
+      -- One env-keyed results row for `ix bench run --backend aiur-sharded-env`:
+      -- the measured window is the batch FFI call (env load and blob
+      -- setup are excluded, matching what the benchmark tracks — the
+      -- execution engine, not the loader).
+      if let some (path, key) := json? then
+        let secs := elapsedMs.toFloat / 1000.0
+        let tput := if elapsedMs > 0
+          then totalConsts.toFloat * 1000.0 / elapsedMs.toFloat else 0.0
+        let peakRss ← TracingTexray.peakTreeRssBytes
+        let status := if failures == 0 then "ok" else "rejected"
+        Ix.Benchmark.Results.writeRow path key status
+          [ ("constants", Lean.toJson totalConsts)
+          , ("shards", Lean.toJson results.size)
+          , ("check-time", Ix.Benchmark.Results.jsonRound 3 secs)
+          , ("throughput", Ix.Benchmark.Results.jsonRound 2 tput)
+          , ("peak-rss", Lean.toJson peakRss) ]
       if failures == 0 then
         IO.println s!"All {results.size} shard(s) passed"
         return 0
       IO.eprintln s!"{failures} of {results.size} shard(s) FAILED"
-      return 1
+      -- Under `--json` a kernel rejection is the benchmark's `rejected`
+      -- exit (the row is already written), same contract as `check-rs`.
+      return if json?.isSome then Ix.Benchmark.Results.exitRejected else 1
 
 /-- Run the shard operation over EVERY shard — the whole-partition behavior of
     `--ixes` with no `--shard` (used by `prove`). Loads the env once. Returns 1
@@ -794,8 +822,10 @@ def runCheckCmd (p : Cli.Parsed) : IO UInt32 := do
       let compiled ← match toplevel.compile with
         | .error e => IO.eprintln s!"Compilation failed: {e}"; return 1
         | .ok c => pure c
+      let json? := (p.flag? "json").map fun f =>
+        (f.as! String, ((p.flag? "json-name").map (·.as! String)).getD "env")
       return (← runShardBatchNative manifest ixe
-        ((p.flag? "jobs").map (·.as! Nat)) compiled useBytecode)
+        ((p.flag? "jobs").map (·.as! Nat)) compiled useBytecode json?)
   | _, _, _ =>
     -- `--jobs N` (N ≠ 1) with an `--ixe` env and no `--claim` takes the
     -- parallel batch path: one FFI call, rayon over the target list,
@@ -828,6 +858,8 @@ def checkCmd : Cli.Cmd := `[Cli|
     "ixes"      : String;   "Path to a `.ixes` shard manifest (with --ixe). With --shard K: check the constants owned by shard K (ingress their closure, skip the frontier). Without --shard: check every shard of the partition concurrently, after a coverage check."
     "shard"     : Nat;      "0-based shard index K (with --ixe + --ixes): check the constants owned by shard K of the manifest's partition."
     "jobs"      : Nat;      "Parallelism. With --ixes (no --shard): max shards checked concurrently (default: all at once). With --ixe alone and N ≠ 1: check the targeted constants on N Rust threads (0 = all cores), each claim over its own private record — peak RAM is bounded by N in-flight claim closures."
+    "json"      : String;   "With --ixes (no --shard): append one env-keyed results row (see Ix.Benchmark.Results) for the batch to this file — check-time, throughput, peak-rss, constants, shards. Used by `ix bench run --backend aiur-sharded-env`."
+    "json-name" : String;   "Row key for the --json row (default: `env`)."
 
   ARGS:
     ...names : String; "Fully-qualified Lean.Name(s) to check. With none, iterate every named constant in the env (sorted)."

--- a/Ix/Cli/ShardCmd.lean
+++ b/Ix/Cli/ShardCmd.lean
@@ -143,17 +143,38 @@ def runShardCmd (p : Cli.Parsed) : IO UInt32 := do
   | none =>
     -- STATIC strategy (no out-of-circuit profiling): byte-balanced min-cut
     -- over the env's walk-edge nets + predicted-FFT rebalance post-pass.
-    -- Fixed shard count only for now — the cap modes' cycle/RAM budgeting
-    -- is calibrated against the profiled op counters, which the static
-    -- profile does not carry.
-    let some n := shardsFlag
-      | p.printError "error: the static strategy (no --profile) requires \
-          --shards N; --max-cycles/--max-ram budgeting needs --profile"
-        return 1
-    if maxCycles.isSome || maxRam.isSome then
-      p.printError "error: --max-cycles/--max-ram require --profile (their \
-        budget model is calibrated on profiled op counters)"
+    -- Shard count comes from `--shards N`, or NAIVELY from `--max-ram G`:
+    -- without a profile the planner cannot know a shard's real prover
+    -- peak, so it estimates it from serialized env bytes via a measured
+    -- amplification factor and picks N so the estimated per-shard peak
+    -- fits the budget. The projections printed by an executed run
+    -- (`ix check --ixes --batch`) are the ground truth that corrects
+    -- the estimate — over-budget shards re-split, far-under merge.
+    if maxCycles.isSome then
+      p.printError "error: --max-cycles requires --profile (its budget \
+        model is calibrated on profiled op counters)"
       return 1
+    let n ← match shardsFlag, maxRam with
+      | some n, _ => pure n
+      | none, some gib =>
+        if gib == 0 then
+          p.printError "error: --max-ram must be positive"; return 1
+        let envBytes := (← System.FilePath.metadata envPath).byteSize.toNat
+        -- Prover-peak-per-env-byte, measured on init and FLT partitions
+        -- (2026-08-21): analytic prover peaks landed at ~20,000-21,000x
+        -- the shard's serialized bytes. Target ~2/3 of the budget so
+        -- the median sits under it with headroom for the measured
+        -- ~2.5x median-to-max spread across shards of one partition.
+        let amplification := 20000
+        let targetBytes := gib * 1024 * 1024 * 1024 * 2 / 3
+        let n := max 1 ((envBytes * amplification + targetBytes - 1) / targetBytes)
+        IO.println s!"[shard] naive RAM sizing: {envBytes} env bytes × \
+          {amplification} / ({gib} GiB × 2/3) → {n} shard(s)"
+        pure n
+      | none, none =>
+        p.printError "error: the static strategy (no --profile) requires \
+          --shards N or --max-ram G"
+        return 1
     IO.println s!"Sharding {envPath} into {n} shards (static strategy, balance ±{balancePct}%)"
     rsShardEnvStaticFFI envPath (toString n) (toString balancePct) outPath
   | some espPath =>
@@ -185,9 +206,9 @@ def shardCmd : Cli.Cmd := `[Cli|
 
   FLAGS:
     profile      : String; "Path to a `.ixprof` from `ix profile`. When given, use the profiled strategy (cap budgeting / balanced min-cut over measured costs); when absent, the static strategy partitions the `.ixe` directly."
-    shards       : Nat;    "Fixed number of shards N (required for the static strategy; overrides the profiled default budget sizing)"
+    shards       : Nat;    "Fixed number of shards N (static strategy; overrides --max-ram sizing and the profiled default budget sizing)"
     "max-cycles" : Nat;    "Per-shard guest-cycle budget (profiled strategy only)"
-    "max-ram"    : Nat;    "Per-shard host-RAM budget, GiB (profiled strategy only; default: detected system RAM)"
+    "max-ram"    : Nat;    "Per-shard prover-RAM budget, GiB. Static strategy: NAIVE sizing — estimates per-shard prover peak from serialized env bytes (measured ~20,000x amplification) and picks the shard count so the estimate fits ~2/3 of the budget; executed projections then correct it (split/merge). Profiled strategy: budget from measured op counters (default: detected system RAM)."
     balance      : Nat;    "Per-bisection balance tolerance, percent (default 5)"
     parallelism  : Nat;    "Provers assumed for the prove-time estimate (profiled strategy only; default 1 = sequential)"
     out          : String; "Output .ixes manifest path (default: env base name + `.ixes`, e.g. init.ixe → init.ixes)"

--- a/crates/aiur/src/execute.rs
+++ b/crates/aiur/src/execute.rs
@@ -1103,3 +1103,22 @@ fn build_klimbs_u64(
   }
   Ok(tail_ptr)
 }
+
+/// Approximate retained bytes of a record's query maps: field elements
+/// (keys + outputs) at 8 bytes plus ~21 bytes of per-entry index
+/// overhead (hash-table slot, stored hash, multiplicity). Feeds the
+/// witness phase of the prover RAM model
+/// ([`crate::synthesis::AiurSystem::peak_prove_bytes`]).
+pub fn record_retained_bytes(record: &QueryRecord) -> usize {
+  let mut elems = 0usize;
+  let mut entries = 0usize;
+  for m in &record.function_queries {
+    elems += m.retained_elems();
+    entries += m.len();
+  }
+  for (_, m) in &record.memory_queries {
+    elems += m.retained_elems();
+    entries += m.len();
+  }
+  elems * 8 + entries * 21
+}

--- a/crates/aiur/src/synthesis.rs
+++ b/crates/aiur/src/synthesis.rs
@@ -28,6 +28,16 @@ pub type AiurConfig = GoldilocksBlake3Config;
 /// A proof under [`AiurConfig`].
 pub type AiurProof = Proof<AiurConfig>;
 
+/// The prover RAM model's phase breakdown; `peak` is the number the
+/// budget gate compares (see [`AiurSystem::peak_prove_bytes`]).
+pub struct PeakProveBytes {
+  pub phase_witness: usize,
+  pub phase_stage2: usize,
+  pub phase_open: usize,
+  pub preprocessed: usize,
+  pub peak: usize,
+}
+
 pub struct AiurSystem {
   toplevel: Toplevel,
   // perhaps remove the key from the system in verifier only mode?
@@ -193,6 +203,103 @@ impl AiurSystem {
         preprocessed_height: circuit.preprocessed_height,
       })
       .collect()
+  }
+
+  /// Predicted peak prover resident bytes for a record, from circuit
+  /// shapes alone — the analytic counterpart of an empirical GiB-per-fft
+  /// line. Mirrors this system's actual allocation schedule (multi-stark
+  /// rev `be1755e`, the workspace pin; an upstream allocation-schedule
+  /// change skews every prediction, so re-validate against a measured
+  /// prove when bumping multi-stark — real proves at ~472 GiB measured
+  /// +1.6-1.7% over prediction):
+  ///
+  /// 1. WITNESS phase: the `QueryRecord` plus every circuit's padded main
+  ///    trace and base-field lookup witness, built in parallel and all
+  ///    alive at once.
+  /// 2. STAGE-2 transition: stage-1 LDEs and their Merkle tree, the
+  ///    still-alive lookup witness, the logUp message array plus its
+  ///    batch-inverse copy, and the new extension traces.
+  /// 3. FRI OPEN: all committed LDEs (main + stage-2 + quotient, at
+  ///    `8·2^log_blowup` bytes per trace cell) and their trees, the
+  ///    retained FRI fold layers (geometric in `max_log_arity`), and the
+  ///    open-phase buffers — all proportional to `H = blowup · tallest`.
+  ///
+  /// The peak is the max of the three plus the preprocessed-gadget
+  /// residency committed at setup. Heights are `next_power_of_two` of the
+  /// record's unique queries — the padding the trace actually commits,
+  /// which per-fft models blur.
+  pub fn peak_prove_bytes(&self, record: &QueryRecord) -> PeakProveBytes {
+    self.peak_prove_bytes_by(
+      |_, ct| match ct {
+        CircuitType::Function { idx } => record.function_queries[*idx].len(),
+        CircuitType::Memory { width } => {
+          record.memory_queries.get(width).map_or(0, |m| m.len())
+        },
+        CircuitType::Bytes1 => 256,
+        CircuitType::Bytes2 => 65536,
+      },
+      crate::execute::record_retained_bytes(record),
+    )
+  }
+
+  fn peak_prove_bytes_by(
+    &self,
+    raw_of: impl Fn(usize, &CircuitType) -> usize,
+    record_bytes: usize,
+  ) -> PeakProveBytes {
+    const S: usize = 8; // bytes per base field element (Goldilocks)
+    const DG: usize = 32; // blake3 digest bytes (Merkle nodes, arity 2)
+    let b = 1usize << self.commitment_parameters.log_blowup;
+    let fold = 1usize << self.fri_parameters.max_log_arity;
+    let circuit_types = self.circuit_types();
+    let ncirc = self.system.circuits.len();
+    let mut tallest = 0usize;
+    for (i, ct) in circuit_types.iter().enumerate().take(ncirc) {
+      let raw = raw_of(i, ct);
+      if raw != 0 {
+        tallest = tallest.max(raw.next_power_of_two());
+      }
+    }
+    let mut witness = 0usize;
+    let mut s1_lde = 0usize; // stage-1 LDEs
+    let mut lookup_w = 0usize; // base-field lookup witness
+    let mut msgs = 0usize; // logUp messages (+ inverse copy)
+    let mut s2_trace = 0usize; // stage-2 extension traces
+    let mut committed = 0usize; // all committed LDE bytes
+    let mut prep = 0usize;
+    for (i, ct) in circuit_types.iter().enumerate().take(ncirc) {
+      let raw = raw_of(i, ct);
+      if raw == 0 {
+        continue;
+      }
+      let n = raw.next_power_of_two();
+      let c = &self.system.circuits[i];
+      let d = c.stage_2_width / (1 + c.num_lookups); // extension degree
+      let args: usize = self.slot_widths[i].iter().sum();
+      let q = c.quotient_degree();
+      witness +=
+        S * n * c.main_width + S * n * (c.num_lookups + args) + 40 * raw;
+      s1_lde += S * b * n * c.main_width;
+      lookup_w += S * n * (c.num_lookups + args);
+      msgs += 2 * S * d * n * c.num_lookups;
+      s2_trace += S * n * c.stage_2_width;
+      committed += S * b * n * (c.main_width + c.stage_2_width + q * d);
+      prep += S * (1 + b) * c.preprocessed_width * c.preprocessed_height
+        + 2 * DG * b * c.preprocessed_height;
+    }
+    let h = b * tallest;
+    let phase_witness = record_bytes + witness;
+    let phase_stage2 = s1_lde + 2 * DG * h + lookup_w + msgs + s2_trace;
+    // Trees (3 rounds) + retained FRI fold layers + open buffers, all ∝ H.
+    let fri_layers = (2 * S + 2 * DG) * h * fold / (fold - 1).max(1);
+    let phase_open = committed + 3 * 2 * DG * h + fri_layers + 11 * S * h;
+    PeakProveBytes {
+      phase_witness,
+      phase_stage2,
+      phase_open,
+      preprocessed: prep,
+      peak: phase_witness.max(phase_stage2).max(phase_open) + prep,
+    }
   }
 
   #[tracing::instrument(level = "info", skip_all, name = "aiur/prove")]

--- a/crates/ffi/src/aiur/protocol.rs
+++ b/crates/ffi/src/aiur/protocol.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 
 use lean_ffi::object::{
   ExternalClass, LeanArray, LeanBorrowed, LeanByteArray, LeanExcept,
-  LeanExternal, LeanNat, LeanOwned, LeanProd, LeanRef,
+  LeanExternal, LeanNat, LeanOwned, LeanProd, LeanRef, LeanString,
 };
 
 use crate::{
@@ -487,6 +487,91 @@ extern "C" fn rs_aiur_toplevel_check_addr_with_env(
     &query_record,
     &toplevel,
   ))
+}
+
+/// `Bytecode.Toplevel.checkAddrsWithEnv`: check a BATCH of full-closure
+/// claims (`Claim.check addr none`, one per address in `addrs_blob`) in
+/// PARALLEL — rayon over the list, each task running exactly the
+/// single-claim machinery above (`build_claim_check_witness` +
+/// `dispatch_execute`) over entirely task-private data: its own
+/// `IOBuffer`, its own `QueryRecord`, both dropped inside the task.
+/// Parallel, not concurrent: nothing is shared between tasks except
+/// the read-only `toplevel` and `env` (the compiler enforces this —
+/// `par_iter` closures only capture `Sync` data). Each claim's record
+/// is single-threaded and therefore bit-deterministic regardless of
+/// `jobs` or scheduling. Peak RAM is bounded by `jobs` concurrent
+/// claim cones (rayon keeps at most one in-flight task per pool
+/// thread; records free at task end).
+///
+/// Returns the FAILURES as an array of `(batch index, error)` pairs
+/// (the index as a decimal string, resolving back to the caller's
+/// label order) —
+/// empty means every claim passed. Per-claim outputs and records are
+/// deliberately not round-tripped to Lean; the single-claim entry
+/// keeps the full result shape for that. `jobs = 0` uses rayon's
+/// default pool width.
+#[unsafe(no_mangle)]
+extern "C" fn rs_aiur_toplevel_check_addrs_with_env(
+  toplevel: LeanAiurToplevel<LeanBorrowed<'_>>,
+  fun_idx: LeanNat<LeanBorrowed<'_>>,
+  env_handle: LeanExternal<
+    ixvm_codegen::env_handle::EnvHandle,
+    LeanBorrowed<'_>,
+  >,
+  addrs_blob: LeanByteArray<LeanBorrowed<'_>>,
+  use_bytecode: bool,
+  jobs: LeanNat<LeanBorrowed<'_>>,
+) -> LeanExcept<LeanOwned> {
+  use rayon::prelude::*;
+  let toplevel = decode_toplevel(&toplevel);
+  let fun_idx = lean_unbox_nat_as_usize(fun_idx.inner());
+  let jobs = lean_unbox_nat_as_usize(jobs.inner());
+  let addrs = match decode_owned_blob(&addrs_blob) {
+    Ok(v) => v,
+    Err(e) => return LeanExcept::error_string(&e),
+  };
+  let env = &env_handle.get().env;
+  let check_batch = || -> Vec<(String, String)> {
+    addrs
+      .par_iter()
+      .enumerate()
+      .filter_map(|(i, addr)| {
+        let err = match ixvm_codegen::aiur_ixvm_witness::build_claim_check_witness(
+          env, addr,
+        ) {
+          Err(e) => Some(format!("witness build: {e}")),
+          Ok((_claim, input, mut io_buffer)) => dispatch_execute(
+            &toplevel,
+            fun_idx,
+            input,
+            &mut io_buffer,
+            use_bytecode,
+          )
+          .err(),
+        };
+        err.map(|e| (i.to_string(), e))
+      })
+      .collect()
+  };
+  let failures = if jobs == 0 {
+    check_batch()
+  } else {
+    let pool = match rayon::ThreadPoolBuilder::new()
+      .num_threads(jobs)
+      .build()
+    {
+      Ok(p) => p,
+      Err(e) => {
+        return LeanExcept::error_string(&format!("rayon pool: {e}"));
+      },
+    };
+    pool.install(check_batch)
+  };
+  let arr = LeanArray::alloc(failures.len());
+  for (i, (idx, err)) in failures.iter().enumerate() {
+    arr.set(i, LeanProd::new(LeanString::new(idx), LeanString::new(err)));
+  }
+  LeanExcept::ok(arr)
 }
 
 /// `Bytecode.Toplevel.shardCheckWithEnv`: per-shard check against a

--- a/crates/ffi/src/aiur/protocol.rs
+++ b/crates/ffi/src/aiur/protocol.rs
@@ -574,6 +574,120 @@ extern "C" fn rs_aiur_toplevel_check_addrs_with_env(
   LeanExcept::ok(arr)
 }
 
+/// `Bytecode.Toplevel.shardCheckBatchWithEnv`: check EVERY shard of a
+/// partition in one call — rayon over the shard list with true
+/// work-stealing (no chunk barriers), each shard through the exact
+/// single-shard machinery (`build_shard_check_env_witness` +
+/// `dispatch_execute`) over its own private record and witness io.
+/// Parallel, not concurrent: tasks share only the read-only toplevel,
+/// env, and the `AiurSystem` built once here for the prover RAM model.
+///
+/// `shards_blob` encodes the partition as, per shard, a 4-byte LE
+/// owned-constant count followed by that many 32-byte addresses.
+/// Returns one `(error, peak_bytes)` pair PER SHARD in shard order:
+/// an empty error string means the shard checked clean, and
+/// `peak_bytes` is the analytic prover peak
+/// ([`aiur::synthesis::AiurSystem::peak_prove_bytes`]) of its executed
+/// record — the number split/merge decisions compare against a prover
+/// budget (0 when the shard failed). `jobs = 0` uses rayon's default
+/// pool width.
+#[unsafe(no_mangle)]
+extern "C" fn rs_aiur_toplevel_shard_check_batch(
+  toplevel_obj: LeanAiurToplevel<LeanBorrowed<'_>>,
+  fun_idx: LeanNat<LeanBorrowed<'_>>,
+  env_handle: LeanExternal<
+    ixvm_codegen::env_handle::EnvHandle,
+    LeanBorrowed<'_>,
+  >,
+  shards_blob: LeanByteArray<LeanBorrowed<'_>>,
+  use_bytecode: bool,
+  jobs: LeanNat<LeanBorrowed<'_>>,
+  commitment_parameters: LeanAiurCommitmentParameters<LeanBorrowed<'_>>,
+  fri_parameters: LeanAiurFriParameters<LeanBorrowed<'_>>,
+) -> LeanExcept<LeanOwned> {
+  use rayon::prelude::*;
+  let toplevel = decode_toplevel(&toplevel_obj);
+  let fun_idx = lean_unbox_nat_as_usize(fun_idx.inner());
+  let jobs = lean_unbox_nat_as_usize(jobs.inner());
+  let mut shards: Vec<Vec<ix_common::address::Address>> = Vec::new();
+  {
+    let bytes = shards_blob.as_bytes();
+    let mut off = 0usize;
+    while off < bytes.len() {
+      if off + 4 > bytes.len() {
+        return LeanExcept::error_string("shards_blob: truncated count");
+      }
+      let n = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap())
+        as usize;
+      off += 4;
+      if off + n * 32 > bytes.len() {
+        return LeanExcept::error_string("shards_blob: truncated addresses");
+      }
+      shards.push(
+        bytes[off..off + n * 32]
+          .chunks_exact(32)
+          .map(|c| ix_common::address::Address::from_slice(c).unwrap())
+          .collect(),
+      );
+      off += n * 32;
+    }
+  }
+  let env = &env_handle.get().env;
+  // One system build for the whole batch: the RAM model reads circuit
+  // widths and lookup counts off the compiled circuits.
+  let system = AiurSystem::build(
+    decode_toplevel(&toplevel_obj),
+    decode_commitment_parameters(&commitment_parameters),
+    decode_fri_parameters(&fri_parameters),
+  );
+  let check_batch = || -> Vec<(String, usize)> {
+    shards
+      .par_iter()
+      .map(|owned| {
+        match ixvm_codegen::aiur_ixvm_witness::build_shard_check_env_witness(
+          env, owned,
+        ) {
+          Err(e) => (format!("witness build: {e}"), 0),
+          Ok((_claim, input, mut io_buffer)) => match dispatch_execute(
+            &toplevel,
+            fun_idx,
+            input,
+            &mut io_buffer,
+            use_bytecode,
+          ) {
+            Err(e) => (e, 0),
+            Ok((record, _output)) => {
+              (String::new(), system.peak_prove_bytes(&record).peak)
+            },
+          },
+        }
+      })
+      .collect()
+  };
+  let results = if jobs == 0 {
+    check_batch()
+  } else {
+    let pool = match rayon::ThreadPoolBuilder::new()
+      .num_threads(jobs)
+      .build()
+    {
+      Ok(p) => p,
+      Err(e) => {
+        return LeanExcept::error_string(&format!("rayon pool: {e}"));
+      },
+    };
+    pool.install(check_batch)
+  };
+  let arr = LeanArray::alloc(results.len());
+  for (i, (err, peak)) in results.iter().enumerate() {
+    arr.set(
+      i,
+      LeanProd::new(LeanString::new(err), LeanOwned::box_usize(*peak)),
+    );
+  }
+  LeanExcept::ok(arr)
+}
+
 /// `Bytecode.Toplevel.shardCheckWithEnv`: per-shard check against a
 /// Rust-owned `EnvHandle`. See `checkAddrWithEnv` for `use_bytecode`
 /// semantics.

--- a/crates/ffi/src/aiur/protocol.rs
+++ b/crates/ffi/src/aiur/protocol.rs
@@ -536,19 +536,20 @@ extern "C" fn rs_aiur_toplevel_check_addrs_with_env(
       .par_iter()
       .enumerate()
       .filter_map(|(i, addr)| {
-        let err = match ixvm_codegen::aiur_ixvm_witness::build_claim_check_witness(
-          env, addr,
-        ) {
-          Err(e) => Some(format!("witness build: {e}")),
-          Ok((_claim, input, mut io_buffer)) => dispatch_execute(
-            &toplevel,
-            fun_idx,
-            input,
-            &mut io_buffer,
-            use_bytecode,
-          )
-          .err(),
-        };
+        let err =
+          match ixvm_codegen::aiur_ixvm_witness::build_claim_check_witness(
+            env, addr,
+          ) {
+            Err(e) => Some(format!("witness build: {e}")),
+            Ok((_claim, input, mut io_buffer)) => dispatch_execute(
+              &toplevel,
+              fun_idx,
+              input,
+              &mut io_buffer,
+              use_bytecode,
+            )
+            .err(),
+          };
         err.map(|e| (i.to_string(), e))
       })
       .collect()
@@ -556,10 +557,7 @@ extern "C" fn rs_aiur_toplevel_check_addrs_with_env(
   let failures = if jobs == 0 {
     check_batch()
   } else {
-    let pool = match rayon::ThreadPoolBuilder::new()
-      .num_threads(jobs)
-      .build()
-    {
+    let pool = match rayon::ThreadPoolBuilder::new().num_threads(jobs).build() {
       Ok(p) => p,
       Err(e) => {
         return LeanExcept::error_string(&format!("rayon pool: {e}"));
@@ -572,6 +570,61 @@ extern "C" fn rs_aiur_toplevel_check_addrs_with_env(
     arr.set(i, LeanProd::new(LeanString::new(idx), LeanString::new(err)));
   }
   LeanExcept::ok(arr)
+}
+
+/// Byte-weighted admission gate: a counting semaphore over estimated
+/// execution RSS, expressed with the std Mutex+Condvar construction.
+/// Bounds MEMORY in flight instead of shards in flight, so the rayon
+/// pool can run at full width: cheap shards run many-wide while a
+/// heavy one takes a proportional slice of the budget. Workers block
+/// in `acquire` until reserving their estimate fits the budget.
+struct RamGate {
+  reserved: std::sync::Mutex<usize>,
+  cv: std::sync::Condvar,
+  budget: usize,
+}
+
+impl RamGate {
+  fn acquire(&self, bytes: usize) {
+    let mut used = self.reserved.lock().unwrap();
+    // Admit-when-alone: a shard whose estimate alone exceeds the
+    // budget must still run (by itself) rather than deadlock.
+    while *used > 0 && *used + bytes > self.budget {
+      used = self.cv.wait(used).unwrap();
+    }
+    *used += bytes;
+  }
+
+  fn release(&self, bytes: usize) {
+    *self.reserved.lock().unwrap() -= bytes;
+    self.cv.notify_all();
+  }
+}
+
+/// Per-shard execution-RSS reserve for [`RamGate`], an AFFINE model:
+/// `EXEC_RSS_FIXED_BYTES + EXEC_RSS_PER_OWNED_BYTE x owned bytes`. The
+/// byte basis is the sum of the shard's owned constants' raw
+/// serialized bytes (`Env::get_const_bytes`) — NOT the shard's share
+/// of `.ixe` FILE bytes, which also carry blobs, names, and indices
+/// and run ~2.6x larger. The fixed term is the closure/frontier
+/// ingress every shard pays regardless of owned size; without it a
+/// pure ratio calibrated on large shards under-reserves small ones
+/// (measured: 151 ISLB shards at 1.1-4.8 GiB estimated ran to 175 GB
+/// actual against a 110 GiB budget — an OOM on a real 128 GB box).
+/// Fit on the two ISLB partitions (2026-08-22, measured in-flight
+/// RSS): 5.7 MB owned -> ~9.6 GB and 1.4 MB -> ~5.5 GB, giving
+/// ~4 GiB + ~1000x; both terms rounded up for cross-shard spread.
+const EXEC_RSS_FIXED_BYTES: usize = 9 * (1 << 29); // 4.5 GiB
+const EXEC_RSS_PER_OWNED_BYTE: usize = 1100;
+
+/// `MemAvailable` from `/proc/meminfo`, in bytes (Linux; includes
+/// reclaimable page cache). `None` if unreadable — the caller then
+/// disables the gate rather than guessing.
+fn available_ram_bytes() -> Option<usize> {
+  let s = std::fs::read_to_string("/proc/meminfo").ok()?;
+  let rest = s.lines().find_map(|l| l.strip_prefix("MemAvailable:"))?;
+  let kib: usize = rest.trim().trim_end_matches("kB").trim().parse().ok()?;
+  Some(kib * 1024)
 }
 
 /// `Bytecode.Toplevel.shardCheckBatchWithEnv`: check EVERY shard of a
@@ -590,7 +643,12 @@ extern "C" fn rs_aiur_toplevel_check_addrs_with_env(
 /// ([`aiur::synthesis::AiurSystem::peak_prove_bytes`]) of its executed
 /// record — the number split/merge decisions compare against a prover
 /// budget (0 when the shard failed). `jobs = 0` uses rayon's default
-/// pool width.
+/// pool width (all cores) — safe at full width because admission is
+/// bounded by [`RamGate`], not by thread count; pass `jobs` only to
+/// narrow CPU use.
+// cast_precision_loss: the [ram-gate] line renders byte counts in GiB
+// for humans; f64's 52-bit mantissa is exact far past any real budget.
+#[allow(clippy::cast_precision_loss)]
 #[unsafe(no_mangle)]
 extern "C" fn rs_aiur_toplevel_shard_check_batch(
   toplevel_obj: LeanAiurToplevel<LeanBorrowed<'_>>,
@@ -617,8 +675,8 @@ extern "C" fn rs_aiur_toplevel_shard_check_batch(
       if off + 4 > bytes.len() {
         return LeanExcept::error_string("shards_blob: truncated count");
       }
-      let n = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap())
-        as usize;
+      let n =
+        u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()) as usize;
       off += 4;
       if off + n * 32 > bytes.len() {
         return LeanExcept::error_string("shards_blob: truncated addresses");
@@ -640,37 +698,73 @@ extern "C" fn rs_aiur_toplevel_shard_check_batch(
     decode_commitment_parameters(&commitment_parameters),
     decode_fri_parameters(&fri_parameters),
   );
+  // RAM-gated admission: reserve each shard's estimated execution RSS
+  // (fixed ingress cost + owned serialized bytes x measured slope)
+  // against most of the RAM available at entry. Memory in flight —
+  // not `jobs` — is what bounds peak RSS; an unreadable meminfo
+  // disables the gate.
+  let estimates: Vec<usize> = shards
+    .iter()
+    .map(|owned| {
+      EXEC_RSS_FIXED_BYTES.saturating_add(
+        owned
+          .iter()
+          .filter_map(|a| env.get_const_bytes(a).map(|b| b.len()))
+          .sum::<usize>()
+          .saturating_mul(EXEC_RSS_PER_OWNED_BYTE),
+      )
+    })
+    .collect();
+  let gate = RamGate {
+    reserved: std::sync::Mutex::new(0),
+    cv: std::sync::Condvar::new(),
+    budget: available_ram_bytes().map_or(usize::MAX, |b| b / 100 * 85),
+  };
+  {
+    let gib = 1024.0 * 1024.0 * 1024.0;
+    let min = estimates.iter().min().copied().unwrap_or(0);
+    let max = estimates.iter().max().copied().unwrap_or(0);
+    eprintln!(
+      "[ram-gate] budget {:.1} GiB, {} shard estimates: min {:.1} / max {:.1} GiB",
+      gate.budget as f64 / gib,
+      estimates.len(),
+      min as f64 / gib,
+      max as f64 / gib,
+    );
+  }
   let check_batch = || -> Vec<(String, usize)> {
     shards
       .par_iter()
-      .map(|owned| {
-        match ixvm_codegen::aiur_ixvm_witness::build_shard_check_env_witness(
-          env, owned,
-        ) {
-          Err(e) => (format!("witness build: {e}"), 0),
-          Ok((_claim, input, mut io_buffer)) => match dispatch_execute(
-            &toplevel,
-            fun_idx,
-            input,
-            &mut io_buffer,
-            use_bytecode,
+      .zip(estimates.par_iter())
+      .map(|(owned, est)| {
+        gate.acquire(*est);
+        let result =
+          match ixvm_codegen::aiur_ixvm_witness::build_shard_check_env_witness(
+            env, owned,
           ) {
-            Err(e) => (e, 0),
-            Ok((record, _output)) => {
-              (String::new(), system.peak_prove_bytes(&record).peak)
+            Err(e) => (format!("witness build: {e}"), 0),
+            Ok((_claim, input, mut io_buffer)) => match dispatch_execute(
+              &toplevel,
+              fun_idx,
+              input,
+              &mut io_buffer,
+              use_bytecode,
+            ) {
+              Err(e) => (e, 0),
+              Ok((record, _output)) => {
+                (String::new(), system.peak_prove_bytes(&record).peak)
+              },
             },
-          },
-        }
+          };
+        gate.release(*est);
+        result
       })
       .collect()
   };
   let results = if jobs == 0 {
     check_batch()
   } else {
-    let pool = match rayon::ThreadPoolBuilder::new()
-      .num_threads(jobs)
-      .build()
-    {
+    let pool = match rayon::ThreadPoolBuilder::new().num_threads(jobs).build() {
       Ok(p) => p,
       Err(e) => {
         return LeanExcept::error_string(&format!("rayon pool: {e}"));
@@ -680,10 +774,8 @@ extern "C" fn rs_aiur_toplevel_shard_check_batch(
   };
   let arr = LeanArray::alloc(results.len());
   for (i, (err, peak)) in results.iter().enumerate() {
-    arr.set(
-      i,
-      LeanProd::new(LeanString::new(err), LeanOwned::box_usize(*peak)),
-    );
+    arr
+      .set(i, LeanProd::new(LeanString::new(err), LeanOwned::box_usize(*peak)));
   }
   LeanExcept::ok(arr)
 }


### PR DESCRIPTION
# Parallel Aiur execution over separate records; RAM-gated shard batches

Whole-env Aiur (IxVM) checking now runs as **one rayon batch over the
partition's shards** — parallel, not concurrent: each shard executes
through the unchanged single-shard machinery into its own private
`QueryRecord`, sharing only the read-only env and toplevel. Peak RSS is
bounded by a **byte-weighted RAM gate** (a std Mutex+Condvar semaphore:
each shard reserves its estimated execution RSS against 85% of available
RAM before starting), so the pool runs at full core width with no
`--jobs` tuning on any box/env pairing. The Lean-task scheduler this
replaces (chunks of N with a full barrier per chunk) measured 2.3–2.5×
slower and is deleted, along with the `--batch` flag — the rayon batch
is now the only whole-partition path.

Also in this PR:

- **Per-claim parallel batch** (`ix check --ixe E names… --jobs N`):
  rayon over resolved addresses for name-list workflows.
- **Analytic prover-RAM projections**: every executed shard reports its
  projected prover peak (three-phase model, calibrated to +1.6–1.7% on
  real ~472 GiB proves) — the input to split/merge repartitioning.
- **Naive `--max-ram` sizing** for the static shard strategy: shard
  count from serialized env bytes × measured ~20,000× amplification,
  targeting ⅔ budget. Median measured projections landed within a few
  percent of target on every env below.
- **`aiur-sharded-env` CI benchmark**: whole-env execution over ISLB
  (new Init+Std+Lean+Batteries env), FLT, and Mathlib — runner-sized
  manifests (`--max-ram 100`), one gated full-width batch per env,
  self-reported bencher rows (check-time, throughput, peak-rss,
  constants, shards).

## Gated full-width sweep (no `--jobs`, naive `--max-ram 400` manifests)

Xeon 6975P-C, 32 cores / 495 GB. Every shard of every env passes; the
gate held peak RSS without a hand-tuned width anywhere.

| env | `.ixe` | shards | wall | peak RSS |
|---|---:|---:|---:|---:|
| init | 194 MB | 14 | 51.8 s | 149 GB |
| initstd | 340 MB | 24 | 1:10 | 255 GB |
| batteries | 326 MB | 24 | 1:18 | 251 GB |
| lean | 504 MB | 36 | 1:40 | 330 GB |
| mathlib | 3.33 GB | 233 | 13:38 | 425 GB |
| flt | 3.44 GB | 241 | 13:22 | 420 GB |

Reference points: FLT at a hand-tuned `--jobs 16` took 18:16 (the gate's
full width is 27% faster); the same 241 shards as 241 processes under
`xargs -P16` took 28:34 — the in-process batch pays the env parse once
where multi-process pays it per shard, a 1.4–1.6× tax at env scale.
