### PR TITLE
fix: Authenticate all frontier group members in the recursive verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=33b4454aa63b88427b3d3cc09980fe86ddeb7e5f#33b4454aa63b88427b3d3cc09980fe86ddeb7e5f"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=71768278beb492223c7b89ccc74279a09628d3e4#71768278beb492223c7b89ccc74279a09628d3e4"
 dependencies = [
  "bincode",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "multi-stark"
 version = "0.1.0"
-source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=71768278beb492223c7b89ccc74279a09628d3e4#71768278beb492223c7b89ccc74279a09628d3e4"
+source = "git+https://github.com/argumentcomputer/multi-stark.git?rev=8f3c50d8f48aad2efc90c24729c441677b296fe2#8f3c50d8f48aad2efc90c24729c441677b296fe2"
 dependencies = [
  "bincode",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "71768278beb492223c7b89ccc74279a09628d3e4" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "8f3c50d8f48aad2efc90c24729c441677b296fe2" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ libc = "0.2"
 log = "0.4"
 memmap2 = "0.9"
 mimalloc = { version = "0.1", default-features = false }
-multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "33b4454aa63b88427b3d3cc09980fe86ddeb7e5f" }
+multi-stark = { git = "https://github.com/argumentcomputer/multi-stark.git", rev = "71768278beb492223c7b89ccc74279a09628d3e4" }
 nom = "7.1.3"
 num-bigint = "0.4.6"
 quickcheck = "1.0.3"

--- a/Ix/MultiStark/Pcs.lean
+++ b/Ix/MultiStark/Pcs.lean
@@ -389,6 +389,27 @@ def pcs := ⟦
     }
   }
 
+  -- Rows of matrices at log-height <= `target`, in circuit order. Used to
+  -- cross-check that two frontier queries sharing a parent agree on every
+  -- not-yet-injected (shorter) matrix: only the group lead's rows are hashed
+  -- into the shared frontier, so the others must be pinned to match it
+  -- (Plonky3 `verify_batch_pruned`'s `InconsistentGroupOpening`). Skips
+  -- empty (inactive-circuit) rows exactly as `select_rows`.
+  fn select_rows_le(rows: List‹List‹U64››, lhs: List‹G›, target: G) -> List‹List‹U64›› {
+    match load(rows) {
+      ListNode.Nil => store(ListNode.Nil),
+      ListNode.Cons(r, rrest) =>
+        let &ListNode.Cons(lh, lrest) = lhs;
+        match u32_less_than(target, lh) {
+          1 => select_rows_le(rrest, lrest, target),
+          _ => match load(r) {
+            ListNode.Nil => select_rows_le(rrest, lrest, target),
+            _ => store(ListNode.Cons(r, select_rows_le(rrest, lrest, target))),
+          },
+        },
+    }
+  }
+
   -- Pop one canonicalized lane across row boundaries. `got = 0` iff both the
   -- current row and the remaining rows are exhausted (selected rows are
   -- non-empty, so advancing to the next row always yields a lane).
@@ -525,16 +546,20 @@ def pcs := ⟦
       ListNode.Cons(x, xrest) => match load(ys) {
         ListNode.Nil => xs,
         ListNode.Cons(y, yrest) =>
-          let FrontierNode.Mk(xi, _xb, _xr, xd) = x;
-          let FrontierNode.Mk(yi, _yb, _yr, yd) = y;
+          let FrontierNode.Mk(xi, _xb, xr, xd) = x;
+          let FrontierNode.Mk(yi, _yb, yr, yd) = y;
           match memo_u32_less_than(xi, yi) {
             1 => store(ListNode.Cons(x, frontier_merge(xrest, ys))),
             _ => match eq_zero(xi - yi) {
               1 =>
-                -- Duplicate transcript queries must open the same leaf. A
-                -- direct pointer assertion is sound here: only equality is
-                -- accepted; non-canonical equal digests can at worst reject.
+                -- Duplicate transcript queries (same index) must open the
+                -- SAME full opened rows, not merely the same tallest-matrix
+                -- leaf digest: their shorter-matrix rows share a reduced index
+                -- too and both feed the FRI arithmetic (Plonky3
+                -- `verify_batch_pruned`'s `InconsistentDuplicateOpenings`).
+                -- Pointer equality is admissible inside `assert_eq!`.
                 assert_eq!(ptr_val(xd), ptr_val(yd));
+                assert_eq!(ptr_val(xr), ptr_val(yr));
                 store(ListNode.Cons(x, frontier_merge(xrest, yrest))),
               _ => store(ListNode.Cons(y, frontier_merge(xs, yrest))),
             },
@@ -595,10 +620,21 @@ def pcs := ⟦
         let aparent = bits_to_num(aparent_bits);
         match load(rest) {
           ListNode.Cons(b, brest) =>
-            let FrontierNode.Mk(bi, bbits, _br, bd) = b;
+            let FrontierNode.Mk(bi, bbits, br, bd) = b;
             let &ListNode.Cons(_bbit, bparent_bits) = bbits;
             match eq_zero(aparent - bits_to_num(bparent_bits)) {
               1 =>
+                -- Group members sharing a parent are collapsed to the lead
+                -- `a`; only `ar` is injected from here up, so `b` must agree
+                -- with `a` on every not-yet-injected (height <= next_lh)
+                -- matrix. Otherwise `b`'s shorter-matrix opened rows, still
+                -- consumed in its own FRI arithmetic, would go unauthenticated
+                -- (Plonky3 `verify_batch_pruned`'s `InconsistentGroupOpening`;
+                -- pointer equality is admissible inside `assert_eq!` — see
+                -- `IxVM.Core`). Transitive across pairwise merges, so the whole
+                -- group is pinned.
+                assert_eq!(ptr_val(select_rows_le(ar, lhs, next_lh)),
+                           ptr_val(select_rows_le(br, lhs, next_lh)));
                 let parent = inject_maybe(ar, lhs, next_lh, mmcs_compress(ad, bd));
                 let (tail, p2) = frontier_level(brest, proof, lhs, next_lh);
                 (store(ListNode.Cons(FrontierNode.Mk(aparent, aparent_bits, ar, parent), tail)), p2),

--- a/crates/aiur/src/synthesis.rs
+++ b/crates/aiur/src/synthesis.rs
@@ -450,11 +450,9 @@ impl AiurSystem {
     &self,
     claim: &[G],
     proof: &AiurProof,
-  ) -> Result<Vec<u8>, multi_stark::advice::AdviceError> {
-    self.verify(claim, proof).map_err(|e| {
-      multi_stark::advice::AdviceError::Verification(format!("{e:?}"))
-    })?;
-    proof.to_bytes().map_err(multi_stark::advice::AdviceError::Encode)
+  ) -> Result<Vec<u8>, String> {
+    self.verify(claim, proof).map_err(|e| format!("{e:?}"))?;
+    proof.to_bytes().map_err(|e| format!("{e:?}"))
   }
 }
 

--- a/crates/ffi/src/aiur/protocol.rs
+++ b/crates/ffi/src/aiur/protocol.rs
@@ -154,7 +154,7 @@ extern "C" fn rs_aiur_proof_to_advice_bytes(
   let claim = claim.map(|x| lean_unbox_g(&x));
   match aiur_system_obj.get().proof_to_advice_bytes(&claim, proof_obj.get()) {
     Ok(bytes) => LeanExcept::ok(LeanByteArray::from_bytes(&bytes)),
-    Err(err) => LeanExcept::error_string(&format!("{err:?}")),
+    Err(err) => LeanExcept::error_string(&err),
   }
 }
 

--- a/crates/ixvm-codegen/src/aiur_multi_stark.rs
+++ b/crates/ixvm-codegen/src/aiur_multi_stark.rs
@@ -4667,7 +4667,7 @@ fn aiur_fn_69(
     let __v_72: G = __r_arr[63];
     match __v_2.as_canonical_u64() {
       1023u64 => {
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_212(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_74: G = __loaded[0];
@@ -4848,10 +4848,10 @@ fn aiur_fn_69(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_212(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_73: G = __r_arr[0];
         let __v_74: G = (__v_73 * __v_7);
-        let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_212(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
         let __v_75: G = __r_arr[0];
         let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_3.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
         let __v_76: G = __loaded[0];
@@ -9158,7 +9158,7 @@ fn aiur_fn_94(
     let __v_105: G = __r_arr[1];
     let __v_106: G = G::from_u64(0);
     let __v_107: G = { let __values: [G; 10] = [__v_106, __v_89, __v_90, __v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_99]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_87, __v_107]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_87, __v_107]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
     let __v_108: G = __r_arr[0];
     let __ret: [G; OUT_94] = [__v_1, __v_11, __v_21, __v_31, __v_41, __v_51, __v_61, __v_108, __v_98, __v_101, __v_102, __v_104, __v_105];
     if let Some(result) = record.function_queries[94].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[94].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
@@ -9660,15 +9660,102 @@ fn aiur_fn_101(
   })
 }
 
-const INPUT_SIZE_102: usize = 2;
-const IN_102: usize = 2;
-const OUT_102: usize = 11;
+const INPUT_SIZE_102: usize = 3;
+const IN_102: usize = 3;
+const OUT_102: usize = 1;
 fn aiur_fn_102(
   inp: [G; IN_102],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_102], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    match __v_3.as_canonical_u64() {
+      1u64 => {
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = { let __values: [G; 3] = [__v_6, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_102] = [__v_8];
+        if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_6: G = __loaded[0];
+        let __v_7: G = __loaded[1];
+        let __v_8: G = __loaded[2];
+        match __v_6.as_canonical_u64() {
+          0u64 => {
+            let __v_9: G = { let __a_val = __v_2.as_canonical_u64(); let __b_val = __v_7.as_canonical_u64(); let __a_u32 = u32::try_from(__a_val).ok().ok_or(ExecError::U32OutOfRange(__a_val))?; let __b_u32 = u32::try_from(__b_val).ok().ok_or(ExecError::U32OutOfRange(__b_val))?; let __result = G::from_bool(__a_u32 < __b_u32); if !unconstrained { let __x_bytes = __a_u32.to_le_bytes(); let __z_bytes = __b_u32.to_le_bytes(); let __c_u32 = __b_u32.wrapping_sub(__a_u32).wrapping_sub(1); let __y_bytes = __c_u32.to_le_bytes(); record.bytes2_queries.bump_range_check(&G::from_u8(__x_bytes[0]), &G::from_u8(__x_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__x_bytes[2]), &G::from_u8(__x_bytes[3])); record.bytes2_queries.bump_range_check(&G::from_u8(__y_bytes[0]), &G::from_u8(__y_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__y_bytes[2]), &G::from_u8(__y_bytes[3])); record.bytes2_queries.bump_range_check(&G::from_u8(__z_bytes[0]), &G::from_u8(__z_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__z_bytes[2]), &G::from_u8(__z_bytes[3])); } __result };
+            match __v_9.as_canonical_u64() {
+              1u64 => {
+                let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                let __v_10: G = __r_arr[0];
+                let __ret: [G; OUT_102] = [__v_10];
+                if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                return Ok(__ret);
+              },
+              _ => {
+                let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
+                let __v_10: G = __loaded[0];
+                let __v_11: G = __loaded[1];
+                let __v_12: G = __loaded[2];
+                let __v_13: G = __loaded[3];
+                let __v_14: G = __loaded[4];
+                let __v_15: G = __loaded[5];
+                let __v_16: G = __loaded[6];
+                let __v_17: G = __loaded[7];
+                let __v_18: G = __loaded[8];
+                let __v_19: G = __loaded[9];
+                match __v_10.as_canonical_u64() {
+                  1u64 => {
+                    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                    let __v_20: G = __r_arr[0];
+                    let __ret: [G; OUT_102] = [__v_20];
+                    if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                    return Ok(__ret);
+                  },
+                  _ => {
+                    let __v_20: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_5, __v_8, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                    let __v_21: G = __r_arr[0];
+                    let __v_22: G = { let __values: [G; 3] = [__v_20, __v_4, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                    let __ret: [G; OUT_102] = [__v_22];
+                    if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                    return Ok(__ret);
+                  },
+                }
+              },
+            }
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_6.as_canonical_u64()));
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_103: usize = 2;
+const IN_103: usize = 2;
+const OUT_103: usize = 11;
+fn aiur_fn_103(
+  inp: [G; IN_103],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_103], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9763,8 +9850,8 @@ fn aiur_fn_102(
           return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64(), msg: None });
         }
         let __v_78: G = G::from_u64(1);
-        let __ret: [G; OUT_102] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_11, __v_1, __v_78];
-        if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_103] = [__v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_11, __v_1, __v_78];
+        if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       1u64 => {
@@ -9783,12 +9870,12 @@ fn aiur_fn_102(
             let __v_21: G = G::from_u64(0);
             let __v_22: G = G::from_u64(0);
             let __v_23: G = G::from_u64(0);
-            let __ret: [G; OUT_102] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
-            if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_103] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_0, __v_1, __v_23];
+            if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
             let __v_15: G = __r_arr[0];
             let __v_16: G = __r_arr[1];
             let __v_17: G = __r_arr[2];
@@ -9800,8 +9887,8 @@ fn aiur_fn_102(
             let __v_23: G = __r_arr[8];
             let __v_24: G = __r_arr[9];
             let __v_25: G = __r_arr[10];
-            let __ret: [G; OUT_102] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
-            if let Some(result) = record.function_queries[102].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[102].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_103] = [__v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25];
+            if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -9816,15 +9903,15 @@ fn aiur_fn_102(
   })
 }
 
-const INPUT_SIZE_103: usize = 6;
-const IN_103: usize = 6;
-const OUT_103: usize = 1;
-fn aiur_fn_103(
-  inp: [G; IN_103],
+const INPUT_SIZE_104: usize = 6;
+const IN_104: usize = 6;
+const OUT_104: usize = 1;
+fn aiur_fn_104(
+  inp: [G; IN_104],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_103], ExecError> {
+) -> Result<[G; OUT_104], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -9832,7 +9919,7 @@ fn aiur_fn_103(
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
     let __v_7: G = __r_arr[1];
     let __v_8: G = __r_arr[2];
@@ -10037,68 +10124,68 @@ fn aiur_fn_103(
                                         let __v_185: G = __r_arr[30];
                                         let __v_186: G = __r_arr[31];
                                         let __v_187: G = { let __values: [G; 34] = [__v_153, __v_5, __v_155, __v_156, __v_157, __v_158, __v_159, __v_160, __v_161, __v_162, __v_163, __v_164, __v_165, __v_166, __v_167, __v_168, __v_169, __v_170, __v_171, __v_172, __v_173, __v_174, __v_175, __v_176, __v_177, __v_178, __v_179, __v_180, __v_181, __v_182, __v_183, __v_184, __v_185, __v_186]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                        let __ret: [G; OUT_103] = [__v_187];
-                                        if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                        let __ret: [G; OUT_104] = [__v_187];
+                                        if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                         return Ok(__ret);
                                       },
                                       _ => {
-                                        let __ret: [G; OUT_103] = [__v_5];
-                                        if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                        let __ret: [G; OUT_104] = [__v_5];
+                                        if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                         return Ok(__ret);
                                       },
                                     }
                                   },
                                   _ => {
-                                    let __ret: [G; OUT_103] = [__v_5];
-                                    if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                    let __ret: [G; OUT_104] = [__v_5];
+                                    if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                     return Ok(__ret);
                                   },
                                 }
                               },
                               _ => {
-                                let __ret: [G; OUT_103] = [__v_5];
-                                if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                let __ret: [G; OUT_104] = [__v_5];
+                                if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                 return Ok(__ret);
                               },
                             }
                           },
                           _ => {
-                            let __ret: [G; OUT_103] = [__v_5];
-                            if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                            let __ret: [G; OUT_104] = [__v_5];
+                            if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                             return Ok(__ret);
                           },
                         }
                       },
                       _ => {
-                        let __ret: [G; OUT_103] = [__v_5];
-                        if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                        let __ret: [G; OUT_104] = [__v_5];
+                        if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                         return Ok(__ret);
                       },
                     }
                   },
                   _ => {
-                    let __ret: [G; OUT_103] = [__v_5];
-                    if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                    let __ret: [G; OUT_104] = [__v_5];
+                    if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                     return Ok(__ret);
                   },
                 }
               },
               _ => {
-                let __ret: [G; OUT_103] = [__v_5];
-                if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_104] = [__v_5];
+                if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
           },
           _ => {
-            let __ret: [G; OUT_103] = [__v_5];
-            if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_104] = [__v_5];
+            if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
       },
       _ => {
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_14, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = __r_arr[1];
         let __v_19: G = __r_arr[2];
@@ -10110,7 +10197,7 @@ fn aiur_fn_103(
         let __v_25: G = __r_arr[8];
         let __v_26: G = __r_arr[9];
         let __v_27: G = __r_arr[10];
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_25, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         let __v_29: G = __r_arr[1];
         let __v_30: G = __r_arr[2];
@@ -10122,7 +10209,7 @@ fn aiur_fn_103(
         let __v_36: G = __r_arr[8];
         let __v_37: G = __r_arr[9];
         let __v_38: G = __r_arr[10];
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
         let __v_40: G = __r_arr[1];
         let __v_41: G = __r_arr[2];
@@ -10134,7 +10221,7 @@ fn aiur_fn_103(
         let __v_47: G = __r_arr[8];
         let __v_48: G = __r_arr[9];
         let __v_49: G = __r_arr[10];
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_47, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_50: G = __r_arr[0];
         let __v_51: G = __r_arr[1];
         let __v_52: G = __r_arr[2];
@@ -10146,7 +10233,7 @@ fn aiur_fn_103(
         let __v_58: G = __r_arr[8];
         let __v_59: G = __r_arr[9];
         let __v_60: G = __r_arr[10];
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_58, __v_59]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_61: G = __r_arr[0];
         let __v_62: G = __r_arr[1];
         let __v_63: G = __r_arr[2];
@@ -10158,7 +10245,7 @@ fn aiur_fn_103(
         let __v_69: G = __r_arr[8];
         let __v_70: G = __r_arr[9];
         let __v_71: G = __r_arr[10];
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_69, __v_70]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_72: G = __r_arr[0];
         let __v_73: G = __r_arr[1];
         let __v_74: G = __r_arr[2];
@@ -10170,7 +10257,7 @@ fn aiur_fn_103(
         let __v_80: G = __r_arr[8];
         let __v_81: G = __r_arr[9];
         let __v_82: G = __r_arr[10];
-        let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_80, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
         let __v_83: G = __r_arr[0];
         let __v_84: G = __r_arr[1];
         let __v_85: G = __r_arr[2];
@@ -10353,8 +10440,8 @@ fn aiur_fn_103(
           1u64 => {
             let __v_232: G = G::from_u64(0);
             let __v_233: G = { let __values: [G; 34] = [__v_232, __v_5, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218, __v_219, __v_220, __v_221, __v_222, __v_223, __v_224, __v_225, __v_226, __v_227, __v_228, __v_229, __v_230, __v_231]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_103] = [__v_233];
-            if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_104] = [__v_233];
+            if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -10415,20 +10502,20 @@ fn aiur_fn_103(
                 let __v_282: G = { let __values: [G; 32] = [__v_232, __v_233, __v_234, __v_235, __v_236, __v_237, __v_238, __v_239, __v_240, __v_241, __v_242, __v_243, __v_244, __v_245, __v_246, __v_247, __v_248, __v_249, __v_250, __v_251, __v_252, __v_253, __v_254, __v_255, __v_256, __v_257, __v_258, __v_259, __v_260, __v_261, __v_262, __v_263]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_283: G = G::from_u64(0);
                 let __v_284: G = { let __values: [G; 34] = [__v_283, __v_5, __v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218, __v_219, __v_220, __v_221, __v_222, __v_223, __v_224, __v_225, __v_226, __v_227, __v_228, __v_229, __v_230, __v_231]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_91, __v_92, __v_264, __v_281, __v_282, __v_284]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_91, __v_92, __v_264, __v_281, __v_282, __v_284]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_104(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                 let __v_285: G = __r_arr[0];
-                let __ret: [G; OUT_103] = [__v_285];
-                if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_104] = [__v_285];
+                if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
               _ => {
                 let __v_232: G = G::from_u64(1);
                 let __v_233: G = (__v_2 + __v_232);
                 let __v_234: G = { let __values: [G; 32] = [__v_200, __v_201, __v_202, __v_203, __v_204, __v_205, __v_206, __v_207, __v_208, __v_209, __v_210, __v_211, __v_212, __v_213, __v_214, __v_215, __v_216, __v_217, __v_218, __v_219, __v_220, __v_221, __v_222, __v_223, __v_224, __v_225, __v_226, __v_227, __v_228, __v_229, __v_230, __v_231]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_91, __v_92, __v_233, __v_3, __v_234, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_91, __v_92, __v_233, __v_3, __v_234, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_104(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
                 let __v_235: G = __r_arr[0];
-                let __ret: [G; OUT_103] = [__v_235];
-                if let Some(result) = record.function_queries[103].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[103].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_104] = [__v_235];
+                if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
@@ -10439,15 +10526,15 @@ fn aiur_fn_103(
   })
 }
 
-const INPUT_SIZE_104: usize = 1;
-const IN_104: usize = 1;
-const OUT_104: usize = 32;
-fn aiur_fn_104(
-  inp: [G; IN_104],
+const INPUT_SIZE_105: usize = 1;
+const IN_105: usize = 1;
+const OUT_105: usize = 32;
+fn aiur_fn_105(
+  inp: [G; IN_105],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_104], ExecError> {
+) -> Result<[G; OUT_105], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(103);
@@ -10499,7 +10586,7 @@ fn aiur_fn_104(
     let __v_47: G = G::from_u64(1);
     let __v_48: G = G::from_u64(1);
     let __v_49: G = { let __values: [G; 34] = [__v_47, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48, __v_48]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_35, __v_0, __v_36, __v_45, __v_46, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_104(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
     let __r_arr: [G; OUT_64] = { let __args: [G; IN_64] = [__v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[64].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_64(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_64] = unsafe { *(result.output.as_ptr() as *const [G; OUT_64]) }; __ret } } else { aiur_fn_64(__args, record, io_buffer, __cu)? } };
     let __v_51: G = __r_arr[0];
@@ -10534,21 +10621,21 @@ fn aiur_fn_104(
     let __v_80: G = __r_arr[29];
     let __v_81: G = __r_arr[30];
     let __v_82: G = __r_arr[31];
-    let __ret: [G; OUT_104] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82];
-    if let Some(result) = record.function_queries[104].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[104].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_105] = [__v_51, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82];
+    if let Some(result) = record.function_queries[105].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_105: usize = 3;
-const IN_105: usize = 3;
-const OUT_105: usize = 1;
-fn aiur_fn_105(
-  inp: [G; IN_105],
+const INPUT_SIZE_106: usize = 3;
+const IN_106: usize = 3;
+const OUT_106: usize = 1;
+fn aiur_fn_106(
+  inp: [G; IN_106],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_105], ExecError> {
+) -> Result<[G; OUT_106], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10604,7 +10691,7 @@ fn aiur_fn_105(
     let __v_50: G = G::from_u64(1);
     let __v_51: G = G::from_u64(1);
     let __v_52: G = { let __values: [G; 34] = [__v_50, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51, __v_51]; let __mq = record.memory_queries.get_mut(&34).ok_or(ExecError::InvalidMemorySize(34))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_103] = { let __args: [G; IN_103] = [__v_38, __v_3, __v_39, __v_48, __v_49, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[103].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_103(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_103] = unsafe { *(result.output.as_ptr() as *const [G; OUT_103]) }; __ret } } else { aiur_fn_103(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_104] = { let __args: [G; IN_104] = [__v_38, __v_3, __v_39, __v_48, __v_49, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[104].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_104(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_104] = unsafe { *(result.output.as_ptr() as *const [G; OUT_104]) }; __ret } } else { aiur_fn_104(__args, record, io_buffer, __cu)? } };
     let __v_53: G = __r_arr[0];
     let __r_arr: [G; OUT_64] = { let __args: [G; IN_64] = [__v_53]; let __cu = unconstrained; if let Some(result) = record.function_queries[64].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_64(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_64] = unsafe { *(result.output.as_ptr() as *const [G; OUT_64]) }; __ret } } else { aiur_fn_64(__args, record, io_buffer, __cu)? } };
     let __v_54: G = __r_arr[0];
@@ -10640,49 +10727,14 @@ fn aiur_fn_105(
     let __v_84: G = __r_arr[30];
     let __v_85: G = __r_arr[31];
     let __v_86: G = { let __values: [G; 32] = [__v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_75, __v_76, __v_77, __v_78, __v_79, __v_80, __v_81, __v_82, __v_83, __v_84, __v_85]; let __mq = record.memory_queries.get_mut(&32).ok_or(ExecError::InvalidMemorySize(32))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_105] = [__v_86];
-    if let Some(result) = record.function_queries[105].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[105].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_106] = [__v_86];
+    if let Some(result) = record.function_queries[106].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_106: usize = 4;
-const IN_106: usize = 4;
-const OUT_106: usize = 1;
-fn aiur_fn_106(
-  inp: [G; IN_106],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_106], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_100(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
-    let __v_4: G = __r_arr[0];
-    match __v_4.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_106] = [__v_3];
-        if let Some(result) = record.function_queries[106].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_105(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_98(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_106] = [__v_6];
-        if let Some(result) = record.function_queries[106].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[106].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_107: usize = 1;
-const IN_107: usize = 1;
+const INPUT_SIZE_107: usize = 4;
+const IN_107: usize = 4;
 const OUT_107: usize = 1;
 fn aiur_fn_107(
   inp: [G; IN_107],
@@ -10692,6 +10744,41 @@ fn aiur_fn_107(
 ) -> Result<[G; OUT_107], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __r_arr: [G; OUT_100] = { let __args: [G; IN_100] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[100].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_100(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_100] = unsafe { *(result.output.as_ptr() as *const [G; OUT_100]) }; __ret } } else { aiur_fn_100(__args, record, io_buffer, __cu)? } };
+    let __v_4: G = __r_arr[0];
+    match __v_4.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_107] = [__v_3];
+        if let Some(result) = record.function_queries[107].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_106(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_98(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_107] = [__v_6];
+        if let Some(result) = record.function_queries[107].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_108: usize = 1;
+const IN_108: usize = 1;
+const OUT_108: usize = 1;
+fn aiur_fn_108(
+  inp: [G; IN_108],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_108], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -10699,18 +10786,18 @@ fn aiur_fn_107(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_107] = [__v_4];
-        if let Some(result) = record.function_queries[107].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_108] = [__v_4];
+        if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(2);
-        let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         let __v_6: G = (__v_4 * __v_5);
         let __v_7: G = (__v_2 + __v_6);
-        let __ret: [G; OUT_107] = [__v_7];
-        if let Some(result) = record.function_queries[107].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[107].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_108] = [__v_7];
+        if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -10720,15 +10807,15 @@ fn aiur_fn_107(
   })
 }
 
-const INPUT_SIZE_108: usize = 2;
-const IN_108: usize = 2;
-const OUT_108: usize = 1;
-fn aiur_fn_108(
-  inp: [G; IN_108],
+const INPUT_SIZE_109: usize = 2;
+const IN_109: usize = 2;
+const OUT_109: usize = 1;
+fn aiur_fn_109(
+  inp: [G; IN_109],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_108], ExecError> {
+) -> Result<[G; OUT_109], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10741,8 +10828,8 @@ fn aiur_fn_108(
     let __v_7: G = __loaded[5];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_108] = [__v_1];
-        if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_109] = [__v_1];
+        if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -10755,8 +10842,8 @@ fn aiur_fn_108(
         let __v_13: G = __loaded[5];
         match __v_8.as_canonical_u64() {
           1u64 => {
-            let __ret: [G; OUT_108] = [__v_0];
-            if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_109] = [__v_0];
+            if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           0u64 => {
@@ -10769,11 +10856,11 @@ fn aiur_fn_108(
                     match __v_14.as_canonical_u64() {
                       1u64 => {
                         let __v_15: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_7, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_7, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_109(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
                         let __v_16: G = __r_arr[0];
                         let __v_17: G = { let __values: [G; 6] = [__v_15, __v_3, __v_4, __v_5, __v_6, __v_16]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __ret: [G; OUT_108] = [__v_17];
-                        if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                        let __ret: [G; OUT_109] = [__v_17];
+                        if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                         return Ok(__ret);
                       },
                       _ => {
@@ -10784,21 +10871,24 @@ fn aiur_fn_108(
                             if (__v_6 != __v_12) {
                               return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_12.as_canonical_u64(), msg: None });
                             }
+                            if (__v_5 != __v_11) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_5.as_canonical_u64(), rhs: __v_11.as_canonical_u64(), msg: None });
+                            }
                             let __v_17: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_7, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_7, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_109(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
                             let __v_18: G = __r_arr[0];
                             let __v_19: G = { let __values: [G; 6] = [__v_17, __v_3, __v_4, __v_5, __v_6, __v_18]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                            let __ret: [G; OUT_108] = [__v_19];
-                            if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                            let __ret: [G; OUT_109] = [__v_19];
+                            if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                             return Ok(__ret);
                           },
                           _ => {
                             let __v_17: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_109(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
                             let __v_18: G = __r_arr[0];
                             let __v_19: G = { let __values: [G; 6] = [__v_17, __v_9, __v_10, __v_11, __v_12, __v_18]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                            let __ret: [G; OUT_108] = [__v_19];
-                            if let Some(result) = record.function_queries[108].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[108].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                            let __ret: [G; OUT_109] = [__v_19];
+                            if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                             return Ok(__ret);
                           },
                         }
@@ -10821,15 +10911,15 @@ fn aiur_fn_108(
   })
 }
 
-const INPUT_SIZE_109: usize = 1;
-const IN_109: usize = 1;
-const OUT_109: usize = 2;
-fn aiur_fn_109(
-  inp: [G; IN_109],
+const INPUT_SIZE_110: usize = 1;
+const IN_110: usize = 1;
+const OUT_110: usize = 2;
+fn aiur_fn_110(
+  inp: [G; IN_110],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_109], ExecError> {
+) -> Result<[G; OUT_110], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
@@ -10847,8 +10937,8 @@ fn aiur_fn_109(
         let __v_10: G = G::from_u64(1);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = { let __values: [G; 6] = [__v_10, __v_11, __v_11, __v_11, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_109] = [__v_9, __v_12];
-        if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_110] = [__v_9, __v_12];
+        if let Some(result) = record.function_queries[110].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -10869,20 +10959,20 @@ fn aiur_fn_109(
             let __v_18: G = G::from_u64(1);
             let __v_19: G = G::from_u64(1);
             let __v_20: G = { let __values: [G; 6] = [__v_18, __v_19, __v_19, __v_19, __v_19, __v_19]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_109] = [__v_17, __v_20];
-            if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_110] = [__v_17, __v_20];
+            if let Some(result) = record.function_queries[110].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_109(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_110(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = __r_arr[1];
             let __v_15: G = G::from_u64(0);
             let __v_16: G = { let __values: [G; 6] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_13]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
             let __v_17: G = G::from_u64(0);
             let __v_18: G = { let __values: [G; 6] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_14]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_109] = [__v_16, __v_18];
-            if let Some(result) = record.function_queries[109].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[109].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_110] = [__v_16, __v_18];
+            if let Some(result) = record.function_queries[110].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -10897,15 +10987,15 @@ fn aiur_fn_109(
   })
 }
 
-const INPUT_SIZE_110: usize = 1;
-const IN_110: usize = 1;
-const OUT_110: usize = 1;
-fn aiur_fn_110(
-  inp: [G; IN_110],
+const INPUT_SIZE_111: usize = 1;
+const IN_111: usize = 1;
+const OUT_111: usize = 1;
+fn aiur_fn_111(
+  inp: [G; IN_111],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_110], ExecError> {
+) -> Result<[G; OUT_111], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
@@ -10917,8 +11007,8 @@ fn aiur_fn_110(
     let __v_6: G = __loaded[5];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_110] = [__v_0];
-        if let Some(result) = record.function_queries[110].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_111] = [__v_0];
+        if let Some(result) = record.function_queries[111].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -10931,22 +11021,22 @@ fn aiur_fn_110(
         let __v_12: G = __loaded[5];
         match __v_7.as_canonical_u64() {
           1u64 => {
-            let __ret: [G; OUT_110] = [__v_0];
-            if let Some(result) = record.function_queries[110].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_111] = [__v_0];
+            if let Some(result) = record.function_queries[111].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           0u64 => {
-            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_109(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_110(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = __r_arr[1];
-            let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_110(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_111(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
             let __v_15: G = __r_arr[0];
-            let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_110(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_111(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
             let __v_16: G = __r_arr[0];
-            let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_109] = { let __args: [G; IN_109] = [__v_15, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[109].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_109(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_109] = unsafe { *(result.output.as_ptr() as *const [G; OUT_109]) }; __ret } } else { aiur_fn_109(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
-            let __ret: [G; OUT_110] = [__v_17];
-            if let Some(result) = record.function_queries[110].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[110].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_111] = [__v_17];
+            if let Some(result) = record.function_queries[111].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -10961,15 +11051,15 @@ fn aiur_fn_110(
   })
 }
 
-const INPUT_SIZE_111: usize = 4;
-const IN_111: usize = 4;
-const OUT_111: usize = 1;
-fn aiur_fn_111(
-  inp: [G; IN_111],
+const INPUT_SIZE_112: usize = 4;
+const IN_112: usize = 4;
+const OUT_112: usize = 1;
+fn aiur_fn_112(
+  inp: [G; IN_112],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_111], ExecError> {
+) -> Result<[G; OUT_112], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -10981,7 +11071,7 @@ fn aiur_fn_111(
     let __v_6: G = __loaded[2];
     match __v_4.as_canonical_u64() {
       1u64 => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_7: G = __r_arr[0];
         let __v_8: G = G::from_u64(0);
         if (__v_7 != __v_8) {
@@ -10990,8 +11080,8 @@ fn aiur_fn_111(
         let __v_9: G = G::from_u64(1);
         let __v_10: G = G::from_u64(1);
         let __v_11: G = { let __values: [G; 6] = [__v_9, __v_10, __v_10, __v_10, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_111] = [__v_11];
-        if let Some(result) = record.function_queries[111].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_112] = [__v_11];
+        if let Some(result) = record.function_queries[112].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -11001,16 +11091,16 @@ fn aiur_fn_111(
         let __v_9: G = __loaded[2];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_105] = { let __args: [G; IN_105] = [__v_8, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[105].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_105(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_105] = unsafe { *(result.output.as_ptr() as *const [G; OUT_105]) }; __ret } } else { aiur_fn_105(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_8, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_106(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
             let __v_10: G = __r_arr[0];
             let __v_11: G = G::from_u64(0);
-            let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
-            let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_6, __v_9, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_111(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_6, __v_9, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_112(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = { let __values: [G; 6] = [__v_11, __v_12, __v_5, __v_8, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_111] = [__v_14];
-            if let Some(result) = record.function_queries[111].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[111].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_112] = [__v_14];
+            if let Some(result) = record.function_queries[112].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -11025,15 +11115,15 @@ fn aiur_fn_111(
   })
 }
 
-const INPUT_SIZE_112: usize = 4;
-const IN_112: usize = 4;
-const OUT_112: usize = 2;
-fn aiur_fn_112(
-  inp: [G; IN_112],
+const INPUT_SIZE_113: usize = 4;
+const IN_113: usize = 4;
+const OUT_113: usize = 2;
+fn aiur_fn_113(
+  inp: [G; IN_113],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_112], ExecError> {
+) -> Result<[G; OUT_113], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11051,8 +11141,8 @@ fn aiur_fn_112(
         let __v_10: G = G::from_u64(1);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = { let __values: [G; 6] = [__v_10, __v_11, __v_11, __v_11, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_112] = [__v_12, __v_1];
-        if let Some(result) = record.function_queries[112].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_113] = [__v_12, __v_1];
+        if let Some(result) = record.function_queries[113].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -11064,7 +11154,7 @@ fn aiur_fn_112(
             let __v_12: G = __loaded[2];
             match __v_10.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
                 let __v_13: G = __r_arr[0];
                 let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_9.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
                 let __v_14: G = __loaded[0];
@@ -11083,7 +11173,7 @@ fn aiur_fn_112(
                         let __v_22: G = __loaded[2];
                         match __v_20.as_canonical_u64() {
                           0u64 => {
-                            let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+                            let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
                             let __v_23: G = __r_arr[0];
                             let __v_24: G = (__v_13 - __v_23);
                             let __v_25: G = G::from_bool((__v_24 == G::ZERO));
@@ -11091,15 +11181,22 @@ fn aiur_fn_112(
                               1u64 => {
                                 let __r_arr: [G; OUT_98] = { let __args: [G; IN_98] = [__v_8, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[98].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_98(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_98] = unsafe { *(result.output.as_ptr() as *const [G; OUT_98]) }; __ret } } else { aiur_fn_98(__args, record, io_buffer, __cu)? } };
                                 let __v_26: G = __r_arr[0];
-                                let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_7, __v_2, __v_3, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_106(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                                let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_7, __v_2, __v_3, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
                                 let __v_27: G = __r_arr[0];
-                                let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_19, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_112(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                                let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_19, __v_1, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_113(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
                                 let __v_28: G = __r_arr[0];
                                 let __v_29: G = __r_arr[1];
-                                let __v_30: G = G::from_u64(0);
-                                let __v_31: G = { let __values: [G; 6] = [__v_30, __v_13, __v_12, __v_7, __v_27, __v_28]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                let __ret: [G; OUT_112] = [__v_31, __v_29];
-                                if let Some(result) = record.function_queries[112].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_7, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                                let __v_30: G = __r_arr[0];
+                                let __r_arr: [G; OUT_102] = { let __args: [G; IN_102] = [__v_17, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[102].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_102(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_102] = unsafe { *(result.output.as_ptr() as *const [G; OUT_102]) }; __ret } } else { aiur_fn_102(__args, record, io_buffer, __cu)? } };
+                                let __v_31: G = __r_arr[0];
+                                if (__v_30 != __v_31) {
+                                  return Err(ExecError::AssertEqMismatch { lhs: __v_30.as_canonical_u64(), rhs: __v_31.as_canonical_u64(), msg: None });
+                                }
+                                let __v_32: G = G::from_u64(0);
+                                let __v_33: G = { let __values: [G; 6] = [__v_32, __v_13, __v_12, __v_7, __v_27, __v_28]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                                let __ret: [G; OUT_113] = [__v_33, __v_29];
+                                if let Some(result) = record.function_queries[113].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                 return Ok(__ret);
                               },
                               _ => {
@@ -11111,15 +11208,15 @@ fn aiur_fn_112(
                                   0u64 => {
                                     let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_11, __v_8, __v_27]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_99(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
                                     let __v_29: G = __r_arr[0];
-                                    let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_7, __v_2, __v_3, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_106(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                                    let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_7, __v_2, __v_3, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
                                     let __v_30: G = __r_arr[0];
-                                    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_9, __v_28, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_112(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
+                                    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_9, __v_28, __v_2, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_113(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
                                     let __v_31: G = __r_arr[0];
                                     let __v_32: G = __r_arr[1];
                                     let __v_33: G = G::from_u64(0);
                                     let __v_34: G = { let __values: [G; 6] = [__v_33, __v_13, __v_12, __v_7, __v_30, __v_31]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                                    let __ret: [G; OUT_112] = [__v_34, __v_32];
-                                    if let Some(result) = record.function_queries[112].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                    let __ret: [G; OUT_113] = [__v_34, __v_32];
+                                    if let Some(result) = record.function_queries[113].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                     return Ok(__ret);
                                   },
                                   _ => {
@@ -11145,15 +11242,15 @@ fn aiur_fn_112(
                       0u64 => {
                         let __r_arr: [G; OUT_99] = { let __args: [G; IN_99] = [__v_11, __v_8, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[99].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_99(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_99] = unsafe { *(result.output.as_ptr() as *const [G; OUT_99]) }; __ret } } else { aiur_fn_99(__args, record, io_buffer, __cu)? } };
                         let __v_23: G = __r_arr[0];
-                        let __r_arr: [G; OUT_106] = { let __args: [G; IN_106] = [__v_7, __v_2, __v_3, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[106].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_106(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_106] = unsafe { *(result.output.as_ptr() as *const [G; OUT_106]) }; __ret } } else { aiur_fn_106(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_7, __v_2, __v_3, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
                         let __v_24: G = __r_arr[0];
                         let __v_25: G = G::from_u64(0);
                         let __v_26: G = G::from_u64(1);
                         let __v_27: G = G::from_u64(1);
                         let __v_28: G = { let __values: [G; 6] = [__v_26, __v_27, __v_27, __v_27, __v_27, __v_27]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                         let __v_29: G = { let __values: [G; 6] = [__v_25, __v_13, __v_12, __v_7, __v_24, __v_28]; let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __ret: [G; OUT_112] = [__v_29, __v_22];
-                        if let Some(result) = record.function_queries[112].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[112].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                        let __ret: [G; OUT_113] = [__v_29, __v_22];
+                        if let Some(result) = record.function_queries[113].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                         return Ok(__ret);
                       },
                       _ => {
@@ -11180,48 +11277,9 @@ fn aiur_fn_112(
   })
 }
 
-const INPUT_SIZE_113: usize = 4;
-const IN_113: usize = 4;
-const OUT_113: usize = 2;
-fn aiur_fn_113(
-  inp: [G; IN_113],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_113], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_113] = [__v_0, __v_1];
-        if let Some(result) = record.function_queries[113].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = (__v_3 - __v_4);
-        let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_0, __v_1, __v_2, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_112(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = __r_arr[1];
-        let __v_8: G = G::from_u64(1);
-        let __v_9: G = (__v_3 - __v_8);
-        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_6, __v_7, __v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_113(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
-        let __v_10: G = __r_arr[0];
-        let __v_11: G = __r_arr[1];
-        let __ret: [G; OUT_113] = [__v_10, __v_11];
-        if let Some(result) = record.function_queries[113].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[113].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_114: usize = 6;
-const IN_114: usize = 6;
-const OUT_114: usize = 1;
+const INPUT_SIZE_114: usize = 4;
+const IN_114: usize = 4;
+const OUT_114: usize = 2;
 fn aiur_fn_114(
   inp: [G; IN_114],
   record: &mut QueryRecord,
@@ -11233,13 +11291,52 @@ fn aiur_fn_114(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_114] = [__v_0, __v_1];
+        if let Some(result) = record.function_queries[114].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = (__v_3 - __v_4);
+        let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_0, __v_1, __v_2, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_113(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = __r_arr[1];
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = (__v_3 - __v_8);
+        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_6, __v_7, __v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+        let __v_10: G = __r_arr[0];
+        let __v_11: G = __r_arr[1];
+        let __ret: [G; OUT_114] = [__v_10, __v_11];
+        if let Some(result) = record.function_queries[114].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_115: usize = 6;
+const IN_115: usize = 6;
+const OUT_115: usize = 1;
+fn aiur_fn_115(
+  inp: [G; IN_115],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_115], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
     let __v_4: G = inp[4];
     let __v_5: G = inp[5];
-    let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_3, __v_1, __v_2, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_111(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_112] = { let __args: [G; IN_112] = [__v_3, __v_1, __v_2, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[112].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_112(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_112] = unsafe { *(result.output.as_ptr() as *const [G; OUT_112]) }; __ret } } else { aiur_fn_112(__args, record, io_buffer, __cu)? } };
     let __v_6: G = __r_arr[0];
-    let __r_arr: [G; OUT_110] = { let __args: [G; IN_110] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[110].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_110(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_110] = unsafe { *(result.output.as_ptr() as *const [G; OUT_110]) }; __ret } } else { aiur_fn_110(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_111] = { let __args: [G; IN_111] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[111].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_111(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_111] = unsafe { *(result.output.as_ptr() as *const [G; OUT_111]) }; __ret } } else { aiur_fn_111(__args, record, io_buffer, __cu)? } };
     let __v_7: G = __r_arr[0];
-    let __r_arr: [G; OUT_113] = { let __args: [G; IN_113] = [__v_7, __v_4, __v_2, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[113].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_113(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_113] = unsafe { *(result.output.as_ptr() as *const [G; OUT_113]) }; __ret } } else { aiur_fn_113(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_7, __v_4, __v_2, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
     let __v_8: G = __r_arr[0];
     let __v_9: G = __r_arr[1];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_8.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
@@ -11253,9 +11350,9 @@ fn aiur_fn_114(
       0u64 => {
         match __v_11.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
             let __v_16: G = __r_arr[0];
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
             let __v_18: G = (__v_16 - __v_17);
             let __v_19: G = G::from_bool((__v_18 == G::ZERO));
@@ -11263,68 +11360,30 @@ fn aiur_fn_114(
             if (__v_19 != __v_20) {
               return Err(ExecError::AssertEqMismatch { lhs: __v_19.as_canonical_u64(), rhs: __v_20.as_canonical_u64(), msg: None });
             }
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = G::from_u64(0);
             if (__v_21 != __v_22) {
               return Err(ExecError::AssertEqMismatch { lhs: __v_21.as_canonical_u64(), rhs: __v_22.as_canonical_u64(), msg: None });
             }
-            let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_209(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
             let __v_23: G = __r_arr[0];
             let __v_24: G = G::from_u64(0);
             if (__v_23 != __v_24) {
               return Err(ExecError::AssertEqMismatch { lhs: __v_23.as_canonical_u64(), rhs: __v_24.as_canonical_u64(), msg: None });
             }
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_0, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_25: G = __r_arr[0];
             let __v_26: G = (__v_25 - __v_14);
             let __v_27: G = G::from_bool((__v_26 == G::ZERO));
-            let __ret: [G; OUT_114] = [__v_27];
-            if let Some(result) = record.function_queries[114].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[114].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_115] = [__v_27];
+            if let Some(result) = record.function_queries[115].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_10.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_115: usize = 2;
-const IN_115: usize = 2;
-const OUT_115: usize = 1;
-fn aiur_fn_115(
-  inp: [G; IN_115],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_115], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_115] = [__v_1];
-        if let Some(result) = record.function_queries[115].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = { let __values: [G; 3] = [__v_5, __v_3, __v_1]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __ret: [G; OUT_115] = [__v_7];
-        if let Some(result) = record.function_queries[115].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[115].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -11342,6 +11401,44 @@ fn aiur_fn_116(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_116] = [__v_1];
+        if let Some(result) = record.function_queries[116].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = { let __values: [G; 3] = [__v_5, __v_3, __v_1]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_4, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __ret: [G; OUT_116] = [__v_7];
+        if let Some(result) = record.function_queries[116].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_117: usize = 2;
+const IN_117: usize = 2;
+const OUT_117: usize = 1;
+fn aiur_fn_117(
+  inp: [G; IN_117],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_117], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
@@ -11349,24 +11446,24 @@ fn aiur_fn_116(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(1);
-        let __ret: [G; OUT_116] = [__v_5];
-        if let Some(result) = record.function_queries[116].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_117] = [__v_5];
+        if let Some(result) = record.function_queries[117].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         let __v_5: G = (__v_0 * __v_0);
-        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_5, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_117(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         match __v_3.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_116] = [__v_6];
-            if let Some(result) = record.function_queries[116].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_117] = [__v_6];
+            if let Some(result) = record.function_queries[117].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
             let __v_7: G = (__v_0 * __v_6);
-            let __ret: [G; OUT_116] = [__v_7];
-            if let Some(result) = record.function_queries[116].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[116].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_117] = [__v_7];
+            if let Some(result) = record.function_queries[117].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
@@ -11378,15 +11475,15 @@ fn aiur_fn_116(
   })
 }
 
-const INPUT_SIZE_117: usize = 8;
-const IN_117: usize = 8;
-const OUT_117: usize = 2;
-fn aiur_fn_117(
-  inp: [G; IN_117],
+const INPUT_SIZE_118: usize = 8;
+const IN_118: usize = 8;
+const OUT_118: usize = 2;
+fn aiur_fn_118(
+  inp: [G; IN_118],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_117], ExecError> {
+) -> Result<[G; OUT_118], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11398,14 +11495,14 @@ fn aiur_fn_117(
     let __v_7: G = inp[7];
     let __v_8: G = G::from_u64(1);
     let __v_9: G = (__v_1 + __v_8);
-    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
     let __v_11: G = G::from_u64(1);
     let __v_12: G = G::from_u64(1);
     let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_0, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_10, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_117(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __v_16: G = (__v_15 + __v_15);
     let __v_17: G = (__v_4 + __v_6);
@@ -11487,50 +11584,50 @@ fn aiur_fn_117(
     let __v_81: G = (__v_79 + __v_80);
     let __v_82: G = (__v_42 + __v_78);
     let __v_83: G = (__v_45 + __v_81);
-    let __ret: [G; OUT_117] = [__v_82, __v_83];
-    if let Some(result) = record.function_queries[117].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[117].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_118: usize = 2;
-const IN_118: usize = 2;
-const OUT_118: usize = 1;
-fn aiur_fn_118(
-  inp: [G; IN_118],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_118], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_u64(7);
-    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = G::from_u64(1);
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
-    let __v_7: G = __r_arr[0];
-    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
-    let __v_8: G = __r_arr[0];
-    let __v_9: G = (__v_2 * __v_8);
-    let __ret: [G; OUT_118] = [__v_9];
+    let __ret: [G; OUT_118] = [__v_82, __v_83];
     if let Some(result) = record.function_queries[118].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[118].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_119: usize = 8;
-const IN_119: usize = 8;
-const OUT_119: usize = 4;
+const INPUT_SIZE_119: usize = 2;
+const IN_119: usize = 2;
+const OUT_119: usize = 1;
 fn aiur_fn_119(
   inp: [G; IN_119],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_119], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_u64(7);
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = G::from_u64(1);
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_0, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+    let __v_7: G = __r_arr[0];
+    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_3, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_117(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+    let __v_8: G = __r_arr[0];
+    let __v_9: G = (__v_2 * __v_8);
+    let __ret: [G; OUT_119] = [__v_9];
+    if let Some(result) = record.function_queries[119].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_120: usize = 8;
+const IN_120: usize = 8;
+const OUT_120: usize = 4;
+fn aiur_fn_120(
+  inp: [G; IN_120],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_120], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11553,8 +11650,8 @@ fn aiur_fn_119(
     let __v_17: G = __loaded[9];
     match __v_8.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_119] = [__v_4, __v_5, __v_6, __v_7];
-        if let Some(result) = record.function_queries[119].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_120] = [__v_4, __v_5, __v_6, __v_7];
+        if let Some(result) = record.function_queries[120].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -11607,13 +11704,13 @@ fn aiur_fn_119(
             let __v_61: G = (__v_6 * __v_3);
             let __v_62: G = (__v_7 * __v_2);
             let __v_63: G = (__v_61 + __v_62);
-            let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_17, __v_21, __v_2, __v_3, __v_54, __v_55, __v_60, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_119(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_17, __v_21, __v_2, __v_3, __v_54, __v_55, __v_60, __v_63]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
             let __v_64: G = __r_arr[0];
             let __v_65: G = __r_arr[1];
             let __v_66: G = __r_arr[2];
             let __v_67: G = __r_arr[3];
-            let __ret: [G; OUT_119] = [__v_64, __v_65, __v_66, __v_67];
-            if let Some(result) = record.function_queries[119].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[119].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_120] = [__v_64, __v_65, __v_66, __v_67];
+            if let Some(result) = record.function_queries[120].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -11628,15 +11725,15 @@ fn aiur_fn_119(
   })
 }
 
-const INPUT_SIZE_120: usize = 2;
-const IN_120: usize = 2;
-const OUT_120: usize = 1;
-fn aiur_fn_120(
-  inp: [G; IN_120],
+const INPUT_SIZE_121: usize = 2;
+const IN_121: usize = 2;
+const OUT_121: usize = 1;
+fn aiur_fn_121(
+  inp: [G; IN_121],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_120], ExecError> {
+) -> Result<[G; OUT_121], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11647,8 +11744,8 @@ fn aiur_fn_120(
     let __v_5: G = __loaded[3];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_120] = [__v_1];
-        if let Some(result) = record.function_queries[120].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_121] = [__v_1];
+        if let Some(result) = record.function_queries[121].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -11764,51 +11861,13 @@ fn aiur_fn_120(
         if (__v_94 != __v_95) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_94.as_canonical_u64(), rhs: __v_95.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_96: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_97: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_98: G = __r_arr[0];
-        let __ret: [G; OUT_120] = [__v_98];
-        if let Some(result) = record.function_queries[120].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[120].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_121: usize = 2;
-const IN_121: usize = 2;
-const OUT_121: usize = 1;
-fn aiur_fn_121(
-  inp: [G; IN_121],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_121], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_121] = [__v_1];
-        if let Some(result) = record.function_queries[121].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __ret: [G; OUT_121] = [__v_6];
+        let __ret: [G; OUT_121] = [__v_98];
         if let Some(result) = record.function_queries[121].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[121].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -11857,8 +11916,8 @@ fn aiur_fn_122(
   })
 }
 
-const INPUT_SIZE_123: usize = 3;
-const IN_123: usize = 3;
+const INPUT_SIZE_123: usize = 2;
+const IN_123: usize = 2;
 const OUT_123: usize = 1;
 fn aiur_fn_123(
   inp: [G; IN_123],
@@ -11869,29 +11928,34 @@ fn aiur_fn_123(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_123] = [__v_2];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_123] = [__v_1];
         if let Some(result) = record.function_queries[123].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
-      1u64 => {
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __ret: [G; OUT_123] = [__v_3];
+      0u64 => {
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __ret: [G; OUT_123] = [__v_6];
         if let Some(result) = record.function_queries[123].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[123].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_124: usize = 2;
-const IN_124: usize = 2;
+const INPUT_SIZE_124: usize = 3;
+const IN_124: usize = 3;
 const OUT_124: usize = 1;
 fn aiur_fn_124(
   inp: [G; IN_124],
@@ -11902,14 +11966,47 @@ fn aiur_fn_124(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_124] = [__v_2];
+        if let Some(result) = record.function_queries[124].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __ret: [G; OUT_124] = [__v_3];
+        if let Some(result) = record.function_queries[124].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_0.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_125: usize = 2;
+const IN_125: usize = 2;
+const OUT_125: usize = 1;
+fn aiur_fn_125(
+  inp: [G; IN_125],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_125], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_124] = [__v_0];
-        if let Some(result) = record.function_queries[124].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_125] = [__v_0];
+        if let Some(result) = record.function_queries[125].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -11921,12 +12018,12 @@ fn aiur_fn_124(
         let __v_10: G = G::from_u64(0);
         let __v_11: G = G::from_u64(0);
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_167(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_124(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_13, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
-        let __ret: [G; OUT_124] = [__v_14];
-        if let Some(result) = record.function_queries[124].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[124].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_125] = [__v_14];
+        if let Some(result) = record.function_queries[125].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -11936,15 +12033,15 @@ fn aiur_fn_124(
   })
 }
 
-const INPUT_SIZE_125: usize = 10;
-const IN_125: usize = 10;
-const OUT_125: usize = 2;
-fn aiur_fn_125(
-  inp: [G; IN_125],
+const INPUT_SIZE_126: usize = 10;
+const IN_126: usize = 10;
+const OUT_126: usize = 2;
+fn aiur_fn_126(
+  inp: [G; IN_126],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_125], ExecError> {
+) -> Result<[G; OUT_126], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -11961,43 +12058,43 @@ fn aiur_fn_125(
         let __v_10: G = G::from_u64(1);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = { let __values: [G; 3] = [__v_10, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_125] = [__v_0, __v_12];
-        if let Some(result) = record.function_queries[125].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_126] = [__v_0, __v_12];
+        if let Some(result) = record.function_queries[126].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_167(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = G::from_u64(1);
         let __v_13: G = { let __values: [G; 3] = [__v_11, __v_12, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_166(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_10, __v_13, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_167(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
         let __v_14: G = __r_arr[0];
         let __v_15: G = __r_arr[1];
         let __v_16: G = __r_arr[2];
-        let __r_arr: [G; OUT_107] = { let __args: [G; IN_107] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[107].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_107(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_107] = unsafe { *(result.output.as_ptr() as *const [G; OUT_107]) }; __ret } } else { aiur_fn_107(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_108] = { let __args: [G; IN_108] = [__v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[108].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_108(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_108] = unsafe { *(result.output.as_ptr() as *const [G; OUT_108]) }; __ret } } else { aiur_fn_108(__args, record, io_buffer, __cu)? } };
         let __v_17: G = __r_arr[0];
         let __v_18: G = G::from_u64(0);
         if (__v_17 != __v_18) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64(), msg: None });
         }
-        let __ret: [G; OUT_125] = [__v_15, __v_16];
-        if let Some(result) = record.function_queries[125].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[125].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_126] = [__v_15, __v_16];
+        if let Some(result) = record.function_queries[126].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_126: usize = 4;
-const IN_126: usize = 4;
-const OUT_126: usize = 2;
-fn aiur_fn_126(
-  inp: [G; IN_126],
+const INPUT_SIZE_127: usize = 4;
+const IN_127: usize = 4;
+const OUT_127: usize = 2;
+fn aiur_fn_127(
+  inp: [G; IN_127],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_126], ExecError> {
+) -> Result<[G; OUT_127], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12012,8 +12109,8 @@ fn aiur_fn_126(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_126] = [__v_9, __v_0];
-        if let Some(result) = record.function_queries[126].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_127] = [__v_9, __v_0];
+        if let Some(result) = record.function_queries[127].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -12030,12 +12127,12 @@ fn aiur_fn_126(
         let __v_16: G = __loaded[9];
         match __v_7.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
             let __v_17: G = __r_arr[0];
-            let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_17, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
             let __v_18: G = __r_arr[0];
             let __v_19: G = __r_arr[1];
-            let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
             let __v_20: G = __r_arr[0];
             let __v_21: G = __r_arr[1];
             let __v_22: G = __r_arr[2];
@@ -12054,7 +12151,7 @@ fn aiur_fn_126(
             let __v_35: G = __r_arr[15];
             let __v_36: G = __r_arr[16];
             let __v_37: G = __r_arr[17];
-            let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_36, __v_6, __v_16, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_127(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
             let __v_38: G = __r_arr[0];
             let __v_39: G = __r_arr[1];
             let __v_40: G = G::from_u64(0);
@@ -12101,8 +12198,8 @@ fn aiur_fn_126(
             let __v_81: G = (__v_63 + __v_80);
             let __v_82: G = (__v_28 + __v_81);
             let __v_83: G = { let __values: [G; 4] = [__v_40, __v_61, __v_82, __v_38]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_126] = [__v_83, __v_39];
-            if let Some(result) = record.function_queries[126].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[126].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_127] = [__v_83, __v_39];
+            if let Some(result) = record.function_queries[127].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -12117,60 +12214,8 @@ fn aiur_fn_126(
   })
 }
 
-const INPUT_SIZE_127: usize = 5;
-const IN_127: usize = 5;
-const OUT_127: usize = 1;
-fn aiur_fn_127(
-  inp: [G; IN_127],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_127], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_2.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_127] = [__v_5];
-        if let Some(result) = record.function_queries[127].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_1 - __v_4);
-        let __v_7: G = (__v_5 + __v_6);
-        let __v_8: G = G::from_bool((__v_7 == G::ZERO));
-        match __v_8.as_canonical_u64() {
-          1u64 => {
-            let __v_9: G = G::from_u64(1);
-            let __ret: [G; OUT_127] = [__v_9];
-            if let Some(result) = record.function_queries[127].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-          _ => {
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_2 - __v_9);
-            let __v_11: G = G::from_u64(1);
-            let __v_12: G = (__v_3 + __v_11);
-            let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_127(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
-            let __v_13: G = __r_arr[0];
-            let __ret: [G; OUT_127] = [__v_13];
-            if let Some(result) = record.function_queries[127].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[127].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-        }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_128: usize = 4;
-const IN_128: usize = 4;
+const INPUT_SIZE_128: usize = 5;
+const IN_128: usize = 5;
 const OUT_128: usize = 1;
 fn aiur_fn_128(
   inp: [G; IN_128],
@@ -12183,27 +12228,79 @@ fn aiur_fn_128(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_2.as_canonical_u64() {
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_128] = [__v_5];
+        if let Some(result) = record.function_queries[128].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_1 - __v_4);
+        let __v_7: G = (__v_5 + __v_6);
+        let __v_8: G = G::from_bool((__v_7 == G::ZERO));
+        match __v_8.as_canonical_u64() {
+          1u64 => {
+            let __v_9: G = G::from_u64(1);
+            let __ret: [G; OUT_128] = [__v_9];
+            if let Some(result) = record.function_queries[128].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+          _ => {
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_2 - __v_9);
+            let __v_11: G = G::from_u64(1);
+            let __v_12: G = (__v_3 + __v_11);
+            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_10, __v_12, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_128(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __v_13: G = __r_arr[0];
+            let __ret: [G; OUT_128] = [__v_13];
+            if let Some(result) = record.function_queries[128].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_129: usize = 4;
+const IN_129: usize = 4;
+const OUT_129: usize = 1;
+fn aiur_fn_129(
+  inp: [G; IN_129],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_129], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
         let __v_4: G = G::from_u64(1);
         let __v_5: G = G::from_u64(1);
         let __v_6: G = { let __values: [G; 7] = [__v_4, __v_5, __v_5, __v_5, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_128] = [__v_6];
-        if let Some(result) = record.function_queries[128].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_129] = [__v_6];
+        if let Some(result) = record.function_queries[129].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
         let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_127(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_4, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_128(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
         let __v_5: G = __r_arr[0];
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_3 - __v_6);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_128(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_2, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_129(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_128] = [__v_8];
-            if let Some(result) = record.function_queries[128].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_129] = [__v_8];
+            if let Some(result) = record.function_queries[129].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -12214,11 +12311,11 @@ fn aiur_fn_128(
             let __v_10: G = G::from_u64(0);
             let __v_11: G = G::from_u64(1);
             let __v_12: G = (__v_3 - __v_11);
-            let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_128(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_2, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_129(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
             let __v_13: G = __r_arr[0];
             let __v_14: G = { let __values: [G; 7] = [__v_6, __v_3, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_128] = [__v_14];
-            if let Some(result) = record.function_queries[128].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[128].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_129] = [__v_14];
+            if let Some(result) = record.function_queries[129].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
@@ -12227,15 +12324,15 @@ fn aiur_fn_128(
   })
 }
 
-const INPUT_SIZE_129: usize = 8;
-const IN_129: usize = 8;
-const OUT_129: usize = 1;
-fn aiur_fn_129(
-  inp: [G; IN_129],
+const INPUT_SIZE_130: usize = 8;
+const IN_130: usize = 8;
+const OUT_130: usize = 1;
+fn aiur_fn_130(
+  inp: [G; IN_130],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_129], ExecError> {
+) -> Result<[G; OUT_130], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12258,8 +12355,8 @@ fn aiur_fn_129(
         let __v_15: G = G::from_u64(1);
         let __v_16: G = G::from_u64(1);
         let __v_17: G = { let __values: [G; 7] = [__v_15, __v_16, __v_16, __v_16, __v_16, __v_16, __v_16]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_129] = [__v_17];
-        if let Some(result) = record.function_queries[129].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_130] = [__v_17];
+        if let Some(result) = record.function_queries[130].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -12271,7 +12368,7 @@ fn aiur_fn_129(
               1u64 => {
                 let __v_17: G = G::from_u64(0);
                 let __v_18: G = G::from_u64(0);
-                let __r_arr: [G; OUT_119] = { let __args: [G; IN_119] = [__v_2, __v_3, __v_6, __v_7, __v_17, __v_18, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[119].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_119(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_119] = unsafe { *(result.output.as_ptr() as *const [G; OUT_119]) }; __ret } } else { aiur_fn_119(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_2, __v_3, __v_6, __v_7, __v_17, __v_18, __v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
                 let __v_19: G = __r_arr[0];
                 let __v_20: G = __r_arr[1];
                 let __v_21: G = __r_arr[2];
@@ -12288,17 +12385,17 @@ fn aiur_fn_129(
                 let __v_32: G = (__v_13 + __v_30);
                 let __v_33: G = G::from_u64(0);
                 let __v_34: G = { let __values: [G; 7] = [__v_33, __v_9, __v_21, __v_22, __v_31, __v_32, __v_14]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_129] = [__v_34];
-                if let Some(result) = record.function_queries[129].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_130] = [__v_34];
+                if let Some(result) = record.function_queries[130].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
               _ => {
                 let __v_17: G = G::from_u64(0);
-                let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_129(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_14, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_130(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
                 let __v_18: G = __r_arr[0];
                 let __v_19: G = { let __values: [G; 7] = [__v_17, __v_9, __v_10, __v_11, __v_12, __v_13, __v_18]; let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_129] = [__v_19];
-                if let Some(result) = record.function_queries[129].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[129].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_130] = [__v_19];
+                if let Some(result) = record.function_queries[130].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
@@ -12312,15 +12409,15 @@ fn aiur_fn_129(
   })
 }
 
-const INPUT_SIZE_130: usize = 2;
-const IN_130: usize = 2;
-const OUT_130: usize = 1;
-fn aiur_fn_130(
-  inp: [G; IN_130],
+const INPUT_SIZE_131: usize = 2;
+const IN_131: usize = 2;
+const OUT_131: usize = 1;
+fn aiur_fn_131(
+  inp: [G; IN_131],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_130], ExecError> {
+) -> Result<[G; OUT_131], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12335,8 +12432,8 @@ fn aiur_fn_130(
     match __v_2.as_canonical_u64() {
       1u64 => {
         let __v_9: G = G::from_u64(1);
-        let __ret: [G; OUT_130] = [__v_9];
-        if let Some(result) = record.function_queries[130].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_131] = [__v_9];
+        if let Some(result) = record.function_queries[131].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -12358,15 +12455,15 @@ fn aiur_fn_130(
                   return Err(ExecError::AssertEqMismatch { lhs: __v_17.as_canonical_u64(), rhs: __v_18.as_canonical_u64(), msg: None });
                 }
                 let __v_19: G = G::from_u64(1);
-                let __ret: [G; OUT_130] = [__v_19];
-                if let Some(result) = record.function_queries[130].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_131] = [__v_19];
+                if let Some(result) = record.function_queries[131].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
               _ => {
-                let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_130(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_131(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
                 let __v_11: G = __r_arr[0];
-                let __ret: [G; OUT_130] = [__v_11];
-                if let Some(result) = record.function_queries[130].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[130].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_131] = [__v_11];
+                if let Some(result) = record.function_queries[131].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
@@ -12380,29 +12477,29 @@ fn aiur_fn_130(
   })
 }
 
-const INPUT_SIZE_131: usize = 2;
-const IN_131: usize = 2;
-const OUT_131: usize = 1;
-fn aiur_fn_131(
-  inp: [G; IN_131],
+const INPUT_SIZE_132: usize = 2;
+const IN_132: usize = 2;
+const OUT_132: usize = 1;
+fn aiur_fn_132(
+  inp: [G; IN_132],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_131], ExecError> {
+) -> Result<[G; OUT_132], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_0.as_canonical_u64() {
       0u64 => {
         let __v_2: G = G::from_u64(0);
-        let __ret: [G; OUT_131] = [__v_2];
-        if let Some(result) = record.function_queries[131].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_132] = [__v_2];
+        if let Some(result) = record.function_queries[132].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       1u64 => {
         let __v_2: G = G::from_u64(1);
-        let __ret: [G; OUT_131] = [__v_2];
-        if let Some(result) = record.function_queries[131].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[131].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_132] = [__v_2];
+        if let Some(result) = record.function_queries[132].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -12412,15 +12509,15 @@ fn aiur_fn_131(
   })
 }
 
-const INPUT_SIZE_132: usize = 10;
-const IN_132: usize = 10;
-const OUT_132: usize = 1;
-fn aiur_fn_132(
-  inp: [G; IN_132],
+const INPUT_SIZE_133: usize = 10;
+const IN_133: usize = 10;
+const OUT_133: usize = 1;
+fn aiur_fn_133(
+  inp: [G; IN_133],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_132], ExecError> {
+) -> Result<[G; OUT_133], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -12433,17 +12530,17 @@ fn aiur_fn_132(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = (__v_3 - __v_1);
-    let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
     let __v_12: G = G::from_u64(7);
-    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
     let __v_14: G = G::from_u64(1);
     let __v_15: G = G::from_u64(1);
     let __v_16: G = { let __values: [G; 3] = [__v_14, __v_15, __v_15]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_11, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_11, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
     let __v_17: G = __r_arr[0];
-    let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_13, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_13, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_117(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
     let __v_18: G = __r_arr[0];
     let __v_19: G = (__v_12 * __v_18);
     let __v_20: G = G::from_u64(0);
@@ -12472,9 +12569,9 @@ fn aiur_fn_132(
     let __v_37: G = G::from_u64(0);
     let __v_38: G = (__v_37 - __v_22);
     let __v_39: G = (__v_38 * __v_28);
-    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_211(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
     let __v_40: G = __r_arr[0];
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_41: G = __r_arr[0];
     let __v_42: G = (__v_40 - __v_41);
     let __v_43: G = G::from_bool((__v_42 == G::ZERO));
@@ -12482,64 +12579,16 @@ fn aiur_fn_132(
     if (__v_43 != __v_44) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_43.as_canonical_u64(), rhs: __v_44.as_canonical_u64(), msg: None });
     }
-    let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_0, __v_1, __v_6, __v_7, __v_36, __v_39, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_129(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_0, __v_1, __v_6, __v_7, __v_36, __v_39, __v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_130(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
     let __v_45: G = __r_arr[0];
-    let __ret: [G; OUT_132] = [__v_45];
-    if let Some(result) = record.function_queries[132].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[132].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_133: usize = 11;
-const IN_133: usize = 11;
-const OUT_133: usize = 1;
-fn aiur_fn_133(
-  inp: [G; IN_133],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_133], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = G::from_u64(0);
-    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-    let __v_12: G = __r_arr[0];
-    let __v_13: G = G::from_u64(1);
-    let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-    let __v_14: G = __r_arr[0];
-    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-    let __v_15: G = __r_arr[0];
-    let __v_16: G = G::from_u64(0);
-    let __v_17: G = (__v_5 * __v_15);
-    let __v_18: G = G::from_u64(7);
-    let __v_19: G = (__v_6 * __v_16);
-    let __v_20: G = (__v_18 * __v_19);
-    let __v_21: G = (__v_17 + __v_20);
-    let __v_22: G = (__v_5 * __v_16);
-    let __v_23: G = (__v_6 * __v_15);
-    let __v_24: G = (__v_22 + __v_23);
-    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-    let __v_25: G = __r_arr[0];
-    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_25, __v_3, __v_1, __v_2, __v_21, __v_24, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-    let __v_26: G = __r_arr[0];
-    let __ret: [G; OUT_133] = [__v_26];
+    let __ret: [G; OUT_133] = [__v_45];
     if let Some(result) = record.function_queries[133].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[133].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_134: usize = 13;
-const IN_134: usize = 13;
+const INPUT_SIZE_134: usize = 11;
+const IN_134: usize = 11;
 const OUT_134: usize = 1;
 fn aiur_fn_134(
   inp: [G; IN_134],
@@ -12559,35 +12608,30 @@ fn aiur_fn_134(
     let __v_8: G = inp[8];
     let __v_9: G = inp[9];
     let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    match __v_5.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_134] = [__v_0];
-        if let Some(result) = record.function_queries[134].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_15, __v_16, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_133(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-        let __v_17: G = __r_arr[0];
-        let __v_18: G = G::from_u64(1);
-        let __v_19: G = (__v_4 + __v_18);
-        let __v_20: G = G::from_u64(1);
-        let __v_21: G = (__v_5 - __v_20);
-        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_17, __v_1, __v_2, __v_3, __v_19, __v_21, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_134(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-        let __v_22: G = __r_arr[0];
-        let __ret: [G; OUT_134] = [__v_22];
-        if let Some(result) = record.function_queries[134].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
+    let __v_11: G = G::from_u64(0);
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __v_12: G = __r_arr[0];
+    let __v_13: G = G::from_u64(1);
+    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __v_14: G = __r_arr[0];
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+    let __v_15: G = __r_arr[0];
+    let __v_16: G = G::from_u64(0);
+    let __v_17: G = (__v_5 * __v_15);
+    let __v_18: G = G::from_u64(7);
+    let __v_19: G = (__v_6 * __v_16);
+    let __v_20: G = (__v_18 * __v_19);
+    let __v_21: G = (__v_17 + __v_20);
+    let __v_22: G = (__v_5 * __v_16);
+    let __v_23: G = (__v_6 * __v_15);
+    let __v_24: G = (__v_22 + __v_23);
+    let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_3, __v_1, __v_2, __v_5, __v_6, __v_7, __v_12, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_133(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+    let __v_25: G = __r_arr[0];
+    let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_25, __v_3, __v_1, __v_2, __v_21, __v_24, __v_7, __v_14, __v_9, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_133(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+    let __v_26: G = __r_arr[0];
+    let __ret: [G; OUT_134] = [__v_26];
+    if let Some(result) = record.function_queries[134].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[134].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
   })
 }
 
@@ -12621,25 +12665,22 @@ fn aiur_fn_135(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = (__v_13 + __v_3);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
-        let __v_17: G = G::from_u64(0);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_18: G = __r_arr[0];
-        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_15, __v_18, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
-        let __v_19: G = __r_arr[0];
+        let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_1, __v_2, __v_14, __v_13, __v_7, __v_8, __v_15, __v_16, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_134(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+        let __v_17: G = __r_arr[0];
+        let __v_18: G = G::from_u64(1);
+        let __v_19: G = (__v_4 + __v_18);
         let __v_20: G = G::from_u64(1);
-        let __v_21: G = (__v_4 + __v_20);
-        let __v_22: G = G::from_u64(1);
-        let __v_23: G = (__v_5 - __v_22);
-        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_19, __v_1, __v_2, __v_3, __v_21, __v_23, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_135(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-        let __v_24: G = __r_arr[0];
-        let __ret: [G; OUT_135] = [__v_24];
+        let __v_21: G = (__v_5 - __v_20);
+        let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_17, __v_1, __v_2, __v_3, __v_19, __v_21, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_135(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+        let __v_22: G = __r_arr[0];
+        let __ret: [G; OUT_135] = [__v_22];
         if let Some(result) = record.function_queries[135].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[135].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -12647,8 +12688,8 @@ fn aiur_fn_135(
   })
 }
 
-const INPUT_SIZE_136: usize = 15;
-const IN_136: usize = 15;
+const INPUT_SIZE_136: usize = 13;
+const IN_136: usize = 13;
 const OUT_136: usize = 1;
 fn aiur_fn_136(
   inp: [G; IN_136],
@@ -12670,8 +12711,6 @@ fn aiur_fn_136(
     let __v_10: G = inp[10];
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
     match __v_5.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_136] = [__v_0];
@@ -12679,47 +12718,27 @@ fn aiur_fn_136(
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_6, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __v_14: G = (__v_13 + __v_3);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_9, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_15: G = __r_arr[0];
-        let __v_16: G = __r_arr[1];
-        match __v_15.as_canonical_u64() {
-          0u64 => {
-            let __v_17: G = G::from_u64(1);
-            let __v_18: G = (__v_4 + __v_17);
-            let __v_19: G = G::from_u64(1);
-            let __v_20: G = (__v_5 - __v_19);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_136(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __ret: [G; OUT_136] = [__v_21];
-            if let Some(result) = record.function_queries[136].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-            let __v_17: G = __r_arr[0];
-            let __v_18: G = (__v_17 + __v_3);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_19, __v_20, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_133(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
-            let __v_21: G = __r_arr[0];
-            let __v_22: G = G::from_u64(1);
-            let __v_23: G = (__v_4 + __v_22);
-            let __v_24: G = G::from_u64(1);
-            let __v_25: G = (__v_5 - __v_24);
-            let __v_26: G = G::from_u64(1);
-            let __v_27: G = (__v_6 + __v_26);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_21, __v_1, __v_2, __v_3, __v_23, __v_25, __v_27, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_136(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_28: G = __r_arr[0];
-            let __ret: [G; OUT_136] = [__v_28];
-            if let Some(result) = record.function_queries[136].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
-          },
-        }
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_10, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        let __v_17: G = G::from_u64(0);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_16, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_18: G = __r_arr[0];
+        let __r_arr: [G; OUT_133] = { let __args: [G; IN_133] = [__v_0, __v_14, __v_1, __v_2, __v_7, __v_8, __v_15, __v_18, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[133].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_133(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_133] = unsafe { *(result.output.as_ptr() as *const [G; OUT_133]) }; __ret } } else { aiur_fn_133(__args, record, io_buffer, __cu)? } };
+        let __v_19: G = __r_arr[0];
+        let __v_20: G = G::from_u64(1);
+        let __v_21: G = (__v_4 + __v_20);
+        let __v_22: G = G::from_u64(1);
+        let __v_23: G = (__v_5 - __v_22);
+        let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_19, __v_1, __v_2, __v_3, __v_21, __v_23, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_136(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+        let __v_24: G = __r_arr[0];
+        let __ret: [G; OUT_136] = [__v_24];
+        if let Some(result) = record.function_queries[136].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[136].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
       },
     }
   })
@@ -12750,52 +12769,61 @@ fn aiur_fn_137(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    match __v_3.as_canonical_u64() {
+    match __v_5.as_canonical_u64() {
       0u64 => {
         let __ret: [G; OUT_137] = [__v_0];
         if let Some(result) = record.function_queries[137].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
-      1u64 => {
-        let __v_15: G = G::from_u64(3);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_16: G = __r_arr[0];
-        match __v_16.as_canonical_u64() {
-          _ => {
-            let __v_17: G = G::from_u64(0);
-            let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_6, __v_10, __v_5, __v_7, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
-            let __v_18: G = __r_arr[0];
-            let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_139(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
-            let __v_19: G = __r_arr[0];
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-            let __v_20: G = __r_arr[0];
-            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+      _ => {
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_8, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+        let __v_15: G = __r_arr[0];
+        let __v_16: G = __r_arr[1];
+        match __v_15.as_canonical_u64() {
+          0u64 => {
+            let __v_17: G = G::from_u64(1);
+            let __v_18: G = (__v_4 + __v_17);
+            let __v_19: G = G::from_u64(1);
+            let __v_20: G = (__v_5 - __v_19);
+            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_1, __v_2, __v_3, __v_18, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_137(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
-            let __v_22: G = (__v_20 - __v_21);
-            let __v_23: G = G::from_bool((__v_22 == G::ZERO));
-            let __v_24: G = G::from_u64(1);
-            if (__v_23 != __v_24) {
-              return Err(ExecError::AssertEqMismatch { lhs: __v_23.as_canonical_u64(), rhs: __v_24.as_canonical_u64(), msg: None });
-            }
-            let __v_25: G = G::from_u64(0);
-            let __v_26: G = G::from_u64(0);
-            let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_0, __v_8, __v_9, __v_10, __v_25, __v_7, __v_26, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_136(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
-            let __v_27: G = __r_arr[0];
-            let __ret: [G; OUT_137] = [__v_27];
+            let __ret: [G; OUT_137] = [__v_21];
             if let Some(result) = record.function_queries[137].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
+          1u64 => {
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_7, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_17: G = __r_arr[0];
+            let __v_18: G = (__v_17 + __v_3);
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_11, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_12, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_0, __v_1, __v_2, __v_18, __v_17, __v_9, __v_10, __v_19, __v_20, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_134(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = G::from_u64(1);
+            let __v_23: G = (__v_4 + __v_22);
+            let __v_24: G = G::from_u64(1);
+            let __v_25: G = (__v_5 - __v_24);
+            let __v_26: G = G::from_u64(1);
+            let __v_27: G = (__v_6 + __v_26);
+            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_21, __v_1, __v_2, __v_3, __v_23, __v_25, __v_27, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_137(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+            let __v_28: G = __r_arr[0];
+            let __ret: [G; OUT_137] = [__v_28];
+            if let Some(result) = record.function_queries[137].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[137].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_15.as_canonical_u64()));
+          },
         }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_138: usize = 4;
-const IN_138: usize = 4;
+const INPUT_SIZE_138: usize = 15;
+const IN_138: usize = 15;
 const OUT_138: usize = 1;
 fn aiur_fn_138(
   inp: [G; IN_138],
@@ -12808,37 +12836,63 @@ fn aiur_fn_138(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    match __v_2.as_canonical_u64() {
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    match __v_3.as_canonical_u64() {
       0u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_6];
+        let __ret: [G; OUT_138] = [__v_0];
         if let Some(result) = record.function_queries[138].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
+      1u64 => {
+        let __v_15: G = G::from_u64(3);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_16: G = __r_arr[0];
+        match __v_16.as_canonical_u64() {
+          _ => {
+            let __v_17: G = G::from_u64(0);
+            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_6, __v_10, __v_5, __v_7, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_141(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+            let __v_18: G = __r_arr[0];
+            let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
+            let __v_19: G = __r_arr[0];
+            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+            let __v_20: G = __r_arr[0];
+            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+            let __v_21: G = __r_arr[0];
+            let __v_22: G = (__v_20 - __v_21);
+            let __v_23: G = G::from_bool((__v_22 == G::ZERO));
+            let __v_24: G = G::from_u64(1);
+            if (__v_23 != __v_24) {
+              return Err(ExecError::AssertEqMismatch { lhs: __v_23.as_canonical_u64(), rhs: __v_24.as_canonical_u64(), msg: None });
+            }
+            let __v_25: G = G::from_u64(0);
+            let __v_26: G = G::from_u64(0);
+            let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_0, __v_8, __v_9, __v_10, __v_25, __v_7, __v_26, __v_6, __v_5, __v_11, __v_12, __v_16, __v_4, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_137(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
+            let __v_27: G = __r_arr[0];
+            let __ret: [G; OUT_138] = [__v_27];
+            if let Some(result) = record.function_queries[138].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+        }
+      },
       _ => {
-        let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = (__v_5 + __v_1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_2 - __v_7);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_3 + __v_9);
-        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_138(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_138] = [__v_12];
-        if let Some(result) = record.function_queries[138].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[138].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_139: usize = 1;
-const IN_139: usize = 1;
+const INPUT_SIZE_139: usize = 4;
+const IN_139: usize = 4;
 const OUT_139: usize = 1;
 fn aiur_fn_139(
   inp: [G; IN_139],
@@ -12848,6 +12902,49 @@ fn aiur_fn_139(
 ) -> Result<[G; OUT_139], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    match __v_2.as_canonical_u64() {
+      0u64 => {
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_139] = [__v_6];
+        if let Some(result) = record.function_queries[139].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_4: G = G::from_u64(0);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = (__v_5 + __v_1);
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_2 - __v_7);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_3 + __v_9);
+        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_139(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = { let __values: [G; 3] = [__v_4, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_139] = [__v_12];
+        if let Some(result) = record.function_queries[139].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_140: usize = 1;
+const IN_140: usize = 1;
+const OUT_140: usize = 1;
+fn aiur_fn_140(
+  inp: [G; IN_140],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_140], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -12855,23 +12952,23 @@ fn aiur_fn_139(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_139] = [__v_4];
-        if let Some(result) = record.function_queries[139].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_140] = [__v_4];
+        if let Some(result) = record.function_queries[140].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_139(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __v_5: G = { let __a_val = __v_4.as_canonical_u64(); let __b_val = __v_2.as_canonical_u64(); let __a_u32 = u32::try_from(__a_val).ok().ok_or(ExecError::U32OutOfRange(__a_val))?; let __b_u32 = u32::try_from(__b_val).ok().ok_or(ExecError::U32OutOfRange(__b_val))?; let __result = G::from_bool(__a_u32 < __b_u32); if !unconstrained { let __x_bytes = __a_u32.to_le_bytes(); let __z_bytes = __b_u32.to_le_bytes(); let __c_u32 = __b_u32.wrapping_sub(__a_u32).wrapping_sub(1); let __y_bytes = __c_u32.to_le_bytes(); record.bytes2_queries.bump_range_check(&G::from_u8(__x_bytes[0]), &G::from_u8(__x_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__x_bytes[2]), &G::from_u8(__x_bytes[3])); record.bytes2_queries.bump_range_check(&G::from_u8(__y_bytes[0]), &G::from_u8(__y_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__y_bytes[2]), &G::from_u8(__y_bytes[3])); record.bytes2_queries.bump_range_check(&G::from_u8(__z_bytes[0]), &G::from_u8(__z_bytes[1])); record.bytes2_queries.bump_range_check(&G::from_u8(__z_bytes[2]), &G::from_u8(__z_bytes[3])); } __result };
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_139] = [__v_4];
-            if let Some(result) = record.function_queries[139].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_140] = [__v_4];
+            if let Some(result) = record.function_queries[140].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
-            let __ret: [G; OUT_139] = [__v_2];
-            if let Some(result) = record.function_queries[139].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[139].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_140] = [__v_2];
+            if let Some(result) = record.function_queries[140].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
@@ -12883,74 +12980,9 @@ fn aiur_fn_139(
   })
 }
 
-const INPUT_SIZE_140: usize = 5;
-const IN_140: usize = 5;
-const OUT_140: usize = 1;
-fn aiur_fn_140(
-  inp: [G; IN_140],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_140], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_140] = [__v_7];
-        if let Some(result) = record.function_queries[140].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = __r_arr[1];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __v_7: G = G::from_u64(1);
-            let __v_8: G = (__v_3 - __v_7);
-            let __v_9: G = G::from_u64(1);
-            let __v_10: G = (__v_4 + __v_9);
-            let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
-            let __v_11: G = __r_arr[0];
-            let __ret: [G; OUT_140] = [__v_11];
-            if let Some(result) = record.function_queries[140].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-          1u64 => {
-            let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-            let __v_8: G = __r_arr[0];
-            let __v_9: G = (__v_8 + __v_1);
-            let __v_10: G = G::from_u64(1);
-            let __v_11: G = (__v_3 - __v_10);
-            let __v_12: G = G::from_u64(1);
-            let __v_13: G = (__v_4 + __v_12);
-            let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
-            let __v_14: G = __r_arr[0];
-            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_140] = [__v_15];
-            if let Some(result) = record.function_queries[140].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[140].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
-      },
-    }
-  })
-}
-
 const INPUT_SIZE_141: usize = 5;
 const IN_141: usize = 5;
-const OUT_141: usize = 4;
+const OUT_141: usize = 1;
 fn aiur_fn_141(
   inp: [G; IN_141],
   record: &mut QueryRecord,
@@ -12963,30 +12995,95 @@ fn aiur_fn_141(
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
     let __v_4: G = inp[4];
-    match __v_0.as_canonical_u64() {
+    match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_141] = [__v_1, __v_2, __v_3, __v_4];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_141] = [__v_7];
         if let Some(result) = record.function_queries[141].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        let __ret: [G; OUT_141] = [__v_3, __v_4, __v_1, __v_2];
-        if let Some(result) = record.function_queries[141].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = __r_arr[1];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __v_7: G = G::from_u64(1);
+            let __v_8: G = (__v_3 - __v_7);
+            let __v_9: G = G::from_u64(1);
+            let __v_10: G = (__v_4 + __v_9);
+            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_0, __v_1, __v_2, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_141(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+            let __v_11: G = __r_arr[0];
+            let __ret: [G; OUT_141] = [__v_11];
+            if let Some(result) = record.function_queries[141].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+          1u64 => {
+            let __v_7: G = G::from_u64(0);
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_0, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __v_9: G = (__v_8 + __v_1);
+            let __v_10: G = G::from_u64(1);
+            let __v_11: G = (__v_3 - __v_10);
+            let __v_12: G = G::from_u64(1);
+            let __v_13: G = (__v_4 + __v_12);
+            let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_0, __v_1, __v_2, __v_11, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_141(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
+            let __v_14: G = __r_arr[0];
+            let __v_15: G = { let __values: [G; 3] = [__v_7, __v_9, __v_14]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_141] = [__v_15];
+            if let Some(result) = record.function_queries[141].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[141].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_142: usize = 4;
-const IN_142: usize = 4;
-const OUT_142: usize = 1;
+const INPUT_SIZE_142: usize = 5;
+const IN_142: usize = 5;
+const OUT_142: usize = 4;
 fn aiur_fn_142(
   inp: [G; IN_142],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_142], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    let __v_4: G = inp[4];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_142] = [__v_1, __v_2, __v_3, __v_4];
+        if let Some(result) = record.function_queries[142].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __ret: [G; OUT_142] = [__v_3, __v_4, __v_1, __v_2];
+        if let Some(result) = record.function_queries[142].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_143: usize = 4;
+const IN_143: usize = 4;
+const OUT_143: usize = 1;
+fn aiur_fn_143(
+  inp: [G; IN_143],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_143], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13227,21 +13324,21 @@ fn aiur_fn_142(
     let __v_192: G = { let __values: [G; 10] = [__v_132, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_191]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_193: G = { let __values: [G; 10] = [__v_104, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_192]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_194: G = { let __values: [G; 10] = [__v_76, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_193]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_142] = [__v_194];
-    if let Some(result) = record.function_queries[142].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[142].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_143] = [__v_194];
+    if let Some(result) = record.function_queries[143].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_143: usize = 6;
-const IN_143: usize = 6;
-const OUT_143: usize = 3;
-fn aiur_fn_143(
-  inp: [G; IN_143],
+const INPUT_SIZE_144: usize = 6;
+const IN_144: usize = 6;
+const OUT_144: usize = 3;
+fn aiur_fn_144(
+  inp: [G; IN_144],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_143], ExecError> {
+) -> Result<[G; OUT_144], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13259,8 +13356,8 @@ fn aiur_fn_143(
     let __v_12: G = __loaded[6];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_143] = [__v_0, __v_1, __v_5];
-        if let Some(result) = record.function_queries[143].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_144] = [__v_0, __v_1, __v_5];
+        if let Some(result) = record.function_queries[144].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -13271,7 +13368,7 @@ fn aiur_fn_143(
             match __v_14.as_canonical_u64() {
               1u64 => {
                 let __v_15: G = G::from_u64(1);
-                let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_173(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_3, __v_4, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
                 let __v_16: G = __r_arr[0];
                 let __v_17: G = __r_arr[1];
                 let __v_18: G = (__v_16 * __v_10);
@@ -13284,13 +13381,13 @@ fn aiur_fn_143(
                 let __v_25: G = (__v_23 + __v_24);
                 let __v_26: G = (__v_0 + __v_22);
                 let __v_27: G = (__v_1 + __v_25);
-                let __ret: [G; OUT_143] = [__v_26, __v_27, __v_12];
-                if let Some(result) = record.function_queries[143].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_144] = [__v_26, __v_27, __v_12];
+                if let Some(result) = record.function_queries[144].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
               _ => {
-                let __ret: [G; OUT_143] = [__v_0, __v_1, __v_5];
-                if let Some(result) = record.function_queries[143].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[143].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_144] = [__v_0, __v_1, __v_5];
+                if let Some(result) = record.function_queries[144].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
@@ -13304,15 +13401,15 @@ fn aiur_fn_143(
   })
 }
 
-const INPUT_SIZE_144: usize = 9;
-const IN_144: usize = 9;
-const OUT_144: usize = 3;
-fn aiur_fn_144(
-  inp: [G; IN_144],
+const INPUT_SIZE_145: usize = 9;
+const IN_145: usize = 9;
+const OUT_145: usize = 3;
+fn aiur_fn_145(
+  inp: [G; IN_145],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_144], ExecError> {
+) -> Result<[G; OUT_145], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -13336,7 +13433,7 @@ fn aiur_fn_144(
         if (__v_14 != __v_15) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_14.as_canonical_u64(), rhs: __v_15.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_209(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
         let __v_16: G = __r_arr[0];
         let __v_17: G = G::from_u64(0);
         if (__v_16 != __v_17) {
@@ -13345,8 +13442,8 @@ fn aiur_fn_144(
         let __v_18: G = G::from_u64(1);
         let __v_19: G = G::from_u64(1);
         let __v_20: G = { let __values: [G; 3] = [__v_18, __v_19, __v_19]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_144] = [__v_0, __v_1, __v_20];
-        if let Some(result) = record.function_queries[144].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_145] = [__v_0, __v_1, __v_20];
+        if let Some(result) = record.function_queries[145].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -13374,7 +13471,7 @@ fn aiur_fn_144(
                         let __v_23: G = G::from_u64(1);
                         let __v_24: G = (__v_6 - __v_23);
                         let __v_25: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_11, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_11, __v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                         let __v_26: G = __r_arr[0];
                         let __v_27: G = __r_arr[1];
                         let __mc_out___mc_0: [G; 4] = '__mc_0: { match __v_21.as_canonical_u64() {
@@ -13390,14 +13487,14 @@ fn aiur_fn_144(
                         let __v_29: G = __mc_out___mc_0[1];
                         let __v_30: G = __mc_out___mc_0[2];
                         let __v_31: G = __mc_out___mc_0[3];
-                        let __r_arr: [G; OUT_117] = { let __args: [G; IN_117] = [__v_22, __v_24, __v_14, __v_15, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[117].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_117(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_117] = unsafe { *(result.output.as_ptr() as *const [G; OUT_117]) }; __ret } } else { aiur_fn_117(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_118] = { let __args: [G; IN_118] = [__v_22, __v_24, __v_14, __v_15, __v_28, __v_29, __v_30, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[118].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_118(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_118] = unsafe { *(result.output.as_ptr() as *const [G; OUT_118]) }; __ret } } else { aiur_fn_118(__args, record, io_buffer, __cu)? } };
                         let __v_32: G = __r_arr[0];
                         let __v_33: G = __r_arr[1];
-                        let __r_arr: [G; OUT_143] = { let __args: [G; IN_143] = [__v_32, __v_33, __v_24, __v_14, __v_15, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[143].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_143(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_143] = unsafe { *(result.output.as_ptr() as *const [G; OUT_143]) }; __ret } } else { aiur_fn_143(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_32, __v_33, __v_24, __v_14, __v_15, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_144(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
                         let __v_34: G = __r_arr[0];
                         let __v_35: G = __r_arr[1];
                         let __v_36: G = __r_arr[2];
-                        let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_34, __v_35, __v_16, __v_19, __v_12, __v_22, __v_24, __v_36, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_144(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_34, __v_35, __v_16, __v_19, __v_12, __v_22, __v_24, __v_36, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_145(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
                         let __v_37: G = __r_arr[0];
                         let __v_38: G = __r_arr[1];
                         let __v_39: G = __r_arr[2];
@@ -13493,7 +13590,7 @@ fn aiur_fn_144(
                         let __v_109: G = (__v_95 + __v_108);
                         let __v_110: G = (__v_94 + __v_109);
                         let __v_111: G = G::from_bool((__v_110 == G::ZERO));
-                        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                         let __v_112: G = __r_arr[0];
                         let __v_113: G = G::from_u64(1);
                         if (__v_112 != __v_113) {
@@ -13644,8 +13741,8 @@ fn aiur_fn_144(
                         let __v_232: G = { let __values: [G; 10] = [__v_143, __v_58, __v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_231]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                         let __v_233: G = { let __values: [G; 10] = [__v_115, __v_40, __v_41, __v_42, __v_43, __v_44, __v_45, __v_46, __v_47, __v_232]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                         let __v_234: G = { let __values: [G; 3] = [__v_114, __v_233, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __ret: [G; OUT_144] = [__v_37, __v_38, __v_234];
-                        if let Some(result) = record.function_queries[144].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[144].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                        let __ret: [G; OUT_145] = [__v_37, __v_38, __v_234];
+                        if let Some(result) = record.function_queries[145].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                         return Ok(__ret);
                       },
                       _ => {
@@ -13667,176 +13764,6 @@ fn aiur_fn_144(
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_9.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_145: usize = 25;
-const IN_145: usize = 25;
-const OUT_145: usize = 1;
-fn aiur_fn_145(
-  inp: [G; IN_145],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_145], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    let __v_4: G = inp[4];
-    let __v_5: G = inp[5];
-    let __v_6: G = inp[6];
-    let __v_7: G = inp[7];
-    let __v_8: G = inp[8];
-    let __v_9: G = inp[9];
-    let __v_10: G = inp[10];
-    let __v_11: G = inp[11];
-    let __v_12: G = inp[12];
-    let __v_13: G = inp[13];
-    let __v_14: G = inp[14];
-    let __v_15: G = inp[15];
-    let __v_16: G = inp[16];
-    let __v_17: G = inp[17];
-    let __v_18: G = inp[18];
-    let __v_19: G = inp[19];
-    let __v_20: G = inp[20];
-    let __v_21: G = inp[21];
-    let __v_22: G = inp[22];
-    let __v_23: G = inp[23];
-    let __v_24: G = inp[24];
-    match __v_1.as_canonical_u64() {
-      _ => {
-        let __r_arr: [G; OUT_128] = { let __args: [G; IN_128] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[128].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_128(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_128] = unsafe { *(result.output.as_ptr() as *const [G; OUT_128]) }; __ret } } else { aiur_fn_128(__args, record, io_buffer, __cu)? } };
-        let __v_25: G = __r_arr[0];
-        let __v_26: G = G::from_u64(0);
-        let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_15, __v_19, __v_18, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_138(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
-        let __v_27: G = __r_arr[0];
-        let __v_28: G = G::from_u64(0);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_29: G = __r_arr[0];
-        match __v_29.as_canonical_u64() {
-          _ => {
-            let __v_30: G = G::from_u64(0);
-            let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_25, __v_0, __v_20, __v_19, __v_30, __v_18, __v_15, __v_16, __v_17, __v_29, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_134(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-            let __v_31: G = __r_arr[0];
-            let __v_32: G = G::from_u64(1);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-            let __v_33: G = __r_arr[0];
-            match __v_33.as_canonical_u64() {
-              _ => {
-                let __v_34: G = G::from_u64(0);
-                let __r_arr: [G; OUT_134] = { let __args: [G; IN_134] = [__v_31, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_33, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[134].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_134(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_134] = unsafe { *(result.output.as_ptr() as *const [G; OUT_134]) }; __ret } } else { aiur_fn_134(__args, record, io_buffer, __cu)? } };
-                let __v_35: G = __r_arr[0];
-                let __v_36: G = G::from_u64(2);
-                let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-                let __v_37: G = __r_arr[0];
-                match __v_37.as_canonical_u64() {
-                  _ => {
-                    let __v_38: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_35, __v_0, __v_20, __v_19, __v_38, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_135(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
-                    let __v_39: G = __r_arr[0];
-                    let __r_arr: [G; OUT_137] = { let __args: [G; IN_137] = [__v_39, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[137].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_137(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_137] = unsafe { *(result.output.as_ptr() as *const [G; OUT_137]) }; __ret } } else { aiur_fn_137(__args, record, io_buffer, __cu)? } };
-                    let __v_40: G = __r_arr[0];
-                    let __r_arr: [G; OUT_130] = { let __args: [G; IN_130] = [__v_40, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[130].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_130(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_130] = unsafe { *(result.output.as_ptr() as *const [G; OUT_130]) }; __ret } } else { aiur_fn_130(__args, record, io_buffer, __cu)? } };
-                    let __v_41: G = __r_arr[0];
-                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_40.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
-                    let __v_42: G = __loaded[0];
-                    let __v_43: G = __loaded[1];
-                    let __v_44: G = __loaded[2];
-                    let __v_45: G = __loaded[3];
-                    let __v_46: G = __loaded[4];
-                    let __v_47: G = __loaded[5];
-                    let __v_48: G = __loaded[6];
-                    match __v_42.as_canonical_u64() {
-                      0u64 => {
-                        match __v_43.as_canonical_u64() {
-                          _ => {
-                            let __r_arr: [G; OUT_144] = { let __args: [G; IN_144] = [__v_46, __v_47, __v_21, __v_22, __v_2, __v_0, __v_20, __v_48, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[144].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_144(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_144] = unsafe { *(result.output.as_ptr() as *const [G; OUT_144]) }; __ret } } else { aiur_fn_144(__args, record, io_buffer, __cu)? } };
-                            let __v_49: G = __r_arr[0];
-                            let __v_50: G = __r_arr[1];
-                            let __v_51: G = __r_arr[2];
-                            let __v_52: G = G::from_u64(0);
-                            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_23, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
-                            let __v_53: G = __r_arr[0];
-                            let __v_54: G = __r_arr[1];
-                            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
-                            let __v_55: G = __r_arr[0];
-                            let __v_56: G = (__v_55 - __v_24);
-                            let __v_57: G = G::from_bool((__v_56 == G::ZERO));
-                            let __v_58: G = G::from_u64(1);
-                            if (__v_57 != __v_58) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_57.as_canonical_u64(), rhs: __v_58.as_canonical_u64(), msg: None });
-                            }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_59: G = __r_arr[0];
-                            let __v_60: G = G::from_u64(3);
-                            let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_131(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
-                            let __v_61: G = __r_arr[0];
-                            let __v_62: G = (__v_60 + __v_61);
-                            let __v_63: G = (__v_59 - __v_62);
-                            let __v_64: G = G::from_bool((__v_63 == G::ZERO));
-                            let __v_65: G = G::from_u64(1);
-                            if (__v_64 != __v_65) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64(), msg: None });
-                            }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_66: G = __r_arr[0];
-                            let __v_67: G = (__v_66 - __v_18);
-                            let __v_68: G = G::from_bool((__v_67 == G::ZERO));
-                            let __v_69: G = G::from_u64(1);
-                            if (__v_68 != __v_69) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_68.as_canonical_u64(), rhs: __v_69.as_canonical_u64(), msg: None });
-                            }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_70: G = __r_arr[0];
-                            let __v_71: G = (__v_70 - __v_18);
-                            let __v_72: G = G::from_bool((__v_71 == G::ZERO));
-                            let __v_73: G = G::from_u64(1);
-                            if (__v_72 != __v_73) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_72.as_canonical_u64(), rhs: __v_73.as_canonical_u64(), msg: None });
-                            }
-                            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-                            let __v_74: G = __r_arr[0];
-                            let __v_75: G = (__v_74 - __v_18);
-                            let __v_76: G = G::from_bool((__v_75 == G::ZERO));
-                            let __v_77: G = G::from_u64(1);
-                            if (__v_76 != __v_77) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64(), msg: None });
-                            }
-                            let __v_78: G = (__v_43 - __v_20);
-                            let __v_79: G = G::from_bool((__v_78 == G::ZERO));
-                            let __v_80: G = G::from_u64(1);
-                            if (__v_79 != __v_80) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_79.as_canonical_u64(), rhs: __v_80.as_canonical_u64(), msg: None });
-                            }
-                            let __v_81: G = (__v_53 - __v_49);
-                            let __v_82: G = G::from_bool((__v_81 == G::ZERO));
-                            let __v_83: G = (__v_54 - __v_50);
-                            let __v_84: G = G::from_bool((__v_83 == G::ZERO));
-                            let __v_85: G = (__v_82 * __v_84);
-                            let __v_86: G = G::from_u64(1);
-                            if (__v_85 != __v_86) {
-                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64(), msg: None });
-                            }
-                            let __ret: [G; OUT_145] = [__v_51];
-                            if let Some(result) = record.function_queries[145].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[145].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-                            return Ok(__ret);
-                          },
-                        }
-                      },
-                      _ => {
-                        return Err(ExecError::MatchNoCase(__v_42.as_canonical_u64()));
-                      },
-                    }
-                  },
-                }
-              },
-            }
-          },
-        }
       },
     }
   })
@@ -13877,44 +13804,143 @@ fn aiur_fn_146(
     let __v_22: G = inp[22];
     let __v_23: G = inp[23];
     let __v_24: G = inp[24];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_25: G = __loaded[0];
-    let __v_26: G = __loaded[1];
-    let __v_27: G = __loaded[2];
-    let __v_28: G = __loaded[3];
-    match __v_25.as_canonical_u64() {
-      1u64 => {
-        let __v_29: G = G::from_u64(1);
-        let __v_30: G = G::from_u64(1);
-        let __v_31: G = { let __values: [G; 3] = [__v_29, __v_30, __v_30]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_146] = [__v_31];
-        if let Some(result) = record.function_queries[146].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_166(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
-        let __v_29: G = __r_arr[0];
-        let __v_30: G = __r_arr[1];
-        let __v_31: G = __r_arr[2];
-        let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_145(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
-        let __v_32: G = __r_arr[0];
-        let __v_33: G = G::from_u64(0);
-        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_146(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
-        let __v_34: G = __r_arr[0];
-        let __v_35: G = { let __values: [G; 3] = [__v_33, __v_32, __v_34]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_146] = [__v_35];
-        if let Some(result) = record.function_queries[146].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
+    match __v_1.as_canonical_u64() {
       _ => {
-        return Err(ExecError::MatchNoCase(__v_25.as_canonical_u64()));
+        let __r_arr: [G; OUT_129] = { let __args: [G; IN_129] = [__v_15, __v_19, __v_18, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[129].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_129(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_129] = unsafe { *(result.output.as_ptr() as *const [G; OUT_129]) }; __ret } } else { aiur_fn_129(__args, record, io_buffer, __cu)? } };
+        let __v_25: G = __r_arr[0];
+        let __v_26: G = G::from_u64(0);
+        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_15, __v_19, __v_18, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_139(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+        let __v_27: G = __r_arr[0];
+        let __v_28: G = G::from_u64(0);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_29: G = __r_arr[0];
+        match __v_29.as_canonical_u64() {
+          _ => {
+            let __v_30: G = G::from_u64(0);
+            let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_25, __v_0, __v_20, __v_19, __v_30, __v_18, __v_15, __v_16, __v_17, __v_29, __v_5, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_135(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+            let __v_31: G = __r_arr[0];
+            let __v_32: G = G::from_u64(1);
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_33: G = __r_arr[0];
+            match __v_33.as_canonical_u64() {
+              _ => {
+                let __v_34: G = G::from_u64(0);
+                let __r_arr: [G; OUT_135] = { let __args: [G; IN_135] = [__v_31, __v_0, __v_20, __v_19, __v_34, __v_18, __v_15, __v_16, __v_17, __v_33, __v_6, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[135].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_135(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_135] = unsafe { *(result.output.as_ptr() as *const [G; OUT_135]) }; __ret } } else { aiur_fn_135(__args, record, io_buffer, __cu)? } };
+                let __v_35: G = __r_arr[0];
+                let __v_36: G = G::from_u64(2);
+                let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                let __v_37: G = __r_arr[0];
+                match __v_37.as_canonical_u64() {
+                  _ => {
+                    let __v_38: G = G::from_u64(0);
+                    let __r_arr: [G; OUT_136] = { let __args: [G; IN_136] = [__v_35, __v_0, __v_20, __v_19, __v_38, __v_18, __v_15, __v_16, __v_17, __v_37, __v_7, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[136].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_136(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_136] = unsafe { *(result.output.as_ptr() as *const [G; OUT_136]) }; __ret } } else { aiur_fn_136(__args, record, io_buffer, __cu)? } };
+                    let __v_39: G = __r_arr[0];
+                    let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_39, __v_1, __v_13, __v_8, __v_9, __v_14, __v_15, __v_18, __v_0, __v_20, __v_19, __v_16, __v_17, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_138(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+                    let __v_40: G = __r_arr[0];
+                    let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_40, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_131(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+                    let __v_41: G = __r_arr[0];
+                    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_40.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+                    let __v_42: G = __loaded[0];
+                    let __v_43: G = __loaded[1];
+                    let __v_44: G = __loaded[2];
+                    let __v_45: G = __loaded[3];
+                    let __v_46: G = __loaded[4];
+                    let __v_47: G = __loaded[5];
+                    let __v_48: G = __loaded[6];
+                    match __v_42.as_canonical_u64() {
+                      0u64 => {
+                        match __v_43.as_canonical_u64() {
+                          _ => {
+                            let __r_arr: [G; OUT_145] = { let __args: [G; IN_145] = [__v_46, __v_47, __v_21, __v_22, __v_2, __v_0, __v_20, __v_48, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[145].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_145(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_145] = unsafe { *(result.output.as_ptr() as *const [G; OUT_145]) }; __ret } } else { aiur_fn_145(__args, record, io_buffer, __cu)? } };
+                            let __v_49: G = __r_arr[0];
+                            let __v_50: G = __r_arr[1];
+                            let __v_51: G = __r_arr[2];
+                            let __v_52: G = G::from_u64(0);
+                            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_23, __v_52]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+                            let __v_53: G = __r_arr[0];
+                            let __v_54: G = __r_arr[1];
+                            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                            let __v_55: G = __r_arr[0];
+                            let __v_56: G = (__v_55 - __v_24);
+                            let __v_57: G = G::from_bool((__v_56 == G::ZERO));
+                            let __v_58: G = G::from_u64(1);
+                            if (__v_57 != __v_58) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_57.as_canonical_u64(), rhs: __v_58.as_canonical_u64(), msg: None });
+                            }
+                            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                            let __v_59: G = __r_arr[0];
+                            let __v_60: G = G::from_u64(3);
+                            let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
+                            let __v_61: G = __r_arr[0];
+                            let __v_62: G = (__v_60 + __v_61);
+                            let __v_63: G = (__v_59 - __v_62);
+                            let __v_64: G = G::from_bool((__v_63 == G::ZERO));
+                            let __v_65: G = G::from_u64(1);
+                            if (__v_64 != __v_65) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_64.as_canonical_u64(), rhs: __v_65.as_canonical_u64(), msg: None });
+                            }
+                            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                            let __v_66: G = __r_arr[0];
+                            let __v_67: G = (__v_66 - __v_18);
+                            let __v_68: G = G::from_bool((__v_67 == G::ZERO));
+                            let __v_69: G = G::from_u64(1);
+                            if (__v_68 != __v_69) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_68.as_canonical_u64(), rhs: __v_69.as_canonical_u64(), msg: None });
+                            }
+                            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                            let __v_70: G = __r_arr[0];
+                            let __v_71: G = (__v_70 - __v_18);
+                            let __v_72: G = G::from_bool((__v_71 == G::ZERO));
+                            let __v_73: G = G::from_u64(1);
+                            if (__v_72 != __v_73) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_72.as_canonical_u64(), rhs: __v_73.as_canonical_u64(), msg: None });
+                            }
+                            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                            let __v_74: G = __r_arr[0];
+                            let __v_75: G = (__v_74 - __v_18);
+                            let __v_76: G = G::from_bool((__v_75 == G::ZERO));
+                            let __v_77: G = G::from_u64(1);
+                            if (__v_76 != __v_77) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_76.as_canonical_u64(), rhs: __v_77.as_canonical_u64(), msg: None });
+                            }
+                            let __v_78: G = (__v_43 - __v_20);
+                            let __v_79: G = G::from_bool((__v_78 == G::ZERO));
+                            let __v_80: G = G::from_u64(1);
+                            if (__v_79 != __v_80) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_79.as_canonical_u64(), rhs: __v_80.as_canonical_u64(), msg: None });
+                            }
+                            let __v_81: G = (__v_53 - __v_49);
+                            let __v_82: G = G::from_bool((__v_81 == G::ZERO));
+                            let __v_83: G = (__v_54 - __v_50);
+                            let __v_84: G = G::from_bool((__v_83 == G::ZERO));
+                            let __v_85: G = (__v_82 * __v_84);
+                            let __v_86: G = G::from_u64(1);
+                            if (__v_85 != __v_86) {
+                              return Err(ExecError::AssertEqMismatch { lhs: __v_85.as_canonical_u64(), rhs: __v_86.as_canonical_u64(), msg: None });
+                            }
+                            let __ret: [G; OUT_146] = [__v_51];
+                            if let Some(result) = record.function_queries[146].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[146].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                            return Ok(__ret);
+                          },
+                        }
+                      },
+                      _ => {
+                        return Err(ExecError::MatchNoCase(__v_42.as_canonical_u64()));
+                      },
+                    }
+                  },
+                }
+              },
+            }
+          },
+        }
       },
     }
   })
 }
 
-const INPUT_SIZE_147: usize = 4;
-const IN_147: usize = 4;
+const INPUT_SIZE_147: usize = 25;
+const IN_147: usize = 25;
 const OUT_147: usize = 1;
 fn aiur_fn_147(
   inp: [G; IN_147],
@@ -13927,36 +13953,65 @@ fn aiur_fn_147(
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     let __v_3: G = inp[3];
-    match __v_2.as_canonical_u64() {
+    let __v_4: G = inp[4];
+    let __v_5: G = inp[5];
+    let __v_6: G = inp[6];
+    let __v_7: G = inp[7];
+    let __v_8: G = inp[8];
+    let __v_9: G = inp[9];
+    let __v_10: G = inp[10];
+    let __v_11: G = inp[11];
+    let __v_12: G = inp[12];
+    let __v_13: G = inp[13];
+    let __v_14: G = inp[14];
+    let __v_15: G = inp[15];
+    let __v_16: G = inp[16];
+    let __v_17: G = inp[17];
+    let __v_18: G = inp[18];
+    let __v_19: G = inp[19];
+    let __v_20: G = inp[20];
+    let __v_21: G = inp[21];
+    let __v_22: G = inp[22];
+    let __v_23: G = inp[23];
+    let __v_24: G = inp[24];
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_25: G = __loaded[0];
+    let __v_26: G = __loaded[1];
+    let __v_27: G = __loaded[2];
+    let __v_28: G = __loaded[3];
+    match __v_25.as_canonical_u64() {
+      1u64 => {
+        let __v_29: G = G::from_u64(1);
+        let __v_30: G = G::from_u64(1);
+        let __v_31: G = { let __values: [G; 3] = [__v_29, __v_30, __v_30]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_147] = [__v_31];
+        if let Some(result) = record.function_queries[147].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
       0u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_147] = [__v_6];
+        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_0, __v_1, __v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_167(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+        let __v_29: G = __r_arr[0];
+        let __v_30: G = __r_arr[1];
+        let __v_31: G = __r_arr[2];
+        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_29, __v_26, __v_27, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_146(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+        let __v_32: G = __r_arr[0];
+        let __v_33: G = G::from_u64(0);
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_30, __v_31, __v_28, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __v_34: G = __r_arr[0];
+        let __v_35: G = { let __values: [G; 3] = [__v_33, __v_32, __v_34]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_147] = [__v_35];
         if let Some(result) = record.function_queries[147].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_0, __v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_166(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = __r_arr[1];
-        let __v_6: G = __r_arr[2];
-        let __v_7: G = G::from_u64(0);
-        let __v_8: G = G::from_u64(1);
-        let __v_9: G = (__v_2 - __v_8);
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_5, __v_6, __v_9, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
-        let __v_10: G = __r_arr[0];
-        let __v_11: G = { let __values: [G; 3] = [__v_7, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_147] = [__v_11];
-        if let Some(result) = record.function_queries[147].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[147].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
+        return Err(ExecError::MatchNoCase(__v_25.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_148: usize = 2;
-const IN_148: usize = 2;
+const INPUT_SIZE_148: usize = 4;
+const IN_148: usize = 4;
 const OUT_148: usize = 1;
 fn aiur_fn_148(
   inp: [G; IN_148],
@@ -13967,37 +14022,31 @@ fn aiur_fn_148(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
     match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = { let __values: [G; 3] = [__v_6, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_148] = [__v_8];
+      0u64 => {
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 3] = [__v_4, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_148] = [__v_6];
         if let Some(result) = record.function_queries[148].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
-      0u64 => {
-        match __v_3.as_canonical_u64() {
-          _ => {
-            let __v_6: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_3, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-            let __v_7: G = __r_arr[0];
-            let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_148(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-            let __v_8: G = __r_arr[0];
-            let __v_9: G = { let __values: [G; 3] = [__v_6, __v_7, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_148] = [__v_9];
-            if let Some(result) = record.function_queries[148].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-        }
-      },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        let __r_arr: [G; OUT_167] = { let __args: [G; IN_167] = [__v_0, __v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[167].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_167(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_167] = unsafe { *(result.output.as_ptr() as *const [G; OUT_167]) }; __ret } } else { aiur_fn_167(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = __r_arr[1];
+        let __v_6: G = __r_arr[2];
+        let __v_7: G = G::from_u64(0);
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = (__v_2 - __v_8);
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_5, __v_6, __v_9, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_148(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
+        let __v_10: G = __r_arr[0];
+        let __v_11: G = { let __values: [G; 3] = [__v_7, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_148] = [__v_11];
+        if let Some(result) = record.function_queries[148].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[148].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
       },
     }
   })
@@ -14015,31 +14064,30 @@ fn aiur_fn_149(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
     let __v_4: G = __loaded[2];
     let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
     match __v_2.as_canonical_u64() {
       1u64 => {
+        let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
-        let __v_8: G = G::from_u64(1);
-        let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_149] = [__v_9];
+        let __v_8: G = { let __values: [G; 3] = [__v_6, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_149] = [__v_8];
         if let Some(result) = record.function_queries[149].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         match __v_3.as_canonical_u64() {
           _ => {
-            let __v_7: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __v_6: G = G::from_u64(0);
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_7: G = __r_arr[0];
+            let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_5, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_149(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_6, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_149(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-            let __v_9: G = __r_arr[0];
-            let __v_10: G = { let __values: [G; 4] = [__v_7, __v_3, __v_8, __v_9]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_149] = [__v_10];
+            let __v_9: G = { let __values: [G; 3] = [__v_6, __v_7, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_149] = [__v_9];
             if let Some(result) = record.function_queries[149].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[149].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
@@ -14052,8 +14100,8 @@ fn aiur_fn_149(
   })
 }
 
-const INPUT_SIZE_150: usize = 4;
-const IN_150: usize = 4;
+const INPUT_SIZE_150: usize = 2;
+const IN_150: usize = 2;
 const OUT_150: usize = 1;
 fn aiur_fn_150(
   inp: [G; IN_150],
@@ -14064,40 +14112,45 @@ fn aiur_fn_150(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __v_3: G = inp[3];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __v_4: G = G::from_u64(1);
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = { let __values: [G; 4] = [__v_4, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_150] = [__v_6];
+    let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_150] = [__v_9];
         if let Some(result) = record.function_queries[150].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
+      0u64 => {
+        match __v_3.as_canonical_u64() {
+          _ => {
+            let __v_7: G = G::from_u64(0);
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+            let __v_8: G = __r_arr[0];
+            let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_6, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_150(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+            let __v_9: G = __r_arr[0];
+            let __v_10: G = { let __values: [G; 4] = [__v_7, __v_3, __v_8, __v_9]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+            let __ret: [G; OUT_150] = [__v_10];
+            if let Some(result) = record.function_queries[150].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+        }
+      },
       _ => {
-        let __v_4: G = G::from_u64(0);
-        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_0, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_148(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_149(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = G::from_u64(1);
-        let __v_8: G = (__v_2 + __v_7);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_3 - __v_9);
-        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_150(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
-        let __v_11: G = __r_arr[0];
-        let __v_12: G = { let __values: [G; 4] = [__v_4, __v_5, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_150] = [__v_12];
-        if let Some(result) = record.function_queries[150].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[150].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_151: usize = 13;
-const IN_151: usize = 13;
+const INPUT_SIZE_151: usize = 4;
+const IN_151: usize = 4;
 const OUT_151: usize = 1;
 fn aiur_fn_151(
   inp: [G; IN_151],
@@ -14105,6 +14158,50 @@ fn aiur_fn_151(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_151], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __v_3: G = inp[3];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
+        let __v_4: G = G::from_u64(1);
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = { let __values: [G; 4] = [__v_4, __v_5, __v_5, __v_5]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_151] = [__v_6];
+        if let Some(result) = record.function_queries[151].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_4: G = G::from_u64(0);
+        let __r_arr: [G; OUT_149] = { let __args: [G; IN_149] = [__v_0, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[149].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_149(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_149] = unsafe { *(result.output.as_ptr() as *const [G; OUT_149]) }; __ret } } else { aiur_fn_149(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_150(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = G::from_u64(1);
+        let __v_8: G = (__v_2 + __v_7);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_3 - __v_9);
+        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_0, __v_1, __v_8, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+        let __v_11: G = __r_arr[0];
+        let __v_12: G = { let __values: [G; 4] = [__v_4, __v_5, __v_6, __v_11]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_151] = [__v_12];
+        if let Some(result) = record.function_queries[151].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_152: usize = 13;
+const IN_152: usize = 13;
+const OUT_152: usize = 1;
+fn aiur_fn_152(
+  inp: [G; IN_152],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_152], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14120,39 +14217,39 @@ fn aiur_fn_151(
     let __v_11: G = inp[11];
     let __v_12: G = inp[12];
     let __v_13: G = G::from_u64(0);
-    let __r_arr: [G; OUT_138] = { let __args: [G; IN_138] = [__v_9, __v_11, __v_10, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[138].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_138(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_138] = unsafe { *(result.output.as_ptr() as *const [G; OUT_138]) }; __ret } } else { aiur_fn_138(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_9, __v_11, __v_10, __v_13]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_139(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
     let __v_14: G = __r_arr[0];
     let __v_15: G = G::from_u64(0);
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_16: G = __r_arr[0];
     let __v_17: G = __r_arr[1];
     match __v_16.as_canonical_u64() {
       _ => {
         let __v_18: G = G::from_u64(1);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
         match __v_19.as_canonical_u64() {
           _ => {
             let __v_21: G = G::from_u64(2);
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_22: G = __r_arr[0];
             let __v_23: G = __r_arr[1];
             match __v_22.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_2, __v_16, __v_14, __v_1, __v_17, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_2, __v_16, __v_14, __v_1, __v_17, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                 let __v_24: G = __r_arr[0];
                 let __v_25: G = G::from_u64(1);
                 if (__v_24 != __v_25) {
                   return Err(ExecError::AssertEqMismatch { lhs: __v_24.as_canonical_u64(), rhs: __v_25.as_canonical_u64(), msg: None });
                 }
-                let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_3, __v_19, __v_14, __v_1, __v_20, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_3, __v_19, __v_14, __v_1, __v_20, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                 let __v_26: G = __r_arr[0];
                 let __v_27: G = G::from_u64(1);
                 if (__v_26 != __v_27) {
                   return Err(ExecError::AssertEqMismatch { lhs: __v_26.as_canonical_u64(), rhs: __v_27.as_canonical_u64(), msg: None });
                 }
-                let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_4, __v_22, __v_14, __v_1, __v_23, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_4, __v_22, __v_14, __v_1, __v_23, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                 let __v_28: G = __r_arr[0];
                 let __v_29: G = G::from_u64(1);
                 if (__v_28 != __v_29) {
@@ -14161,29 +14258,29 @@ fn aiur_fn_151(
                 match __v_6.as_canonical_u64() {
                   0u64 => {
                     let __v_30: G = G::from_u64(1);
-                    let __ret: [G; OUT_151] = [__v_30];
-                    if let Some(result) = record.function_queries[151].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                    let __ret: [G; OUT_152] = [__v_30];
+                    if let Some(result) = record.function_queries[152].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                     return Ok(__ret);
                   },
                   1u64 => {
                     let __v_30: G = G::from_u64(3);
-                    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_0, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_0, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                     let __v_31: G = __r_arr[0];
                     let __v_32: G = __r_arr[1];
                     match __v_31.as_canonical_u64() {
                       _ => {
                         let __v_33: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_9, __v_11, __v_8, __v_10, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_141] = { let __args: [G; IN_141] = [__v_9, __v_11, __v_8, __v_10, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[141].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_141(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_141] = unsafe { *(result.output.as_ptr() as *const [G; OUT_141]) }; __ret } } else { aiur_fn_141(__args, record, io_buffer, __cu)? } };
                         let __v_34: G = __r_arr[0];
-                        let __r_arr: [G; OUT_139] = { let __args: [G; IN_139] = [__v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[139].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_139(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_139] = unsafe { *(result.output.as_ptr() as *const [G; OUT_139]) }; __ret } } else { aiur_fn_139(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_140] = { let __args: [G; IN_140] = [__v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[140].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_140(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_140] = unsafe { *(result.output.as_ptr() as *const [G; OUT_140]) }; __ret } } else { aiur_fn_140(__args, record, io_buffer, __cu)? } };
                         let __v_35: G = __r_arr[0];
                         let __v_36: G = (__v_12 - __v_35);
-                        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_152(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_1, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_153(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
                         let __v_37: G = __r_arr[0];
-                        let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_5, __v_31, __v_34, __v_37, __v_32, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_5, __v_31, __v_34, __v_37, __v_32, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                         let __v_38: G = __r_arr[0];
-                        let __ret: [G; OUT_151] = [__v_38];
-                        if let Some(result) = record.function_queries[151].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[151].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                        let __ret: [G; OUT_152] = [__v_38];
+                        if let Some(result) = record.function_queries[152].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                         return Ok(__ret);
                       },
                     }
@@ -14196,46 +14293,6 @@ fn aiur_fn_151(
             }
           },
         }
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_152: usize = 2;
-const IN_152: usize = 2;
-const OUT_152: usize = 1;
-fn aiur_fn_152(
-  inp: [G; IN_152],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_152], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_152] = [__v_0];
-        if let Some(result) = record.function_queries[152].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_3, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_152(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = { let __values: [G; 3] = [__v_5, __v_6, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_152] = [__v_8];
-        if let Some(result) = record.function_queries[152].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[152].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -14259,26 +14316,18 @@ fn aiur_fn_153(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_153] = [__v_7];
+        let __ret: [G; OUT_153] = [__v_0];
         if let Some(result) = record.function_queries[153].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         let __v_5: G = G::from_u64(0);
-        let __v_6: G = G::from_u64(0);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_3, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = G::from_u64(1);
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = { let __values: [G; 3] = [__v_8, __v_9, __v_9]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __v_11: G = { let __values: [G; 3] = [__v_6, __v_7, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_3, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
         let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_153(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __v_13: G = { let __values: [G; 3] = [__v_5, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_153] = [__v_13];
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = { let __values: [G; 3] = [__v_5, __v_6, __v_7]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_153] = [__v_8];
         if let Some(result) = record.function_queries[153].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[153].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -14289,8 +14338,8 @@ fn aiur_fn_153(
   })
 }
 
-const INPUT_SIZE_154: usize = 6;
-const IN_154: usize = 6;
+const INPUT_SIZE_154: usize = 2;
+const IN_154: usize = 2;
 const OUT_154: usize = 1;
 fn aiur_fn_154(
   inp: [G; IN_154],
@@ -14298,6 +14347,54 @@ fn aiur_fn_154(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_154], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_154] = [__v_7];
+        if let Some(result) = record.function_queries[154].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = { let __values: [G; 3] = [__v_8, __v_9, __v_9]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __v_11: G = { let __values: [G; 3] = [__v_6, __v_7, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_154(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __v_13: G = { let __values: [G; 3] = [__v_5, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_154] = [__v_13];
+        if let Some(result) = record.function_queries[154].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_155: usize = 6;
+const IN_155: usize = 6;
+const OUT_155: usize = 1;
+fn aiur_fn_155(
+  inp: [G; IN_155],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_155], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14313,11 +14410,11 @@ fn aiur_fn_154(
     let __v_10: G = __loaded[4];
     match __v_6.as_canonical_u64() {
       1u64 => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_bool((__v_11 == G::ZERO));
-        let __ret: [G; OUT_154] = [__v_12];
-        if let Some(result) = record.function_queries[154].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_155] = [__v_12];
+        if let Some(result) = record.function_queries[155].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -14330,7 +14427,7 @@ fn aiur_fn_154(
             match __v_7.as_canonical_u64() {
               _ => {
                 let __v_14: G = G::from_u64(1);
-                let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_3, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_152(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_3, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_153(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
                 let __v_15: G = __r_arr[0];
                 let __v_16: G = G::from_u64(1);
                 let __v_17: G = (__v_5 - __v_16);
@@ -14338,21 +14435,21 @@ fn aiur_fn_154(
                 if (__v_7 != __v_18) {
                   return Err(ExecError::AssertEqMismatch { lhs: __v_7.as_canonical_u64(), rhs: __v_18.as_canonical_u64(), msg: None });
                 }
-                let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
                 let __v_19: G = __r_arr[0];
-                let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
                 let __v_20: G = __r_arr[0];
                 if (__v_19 != __v_20) {
                   return Err(ExecError::AssertEqMismatch { lhs: __v_19.as_canonical_u64(), rhs: __v_20.as_canonical_u64(), msg: None });
                 }
-                let __r_arr: [G; OUT_153] = { let __args: [G; IN_153] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[153].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_153(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_153] = unsafe { *(result.output.as_ptr() as *const [G; OUT_153]) }; __ret } } else { aiur_fn_153(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_2, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_154(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
                 let __v_21: G = __r_arr[0];
                 let __v_22: G = G::from_u64(0);
                 let __v_23: G = G::from_u64(1);
                 let __v_24: G = G::from_u64(1);
                 let __v_25: G = { let __values: [G; 3] = [__v_23, __v_24, __v_24]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
                 let __v_26: G = { let __values: [G; 3] = [__v_22, __v_17, __v_25]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_114] = { let __args: [G; IN_114] = [__v_12, __v_21, __v_26, __v_15, __v_9, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[114].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_114(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_114] = unsafe { *(result.output.as_ptr() as *const [G; OUT_114]) }; __ret } } else { aiur_fn_114(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_12, __v_21, __v_26, __v_15, __v_9, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
                 let __v_27: G = __r_arr[0];
                 let __v_28: G = G::from_u64(1);
                 if (__v_27 != __v_28) {
@@ -14360,10 +14457,10 @@ fn aiur_fn_154(
                 }
                 let __v_29: G = G::from_u64(1);
                 let __v_30: G = (__v_4 + __v_29);
-                let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_10, __v_13, __v_2, __v_15, __v_30, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_154(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_10, __v_13, __v_2, __v_15, __v_30, __v_17]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_155(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
                 let __v_31: G = __r_arr[0];
-                let __ret: [G; OUT_154] = [__v_31];
-                if let Some(result) = record.function_queries[154].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[154].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_155] = [__v_31];
+                if let Some(result) = record.function_queries[155].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
@@ -14380,15 +14477,15 @@ fn aiur_fn_154(
   })
 }
 
-const INPUT_SIZE_155: usize = 32;
-const IN_155: usize = 32;
-const OUT_155: usize = 1;
-fn aiur_fn_155(
-  inp: [G; IN_155],
+const INPUT_SIZE_156: usize = 32;
+const IN_156: usize = 32;
+const OUT_156: usize = 1;
+fn aiur_fn_156(
+  inp: [G; IN_156],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_155], ExecError> {
+) -> Result<[G; OUT_156], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14424,7 +14521,7 @@ fn aiur_fn_155(
     let __v_31: G = inp[31];
     match __v_6.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_32: G = __r_arr[0];
         let __v_33: G = G::from_u64(1);
         let __v_34: G = G::from_u64(1);
@@ -14434,7 +14531,7 @@ fn aiur_fn_155(
     break '__mc_0 [__v_35];
   },
   1u64 => {
-    let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_5, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_5, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
     break '__mc_0 [__v_36];
   },
@@ -14444,18 +14541,18 @@ fn aiur_fn_155(
 }
  };
         let __v_36: G = __mc_out___mc_0[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_3, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_3, __v_36]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_2, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_2, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_1, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_1, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
         let __v_39: G = __r_arr[0];
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
         let __v_40: G = __r_arr[0];
         let __v_41: G = G::from_u64(1);
         let __v_42: G = G::from_u64(1);
         let __v_43: G = { let __values: [G; 3] = [__v_41, __v_42, __v_42]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_40, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
         let __v_44: G = __r_arr[0];
         let __v_45: G = __r_arr[1];
         let __v_46: G = __r_arr[2];
@@ -14516,30 +14613,30 @@ fn aiur_fn_155(
         let __v_101: G = (__v_86 + __v_100);
         let __v_102: G = (__v_84 + __v_101);
         let __v_103: G = (__v_52 + __v_102);
-        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_60, __v_6, __v_7, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_60, __v_6, __v_7, __v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_127(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
         let __v_104: G = __r_arr[0];
         let __v_105: G = __r_arr[1];
         let __v_106: G = G::from_u64(1);
         let __v_107: G = G::from_u64(1);
         let __v_108: G = { let __values: [G; 3] = [__v_106, __v_107, __v_107]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_10, __v_108]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_10, __v_108]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
         let __v_109: G = __r_arr[0];
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_105, __v_109]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_105, __v_109]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
         let __v_110: G = __r_arr[0];
-        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_110, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_124(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_110, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
         let __v_111: G = __r_arr[0];
-        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_111, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_111, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_31]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
         let __v_112: G = __r_arr[0];
         let __v_113: G = __r_arr[1];
         let __v_114: G = (__v_32 + __v_28);
-        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_112, __v_113, __v_29, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_112, __v_113, __v_29, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_148(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
         let __v_115: G = __r_arr[0];
         let __v_116: G = G::from_u64(0);
-        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_8, __v_9, __v_116, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_150(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_8, __v_9, __v_116, __v_29]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
         let __v_117: G = __r_arr[0];
-        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_112, __v_113, __v_117, __v_82, __v_103, __v_1, __v_2, __v_3, __v_4, __v_5, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_114, __v_104, __v_6, __v_10, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_146(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_112, __v_113, __v_117, __v_82, __v_103, __v_1, __v_2, __v_3, __v_4, __v_5, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_114, __v_104, __v_6, __v_10, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
         let __v_118: G = __r_arr[0];
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_211(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
         let __v_119: G = __r_arr[0];
         let __v_120: G = (__v_119 - __v_32);
         let __v_121: G = G::from_bool((__v_120 == G::ZERO));
@@ -14547,16 +14644,16 @@ fn aiur_fn_155(
         if (__v_121 != __v_122) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_121.as_canonical_u64(), rhs: __v_122.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_123: G = __r_arr[0];
         let __v_124: G = G::from_u64(3);
-        let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_131(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
         let __v_125: G = __r_arr[0];
         let __v_126: G = (__v_124 + __v_125);
         if (__v_123 != __v_126) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_123.as_canonical_u64(), rhs: __v_126.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
         let __v_127: G = __r_arr[0];
         let __v_128: G = (__v_127 - __v_32);
         let __v_129: G = G::from_bool((__v_128 == G::ZERO));
@@ -14564,7 +14661,7 @@ fn aiur_fn_155(
         if (__v_129 != __v_130) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_129.as_canonical_u64(), rhs: __v_130.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_131: G = __r_arr[0];
         let __v_132: G = G::from_u64(1);
         if (__v_131 != __v_132) {
@@ -14576,46 +14673,25 @@ fn aiur_fn_155(
         if (__v_134 != __v_135) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_134.as_canonical_u64(), rhs: __v_135.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_8, __v_115, __v_19, __v_20, __v_21, __v_22, __v_4, __v_5, __v_23, __v_24, __v_27, __v_28, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_8, __v_115, __v_19, __v_20, __v_21, __v_22, __v_4, __v_5, __v_23, __v_24, __v_27, __v_28, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_152(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
         let __v_136: G = __r_arr[0];
         let __v_137: G = G::from_u64(1);
         if (__v_136 != __v_137) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_136.as_canonical_u64(), rhs: __v_137.as_canonical_u64(), msg: None });
         }
         let __v_138: G = G::from_u64(0);
-        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_9, __v_6, __v_118, __v_115, __v_138, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_154(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_9, __v_6, __v_118, __v_115, __v_138, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_155(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
         let __v_139: G = __r_arr[0];
-        let __ret: [G; OUT_155] = [__v_139];
-        if let Some(result) = record.function_queries[155].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[155].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_156] = [__v_139];
+        if let Some(result) = record.function_queries[156].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_156: usize = 2;
-const IN_156: usize = 2;
-const OUT_156: usize = 1;
-fn aiur_fn_156(
-  inp: [G; IN_156],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_156], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_bool((__v_0 == G::ZERO));
-    let __v_3: G = G::from_bool((__v_1 == G::ZERO));
-    let __v_4: G = (__v_2 * __v_3);
-    let __ret: [G; OUT_156] = [__v_4];
-    if let Some(result) = record.function_queries[156].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[156].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_157: usize = 1;
-const IN_157: usize = 1;
+const INPUT_SIZE_157: usize = 2;
+const IN_157: usize = 2;
 const OUT_157: usize = 1;
 fn aiur_fn_157(
   inp: [G; IN_157],
@@ -14623,6 +14699,27 @@ fn aiur_fn_157(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_157], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_bool((__v_0 == G::ZERO));
+    let __v_3: G = G::from_bool((__v_1 == G::ZERO));
+    let __v_4: G = (__v_2 * __v_3);
+    let __ret: [G; OUT_157] = [__v_4];
+    if let Some(result) = record.function_queries[157].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_158: usize = 1;
+const IN_158: usize = 1;
+const OUT_158: usize = 1;
+fn aiur_fn_158(
+  inp: [G; IN_158],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_158], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -14633,8 +14730,8 @@ fn aiur_fn_157(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_157] = [__v_5];
-        if let Some(result) = record.function_queries[157].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_158] = [__v_5];
+        if let Some(result) = record.function_queries[158].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -14648,15 +14745,15 @@ fn aiur_fn_157(
             let __v_9: G = G::from_bool((__v_2 == G::ZERO));
             let __v_10: G = G::from_bool((__v_3 == G::ZERO));
             let __v_11: G = (__v_9 * __v_10);
-            let __ret: [G; OUT_157] = [__v_11];
-            if let Some(result) = record.function_queries[157].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_158] = [__v_11];
+            if let Some(result) = record.function_queries[158].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_157(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
             let __v_9: G = __r_arr[0];
-            let __ret: [G; OUT_157] = [__v_9];
-            if let Some(result) = record.function_queries[157].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[157].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_158] = [__v_9];
+            if let Some(result) = record.function_queries[158].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
@@ -14668,15 +14765,15 @@ fn aiur_fn_157(
   })
 }
 
-const INPUT_SIZE_158: usize = 9;
-const IN_158: usize = 9;
-const OUT_158: usize = 1;
-fn aiur_fn_158(
-  inp: [G; IN_158],
+const INPUT_SIZE_159: usize = 9;
+const IN_159: usize = 9;
+const OUT_159: usize = 1;
+fn aiur_fn_159(
+  inp: [G; IN_159],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_158], ExecError> {
+) -> Result<[G; OUT_159], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14703,21 +14800,21 @@ fn aiur_fn_158(
     let __v_22: G = { let __values: [G; 3] = [__v_11, __v_2, __v_21]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_23: G = { let __values: [G; 3] = [__v_10, __v_1, __v_22]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_24: G = { let __values: [G; 3] = [__v_9, __v_0, __v_23]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_158] = [__v_24];
-    if let Some(result) = record.function_queries[158].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[158].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_159] = [__v_24];
+    if let Some(result) = record.function_queries[159].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_159: usize = 33;
-const IN_159: usize = 33;
-const OUT_159: usize = 1;
-fn aiur_fn_159(
-  inp: [G; IN_159],
+const INPUT_SIZE_160: usize = 33;
+const IN_160: usize = 33;
+const OUT_160: usize = 1;
+fn aiur_fn_160(
+  inp: [G; IN_160],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_159], ExecError> {
+) -> Result<[G; OUT_160], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14752,29 +14849,29 @@ fn aiur_fn_159(
     let __v_30: G = inp[30];
     let __v_31: G = inp[31];
     let __v_32: G = inp[32];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_33: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_16, __v_17, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_34: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_34]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_35: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_0, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_36: G = __r_arr[0];
-    let __ret: [G; OUT_159] = [__v_36];
-    if let Some(result) = record.function_queries[159].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[159].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_160] = [__v_36];
+    if let Some(result) = record.function_queries[160].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_160: usize = 2;
-const IN_160: usize = 2;
-const OUT_160: usize = 1;
-fn aiur_fn_160(
-  inp: [G; IN_160],
+const INPUT_SIZE_161: usize = 2;
+const IN_161: usize = 2;
+const OUT_161: usize = 1;
+fn aiur_fn_161(
+  inp: [G; IN_161],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_160], ExecError> {
+) -> Result<[G; OUT_161], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -14784,8 +14881,8 @@ fn aiur_fn_160(
     let __v_4: G = __loaded[2];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_160] = [__v_1];
-        if let Some(result) = record.function_queries[160].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_161] = [__v_1];
+        if let Some(result) = record.function_queries[161].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -14822,62 +14919,17 @@ fn aiur_fn_160(
         let __v_34: G = __loaded[29];
         let __v_35: G = __loaded[30];
         let __v_36: G = __loaded[31];
-        let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
-        let __v_37: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
-        let __v_38: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
-        let __v_39: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
-        let __v_40: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
-        let __v_41: G = __r_arr[0];
-        let __ret: [G; OUT_160] = [__v_41];
-        if let Some(result) = record.function_queries[160].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[160].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_161: usize = 2;
-const IN_161: usize = 2;
-const OUT_161: usize = 1;
-fn aiur_fn_161(
-  inp: [G; IN_161],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_161], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __ret: [G; OUT_161] = [__v_1];
-        if let Some(result) = record.function_queries[161].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __v_6: G = G::from_u64(0);
-        let __v_7: G = G::from_u64(0);
-        let __v_8: G = G::from_u64(0);
-        let __v_9: G = G::from_u64(0);
-        let __v_10: G = G::from_u64(0);
-        let __v_11: G = G::from_u64(0);
         let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
-        let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
-        let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_161] = [__v_13];
+        let __v_37: G = __r_arr[0];
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_38: G = __r_arr[0];
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_39: G = __r_arr[0];
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_39]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_40: G = __r_arr[0];
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_41: G = __r_arr[0];
+        let __ret: [G; OUT_161] = [__v_41];
         if let Some(result) = record.function_queries[161].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[161].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -14890,13 +14942,58 @@ fn aiur_fn_161(
 
 const INPUT_SIZE_162: usize = 2;
 const IN_162: usize = 2;
-const OUT_162: usize = 10;
+const OUT_162: usize = 1;
 fn aiur_fn_162(
   inp: [G; IN_162],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_162], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __ret: [G; OUT_162] = [__v_1];
+        if let Some(result) = record.function_queries[162].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __v_5: G = G::from_u64(0);
+        let __v_6: G = G::from_u64(0);
+        let __v_7: G = G::from_u64(0);
+        let __v_8: G = G::from_u64(0);
+        let __v_9: G = G::from_u64(0);
+        let __v_10: G = G::from_u64(0);
+        let __v_11: G = G::from_u64(0);
+        let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+        let __v_12: G = __r_arr[0];
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_3, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
+        let __v_13: G = __r_arr[0];
+        let __ret: [G; OUT_162] = [__v_13];
+        if let Some(result) = record.function_queries[162].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_163: usize = 2;
+const IN_163: usize = 2;
+const OUT_163: usize = 10;
+fn aiur_fn_163(
+  inp: [G; IN_163],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_163], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15013,7 +15110,7 @@ fn aiur_fn_162(
         let __v_99: G = G::from_u64(1);
         let __v_100: G = G::from_u64(1);
         let __v_101: G = { let __values: [G; 3] = [__v_99, __v_100, __v_100]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __r_arr: [G; OUT_115] = { let __args: [G; IN_115] = [__v_98, __v_101]; let __cu = unconstrained; if let Some(result) = record.function_queries[115].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_115(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_115] = unsafe { *(result.output.as_ptr() as *const [G; OUT_115]) }; __ret } } else { aiur_fn_115(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_116] = { let __args: [G; IN_116] = [__v_98, __v_101]; let __cu = unconstrained; if let Some(result) = record.function_queries[116].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_116(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_116] = unsafe { *(result.output.as_ptr() as *const [G; OUT_116]) }; __ret } } else { aiur_fn_116(__args, record, io_buffer, __cu)? } };
         let __v_102: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_102.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_103: G = __loaded[0];
@@ -15063,8 +15160,8 @@ fn aiur_fn_162(
                                     let __v_126: G = __loaded[2];
                                     match __v_124.as_canonical_u64() {
                                       0u64 => {
-                                        let __ret: [G; OUT_162] = [__v_104, __v_107, __v_110, __v_113, __v_116, __v_119, __v_122, __v_125, __v_98, __v_126];
-                                        if let Some(result) = record.function_queries[162].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                        let __ret: [G; OUT_163] = [__v_104, __v_107, __v_110, __v_113, __v_116, __v_119, __v_122, __v_125, __v_98, __v_126];
+                                        if let Some(result) = record.function_queries[163].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                         return Ok(__ret);
                                       },
                                       _ => {
@@ -15150,8 +15247,8 @@ fn aiur_fn_162(
                                 let __v_25: G = __loaded[2];
                                 match __v_23.as_canonical_u64() {
                                   0u64 => {
-                                    let __ret: [G; OUT_162] = [__v_3, __v_6, __v_9, __v_12, __v_15, __v_18, __v_21, __v_24, __v_0, __v_25];
-                                    if let Some(result) = record.function_queries[162].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[162].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                                    let __ret: [G; OUT_163] = [__v_3, __v_6, __v_9, __v_12, __v_15, __v_18, __v_21, __v_24, __v_0, __v_25];
+                                    if let Some(result) = record.function_queries[163].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                                     return Ok(__ret);
                                   },
                                   _ => {
@@ -15196,19 +15293,19 @@ fn aiur_fn_162(
   })
 }
 
-const INPUT_SIZE_163: usize = 2;
-const IN_163: usize = 2;
-const OUT_163: usize = 10;
-fn aiur_fn_163(
-  inp: [G; IN_163],
+const INPUT_SIZE_164: usize = 2;
+const IN_164: usize = 2;
+const OUT_164: usize = 10;
+fn aiur_fn_164(
+  inp: [G; IN_164],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_163], ExecError> {
+) -> Result<[G; OUT_164], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_163(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -15236,12 +15333,12 @@ fn aiur_fn_163(
     let __v_26: G = (__v_22 - __v_25);
     match __v_26.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_163] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
-        if let Some(result) = record.function_queries[163].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_164] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11];
+        if let Some(result) = record.function_queries[164].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_163(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         let __v_28: G = __r_arr[1];
         let __v_29: G = __r_arr[2];
@@ -15252,27 +15349,27 @@ fn aiur_fn_163(
         let __v_34: G = __r_arr[7];
         let __v_35: G = __r_arr[8];
         let __v_36: G = __r_arr[9];
-        let __ret: [G; OUT_163] = [__v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36];
-        if let Some(result) = record.function_queries[163].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[163].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_164] = [__v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36];
+        if let Some(result) = record.function_queries[164].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_164: usize = 2;
-const IN_164: usize = 2;
-const OUT_164: usize = 18;
-fn aiur_fn_164(
-  inp: [G; IN_164],
+const INPUT_SIZE_165: usize = 2;
+const IN_165: usize = 2;
+const OUT_165: usize = 18;
+fn aiur_fn_165(
+  inp: [G; IN_165],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_164], ExecError> {
+) -> Result<[G; OUT_165], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_163(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __v_3: G = __r_arr[1];
     let __v_4: G = __r_arr[2];
@@ -15283,7 +15380,7 @@ fn aiur_fn_164(
     let __v_9: G = __r_arr[7];
     let __v_10: G = __r_arr[8];
     let __v_11: G = __r_arr[9];
-    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_163(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_10, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
     let __v_13: G = __r_arr[1];
     let __v_14: G = __r_arr[2];
@@ -15294,21 +15391,21 @@ fn aiur_fn_164(
     let __v_19: G = __r_arr[7];
     let __v_20: G = __r_arr[8];
     let __v_21: G = __r_arr[9];
-    let __ret: [G; OUT_164] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
-    if let Some(result) = record.function_queries[164].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[164].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_165] = [__v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_21];
+    if let Some(result) = record.function_queries[165].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_165: usize = 2;
-const IN_165: usize = 2;
-const OUT_165: usize = 1;
-fn aiur_fn_165(
-  inp: [G; IN_165],
+const INPUT_SIZE_166: usize = 2;
+const IN_166: usize = 2;
+const OUT_166: usize = 1;
+fn aiur_fn_166(
+  inp: [G; IN_166],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_165], ExecError> {
+) -> Result<[G; OUT_166], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15317,8 +15414,8 @@ fn aiur_fn_165(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_165] = [__v_4];
-        if let Some(result) = record.function_queries[165].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_166] = [__v_4];
+        if let Some(result) = record.function_queries[166].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -15331,11 +15428,11 @@ fn aiur_fn_165(
             let __v_5: G = G::from_u64(0);
             let __v_6: G = G::from_u64(1);
             let __v_7: G = (__v_1 - __v_6);
-            let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_166(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
             let __v_9: G = { let __values: [G; 3] = [__v_5, __v_3, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_165] = [__v_9];
-            if let Some(result) = record.function_queries[165].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[165].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_166] = [__v_9];
+            if let Some(result) = record.function_queries[166].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -15347,20 +15444,20 @@ fn aiur_fn_165(
   })
 }
 
-const INPUT_SIZE_166: usize = 3;
-const IN_166: usize = 3;
-const OUT_166: usize = 3;
-fn aiur_fn_166(
-  inp: [G; IN_166],
+const INPUT_SIZE_167: usize = 3;
+const IN_167: usize = 3;
+const OUT_167: usize = 3;
+fn aiur_fn_167(
+  inp: [G; IN_167],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_166], ExecError> {
+) -> Result<[G; OUT_167], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_163] = { let __args: [G; IN_163] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[163].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_163(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_163] = unsafe { *(result.output.as_ptr() as *const [G; OUT_163]) }; __ret } } else { aiur_fn_163(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __v_5: G = __r_arr[2];
@@ -15410,31 +15507,31 @@ fn aiur_fn_166(
     let __v_45: G = G::from_u64(1);
     let __v_46: G = G::from_u64(1);
     let __v_47: G = { let __values: [G; 3] = [__v_45, __v_46, __v_46]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43, __v_44, __v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_48: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_49: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_49]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_50: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19, __v_20, __v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_51: G = __r_arr[0];
-    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_51, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_166] = { let __args: [G; IN_166] = [__v_51, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[166].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_166(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_166] = unsafe { *(result.output.as_ptr() as *const [G; OUT_166]) }; __ret } } else { aiur_fn_166(__args, record, io_buffer, __cu)? } };
     let __v_52: G = __r_arr[0];
-    let __ret: [G; OUT_166] = [__v_52, __v_11, __v_12];
-    if let Some(result) = record.function_queries[166].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[166].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_167] = [__v_52, __v_11, __v_12];
+    if let Some(result) = record.function_queries[167].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_167: usize = 9;
-const IN_167: usize = 9;
-const OUT_167: usize = 1;
-fn aiur_fn_167(
-  inp: [G; IN_167],
+const INPUT_SIZE_168: usize = 9;
+const IN_168: usize = 9;
+const OUT_168: usize = 1;
+fn aiur_fn_168(
+  inp: [G; IN_168],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_167], ExecError> {
+) -> Result<[G; OUT_168], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15448,43 +15545,18 @@ fn aiur_fn_167(
     let __v_9: G = G::from_u64(1);
     let __v_10: G = G::from_u64(1);
     let __v_11: G = { let __values: [G; 3] = [__v_9, __v_10, __v_10]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
-    let __ret: [G; OUT_167] = [__v_13];
-    if let Some(result) = record.function_queries[167].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[167].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_168: usize = 2;
-const IN_168: usize = 2;
-const OUT_168: usize = 1;
-fn aiur_fn_168(
-  inp: [G; IN_168],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_168], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = G::from_u64(1);
-    let __v_3: G = G::from_u64(1);
-    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
-    let __v_5: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-    let __v_6: G = __r_arr[0];
-    let __ret: [G; OUT_168] = [__v_6];
+    let __ret: [G; OUT_168] = [__v_13];
     if let Some(result) = record.function_queries[168].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[168].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_169: usize = 1;
-const IN_169: usize = 1;
+const INPUT_SIZE_169: usize = 2;
+const IN_169: usize = 2;
 const OUT_169: usize = 1;
 fn aiur_fn_169(
   inp: [G; IN_169],
@@ -15492,6 +15564,31 @@ fn aiur_fn_169(
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_169], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    let __v_2: G = G::from_u64(1);
+    let __v_3: G = G::from_u64(1);
+    let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_1, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __v_5: G = __r_arr[0];
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_0, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+    let __v_6: G = __r_arr[0];
+    let __ret: [G; OUT_169] = [__v_6];
+    if let Some(result) = record.function_queries[169].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_170: usize = 1;
+const IN_170: usize = 1;
+const OUT_170: usize = 1;
+fn aiur_fn_170(
+  inp: [G; IN_170],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_170], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = G::from_u64(0);
@@ -15536,21 +15633,21 @@ fn aiur_fn_169(
     let __v_40: G = { let __values: [G; 3] = [__v_5, __v_6, __v_39]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_41: G = { let __values: [G; 3] = [__v_3, __v_4, __v_40]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_42: G = { let __values: [G; 3] = [__v_1, __v_2, __v_41]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_169] = [__v_42];
-    if let Some(result) = record.function_queries[169].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[169].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_170] = [__v_42];
+    if let Some(result) = record.function_queries[170].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_170: usize = 2;
-const IN_170: usize = 2;
-const OUT_170: usize = 1;
-fn aiur_fn_170(
-  inp: [G; IN_170],
+const INPUT_SIZE_171: usize = 2;
+const IN_171: usize = 2;
+const OUT_171: usize = 1;
+fn aiur_fn_171(
+  inp: [G; IN_171],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_170], ExecError> {
+) -> Result<[G; OUT_171], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15567,17 +15664,17 @@ fn aiur_fn_170(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_170] = [__v_1];
-        if let Some(result) = record.function_queries[170].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_171] = [__v_1];
+        if let Some(result) = record.function_queries[171].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_170(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_171(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
         let __v_12: G = __r_arr[0];
-        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
-        let __ret: [G; OUT_170] = [__v_13];
-        if let Some(result) = record.function_queries[170].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[170].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_171] = [__v_13];
+        if let Some(result) = record.function_queries[171].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -15587,15 +15684,15 @@ fn aiur_fn_170(
   })
 }
 
-const INPUT_SIZE_171: usize = 2;
-const IN_171: usize = 2;
-const OUT_171: usize = 1;
-fn aiur_fn_171(
-  inp: [G; IN_171],
+const INPUT_SIZE_172: usize = 2;
+const IN_172: usize = 2;
+const OUT_172: usize = 1;
+fn aiur_fn_172(
+  inp: [G; IN_172],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_171], ExecError> {
+) -> Result<[G; OUT_172], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15604,13 +15701,13 @@ fn aiur_fn_171(
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_171] = [__v_4];
-        if let Some(result) = record.function_queries[171].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_172] = [__v_4];
+        if let Some(result) = record.function_queries[172].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       1u64 => {
-        let __ret: [G; OUT_171] = [__v_1];
-        if let Some(result) = record.function_queries[171].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[171].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_172] = [__v_1];
+        if let Some(result) = record.function_queries[172].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -15620,15 +15717,15 @@ fn aiur_fn_171(
   })
 }
 
-const INPUT_SIZE_172: usize = 9;
-const IN_172: usize = 9;
-const OUT_172: usize = 9;
-fn aiur_fn_172(
-  inp: [G; IN_172],
+const INPUT_SIZE_173: usize = 9;
+const IN_173: usize = 9;
+const OUT_173: usize = 9;
+fn aiur_fn_173(
+  inp: [G; IN_173],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_172], ExecError> {
+) -> Result<[G; OUT_173], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -15639,15 +15736,15 @@ fn aiur_fn_172(
     let __v_6: G = inp[6];
     let __v_7: G = inp[7];
     let __v_8: G = inp[8];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_9: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_10: G = __r_arr[0];
-    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_2, __v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
     let __v_11: G = __r_arr[0];
-    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_1, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_1, __v_11]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
     let __v_12: G = __r_arr[0];
-    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_170(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_0, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_171(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
     let __v_13: G = __r_arr[0];
     let __v_14: G = G::from_u64(0);
     let __v_15: G = G::from_u64(109);
@@ -15694,7 +15791,7 @@ fn aiur_fn_172(
     let __v_56: G = G::from_u64(1);
     let __v_57: G = G::from_u64(1);
     let __v_58: G = { let __values: [G; 3] = [__v_56, __v_57, __v_57]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_55, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_55, __v_58]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_59: G = __r_arr[0];
     let __v_60: G = __r_arr[1];
     let __v_61: G = __r_arr[2];
@@ -15716,16 +15813,16 @@ fn aiur_fn_172(
     let __v_77: G = G::from_u64(1);
     let __v_78: G = G::from_u64(1);
     let __v_79: G = { let __values: [G; 3] = [__v_77, __v_78, __v_78]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_67, __v_68, __v_69, __v_70, __v_71, __v_72, __v_73, __v_74, __v_79]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_80: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_59, __v_60, __v_61, __v_62, __v_63, __v_64, __v_65, __v_66, __v_80]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_81: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_75, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_75, __v_81]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_82: G = __r_arr[0];
     let __v_83: G = G::from_u64(1);
     let __v_84: G = G::from_u64(1);
     let __v_85: G = { let __values: [G; 3] = [__v_83, __v_84, __v_84]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_82, __v_85]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_82, __v_85]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_86: G = __r_arr[0];
     let __v_87: G = __r_arr[1];
     let __v_88: G = __r_arr[2];
@@ -15747,25 +15844,25 @@ fn aiur_fn_172(
     let __v_104: G = G::from_u64(1);
     let __v_105: G = G::from_u64(1);
     let __v_106: G = { let __values: [G; 3] = [__v_104, __v_105, __v_105]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_106]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_94, __v_95, __v_96, __v_97, __v_98, __v_99, __v_100, __v_101, __v_106]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_107: G = __r_arr[0];
-    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_107]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_93, __v_107]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
     let __v_108: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_102, __v_108]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_102, __v_108]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_109: G = __r_arr[0];
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_109, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_109, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_110: G = __r_arr[0];
     let __v_111: G = G::from_u64(1);
     let __v_112: G = G::from_u64(1);
     let __v_113: G = { let __values: [G; 3] = [__v_111, __v_112, __v_112]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_8, __v_113]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_8, __v_113]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
     let __v_114: G = __r_arr[0];
-    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_110, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_110, __v_114]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
     let __v_115: G = __r_arr[0];
     let __v_116: G = G::from_u64(1);
     let __v_117: G = G::from_u64(1);
     let __v_118: G = { let __values: [G; 3] = [__v_116, __v_117, __v_117]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_115, __v_118]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_115, __v_118]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_119: G = __r_arr[0];
     let __v_120: G = __r_arr[1];
     let __v_121: G = __r_arr[2];
@@ -15784,12 +15881,12 @@ fn aiur_fn_172(
     let __v_134: G = __r_arr[15];
     let __v_135: G = __r_arr[16];
     let __v_136: G = __r_arr[17];
-    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_135, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_135, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
     let __v_137: G = __r_arr[0];
     let __v_138: G = G::from_u64(1);
     let __v_139: G = G::from_u64(1);
     let __v_140: G = { let __values: [G; 3] = [__v_138, __v_139, __v_139]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_137, __v_140]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_137, __v_140]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
     let __v_141: G = __r_arr[0];
     let __v_142: G = __r_arr[1];
     let __v_143: G = __r_arr[2];
@@ -15976,29 +16073,29 @@ fn aiur_fn_172(
     let __v_324: G = (__v_309 + __v_323);
     let __v_325: G = (__v_307 + __v_324);
     let __v_326: G = (__v_149 + __v_325);
-    let __ret: [G; OUT_172] = [__v_179, __v_200, __v_221, __v_242, __v_263, __v_284, __v_305, __v_326, __v_157];
-    if let Some(result) = record.function_queries[172].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[172].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_173] = [__v_179, __v_200, __v_221, __v_242, __v_263, __v_284, __v_305, __v_326, __v_157];
+    if let Some(result) = record.function_queries[173].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_173: usize = 3;
-const IN_173: usize = 3;
-const OUT_173: usize = 2;
-fn aiur_fn_173(
-  inp: [G; IN_173],
+const INPUT_SIZE_174: usize = 3;
+const IN_174: usize = 3;
+const OUT_174: usize = 2;
+fn aiur_fn_174(
+  inp: [G; IN_174],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_173], ExecError> {
+) -> Result<[G; OUT_174], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
     match __v_2.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_173] = [__v_0, __v_1];
-        if let Some(result) = record.function_queries[173].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_174] = [__v_0, __v_1];
+        if let Some(result) = record.function_queries[174].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -16012,48 +16109,10 @@ fn aiur_fn_173(
         let __v_10: G = (__v_8 + __v_9);
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_2 - __v_11);
-        let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_7, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_173(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_7, __v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
-        let __ret: [G; OUT_173] = [__v_13, __v_14];
-        if let Some(result) = record.function_queries[173].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[173].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_174: usize = 1;
-const IN_174: usize = 1;
-const OUT_174: usize = 1;
-fn aiur_fn_174(
-  inp: [G; IN_174],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_174], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_174] = [__v_1];
-        if let Some(result) = record.function_queries[174].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      32u64 => {
-        let __v_1: G = G::from_u64(1753635133440165772);
-        let __ret: [G; OUT_174] = [__v_1];
-        if let Some(result) = record.function_queries[174].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(1);
-        let __v_2: G = (__v_0 + __v_1);
-        let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
-        let __v_3: G = __r_arr[0];
-        let __v_4: G = (__v_3 * __v_3);
-        let __ret: [G; OUT_174] = [__v_4];
+        let __ret: [G; OUT_174] = [__v_13, __v_14];
         if let Some(result) = record.function_queries[174].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[174].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -16061,9 +16120,9 @@ fn aiur_fn_174(
   })
 }
 
-const INPUT_SIZE_175: usize = 3;
-const IN_175: usize = 3;
-const OUT_175: usize = 2;
+const INPUT_SIZE_175: usize = 1;
+const IN_175: usize = 1;
+const OUT_175: usize = 1;
 fn aiur_fn_175(
   inp: [G; IN_175],
   record: &mut QueryRecord,
@@ -16072,24 +16131,36 @@ fn aiur_fn_175(
 ) -> Result<[G; OUT_175], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_173(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __v_5: G = G::from_u64(1);
-    let __v_6: G = G::from_u64(0);
-    let __v_7: G = (__v_3 - __v_5);
-    let __v_8: G = (__v_4 - __v_6);
-    let __ret: [G; OUT_175] = [__v_7, __v_8];
-    if let Some(result) = record.function_queries[175].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_175] = [__v_1];
+        if let Some(result) = record.function_queries[175].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      32u64 => {
+        let __v_1: G = G::from_u64(1753635133440165772);
+        let __ret: [G; OUT_175] = [__v_1];
+        if let Some(result) = record.function_queries[175].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(1);
+        let __v_2: G = (__v_0 + __v_1);
+        let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
+        let __v_3: G = __r_arr[0];
+        let __v_4: G = (__v_3 * __v_3);
+        let __ret: [G; OUT_175] = [__v_4];
+        if let Some(result) = record.function_queries[175].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[175].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_176: usize = 1;
-const IN_176: usize = 1;
-const OUT_176: usize = 1;
+const INPUT_SIZE_176: usize = 3;
+const IN_176: usize = 3;
+const OUT_176: usize = 2;
 fn aiur_fn_176(
   inp: [G; IN_176],
   record: &mut QueryRecord,
@@ -16098,31 +16169,24 @@ fn aiur_fn_176(
 ) -> Result<[G; OUT_176], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_176] = [__v_1];
-        if let Some(result) = record.function_queries[176].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(2);
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_0 - __v_2);
-        let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_176(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = (__v_1 * __v_4);
-        let __ret: [G; OUT_176] = [__v_5];
-        if let Some(result) = record.function_queries[176].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
+    let __v_1: G = inp[1];
+    let __v_2: G = inp[2];
+    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __v_5: G = G::from_u64(1);
+    let __v_6: G = G::from_u64(0);
+    let __v_7: G = (__v_3 - __v_5);
+    let __v_8: G = (__v_4 - __v_6);
+    let __ret: [G; OUT_176] = [__v_7, __v_8];
+    if let Some(result) = record.function_queries[176].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[176].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_177: usize = 3;
-const IN_177: usize = 3;
-const OUT_177: usize = 8;
+const INPUT_SIZE_177: usize = 1;
+const IN_177: usize = 1;
+const OUT_177: usize = 1;
 fn aiur_fn_177(
   inp: [G; IN_177],
   record: &mut QueryRecord,
@@ -16131,16 +16195,49 @@ fn aiur_fn_177(
 ) -> Result<[G; OUT_177], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_177] = [__v_1];
+        if let Some(result) = record.function_queries[177].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(2);
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_0 - __v_2);
+        let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_177(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = (__v_1 * __v_4);
+        let __ret: [G; OUT_177] = [__v_5];
+        if let Some(result) = record.function_queries[177].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_178: usize = 3;
+const IN_178: usize = 3;
+const OUT_178: usize = 8;
+fn aiur_fn_178(
+  inp: [G; IN_178],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_178], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     let __v_2: G = inp[2];
-    let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_173(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_0, __v_1, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
     let __v_3: G = __r_arr[0];
     let __v_4: G = __r_arr[1];
     let __v_5: G = G::from_u64(1);
     let __v_6: G = G::from_u64(0);
     let __v_7: G = (__v_3 - __v_5);
     let __v_8: G = (__v_4 - __v_6);
-    let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
     let __v_9: G = __r_arr[0];
     let __v_10: G = g_inverse_value(__v_9);
     let __v_11: G = (__v_9 * __v_10);
@@ -16251,21 +16348,21 @@ fn aiur_fn_177(
     let __v_92: G = G::from_u64(0);
     let __v_93: G = (__v_92 - __v_8);
     let __v_94: G = (__v_93 * __v_83);
-    let __ret: [G; OUT_177] = [__v_43, __v_46, __v_71, __v_74, __v_76, __v_77, __v_91, __v_94];
-    if let Some(result) = record.function_queries[177].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[177].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_178] = [__v_43, __v_46, __v_71, __v_74, __v_76, __v_77, __v_91, __v_94];
+    if let Some(result) = record.function_queries[178].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_178: usize = 24;
-const IN_178: usize = 24;
-const OUT_178: usize = 1;
-fn aiur_fn_178(
-  inp: [G; IN_178],
+const INPUT_SIZE_179: usize = 24;
+const IN_179: usize = 24;
+const OUT_179: usize = 1;
+fn aiur_fn_179(
+  inp: [G; IN_179],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_178], ExecError> {
+) -> Result<[G; OUT_179], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16293,52 +16390,52 @@ fn aiur_fn_178(
     let __v_23: G = inp[23];
     match __v_0.as_canonical_u64() {
       _ => {
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __v_25: G = G::from_bool((__v_24 == G::ZERO));
         let __v_26: G = G::from_u64(0);
         if (__v_25 != __v_26) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_25.as_canonical_u64(), rhs: __v_26.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_27: G = __r_arr[0];
         if (__v_27 != __v_24) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_27.as_canonical_u64(), rhs: __v_24.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_28: G = __r_arr[0];
         if (__v_28 != __v_24) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_28.as_canonical_u64(), rhs: __v_24.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
         let __v_29: G = __r_arr[0];
         if (__v_29 != __v_24) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_29.as_canonical_u64(), rhs: __v_24.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_157(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
         let __v_30: G = __r_arr[0];
         let __v_31: G = G::from_u64(1);
         if (__v_30 != __v_31) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_30.as_canonical_u64(), rhs: __v_31.as_canonical_u64(), msg: None });
         }
         let __v_32: G = G::from_u64(1);
-        let __ret: [G; OUT_178] = [__v_32];
-        if let Some(result) = record.function_queries[178].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[178].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_179] = [__v_32];
+        if let Some(result) = record.function_queries[179].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_179: usize = 6;
-const IN_179: usize = 6;
-const OUT_179: usize = 2;
-fn aiur_fn_179(
-  inp: [G; IN_179],
+const INPUT_SIZE_180: usize = 6;
+const IN_180: usize = 6;
+const OUT_180: usize = 2;
+fn aiur_fn_180(
+  inp: [G; IN_180],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_179], ExecError> {
+) -> Result<[G; OUT_180], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16356,21 +16453,21 @@ fn aiur_fn_179(
     let __v_13: G = (__v_11 + __v_12);
     let __v_14: G = (__v_10 + __v_4);
     let __v_15: G = (__v_13 + __v_5);
-    let __ret: [G; OUT_179] = [__v_14, __v_15];
-    if let Some(result) = record.function_queries[179].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[179].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_180] = [__v_14, __v_15];
+    if let Some(result) = record.function_queries[180].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_180: usize = 4;
-const IN_180: usize = 4;
-const OUT_180: usize = 2;
-fn aiur_fn_180(
-  inp: [G; IN_180],
+const INPUT_SIZE_181: usize = 4;
+const IN_181: usize = 4;
+const OUT_181: usize = 2;
+fn aiur_fn_181(
+  inp: [G; IN_181],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_180], ExecError> {
+) -> Result<[G; OUT_181], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16388,21 +16485,21 @@ fn aiur_fn_180(
     let __v_13: G = (__v_11 + __v_12);
     let __v_14: G = (__v_0 + __v_10);
     let __v_15: G = (__v_1 + __v_13);
-    let __ret: [G; OUT_180] = [__v_14, __v_15];
-    if let Some(result) = record.function_queries[180].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[180].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_181] = [__v_14, __v_15];
+    if let Some(result) = record.function_queries[181].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_181: usize = 1;
-const IN_181: usize = 1;
-const OUT_181: usize = 1;
-fn aiur_fn_181(
-  inp: [G; IN_181],
+const INPUT_SIZE_182: usize = 1;
+const IN_182: usize = 1;
+const OUT_182: usize = 1;
+fn aiur_fn_182(
+  inp: [G; IN_182],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_181], ExecError> {
+) -> Result<[G; OUT_182], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
@@ -16415,8 +16512,8 @@ fn aiur_fn_181(
         let __v_5: G = G::from_u64(1);
         let __v_6: G = G::from_u64(1);
         let __v_7: G = { let __values: [G; 4] = [__v_5, __v_6, __v_6, __v_6]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_181] = [__v_7];
-        if let Some(result) = record.function_queries[181].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_182] = [__v_7];
+        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -16428,14 +16525,14 @@ fn aiur_fn_181(
         match __v_5.as_canonical_u64() {
           0u64 => {
             let __v_9: G = G::from_u64(0);
-            let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_2, __v_3, __v_6, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_181(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
             let __v_10: G = __r_arr[0];
             let __v_11: G = __r_arr[1];
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_181(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_12: G = __r_arr[0];
             let __v_13: G = { let __values: [G; 4] = [__v_9, __v_10, __v_11, __v_12]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_181] = [__v_13];
-            if let Some(result) = record.function_queries[181].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[181].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_182] = [__v_13];
+            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -16450,15 +16547,15 @@ fn aiur_fn_181(
   })
 }
 
-const INPUT_SIZE_182: usize = 15;
-const IN_182: usize = 15;
-const OUT_182: usize = 2;
-fn aiur_fn_182(
-  inp: [G; IN_182],
+const INPUT_SIZE_183: usize = 15;
+const IN_183: usize = 15;
+const OUT_183: usize = 2;
+fn aiur_fn_183(
+  inp: [G; IN_183],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_182], ExecError> {
+) -> Result<[G; OUT_183], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16475,7 +16572,7 @@ fn aiur_fn_182(
     let __v_12: G = inp[12];
     let __v_13: G = inp[13];
     let __v_14: G = inp[14];
-    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_211(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_212] = { let __args: [G; IN_212] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[212].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_212(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_212] = unsafe { *(result.output.as_ptr() as *const [G; OUT_212]) }; __ret } } else { aiur_fn_212(__args, record, io_buffer, __cu)? } };
     let __v_15: G = __r_arr[0];
     let __v_16: G = __r_arr[1];
     let __v_17: G = __r_arr[2];
@@ -16483,8 +16580,8 @@ fn aiur_fn_182(
     match __v_15.as_canonical_u64() {
       0u64 => {
         let __v_19: G = G::from_u64(0);
-        let __ret: [G; OUT_182] = [__v_16, __v_19];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_16, __v_19];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       1u64 => {
@@ -16492,109 +16589,109 @@ fn aiur_fn_182(
         let __v_20: G = (__v_16 + __v_19);
         match __v_20.as_canonical_u64() {
           0u64 => {
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_4, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_182] = [__v_21, __v_22];
-            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_183] = [__v_21, __v_22];
+            if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_5, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_182] = [__v_21, __v_22];
-            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_183] = [__v_21, __v_22];
+            if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           2u64 => {
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_2, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_182] = [__v_21, __v_22];
-            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_183] = [__v_21, __v_22];
+            if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           3u64 => {
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_3, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_182] = [__v_21, __v_22];
-            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_183] = [__v_21, __v_22];
+            if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           4u64 => {
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_6, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_182] = [__v_21, __v_22];
-            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_183] = [__v_21, __v_22];
+            if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_7, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_21: G = __r_arr[0];
             let __v_22: G = __r_arr[1];
-            let __ret: [G; OUT_182] = [__v_21, __v_22];
-            if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_183] = [__v_21, __v_22];
+            if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
       },
       2u64 => {
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_8, __v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __ret: [G; OUT_182] = [__v_19, __v_20];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_19, __v_20];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       3u64 => {
-        let __ret: [G; OUT_182] = [__v_9, __v_10];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_9, __v_10];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       4u64 => {
-        let __ret: [G; OUT_182] = [__v_11, __v_12];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_11, __v_12];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       5u64 => {
-        let __ret: [G; OUT_182] = [__v_13, __v_14];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_13, __v_14];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       6u64 => {
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __v_23: G = (__v_19 + __v_21);
         let __v_24: G = (__v_20 + __v_22);
-        let __ret: [G; OUT_182] = [__v_23, __v_24];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_23, __v_24];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       7u64 => {
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __v_23: G = (__v_19 - __v_21);
         let __v_24: G = (__v_20 - __v_22);
-        let __ret: [G; OUT_182] = [__v_23, __v_24];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_23, __v_24];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       8u64 => {
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_17, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_21: G = __r_arr[0];
         let __v_22: G = __r_arr[1];
         let __v_23: G = (__v_19 * __v_21);
@@ -16605,20 +16702,20 @@ fn aiur_fn_182(
         let __v_28: G = (__v_19 * __v_22);
         let __v_29: G = (__v_20 * __v_21);
         let __v_30: G = (__v_28 + __v_29);
-        let __ret: [G; OUT_182] = [__v_27, __v_30];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_27, __v_30];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       9u64 => {
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_0, __v_16, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_19: G = __r_arr[0];
         let __v_20: G = __r_arr[1];
         let __v_21: G = G::from_u64(0);
         let __v_22: G = (__v_21 - __v_19);
         let __v_23: G = G::from_u64(0);
         let __v_24: G = (__v_23 - __v_20);
-        let __ret: [G; OUT_182] = [__v_22, __v_24];
-        if let Some(result) = record.function_queries[182].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[182].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_183] = [__v_22, __v_24];
+        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -16628,15 +16725,15 @@ fn aiur_fn_182(
   })
 }
 
-const INPUT_SIZE_183: usize = 19;
-const IN_183: usize = 19;
-const OUT_183: usize = 2;
-fn aiur_fn_183(
-  inp: [G; IN_183],
+const INPUT_SIZE_184: usize = 19;
+const IN_184: usize = 19;
+const OUT_184: usize = 2;
+fn aiur_fn_184(
+  inp: [G; IN_184],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_183], ExecError> {
+) -> Result<[G; OUT_184], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16663,22 +16760,22 @@ fn aiur_fn_183(
     let __v_21: G = __loaded[2];
     match __v_19.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_183] = [__v_0, __v_1];
-        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_184] = [__v_0, __v_1];
+        if let Some(result) = record.function_queries[184].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_0, __v_1, __v_2, __v_3, __v_22, __v_23]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
         let __v_24: G = __r_arr[0];
         let __v_25: G = __r_arr[1];
-        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_24, __v_25, __v_2, __v_3, __v_21, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
-        let __ret: [G; OUT_183] = [__v_26, __v_27];
-        if let Some(result) = record.function_queries[183].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[183].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_184] = [__v_26, __v_27];
+        if let Some(result) = record.function_queries[184].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -16688,15 +16785,15 @@ fn aiur_fn_183(
   })
 }
 
-const INPUT_SIZE_184: usize = 8;
-const IN_184: usize = 8;
-const OUT_184: usize = 4;
-fn aiur_fn_184(
-  inp: [G; IN_184],
+const INPUT_SIZE_185: usize = 8;
+const IN_185: usize = 8;
+const OUT_185: usize = 4;
+fn aiur_fn_185(
+  inp: [G; IN_185],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_184], ExecError> {
+) -> Result<[G; OUT_185], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16752,21 +16849,21 @@ fn aiur_fn_184(
     let __v_51: G = (__v_15 + __v_33);
     let __v_52: G = (__v_38 + __v_46);
     let __v_53: G = (__v_41 + __v_49);
-    let __ret: [G; OUT_184] = [__v_50, __v_51, __v_52, __v_53];
-    if let Some(result) = record.function_queries[184].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[184].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_185] = [__v_50, __v_51, __v_52, __v_53];
+    if let Some(result) = record.function_queries[185].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_185: usize = 19;
-const IN_185: usize = 19;
-const OUT_185: usize = 4;
-fn aiur_fn_185(
-  inp: [G; IN_185],
+const INPUT_SIZE_186: usize = 19;
+const IN_186: usize = 19;
+const OUT_186: usize = 4;
+fn aiur_fn_186(
+  inp: [G; IN_186],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_185], ExecError> {
+) -> Result<[G; OUT_186], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16797,28 +16894,28 @@ fn aiur_fn_185(
         let __v_23: G = G::from_u64(0);
         let __v_24: G = G::from_u64(0);
         let __v_25: G = G::from_u64(0);
-        let __ret: [G; OUT_185] = [__v_22, __v_23, __v_24, __v_25];
-        if let Some(result) = record.function_queries[185].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_186] = [__v_22, __v_23, __v_24, __v_25];
+        if let Some(result) = record.function_queries[186].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_21, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_186(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
         let __v_22: G = __r_arr[0];
         let __v_23: G = __r_arr[1];
         let __v_24: G = __r_arr[2];
         let __v_25: G = __r_arr[3];
-        let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_22, __v_23, __v_24, __v_25, __v_1, __v_2, __v_3, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
         let __v_26: G = __r_arr[0];
         let __v_27: G = __r_arr[1];
         let __v_28: G = __r_arr[2];
         let __v_29: G = __r_arr[3];
-        let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_5, __v_20, __v_6, __v_7, __v_8, __v_9, __v_10, __v_11, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
         let __v_30: G = __r_arr[0];
         let __v_31: G = __r_arr[1];
         let __v_32: G = (__v_26 + __v_30);
         let __v_33: G = (__v_27 + __v_31);
-        let __ret: [G; OUT_185] = [__v_32, __v_33, __v_28, __v_29];
-        if let Some(result) = record.function_queries[185].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[185].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_186] = [__v_32, __v_33, __v_28, __v_29];
+        if let Some(result) = record.function_queries[186].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -16828,15 +16925,15 @@ fn aiur_fn_185(
   })
 }
 
-const INPUT_SIZE_186: usize = 44;
-const IN_186: usize = 44;
-const OUT_186: usize = 2;
-fn aiur_fn_186(
-  inp: [G; IN_186],
+const INPUT_SIZE_187: usize = 44;
+const IN_187: usize = 44;
+const OUT_187: usize = 2;
+fn aiur_fn_187(
+  inp: [G; IN_187],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_186], ExecError> {
+) -> Result<[G; OUT_187], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -16889,14 +16986,14 @@ fn aiur_fn_186(
     let __v_47: G = __loaded[3];
     match __v_44.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_186] = [__v_0, __v_1];
-        if let Some(result) = record.function_queries[186].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_187] = [__v_0, __v_1];
+        if let Some(result) = record.function_queries[187].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         match __v_45.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_46, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_46, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_186(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
             let __v_48: G = __r_arr[0];
             let __v_49: G = __r_arr[1];
             let __v_50: G = __r_arr[2];
@@ -16905,10 +17002,10 @@ fn aiur_fn_186(
             let __v_53: G = (__v_49 + __v_23);
             let __v_54: G = (__v_50 + __v_24);
             let __v_55: G = (__v_51 + __v_25);
-            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_30, __v_45, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_30, __v_45, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
             let __v_56: G = __r_arr[0];
             let __v_57: G = __r_arr[1];
-            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_14, __v_15, __v_16, __v_17, __v_52, __v_53, __v_54, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_14, __v_15, __v_16, __v_17, __v_52, __v_53, __v_54, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
             let __v_58: G = __r_arr[0];
             let __v_59: G = __r_arr[1];
             let __v_60: G = __r_arr[2];
@@ -16933,7 +17030,7 @@ fn aiur_fn_186(
             let __v_79: G = (__v_77 + __v_78);
             let __v_80: G = (__v_60 + __v_76);
             let __v_81: G = (__v_61 + __v_79);
-            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_10, __v_11, __v_12, __v_13, __v_52, __v_53, __v_54, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_10, __v_11, __v_12, __v_13, __v_52, __v_53, __v_54, __v_55]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
             let __v_82: G = __r_arr[0];
             let __v_83: G = __r_arr[1];
             let __v_84: G = __r_arr[2];
@@ -16944,23 +17041,23 @@ fn aiur_fn_186(
             match __v_88.as_canonical_u64() {
               0u64 => {
                 let __v_89: G = (__v_7 + __v_7);
-                let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_35, __v_89]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_35, __v_89]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                 let __v_90: G = __r_arr[0];
                 let __v_91: G = __r_arr[1];
                 let __v_92: G = G::from_u64(1);
                 let __v_93: G = (__v_7 + __v_92);
                 let __v_94: G = (__v_7 + __v_93);
-                let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_35, __v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_35, __v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                 let __v_95: G = __r_arr[0];
                 let __v_96: G = __r_arr[1];
                 let __v_97: G = G::from_u64(0);
-                let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_36, __v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_36, __v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                 let __v_98: G = __r_arr[0];
                 let __v_99: G = __r_arr[1];
                 let __v_100: G = (__v_98 + __v_18);
                 let __v_101: G = (__v_99 + __v_19);
                 let __v_102: G = G::from_u64(1);
-                let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_36, __v_102]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_36, __v_102]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                 let __v_103: G = __r_arr[0];
                 let __v_104: G = __r_arr[1];
                 let __v_105: G = (__v_103 + __v_20);
@@ -16969,23 +17066,23 @@ fn aiur_fn_186(
                 let __v_108: G = (__v_101 - __v_91);
                 let __v_109: G = (__v_105 - __v_95);
                 let __v_110: G = (__v_106 - __v_96);
-                let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_82, __v_83, __v_84, __v_85, __v_107, __v_108, __v_109, __v_110]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_82, __v_83, __v_84, __v_85, __v_107, __v_108, __v_109, __v_110]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
                 let __v_111: G = __r_arr[0];
                 let __v_112: G = __r_arr[1];
                 let __v_113: G = __r_arr[2];
                 let __v_114: G = __r_arr[3];
                 let __v_115: G = (__v_111 - __v_70);
                 let __v_116: G = (__v_112 - __v_71);
-                let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_0, __v_1, __v_2, __v_3, __v_115, __v_116]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_0, __v_1, __v_2, __v_3, __v_115, __v_116]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
                 let __v_117: G = __r_arr[0];
                 let __v_118: G = __r_arr[1];
                 let __v_119: G = (__v_113 - __v_80);
                 let __v_120: G = (__v_114 - __v_81);
-                let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_117, __v_118, __v_2, __v_3, __v_119, __v_120]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_117, __v_118, __v_2, __v_3, __v_119, __v_120]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
                 let __v_121: G = __r_arr[0];
                 let __v_122: G = __r_arr[1];
-                let __ret: [G; OUT_186] = [__v_121, __v_122];
-                if let Some(result) = record.function_queries[186].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_187] = [__v_121, __v_122];
+                if let Some(result) = record.function_queries[187].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
               _ => {
@@ -16994,44 +17091,44 @@ fn aiur_fn_186(
                 match __v_90.as_canonical_u64() {
                   0u64 => {
                     let __v_91: G = (__v_7 + __v_7);
-                    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_35, __v_91]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_35, __v_91]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                     let __v_92: G = __r_arr[0];
                     let __v_93: G = __r_arr[1];
                     let __v_94: G = G::from_u64(1);
                     let __v_95: G = (__v_7 + __v_94);
                     let __v_96: G = (__v_7 + __v_95);
-                    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_35, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_35, __v_96]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                     let __v_97: G = __r_arr[0];
                     let __v_98: G = __r_arr[1];
                     let __v_99: G = G::from_u64(2);
                     let __v_100: G = (__v_7 + __v_99);
                     let __v_101: G = (__v_7 + __v_100);
-                    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_35, __v_101]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_35, __v_101]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                     let __v_102: G = __r_arr[0];
                     let __v_103: G = __r_arr[1];
                     let __v_104: G = G::from_u64(3);
                     let __v_105: G = (__v_7 + __v_104);
                     let __v_106: G = (__v_7 + __v_105);
-                    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_35, __v_106]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_35, __v_106]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
                     let __v_107: G = __r_arr[0];
                     let __v_108: G = __r_arr[1];
                     let __v_109: G = (__v_102 - __v_92);
                     let __v_110: G = (__v_103 - __v_93);
                     let __v_111: G = (__v_107 - __v_97);
                     let __v_112: G = (__v_108 - __v_98);
-                    let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_82, __v_83, __v_84, __v_85, __v_109, __v_110, __v_111, __v_112]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_185] = { let __args: [G; IN_185] = [__v_82, __v_83, __v_84, __v_85, __v_109, __v_110, __v_111, __v_112]; let __cu = unconstrained; if let Some(result) = record.function_queries[185].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_185(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_185] = unsafe { *(result.output.as_ptr() as *const [G; OUT_185]) }; __ret } } else { aiur_fn_185(__args, record, io_buffer, __cu)? } };
                     let __v_113: G = __r_arr[0];
                     let __v_114: G = __r_arr[1];
                     let __v_115: G = __r_arr[2];
                     let __v_116: G = __r_arr[3];
                     let __v_117: G = (__v_113 - __v_70);
                     let __v_118: G = (__v_114 - __v_71);
-                    let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_0, __v_1, __v_2, __v_3, __v_117, __v_118]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_0, __v_1, __v_2, __v_3, __v_117, __v_118]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
                     let __v_119: G = __r_arr[0];
                     let __v_120: G = __r_arr[1];
                     let __v_121: G = (__v_115 - __v_80);
                     let __v_122: G = (__v_116 - __v_81);
-                    let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_119, __v_120, __v_2, __v_3, __v_121, __v_122]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_119, __v_120, __v_2, __v_3, __v_121, __v_122]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
                     let __v_123: G = __r_arr[0];
                     let __v_124: G = __r_arr[1];
                     let __v_125: G = G::from_u64(1);
@@ -17046,11 +17143,11 @@ fn aiur_fn_186(
                     let __v_134: G = G::from_u64(0);
                     let __v_135: G = G::from_u64(0);
                     let __v_136: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_123, __v_124, __v_2, __v_3, __v_47, __v_126, __v_6, __v_128, __v_9, __v_9, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_186(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_123, __v_124, __v_2, __v_3, __v_47, __v_126, __v_6, __v_128, __v_9, __v_9, __v_129, __v_130, __v_131, __v_132, __v_133, __v_134, __v_135, __v_136, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_187(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                     let __v_137: G = __r_arr[0];
                     let __v_138: G = __r_arr[1];
-                    let __ret: [G; OUT_186] = [__v_137, __v_138];
-                    if let Some(result) = record.function_queries[186].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                    let __ret: [G; OUT_187] = [__v_137, __v_138];
+                    if let Some(result) = record.function_queries[187].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                     return Ok(__ret);
                   },
                   _ => {
@@ -17058,11 +17155,11 @@ fn aiur_fn_186(
                     let __v_92: G = (__v_5 + __v_91);
                     let __v_93: G = G::from_u64(1);
                     let __v_94: G = (__v_8 - __v_93);
-                    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_0, __v_1, __v_2, __v_3, __v_47, __v_92, __v_6, __v_7, __v_94, __v_9, __v_82, __v_83, __v_84, __v_85, __v_70, __v_71, __v_80, __v_81, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_186(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_0, __v_1, __v_2, __v_3, __v_47, __v_92, __v_6, __v_7, __v_94, __v_9, __v_82, __v_83, __v_84, __v_85, __v_70, __v_71, __v_80, __v_81, __v_18, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_31, __v_32, __v_33, __v_34, __v_35, __v_36, __v_37, __v_38, __v_39, __v_40, __v_41, __v_42, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_187(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
                     let __v_95: G = __r_arr[0];
                     let __v_96: G = __r_arr[1];
-                    let __ret: [G; OUT_186] = [__v_95, __v_96];
-                    if let Some(result) = record.function_queries[186].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[186].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                    let __ret: [G; OUT_187] = [__v_95, __v_96];
+                    if let Some(result) = record.function_queries[187].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                     return Ok(__ret);
                   },
                 }
@@ -17078,15 +17175,15 @@ fn aiur_fn_186(
   })
 }
 
-const INPUT_SIZE_187: usize = 28;
-const IN_187: usize = 28;
-const OUT_187: usize = 2;
-fn aiur_fn_187(
-  inp: [G; IN_187],
+const INPUT_SIZE_188: usize = 28;
+const IN_188: usize = 28;
+const OUT_188: usize = 2;
+fn aiur_fn_188(
+  inp: [G; IN_188],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_187], ExecError> {
+) -> Result<[G; OUT_188], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17118,7 +17215,7 @@ fn aiur_fn_187(
     let __v_27: G = inp[27];
     let __v_28: G = G::from_u64(0);
     let __v_29: G = G::from_u64(0);
-    let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_28, __v_29, __v_25, __v_26, __v_1, __v_0, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_28, __v_29, __v_25, __v_26, __v_1, __v_0, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
     let __v_30: G = __r_arr[0];
     let __v_31: G = __r_arr[1];
     let __v_32: G = G::from_u64(0);
@@ -17175,42 +17272,42 @@ fn aiur_fn_187(
     match __v_78.as_canonical_u64() {
       1u64 => {
         let __v_82: G = G::from_u64(0);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_9, __v_82]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_9, __v_82]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_83: G = __r_arr[0];
         let __v_84: G = __r_arr[1];
         let __v_85: G = G::from_u64(0);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_8, __v_85]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_8, __v_85]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_86: G = __r_arr[0];
         let __v_87: G = __r_arr[1];
         let __v_88: G = (__v_83 - __v_86);
         let __v_89: G = (__v_84 - __v_87);
         let __v_90: G = (__v_88 + __v_55);
         let __v_91: G = (__v_89 + __v_58);
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_30, __v_31, __v_25, __v_26, __v_90, __v_91]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_30, __v_31, __v_25, __v_26, __v_90, __v_91]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
         let __v_92: G = __r_arr[0];
         let __v_93: G = __r_arr[1];
         let __v_94: G = G::from_u64(1);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_9, __v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_9, __v_94]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_95: G = __r_arr[0];
         let __v_96: G = __r_arr[1];
         let __v_97: G = G::from_u64(1);
-        let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_8, __v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_8, __v_97]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
         let __v_98: G = __r_arr[0];
         let __v_99: G = __r_arr[1];
         let __v_100: G = (__v_95 - __v_98);
         let __v_101: G = (__v_96 - __v_99);
         let __v_102: G = (__v_100 + __v_74);
         let __v_103: G = (__v_101 + __v_77);
-        let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_92, __v_93, __v_25, __v_26, __v_102, __v_103]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_92, __v_93, __v_25, __v_26, __v_102, __v_103]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
         let __v_104: G = __r_arr[0];
         let __v_105: G = __r_arr[1];
-        let __ret: [G; OUT_187] = [__v_104, __v_105];
-        if let Some(result) = record.function_queries[187].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_188] = [__v_104, __v_105];
+        if let Some(result) = record.function_queries[188].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         let __v_82: G = G::from_u64(0);
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
         let __v_83: G = __r_arr[0];
         let __v_84: G = G::from_u64(0);
         let __v_85: G = G::from_u64(1);
@@ -17221,11 +17318,11 @@ fn aiur_fn_187(
         let __v_90: G = G::from_u64(0);
         let __v_91: G = G::from_u64(0);
         let __v_92: G = G::from_u64(0);
-        let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_30, __v_31, __v_25, __v_26, __v_2, __v_82, __v_83, __v_84, __v_3, __v_3, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_55, __v_58, __v_74, __v_77, __v_11, __v_32, __v_12, __v_33, __v_13, __v_34, __v_14, __v_35, __v_0, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_186(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_30, __v_31, __v_25, __v_26, __v_2, __v_82, __v_83, __v_84, __v_3, __v_3, __v_85, __v_86, __v_87, __v_88, __v_89, __v_90, __v_91, __v_92, __v_55, __v_58, __v_74, __v_77, __v_11, __v_32, __v_12, __v_33, __v_13, __v_34, __v_14, __v_35, __v_0, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_19, __v_20, __v_21, __v_22, __v_23, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_187(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
         let __v_93: G = __r_arr[0];
         let __v_94: G = __r_arr[1];
-        let __ret: [G; OUT_187] = [__v_93, __v_94];
-        if let Some(result) = record.function_queries[187].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[187].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_188] = [__v_93, __v_94];
+        if let Some(result) = record.function_queries[188].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -17235,15 +17332,15 @@ fn aiur_fn_187(
   })
 }
 
-const INPUT_SIZE_188: usize = 8;
-const IN_188: usize = 8;
-const OUT_188: usize = 1;
-fn aiur_fn_188(
-  inp: [G; IN_188],
+const INPUT_SIZE_189: usize = 8;
+const IN_189: usize = 8;
+const OUT_189: usize = 1;
+fn aiur_fn_189(
+  inp: [G; IN_189],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_188], ExecError> {
+) -> Result<[G; OUT_189], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17280,21 +17377,21 @@ fn aiur_fn_188(
     let __v_32: G = { let __values: [G; 4] = [__v_12, __v_2, __v_13, __v_31]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_33: G = { let __values: [G; 4] = [__v_10, __v_1, __v_11, __v_32]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
     let __v_34: G = { let __values: [G; 4] = [__v_8, __v_0, __v_9, __v_33]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __ret: [G; OUT_188] = [__v_34];
-    if let Some(result) = record.function_queries[188].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[188].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_189] = [__v_34];
+    if let Some(result) = record.function_queries[189].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_189: usize = 5;
-const IN_189: usize = 5;
-const OUT_189: usize = 2;
-fn aiur_fn_189(
-  inp: [G; IN_189],
+const INPUT_SIZE_190: usize = 5;
+const IN_190: usize = 5;
+const OUT_190: usize = 2;
+fn aiur_fn_190(
+  inp: [G; IN_190],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_189], ExecError> {
+) -> Result<[G; OUT_190], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17310,8 +17407,8 @@ fn aiur_fn_189(
       1u64 => {
         let __v_9: G = G::from_u64(0);
         let __v_10: G = G::from_u64(0);
-        let __ret: [G; OUT_189] = [__v_9, __v_10];
-        if let Some(result) = record.function_queries[189].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_190] = [__v_9, __v_10];
+        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -17331,13 +17428,13 @@ fn aiur_fn_189(
         let __v_22: G = (__v_3 * __v_2);
         let __v_23: G = (__v_4 * __v_1);
         let __v_24: G = (__v_22 + __v_23);
-        let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_8, __v_1, __v_2, __v_21, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_189(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_8, __v_1, __v_2, __v_21, __v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_190(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
         let __v_25: G = __r_arr[0];
         let __v_26: G = __r_arr[1];
         let __v_27: G = (__v_13 + __v_25);
         let __v_28: G = (__v_16 + __v_26);
-        let __ret: [G; OUT_189] = [__v_27, __v_28];
-        if let Some(result) = record.function_queries[189].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[189].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_190] = [__v_27, __v_28];
+        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -17347,145 +17444,145 @@ fn aiur_fn_189(
   })
 }
 
-const INPUT_SIZE_190: usize = 1;
-const IN_190: usize = 1;
-const OUT_190: usize = 1;
-fn aiur_fn_190(
-  inp: [G; IN_190],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_190], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    match __v_0.as_canonical_u64() {
-      0u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      1u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      2u64 => {
-        let __v_1: G = G::from_u64(1);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      3u64 => {
-        let __v_1: G = G::from_u64(2);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      4u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      5u64 => {
-        let __v_1: G = G::from_u64(4);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      6u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      7u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      8u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      9u64 => {
-        let __v_1: G = G::from_u64(8);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      10u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      11u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      12u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      13u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      14u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      15u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      16u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      17u64 => {
-        let __v_1: G = G::from_u64(16);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __v_1: G = G::from_u64(32);
-        let __ret: [G; OUT_190] = [__v_1];
-        if let Some(result) = record.function_queries[190].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[190].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_191: usize = 4;
-const IN_191: usize = 4;
-const OUT_191: usize = 2;
+const INPUT_SIZE_191: usize = 1;
+const IN_191: usize = 1;
+const OUT_191: usize = 1;
 fn aiur_fn_191(
   inp: [G; IN_191],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
 ) -> Result<[G; OUT_191], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    match __v_0.as_canonical_u64() {
+      0u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      1u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      2u64 => {
+        let __v_1: G = G::from_u64(1);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      3u64 => {
+        let __v_1: G = G::from_u64(2);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      4u64 => {
+        let __v_1: G = G::from_u64(4);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      5u64 => {
+        let __v_1: G = G::from_u64(4);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      6u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      7u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      8u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      9u64 => {
+        let __v_1: G = G::from_u64(8);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      10u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      11u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      12u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      13u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      14u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      15u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      16u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      17u64 => {
+        let __v_1: G = G::from_u64(16);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_1: G = G::from_u64(32);
+        let __ret: [G; OUT_191] = [__v_1];
+        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_192: usize = 4;
+const IN_192: usize = 4;
+const OUT_192: usize = 2;
+fn aiur_fn_192(
+  inp: [G; IN_192],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_192], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17499,8 +17596,8 @@ fn aiur_fn_191(
         let __v_7: G = G::from_u64(1);
         let __v_8: G = G::from_u64(1);
         let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_191] = [__v_6, __v_9];
-        if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_192] = [__v_6, __v_9];
+        if let Some(result) = record.function_queries[192].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       1u64 => {
@@ -17512,21 +17609,21 @@ fn aiur_fn_191(
             let __v_7: G = G::from_u64(1);
             let __v_8: G = G::from_u64(1);
             let __v_9: G = { let __values: [G; 4] = [__v_7, __v_8, __v_8, __v_8]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __ret: [G; OUT_191] = [__v_6, __v_9];
-            if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_192] = [__v_6, __v_9];
+            if let Some(result) = record.function_queries[192].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           1u64 => {
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_1, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_4: G = __r_arr[0];
             let __v_5: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_6: G = __r_arr[0];
             let __v_7: G = G::from_u64(1);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_8: G = __r_arr[0];
-            let __ret: [G; OUT_191] = [__v_6, __v_8];
-            if let Some(result) = record.function_queries[191].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[191].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_192] = [__v_6, __v_8];
+            if let Some(result) = record.function_queries[192].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -17541,15 +17638,15 @@ fn aiur_fn_191(
   })
 }
 
-const INPUT_SIZE_192: usize = 20;
-const IN_192: usize = 20;
-const OUT_192: usize = 1;
-fn aiur_fn_192(
-  inp: [G; IN_192],
+const INPUT_SIZE_193: usize = 20;
+const IN_193: usize = 20;
+const OUT_193: usize = 1;
+fn aiur_fn_193(
+  inp: [G; IN_193],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_192], ExecError> {
+) -> Result<[G; OUT_193], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -17583,37 +17680,37 @@ fn aiur_fn_192(
     match __v_20.as_canonical_u64() {
       1u64 => {
         let __v_28: G = G::from_u64(1);
-        let __ret: [G; OUT_192] = [__v_28];
-        if let Some(result) = record.function_queries[192].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_193] = [__v_28];
+        if let Some(result) = record.function_queries[193].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         match __v_21.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_2, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_28: G = __r_arr[0];
-            let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_190(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_191] = { let __args: [G; IN_191] = [__v_24]; let __cu = unconstrained; if let Some(result) = record.function_queries[191].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_191(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_191] = unsafe { *(result.output.as_ptr() as *const [G; OUT_191]) }; __ret } } else { aiur_fn_191(__args, record, io_buffer, __cu)? } };
             let __v_29: G = __r_arr[0];
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_3, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_30: G = __r_arr[0];
             let __v_31: G = __r_arr[1];
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_4, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_32: G = __r_arr[0];
             let __v_33: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_32, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_32, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_34: G = __r_arr[0];
             let __v_35: G = G::from_u64(1);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_32, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_32, __v_35]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_36: G = __r_arr[0];
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_5, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_37: G = __r_arr[0];
             let __v_38: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_37, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_37, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_39: G = __r_arr[0];
             let __v_40: G = G::from_u64(1);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_37, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_37, __v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_41: G = __r_arr[0];
-            let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_1, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
             let __v_42: G = __r_arr[0];
             let __v_43: G = __r_arr[1];
             let __mc_out___mc_0: [G; 2] = '__mc_0: { match __v_42.as_canonical_u64() {
@@ -17638,13 +17735,13 @@ fn aiur_fn_192(
         break '__mc_0 [__v_46, __v_49];
       },
       1u64 => {
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_7, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_7, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_44: G = __r_arr[0];
         let __v_45: G = G::from_u64(0);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_44, __v_45]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_46: G = __r_arr[0];
         let __v_47: G = G::from_u64(1);
-        let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_44, __v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_44, __v_47]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
         let __v_48: G = __r_arr[0];
         break '__mc_0 [__v_46, __v_48];
       },
@@ -17660,14 +17757,14 @@ fn aiur_fn_192(
  };
             let __v_44: G = __mc_out___mc_0[0];
             let __v_45: G = __mc_out___mc_0[1];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_18, __v_19, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_173(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_18, __v_19, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
             let __v_46: G = __r_arr[0];
             let __v_47: G = __r_arr[1];
             let __v_48: G = G::from_u64(1);
             let __v_49: G = G::from_u64(0);
             let __v_50: G = (__v_46 - __v_48);
             let __v_51: G = (__v_47 - __v_49);
-            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_52: G = __r_arr[0];
             let __v_53: G = g_inverse_value(__v_52);
             let __v_54: G = (__v_52 * __v_53);
@@ -17805,9 +17902,9 @@ fn aiur_fn_192(
             let __v_162: G = { let __values: [G; 4] = [__v_142, __v_14, __v_143, __v_161]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
             let __v_163: G = { let __values: [G; 4] = [__v_140, __v_13, __v_141, __v_162]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
             let __v_164: G = { let __values: [G; 4] = [__v_138, __v_12, __v_139, __v_163]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-            let __r_arr: [G; OUT_176] = { let __args: [G; IN_176] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[176].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_176(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_176] = unsafe { *(result.output.as_ptr() as *const [G; OUT_176]) }; __ret } } else { aiur_fn_176(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_177] = { let __args: [G; IN_177] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[177].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_177(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_177] = unsafe { *(result.output.as_ptr() as *const [G; OUT_177]) }; __ret } } else { aiur_fn_177(__args, record, io_buffer, __cu)? } };
             let __v_165: G = __r_arr[0];
-            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_175] = { let __args: [G; IN_175] = [__v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[175].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_175(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_175] = unsafe { *(result.output.as_ptr() as *const [G; OUT_175]) }; __ret } } else { aiur_fn_175(__args, record, io_buffer, __cu)? } };
             let __v_166: G = __r_arr[0];
             let __v_167: G = (__v_165 * __v_166);
             let __v_168: G = g_inverse_value(__v_167);
@@ -17826,7 +17923,7 @@ fn aiur_fn_192(
             }
             let __v_176: G = G::from_u64(0);
             let __v_177: G = G::from_u64(0);
-            let __r_arr: [G; OUT_183] = { let __args: [G; IN_183] = [__v_176, __v_177, __v_16, __v_17, __v_23, __v_21, __v_34, __v_36, __v_44, __v_45, __v_39, __v_41, __v_164, __v_86, __v_89, __v_114, __v_117, __v_119, __v_120]; let __cu = unconstrained; if let Some(result) = record.function_queries[183].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_183(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_183] = unsafe { *(result.output.as_ptr() as *const [G; OUT_183]) }; __ret } } else { aiur_fn_183(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_184] = { let __args: [G; IN_184] = [__v_176, __v_177, __v_16, __v_17, __v_23, __v_21, __v_34, __v_36, __v_44, __v_45, __v_39, __v_41, __v_164, __v_86, __v_89, __v_114, __v_117, __v_119, __v_120]; let __cu = unconstrained; if let Some(result) = record.function_queries[184].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_184(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_184] = unsafe { *(result.output.as_ptr() as *const [G; OUT_184]) }; __ret } } else { aiur_fn_184(__args, record, io_buffer, __cu)? } };
             let __v_178: G = __r_arr[0];
             let __v_179: G = __r_arr[1];
             let __v_180: G = G::from_u64(0);
@@ -17883,40 +17980,40 @@ fn aiur_fn_192(
             let __mc_out___mc_1: [G; 2] = '__mc_1: { match __v_226.as_canonical_u64() {
   1u64 => {
     let __v_230: G = G::from_u64(0);
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_41, __v_230]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_41, __v_230]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_231: G = __r_arr[0];
     let __v_232: G = __r_arr[1];
     let __v_233: G = G::from_u64(0);
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_39, __v_233]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_39, __v_233]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_234: G = __r_arr[0];
     let __v_235: G = __r_arr[1];
     let __v_236: G = (__v_231 - __v_234);
     let __v_237: G = (__v_232 - __v_235);
     let __v_238: G = (__v_236 + __v_203);
     let __v_239: G = (__v_237 + __v_206);
-    let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_178, __v_179, __v_16, __v_17, __v_238, __v_239]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_178, __v_179, __v_16, __v_17, __v_238, __v_239]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
     let __v_240: G = __r_arr[0];
     let __v_241: G = __r_arr[1];
     let __v_242: G = G::from_u64(1);
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_41, __v_242]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_41, __v_242]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_243: G = __r_arr[0];
     let __v_244: G = __r_arr[1];
     let __v_245: G = G::from_u64(1);
-    let __r_arr: [G; OUT_213] = { let __args: [G; IN_213] = [__v_39, __v_245]; let __cu = unconstrained; if let Some(result) = record.function_queries[213].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_213(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_213] = unsafe { *(result.output.as_ptr() as *const [G; OUT_213]) }; __ret } } else { aiur_fn_213(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_39, __v_245]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
     let __v_246: G = __r_arr[0];
     let __v_247: G = __r_arr[1];
     let __v_248: G = (__v_243 - __v_246);
     let __v_249: G = (__v_244 - __v_247);
     let __v_250: G = (__v_248 + __v_222);
     let __v_251: G = (__v_249 + __v_225);
-    let __r_arr: [G; OUT_179] = { let __args: [G; IN_179] = [__v_240, __v_241, __v_16, __v_17, __v_250, __v_251]; let __cu = unconstrained; if let Some(result) = record.function_queries[179].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_179(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_179] = unsafe { *(result.output.as_ptr() as *const [G; OUT_179]) }; __ret } } else { aiur_fn_179(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_180] = { let __args: [G; IN_180] = [__v_240, __v_241, __v_16, __v_17, __v_250, __v_251]; let __cu = unconstrained; if let Some(result) = record.function_queries[180].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_180(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_180] = unsafe { *(result.output.as_ptr() as *const [G; OUT_180]) }; __ret } } else { aiur_fn_180(__args, record, io_buffer, __cu)? } };
     let __v_252: G = __r_arr[0];
     let __v_253: G = __r_arr[1];
     break '__mc_1 [__v_252, __v_253];
   },
   0u64 => {
     let __v_230: G = G::from_u64(0);
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_25]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_231: G = __r_arr[0];
     let __v_232: G = G::from_u64(0);
     let __v_233: G = G::from_u64(1);
@@ -17927,7 +18024,7 @@ fn aiur_fn_192(
     let __v_238: G = G::from_u64(0);
     let __v_239: G = G::from_u64(0);
     let __v_240: G = G::from_u64(0);
-    let __r_arr: [G; OUT_186] = { let __args: [G; IN_186] = [__v_178, __v_179, __v_16, __v_17, __v_25, __v_230, __v_231, __v_232, __v_26, __v_26, __v_233, __v_234, __v_235, __v_236, __v_237, __v_238, __v_239, __v_240, __v_203, __v_206, __v_222, __v_225, __v_12, __v_180, __v_13, __v_181, __v_14, __v_182, __v_15, __v_183, __v_21, __v_34, __v_36, __v_44, __v_45, __v_39, __v_41, __v_164, __v_86, __v_89, __v_114, __v_117, __v_119, __v_120]; let __cu = unconstrained; if let Some(result) = record.function_queries[186].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_186(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_186] = unsafe { *(result.output.as_ptr() as *const [G; OUT_186]) }; __ret } } else { aiur_fn_186(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_187] = { let __args: [G; IN_187] = [__v_178, __v_179, __v_16, __v_17, __v_25, __v_230, __v_231, __v_232, __v_26, __v_26, __v_233, __v_234, __v_235, __v_236, __v_237, __v_238, __v_239, __v_240, __v_203, __v_206, __v_222, __v_225, __v_12, __v_180, __v_13, __v_181, __v_14, __v_182, __v_15, __v_183, __v_21, __v_34, __v_36, __v_44, __v_45, __v_39, __v_41, __v_164, __v_86, __v_89, __v_114, __v_117, __v_119, __v_120]; let __cu = unconstrained; if let Some(result) = record.function_queries[187].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_187(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_187] = unsafe { *(result.output.as_ptr() as *const [G; OUT_187]) }; __ret } } else { aiur_fn_187(__args, record, io_buffer, __cu)? } };
     let __v_241: G = __r_arr[0];
     let __v_242: G = __r_arr[1];
     break '__mc_1 [__v_241, __v_242];
@@ -17939,19 +18036,19 @@ fn aiur_fn_192(
  };
             let __v_230: G = __mc_out___mc_1[0];
             let __v_231: G = __mc_out___mc_1[1];
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_8, __v_9]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_232: G = __r_arr[0];
             let __v_233: G = G::from_u64(0);
-            let __r_arr: [G; OUT_204] = { let __args: [G; IN_204] = [__v_232, __v_233]; let __cu = unconstrained; if let Some(result) = record.function_queries[204].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_204(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_204] = unsafe { *(result.output.as_ptr() as *const [G; OUT_204]) }; __ret } } else { aiur_fn_204(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_232, __v_233]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
             let __v_234: G = __r_arr[0];
-            let __r_arr: [G; OUT_181] = { let __args: [G; IN_181] = [__v_234]; let __cu = unconstrained; if let Some(result) = record.function_queries[181].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_181(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_181] = unsafe { *(result.output.as_ptr() as *const [G; OUT_181]) }; __ret } } else { aiur_fn_181(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_182] = { let __args: [G; IN_182] = [__v_234]; let __cu = unconstrained; if let Some(result) = record.function_queries[182].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_182(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_182] = unsafe { *(result.output.as_ptr() as *const [G; OUT_182]) }; __ret } } else { aiur_fn_182(__args, record, io_buffer, __cu)? } };
             let __v_235: G = __r_arr[0];
-            let __r_arr: [G; OUT_173] = { let __args: [G; IN_173] = [__v_18, __v_19, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[173].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_173(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_173] = unsafe { *(result.output.as_ptr() as *const [G; OUT_173]) }; __ret } } else { aiur_fn_173(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_174] = { let __args: [G; IN_174] = [__v_18, __v_19, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[174].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_174(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_174] = unsafe { *(result.output.as_ptr() as *const [G; OUT_174]) }; __ret } } else { aiur_fn_174(__args, record, io_buffer, __cu)? } };
             let __v_236: G = __r_arr[0];
             let __v_237: G = __r_arr[1];
             let __v_238: G = G::from_u64(1);
             let __v_239: G = G::from_u64(0);
-            let __r_arr: [G; OUT_189] = { let __args: [G; IN_189] = [__v_235, __v_236, __v_237, __v_238, __v_239]; let __cu = unconstrained; if let Some(result) = record.function_queries[189].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_189(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_189] = unsafe { *(result.output.as_ptr() as *const [G; OUT_189]) }; __ret } } else { aiur_fn_189(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_190] = { let __args: [G; IN_190] = [__v_235, __v_236, __v_237, __v_238, __v_239]; let __cu = unconstrained; if let Some(result) = record.function_queries[190].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_190(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_190] = unsafe { *(result.output.as_ptr() as *const [G; OUT_190]) }; __ret } } else { aiur_fn_190(__args, record, io_buffer, __cu)? } };
             let __v_240: G = __r_arr[0];
             let __v_241: G = __r_arr[1];
             let __v_242: G = (__v_230 * __v_134);
@@ -17968,7 +18065,7 @@ fn aiur_fn_192(
             if (__v_251 != __v_252) {
               return Err(ExecError::AssertEqMismatch { lhs: __v_251.as_canonical_u64(), rhs: __v_252.as_canonical_u64(), msg: None });
             }
-            let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_235]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_235]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
             let __v_253: G = __r_arr[0];
             let __v_254: G = (__v_253 - __v_29);
             let __v_255: G = G::from_bool((__v_254 == G::ZERO));
@@ -17987,10 +18084,10 @@ fn aiur_fn_192(
             }
             let __v_263: G = G::from_u64(1);
             let __v_264: G = (__v_9 + __v_263);
-            let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_27, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_264, __v_30, __v_31, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_192(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_27, __v_1, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_264, __v_30, __v_31, __v_12, __v_13, __v_14, __v_15, __v_16, __v_17, __v_18, __v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_193(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
             let __v_265: G = __r_arr[0];
-            let __ret: [G; OUT_192] = [__v_265];
-            if let Some(result) = record.function_queries[192].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[192].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_193] = [__v_265];
+            if let Some(result) = record.function_queries[193].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
         }
@@ -18002,15 +18099,15 @@ fn aiur_fn_192(
   })
 }
 
-const INPUT_SIZE_193: usize = 3;
-const IN_193: usize = 3;
-const OUT_193: usize = 2;
-fn aiur_fn_193(
-  inp: [G; IN_193],
+const INPUT_SIZE_194: usize = 3;
+const IN_194: usize = 3;
+const OUT_194: usize = 2;
+fn aiur_fn_194(
+  inp: [G; IN_194],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_193], ExecError> {
+) -> Result<[G; OUT_194], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -18030,8 +18127,8 @@ fn aiur_fn_193(
       1u64 => {
         let __v_13: G = G::from_u64(0);
         let __v_14: G = G::from_u64(0);
-        let __ret: [G; OUT_193] = [__v_13, __v_14];
-        if let Some(result) = record.function_queries[193].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_194] = [__v_13, __v_14];
+        if let Some(result) = record.function_queries[194].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -18057,7 +18154,7 @@ fn aiur_fn_193(
         let __v_32: G = (__v_14 + __v_31);
         let __v_33: G = (__v_4 + __v_32);
         let __v_34: G = G::from_u64(0);
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_193(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_0, __v_1, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_194(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_35: G = __r_arr[0];
         let __v_36: G = __r_arr[1];
         let __v_37: G = (__v_0 * __v_35);
@@ -18070,8 +18167,8 @@ fn aiur_fn_193(
         let __v_44: G = (__v_42 + __v_43);
         let __v_45: G = (__v_33 + __v_41);
         let __v_46: G = (__v_34 + __v_44);
-        let __ret: [G; OUT_193] = [__v_45, __v_46];
-        if let Some(result) = record.function_queries[193].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[193].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_194] = [__v_45, __v_46];
+        if let Some(result) = record.function_queries[194].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -18081,15 +18178,15 @@ fn aiur_fn_193(
   })
 }
 
-const INPUT_SIZE_194: usize = 7;
-const IN_194: usize = 7;
-const OUT_194: usize = 2;
-fn aiur_fn_194(
-  inp: [G; IN_194],
+const INPUT_SIZE_195: usize = 7;
+const IN_195: usize = 7;
+const OUT_195: usize = 2;
+fn aiur_fn_195(
+  inp: [G; IN_195],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_194], ExecError> {
+) -> Result<[G; OUT_195], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -18104,12 +18201,12 @@ fn aiur_fn_194(
     let __v_9: G = __loaded[2];
     match __v_7.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_194] = [__v_0, __v_1];
-        if let Some(result) = record.function_queries[194].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_195] = [__v_0, __v_1];
+        if let Some(result) = record.function_queries[195].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_193(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_5, __v_6, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_194(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
         let __v_10: G = __r_arr[0];
         let __v_11: G = __r_arr[1];
         let __v_12: G = (__v_3 + __v_10);
@@ -18139,11 +18236,11 @@ fn aiur_fn_194(
         let __v_30: G = (__v_29 * __v_19);
         let __v_31: G = (__v_0 + __v_27);
         let __v_32: G = (__v_1 + __v_30);
-        let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_31, __v_32, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_194(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_31, __v_32, __v_9, __v_3, __v_4, __v_5, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_195(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
         let __v_33: G = __r_arr[0];
         let __v_34: G = __r_arr[1];
-        let __ret: [G; OUT_194] = [__v_33, __v_34];
-        if let Some(result) = record.function_queries[194].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[194].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_195] = [__v_33, __v_34];
+        if let Some(result) = record.function_queries[195].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -18153,15 +18250,15 @@ fn aiur_fn_194(
   })
 }
 
-const INPUT_SIZE_195: usize = 38;
-const IN_195: usize = 38;
-const OUT_195: usize = 1;
-fn aiur_fn_195(
-  inp: [G; IN_195],
+const INPUT_SIZE_196: usize = 38;
+const IN_196: usize = 38;
+const OUT_196: usize = 1;
+fn aiur_fn_196(
+  inp: [G; IN_196],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_195], ExecError> {
+) -> Result<[G; OUT_196], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -18207,9 +18304,9 @@ fn aiur_fn_195(
           _ => {
             match __v_12.as_canonical_u64() {
               _ => {
-                let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_8, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
                 let __v_38: G = __r_arr[0];
-                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_11, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_199(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                 let __v_39: G = __r_arr[0];
                 match __v_13.as_canonical_u64() {
                   _ => {
@@ -18229,15 +18326,15 @@ fn aiur_fn_195(
 }
  };
                     let __v_40: G = __mc_out___mc_0[0];
-                    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_17, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_17, __v_37]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
                     let __v_41: G = __r_arr[0];
-                    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_13, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_13, __v_41]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
                     let __v_42: G = __r_arr[0];
-                    let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_40, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_40, __v_42]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
                     let __v_43: G = __r_arr[0];
-                    let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_12, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_12, __v_43]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
                     let __v_44: G = __r_arr[0];
-                    let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_7, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_170(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_7, __v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_171(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
                     let __v_45: G = __r_arr[0];
                     let __v_46: G = G::from_u64(0);
                     let __v_47: G = G::from_u64(109);
@@ -18284,7 +18381,7 @@ fn aiur_fn_195(
                     let __v_88: G = G::from_u64(1);
                     let __v_89: G = G::from_u64(1);
                     let __v_90: G = { let __values: [G; 3] = [__v_88, __v_89, __v_89]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_87, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_87, __v_90]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_91: G = __r_arr[0];
                     let __v_92: G = __r_arr[1];
                     let __v_93: G = __r_arr[2];
@@ -18306,16 +18403,16 @@ fn aiur_fn_195(
                     let __v_109: G = G::from_u64(1);
                     let __v_110: G = G::from_u64(1);
                     let __v_111: G = { let __values: [G; 3] = [__v_109, __v_110, __v_110]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_99, __v_100, __v_101, __v_102, __v_103, __v_104, __v_105, __v_106, __v_111]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                     let __v_112: G = __r_arr[0];
-                    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_112]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_91, __v_92, __v_93, __v_94, __v_95, __v_96, __v_97, __v_98, __v_112]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                     let __v_113: G = __r_arr[0];
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_107, __v_113]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_107, __v_113]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_114: G = __r_arr[0];
                     let __v_115: G = G::from_u64(1);
                     let __v_116: G = G::from_u64(1);
                     let __v_117: G = { let __values: [G; 3] = [__v_115, __v_116, __v_116]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_114, __v_117]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_114, __v_117]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_118: G = __r_arr[0];
                     let __v_119: G = __r_arr[1];
                     let __v_120: G = __r_arr[2];
@@ -18337,25 +18434,25 @@ fn aiur_fn_195(
                     let __v_136: G = G::from_u64(1);
                     let __v_137: G = G::from_u64(1);
                     let __v_138: G = { let __values: [G; 3] = [__v_136, __v_137, __v_137]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_138]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_126, __v_127, __v_128, __v_129, __v_130, __v_131, __v_132, __v_133, __v_138]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                     let __v_139: G = __r_arr[0];
-                    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_118, __v_119, __v_120, __v_121, __v_122, __v_123, __v_124, __v_125, __v_139]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                     let __v_140: G = __r_arr[0];
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_134, __v_140]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_134, __v_140]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_141: G = __r_arr[0];
-                    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_141, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_141, __v_14]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
                     let __v_142: G = __r_arr[0];
                     let __v_143: G = G::from_u64(1);
                     let __v_144: G = G::from_u64(1);
                     let __v_145: G = { let __values: [G; 3] = [__v_143, __v_144, __v_144]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_16, __v_145]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_16, __v_145]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
                     let __v_146: G = __r_arr[0];
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_142, __v_146]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_142, __v_146]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_147: G = __r_arr[0];
                     let __v_148: G = G::from_u64(1);
                     let __v_149: G = G::from_u64(1);
                     let __v_150: G = { let __values: [G; 3] = [__v_148, __v_149, __v_149]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_147, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_147, __v_150]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_151: G = __r_arr[0];
                     let __v_152: G = __r_arr[1];
                     let __v_153: G = __r_arr[2];
@@ -18374,12 +18471,12 @@ fn aiur_fn_195(
                     let __v_166: G = __r_arr[15];
                     let __v_167: G = __r_arr[16];
                     let __v_168: G = __r_arr[17];
-                    let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_167, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_167, __v_15]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
                     let __v_169: G = __r_arr[0];
                     let __v_170: G = G::from_u64(1);
                     let __v_171: G = G::from_u64(1);
                     let __v_172: G = { let __values: [G; 3] = [__v_170, __v_171, __v_171]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_169, __v_172]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_169, __v_172]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_173: G = __r_arr[0];
                     let __v_174: G = __r_arr[1];
                     let __v_175: G = __r_arr[2];
@@ -18568,17 +18665,17 @@ fn aiur_fn_195(
                     let __v_358: G = (__v_181 + __v_357);
                     let __v_359: G = G::from_u64(0);
                     let __v_360: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_359, __v_360, __v_36, __v_211, __v_232, __v_253, __v_274]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_194(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_359, __v_360, __v_36, __v_211, __v_232, __v_253, __v_274]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_195(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                     let __v_361: G = __r_arr[0];
                     let __v_362: G = __r_arr[1];
                     let __v_363: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_38, __v_39, __v_17, __v_16, __v_34, __v_35, __v_32, __v_33, __v_31, __v_363, __v_361, __v_362, __v_211, __v_232, __v_253, __v_274, __v_295, __v_316, __v_337, __v_358]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_192(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_38, __v_39, __v_17, __v_16, __v_34, __v_35, __v_32, __v_33, __v_31, __v_363, __v_361, __v_362, __v_211, __v_232, __v_253, __v_274, __v_295, __v_316, __v_337, __v_358]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_193(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
                     let __v_364: G = __r_arr[0];
-                    let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
                     let __v_365: G = __r_arr[0];
                     match __v_18.as_canonical_u64() {
                       _ => {
-                        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
                         let __v_366: G = __r_arr[0];
                         let __v_367: G = G::from_u64(1);
                         let __v_368: G = G::from_u64(1);
@@ -18588,7 +18685,7 @@ fn aiur_fn_195(
     break '__mc_1 [__v_369];
   },
   1u64 => {
-    let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_33, __v_369]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_33, __v_369]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
     let __v_370: G = __r_arr[0];
     break '__mc_1 [__v_370];
   },
@@ -18598,18 +18695,18 @@ fn aiur_fn_195(
 }
  };
                         let __v_370: G = __mc_out___mc_1[0];
-                        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_31, __v_370]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_31, __v_370]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
                         let __v_371: G = __r_arr[0];
-                        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_35, __v_371]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_35, __v_371]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
                         let __v_372: G = __r_arr[0];
-                        let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_34, __v_372]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_34, __v_372]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
                         let __v_373: G = __r_arr[0];
-                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_189, __v_373]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_189, __v_373]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                         let __v_374: G = __r_arr[0];
                         let __v_375: G = G::from_u64(1);
                         let __v_376: G = G::from_u64(1);
                         let __v_377: G = { let __values: [G; 3] = [__v_375, __v_376, __v_376]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_374, __v_377]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_374, __v_377]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                         let __v_378: G = __r_arr[0];
                         let __v_379: G = __r_arr[1];
                         let __v_380: G = __r_arr[2];
@@ -18670,28 +18767,28 @@ fn aiur_fn_195(
                         let __v_435: G = (__v_420 + __v_434);
                         let __v_436: G = (__v_418 + __v_435);
                         let __v_437: G = (__v_386 + __v_436);
-                        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_394, __v_18, __v_19, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_394, __v_18, __v_19, __v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_127(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
                         let __v_438: G = __r_arr[0];
                         let __v_439: G = __r_arr[1];
                         let __v_440: G = G::from_u64(1);
                         let __v_441: G = G::from_u64(1);
                         let __v_442: G = { let __values: [G; 3] = [__v_440, __v_441, __v_441]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                        let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_22, __v_442]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_22, __v_442]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
                         let __v_443: G = __r_arr[0];
-                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_439, __v_443]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_439, __v_443]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                         let __v_444: G = __r_arr[0];
-                        let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_444, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_124(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_444, __v_18]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
                         let __v_445: G = __r_arr[0];
-                        let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_445, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_445, __v_23, __v_24, __v_25, __v_26, __v_27, __v_28, __v_29, __v_30, __v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
                         let __v_446: G = __r_arr[0];
                         let __v_447: G = __r_arr[1];
                         let __v_448: G = (__v_366 + __v_0);
-                        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_446, __v_447, __v_4, __v_448]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_446, __v_447, __v_4, __v_448]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_148(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
                         let __v_449: G = __r_arr[0];
                         let __v_450: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_20, __v_21, __v_450, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_150(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_20, __v_21, __v_450, __v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
                         let __v_451: G = __r_arr[0];
-                        let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_446, __v_447, __v_451, __v_416, __v_437, __v_34, __v_35, __v_31, __v_32, __v_33, __v_13, __v_14, __v_15, __v_40, __v_39, __v_17, __v_337, __v_358, __v_365, __v_0, __v_448, __v_438, __v_18, __v_22, __v_366]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_146(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_446, __v_447, __v_451, __v_416, __v_437, __v_34, __v_35, __v_31, __v_32, __v_33, __v_13, __v_14, __v_15, __v_40, __v_39, __v_17, __v_337, __v_358, __v_365, __v_0, __v_448, __v_438, __v_18, __v_22, __v_366]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
                         let __v_452: G = __r_arr[0];
                         let __v_453: G = G::from_u64(0);
                         if (__v_1 != __v_453) {
@@ -18705,15 +18802,15 @@ fn aiur_fn_195(
                         if (__v_3 != __v_455) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_3.as_canonical_u64(), rhs: __v_455.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_196(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
                         let __v_456: G = __r_arr[0];
                         let __v_457: G = G::from_u64(1);
                         if (__v_456 != __v_457) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_456.as_canonical_u64(), rhs: __v_457.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
                         let __v_458: G = __r_arr[0];
-                        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
                         let __v_459: G = __r_arr[0];
                         let __v_460: G = (__v_458 - __v_459);
                         let __v_461: G = G::from_bool((__v_460 == G::ZERO));
@@ -18721,9 +18818,9 @@ fn aiur_fn_195(
                         if (__v_461 != __v_462) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_461.as_canonical_u64(), rhs: __v_462.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
                         let __v_463: G = __r_arr[0];
-                        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_16]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                         let __v_464: G = __r_arr[0];
                         let __v_465: G = (__v_463 - __v_464);
                         let __v_466: G = G::from_bool((__v_465 == G::ZERO));
@@ -18731,7 +18828,7 @@ fn aiur_fn_195(
                         if (__v_466 != __v_467) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_466.as_canonical_u64(), rhs: __v_467.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_19]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_211(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
                         let __v_468: G = __r_arr[0];
                         let __v_469: G = (__v_468 - __v_366);
                         let __v_470: G = G::from_bool((__v_469 == G::ZERO));
@@ -18739,16 +18836,16 @@ fn aiur_fn_195(
                         if (__v_470 != __v_471) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_470.as_canonical_u64(), rhs: __v_471.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_20]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                         let __v_472: G = __r_arr[0];
                         let __v_473: G = G::from_u64(3);
-                        let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_32, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_131(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_32, __v_33]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
                         let __v_474: G = __r_arr[0];
                         let __v_475: G = (__v_473 + __v_474);
                         if (__v_472 != __v_475) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_472.as_canonical_u64(), rhs: __v_475.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_21]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
                         let __v_476: G = __r_arr[0];
                         let __v_477: G = (__v_476 - __v_366);
                         let __v_478: G = G::from_bool((__v_477 == G::ZERO));
@@ -18756,7 +18853,7 @@ fn aiur_fn_195(
                         if (__v_478 != __v_479) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_478.as_canonical_u64(), rhs: __v_479.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                         let __v_480: G = __r_arr[0];
                         let __v_481: G = G::from_u64(1);
                         if (__v_480 != __v_481) {
@@ -18768,17 +18865,17 @@ fn aiur_fn_195(
                         if (__v_483 != __v_484) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_483.as_canonical_u64(), rhs: __v_484.as_canonical_u64(), msg: None });
                         }
-                        let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_20, __v_449, __v_13, __v_14, __v_15, __v_40, __v_32, __v_33, __v_39, __v_17, __v_365, __v_0, __v_448]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_20, __v_449, __v_13, __v_14, __v_15, __v_40, __v_32, __v_33, __v_39, __v_17, __v_365, __v_0, __v_448]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_152(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
                         let __v_485: G = __r_arr[0];
                         let __v_486: G = G::from_u64(1);
                         if (__v_485 != __v_486) {
                           return Err(ExecError::AssertEqMismatch { lhs: __v_485.as_canonical_u64(), rhs: __v_486.as_canonical_u64(), msg: None });
                         }
                         let __v_487: G = G::from_u64(0);
-                        let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_21, __v_18, __v_452, __v_449, __v_487, __v_448]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_154(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+                        let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_21, __v_18, __v_452, __v_449, __v_487, __v_448]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_155(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
                         let __v_488: G = __r_arr[0];
-                        let __ret: [G; OUT_195] = [__v_488];
-                        if let Some(result) = record.function_queries[195].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[195].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                        let __ret: [G; OUT_196] = [__v_488];
+                        if let Some(result) = record.function_queries[196].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                         return Ok(__ret);
                       },
                     }
@@ -18793,15 +18890,15 @@ fn aiur_fn_195(
   })
 }
 
-const INPUT_SIZE_196: usize = 1;
-const IN_196: usize = 1;
-const OUT_196: usize = 1;
-fn aiur_fn_196(
-  inp: [G; IN_196],
+const INPUT_SIZE_197: usize = 1;
+const IN_197: usize = 1;
+const OUT_197: usize = 1;
+fn aiur_fn_197(
+  inp: [G; IN_197],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_196], ExecError> {
+) -> Result<[G; OUT_197], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -18811,8 +18908,8 @@ fn aiur_fn_196(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_196] = [__v_4];
-        if let Some(result) = record.function_queries[196].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_197] = [__v_4];
+        if let Some(result) = record.function_queries[197].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -18823,82 +18920,14 @@ fn aiur_fn_196(
         if (__v_6 != __v_7) {
           return Err(ExecError::AssertEqMismatch { lhs: __v_6.as_canonical_u64(), rhs: __v_7.as_canonical_u64(), msg: None });
         }
-        let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_196(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
         let __v_8: G = __r_arr[0];
-        let __ret: [G; OUT_196] = [__v_8];
-        if let Some(result) = record.function_queries[196].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[196].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_197] = [__v_8];
+        if let Some(result) = record.function_queries[197].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
         return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_197: usize = 2;
-const IN_197: usize = 2;
-const OUT_197: usize = 1;
-fn aiur_fn_197(
-  inp: [G; IN_197],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_197], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    let __v_5: G = __loaded[3];
-    let __v_6: G = __loaded[4];
-    let __v_7: G = __loaded[5];
-    let __v_8: G = __loaded[6];
-    let __v_9: G = __loaded[7];
-    match __v_2.as_canonical_u64() {
-      1u64 => {
-        let __v_10: G = G::from_u64(1);
-        let __v_11: G = G::from_u64(1);
-        let __v_12: G = { let __values: [G; 8] = [__v_10, __v_11, __v_11, __v_11, __v_11, __v_11, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_197] = [__v_12];
-        if let Some(result) = record.function_queries[197].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      0u64 => {
-        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-        let __v_10: G = __loaded[0];
-        let __v_11: G = __loaded[1];
-        let __v_12: G = __loaded[2];
-        match __v_10.as_canonical_u64() {
-          0u64 => {
-            match __v_11.as_canonical_u64() {
-              0u64 => {
-                let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                let __v_13: G = __r_arr[0];
-                let __ret: [G; OUT_197] = [__v_13];
-                if let Some(result) = record.function_queries[197].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-                return Ok(__ret);
-              },
-              _ => {
-                let __v_13: G = G::from_u64(0);
-                let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_9, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
-                let __v_14: G = __r_arr[0];
-                let __v_15: G = { let __values: [G; 8] = [__v_13, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_14]; let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_197] = [__v_15];
-                if let Some(result) = record.function_queries[197].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[197].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-                return Ok(__ret);
-              },
-            }
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_10.as_canonical_u64()));
-          },
-        }
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -18916,6 +18945,74 @@ fn aiur_fn_198(
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
+    let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    let __v_5: G = __loaded[3];
+    let __v_6: G = __loaded[4];
+    let __v_7: G = __loaded[5];
+    let __v_8: G = __loaded[6];
+    let __v_9: G = __loaded[7];
+    match __v_2.as_canonical_u64() {
+      1u64 => {
+        let __v_10: G = G::from_u64(1);
+        let __v_11: G = G::from_u64(1);
+        let __v_12: G = { let __values: [G; 8] = [__v_10, __v_11, __v_11, __v_11, __v_11, __v_11, __v_11, __v_11]; let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_198] = [__v_12];
+        if let Some(result) = record.function_queries[198].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_1.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+        let __v_10: G = __loaded[0];
+        let __v_11: G = __loaded[1];
+        let __v_12: G = __loaded[2];
+        match __v_10.as_canonical_u64() {
+          0u64 => {
+            match __v_11.as_canonical_u64() {
+              0u64 => {
+                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_9, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __v_13: G = __r_arr[0];
+                let __ret: [G; OUT_198] = [__v_13];
+                if let Some(result) = record.function_queries[198].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                return Ok(__ret);
+              },
+              _ => {
+                let __v_13: G = G::from_u64(0);
+                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_9, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __v_14: G = __r_arr[0];
+                let __v_15: G = { let __values: [G; 8] = [__v_13, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_14]; let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+                let __ret: [G; OUT_198] = [__v_15];
+                if let Some(result) = record.function_queries[198].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                return Ok(__ret);
+              },
+            }
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_10.as_canonical_u64()));
+          },
+        }
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_199: usize = 2;
+const IN_199: usize = 2;
+const OUT_199: usize = 1;
+fn aiur_fn_199(
+  inp: [G; IN_199],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_199], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_2: G = __loaded[0];
     let __v_3: G = __loaded[1];
@@ -18926,8 +19023,8 @@ fn aiur_fn_198(
         let __v_6: G = G::from_u64(1);
         let __v_7: G = G::from_u64(1);
         let __v_8: G = { let __values: [G; 4] = [__v_6, __v_7, __v_7, __v_7]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_198] = [__v_8];
-        if let Some(result) = record.function_queries[198].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_199] = [__v_8];
+        if let Some(result) = record.function_queries[199].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
@@ -18939,19 +19036,19 @@ fn aiur_fn_198(
           0u64 => {
             match __v_7.as_canonical_u64() {
               0u64 => {
-                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_199(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                 let __v_9: G = __r_arr[0];
-                let __ret: [G; OUT_198] = [__v_9];
-                if let Some(result) = record.function_queries[198].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_199] = [__v_9];
+                if let Some(result) = record.function_queries[199].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
               _ => {
                 let __v_9: G = G::from_u64(0);
-                let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_5, __v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_199(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
                 let __v_10: G = __r_arr[0];
                 let __v_11: G = { let __values: [G; 4] = [__v_9, __v_3, __v_4, __v_10]; let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __ret: [G; OUT_198] = [__v_11];
-                if let Some(result) = record.function_queries[198].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[198].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+                let __ret: [G; OUT_199] = [__v_11];
+                if let Some(result) = record.function_queries[199].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
                 return Ok(__ret);
               },
             }
@@ -18968,31 +19065,8 @@ fn aiur_fn_198(
   })
 }
 
-const INPUT_SIZE_199: usize = 1;
-const IN_199: usize = 1;
-const OUT_199: usize = 2;
-fn aiur_fn_199(
-  inp: [G; IN_199],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_199], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_200(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_199] = [__v_3, __v_4];
-    if let Some(result) = record.function_queries[199].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[199].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
-  })
-}
-
-const INPUT_SIZE_200: usize = 2;
-const IN_200: usize = 2;
+const INPUT_SIZE_200: usize = 1;
+const IN_200: usize = 1;
 const OUT_200: usize = 2;
 fn aiur_fn_200(
   inp: [G; IN_200],
@@ -19002,40 +19076,20 @@ fn aiur_fn_200(
 ) -> Result<[G; OUT_200], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = G::from_u64(1);
-        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_200] = [__v_4, __v_0];
-        if let Some(result) = record.function_queries[200].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
-        let __v_2: G = __r_arr[0];
-        let __v_3: G = __r_arr[1];
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_3, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_202(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = __r_arr[1];
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = (__v_1 - __v_6);
-        let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_5, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_200(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
-        let __v_8: G = __r_arr[0];
-        let __v_9: G = __r_arr[1];
-        let __v_10: G = G::from_u64(0);
-        let __v_11: G = { let __values: [G; 3] = [__v_10, __v_4, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_200] = [__v_11, __v_9];
-        if let Some(result) = record.function_queries[200].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-    }
+    let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_201(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_200] = [__v_3, __v_4];
+    if let Some(result) = record.function_queries[200].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[200].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_201: usize = 1;
-const IN_201: usize = 1;
+const INPUT_SIZE_201: usize = 2;
+const IN_201: usize = 2;
 const OUT_201: usize = 2;
 fn aiur_fn_201(
   inp: [G; IN_201],
@@ -19045,20 +19099,40 @@ fn aiur_fn_201(
 ) -> Result<[G; OUT_201], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
-    let __v_1: G = __r_arr[0];
-    let __v_2: G = __r_arr[1];
-    let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_202(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
-    let __v_3: G = __r_arr[0];
-    let __v_4: G = __r_arr[1];
-    let __ret: [G; OUT_201] = [__v_3, __v_4];
-    if let Some(result) = record.function_queries[201].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-    return Ok(__ret);
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = G::from_u64(1);
+        let __v_4: G = { let __values: [G; 3] = [__v_2, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_201] = [__v_4, __v_0];
+        if let Some(result) = record.function_queries[201].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
+        let __v_2: G = __r_arr[0];
+        let __v_3: G = __r_arr[1];
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_3, __v_2]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_203(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = __r_arr[1];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = (__v_1 - __v_6);
+        let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_5, __v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_201(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
+        let __v_8: G = __r_arr[0];
+        let __v_9: G = __r_arr[1];
+        let __v_10: G = G::from_u64(0);
+        let __v_11: G = { let __values: [G; 3] = [__v_10, __v_4, __v_8]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_201] = [__v_11, __v_9];
+        if let Some(result) = record.function_queries[201].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[201].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+    }
   })
 }
 
-const INPUT_SIZE_202: usize = 2;
-const IN_202: usize = 2;
+const INPUT_SIZE_202: usize = 1;
+const IN_202: usize = 1;
 const OUT_202: usize = 2;
 fn aiur_fn_202(
   inp: [G; IN_202],
@@ -19068,14 +19142,37 @@ fn aiur_fn_202(
 ) -> Result<[G; OUT_202], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_0]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
+    let __v_1: G = __r_arr[0];
+    let __v_2: G = __r_arr[1];
+    let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_2, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_203(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
+    let __v_3: G = __r_arr[0];
+    let __v_4: G = __r_arr[1];
+    let __ret: [G; OUT_202] = [__v_3, __v_4];
+    if let Some(result) = record.function_queries[202].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    return Ok(__ret);
+  })
+}
+
+const INPUT_SIZE_203: usize = 2;
+const IN_203: usize = 2;
+const OUT_203: usize = 2;
+fn aiur_fn_203(
+  inp: [G; IN_203],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_203], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = G::from_u64(1);
         let __v_4: G = { let __values: [G; 10] = [__v_2, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3, __v_3]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_202] = [__v_4, __v_0];
-        if let Some(result) = record.function_queries[202].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_203] = [__v_4, __v_0];
+        if let Some(result) = record.function_queries[203].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -19091,28 +19188,28 @@ fn aiur_fn_202(
         let __v_10: G = __r_arr[8];
         let __v_11: G = G::from_u64(1);
         let __v_12: G = (__v_1 - __v_11);
-        let __r_arr: [G; OUT_202] = { let __args: [G; IN_202] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[202].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_202(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_202] = unsafe { *(result.output.as_ptr() as *const [G; OUT_202]) }; __ret } } else { aiur_fn_202(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_203] = { let __args: [G; IN_203] = [__v_10, __v_12]; let __cu = unconstrained; if let Some(result) = record.function_queries[203].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_203(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_203] = unsafe { *(result.output.as_ptr() as *const [G; OUT_203]) }; __ret } } else { aiur_fn_203(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = __r_arr[1];
         let __v_15: G = G::from_u64(0);
         let __v_16: G = { let __values: [G; 10] = [__v_15, __v_2, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_202] = [__v_16, __v_14];
-        if let Some(result) = record.function_queries[202].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[202].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_203] = [__v_16, __v_14];
+        if let Some(result) = record.function_queries[203].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
     }
   })
 }
 
-const INPUT_SIZE_203: usize = 16;
-const IN_203: usize = 16;
-const OUT_203: usize = 0;
-fn aiur_fn_203(
-  inp: [G; IN_203],
+const INPUT_SIZE_204: usize = 16;
+const IN_204: usize = 16;
+const OUT_204: usize = 0;
+fn aiur_fn_204(
+  inp: [G; IN_204],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_203], ExecError> {
+) -> Result<[G; OUT_204], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -19417,7 +19514,7 @@ fn aiur_fn_203(
     let __v_263: G = __r_arr[1];
     let __v_264: G = G::from_u64(0);
     let __v_265: G = { let __values: [G; 10] = [__v_264, __v_247, __v_248, __v_249, __v_250, __v_251, __v_252, __v_253, __v_254, __v_257]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-    let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_245, __v_265]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_245, __v_265]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
     let __v_266: G = __r_arr[0];
     let __v_267: G = G::from_u64(2);
     let __v_268: G = G::from_u64(0);
@@ -19515,34 +19612,34 @@ fn aiur_fn_203(
     let __r_arr: [G; OUT_25] = { let __args: [G; IN_25] = [__v_272]; let __cu = unconstrained; if let Some(result) = record.function_queries[25].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_25(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_25] = unsafe { *(result.output.as_ptr() as *const [G; OUT_25]) }; __ret } } else { aiur_fn_25(__args, record, io_buffer, __cu)? } };
     let __v_356: G = __r_arr[0];
     let __v_357: G = __r_arr[1];
-    let __r_arr: [G; OUT_200] = { let __args: [G; IN_200] = [__v_357, __v_356]; let __cu = unconstrained; if let Some(result) = record.function_queries[200].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_200(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_200] = unsafe { *(result.output.as_ptr() as *const [G; OUT_200]) }; __ret } } else { aiur_fn_200(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_201] = { let __args: [G; IN_201] = [__v_357, __v_356]; let __cu = unconstrained; if let Some(result) = record.function_queries[201].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_201(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_201] = unsafe { *(result.output.as_ptr() as *const [G; OUT_201]) }; __ret } } else { aiur_fn_201(__args, record, io_buffer, __cu)? } };
     let __v_358: G = __r_arr[0];
     let __v_359: G = __r_arr[1];
     let __mc_out___mc_0: [G; 1] = '__mc_0: { match __v_22.as_canonical_u64() {
   _ => {
-    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
     let __v_360: G = __r_arr[0];
     let __v_361: G = G::from_bool((__v_360 == G::ZERO));
     let __v_362: G = G::from_u64(0);
     if (__v_361 != __v_362) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_361.as_canonical_u64(), rhs: __v_362.as_canonical_u64(), msg: None });
     }
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_66]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_363: G = __r_arr[0];
     if (__v_363 != __v_360) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_363.as_canonical_u64(), rhs: __v_360.as_canonical_u64(), msg: None });
     }
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_68]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_364: G = __r_arr[0];
     if (__v_364 != __v_360) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_364.as_canonical_u64(), rhs: __v_360.as_canonical_u64(), msg: None });
     }
-    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_61]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
     let __v_365: G = __r_arr[0];
     if (__v_365 != __v_360) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_365.as_canonical_u64(), rhs: __v_360.as_canonical_u64(), msg: None });
     }
-    let __r_arr: [G; OUT_157] = { let __args: [G; IN_157] = [__v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[157].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_157(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_157] = unsafe { *(result.output.as_ptr() as *const [G; OUT_157]) }; __ret } } else { aiur_fn_157(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
     let __v_366: G = __r_arr[0];
     let __v_367: G = G::from_u64(1);
     if (__v_366 != __v_367) {
@@ -19560,9 +19657,9 @@ fn aiur_fn_203(
       _ => {
         match __v_22.as_canonical_u64() {
           _ => {
-            let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_256, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_256, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
             let __v_361: G = __r_arr[0];
-            let __r_arr: [G; OUT_198] = { let __args: [G; IN_198] = [__v_262, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[198].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_198(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_198] = unsafe { *(result.output.as_ptr() as *const [G; OUT_198]) }; __ret } } else { aiur_fn_198(__args, record, io_buffer, __cu)? } };
+            let __r_arr: [G; OUT_199] = { let __args: [G; IN_199] = [__v_262, __v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[199].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_199(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_199] = unsafe { *(result.output.as_ptr() as *const [G; OUT_199]) }; __ret } } else { aiur_fn_199(__args, record, io_buffer, __cu)? } };
             let __v_362: G = __r_arr[0];
             match __v_24.as_canonical_u64() {
               _ => {
@@ -19582,15 +19679,15 @@ fn aiur_fn_203(
 }
  };
                 let __v_363: G = __mc_out___mc_2[0];
-                let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_34, __v_272]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_34, __v_272]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
                 let __v_364: G = __r_arr[0];
-                let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_24, __v_364]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_24, __v_364]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
                 let __v_365: G = __r_arr[0];
-                let __r_arr: [G; OUT_160] = { let __args: [G; IN_160] = [__v_363, __v_365]; let __cu = unconstrained; if let Some(result) = record.function_queries[160].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_160(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_160] = unsafe { *(result.output.as_ptr() as *const [G; OUT_160]) }; __ret } } else { aiur_fn_160(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_363, __v_365]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
                 let __v_366: G = __r_arr[0];
-                let __r_arr: [G; OUT_161] = { let __args: [G; IN_161] = [__v_22, __v_366]; let __cu = unconstrained; if let Some(result) = record.function_queries[161].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_161(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_161] = unsafe { *(result.output.as_ptr() as *const [G; OUT_161]) }; __ret } } else { aiur_fn_161(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_162] = { let __args: [G; IN_162] = [__v_22, __v_366]; let __cu = unconstrained; if let Some(result) = record.function_queries[162].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_162(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_162] = unsafe { *(result.output.as_ptr() as *const [G; OUT_162]) }; __ret } } else { aiur_fn_162(__args, record, io_buffer, __cu)? } };
                 let __v_367: G = __r_arr[0];
-                let __r_arr: [G; OUT_170] = { let __args: [G; IN_170] = [__v_266, __v_367]; let __cu = unconstrained; if let Some(result) = record.function_queries[170].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_170(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_170] = unsafe { *(result.output.as_ptr() as *const [G; OUT_170]) }; __ret } } else { aiur_fn_170(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_171] = { let __args: [G; IN_171] = [__v_266, __v_367]; let __cu = unconstrained; if let Some(result) = record.function_queries[171].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_171(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_171] = unsafe { *(result.output.as_ptr() as *const [G; OUT_171]) }; __ret } } else { aiur_fn_171(__args, record, io_buffer, __cu)? } };
                 let __v_368: G = __r_arr[0];
                 let __v_369: G = G::from_u64(0);
                 let __v_370: G = G::from_u64(109);
@@ -19637,7 +19734,7 @@ fn aiur_fn_203(
                 let __v_411: G = G::from_u64(1);
                 let __v_412: G = G::from_u64(1);
                 let __v_413: G = { let __values: [G; 3] = [__v_411, __v_412, __v_412]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_410, __v_413]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_410, __v_413]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                 let __v_414: G = __r_arr[0];
                 let __v_415: G = __r_arr[1];
                 let __v_416: G = __r_arr[2];
@@ -19659,16 +19756,16 @@ fn aiur_fn_203(
                 let __v_432: G = G::from_u64(1);
                 let __v_433: G = G::from_u64(1);
                 let __v_434: G = { let __values: [G; 3] = [__v_432, __v_433, __v_433]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_422, __v_423, __v_424, __v_425, __v_426, __v_427, __v_428, __v_429, __v_434]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_422, __v_423, __v_424, __v_425, __v_426, __v_427, __v_428, __v_429, __v_434]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                 let __v_435: G = __r_arr[0];
-                let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_414, __v_415, __v_416, __v_417, __v_418, __v_419, __v_420, __v_421, __v_435]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_414, __v_415, __v_416, __v_417, __v_418, __v_419, __v_420, __v_421, __v_435]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                 let __v_436: G = __r_arr[0];
-                let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_430, __v_436]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_430, __v_436]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                 let __v_437: G = __r_arr[0];
                 let __v_438: G = G::from_u64(1);
                 let __v_439: G = G::from_u64(1);
                 let __v_440: G = { let __values: [G; 3] = [__v_438, __v_439, __v_439]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_437, __v_440]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_437, __v_440]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                 let __v_441: G = __r_arr[0];
                 let __v_442: G = __r_arr[1];
                 let __v_443: G = __r_arr[2];
@@ -19690,25 +19787,25 @@ fn aiur_fn_203(
                 let __v_459: G = G::from_u64(1);
                 let __v_460: G = G::from_u64(1);
                 let __v_461: G = { let __values: [G; 3] = [__v_459, __v_460, __v_460]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_449, __v_450, __v_451, __v_452, __v_453, __v_454, __v_455, __v_456, __v_461]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_449, __v_450, __v_451, __v_452, __v_453, __v_454, __v_455, __v_456, __v_461]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                 let __v_462: G = __r_arr[0];
-                let __r_arr: [G; OUT_158] = { let __args: [G; IN_158] = [__v_441, __v_442, __v_443, __v_444, __v_445, __v_446, __v_447, __v_448, __v_462]; let __cu = unconstrained; if let Some(result) = record.function_queries[158].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_158(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_158] = unsafe { *(result.output.as_ptr() as *const [G; OUT_158]) }; __ret } } else { aiur_fn_158(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_159] = { let __args: [G; IN_159] = [__v_441, __v_442, __v_443, __v_444, __v_445, __v_446, __v_447, __v_448, __v_462]; let __cu = unconstrained; if let Some(result) = record.function_queries[159].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_159(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_159] = unsafe { *(result.output.as_ptr() as *const [G; OUT_159]) }; __ret } } else { aiur_fn_159(__args, record, io_buffer, __cu)? } };
                 let __v_463: G = __r_arr[0];
-                let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_457, __v_463]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_457, __v_463]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                 let __v_464: G = __r_arr[0];
-                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_464, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_464, __v_26]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
                 let __v_465: G = __r_arr[0];
                 let __v_466: G = G::from_u64(1);
                 let __v_467: G = G::from_u64(1);
                 let __v_468: G = { let __values: [G; 3] = [__v_466, __v_467, __v_467]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_30, __v_468]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_30, __v_468]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
                 let __v_469: G = __r_arr[0];
-                let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_465, __v_469]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_465, __v_469]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                 let __v_470: G = __r_arr[0];
                 let __v_471: G = G::from_u64(1);
                 let __v_472: G = G::from_u64(1);
                 let __v_473: G = { let __values: [G; 3] = [__v_471, __v_472, __v_472]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_470, __v_473]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_470, __v_473]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                 let __v_474: G = __r_arr[0];
                 let __v_475: G = __r_arr[1];
                 let __v_476: G = __r_arr[2];
@@ -19727,12 +19824,12 @@ fn aiur_fn_203(
                 let __v_489: G = __r_arr[15];
                 let __v_490: G = __r_arr[16];
                 let __v_491: G = __r_arr[17];
-                let __r_arr: [G; OUT_168] = { let __args: [G; IN_168] = [__v_490, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[168].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_168(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_168] = unsafe { *(result.output.as_ptr() as *const [G; OUT_168]) }; __ret } } else { aiur_fn_168(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_169] = { let __args: [G; IN_169] = [__v_490, __v_28]; let __cu = unconstrained; if let Some(result) = record.function_queries[169].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_169(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_169] = unsafe { *(result.output.as_ptr() as *const [G; OUT_169]) }; __ret } } else { aiur_fn_169(__args, record, io_buffer, __cu)? } };
                 let __v_492: G = __r_arr[0];
                 let __v_493: G = G::from_u64(1);
                 let __v_494: G = G::from_u64(1);
                 let __v_495: G = { let __values: [G; 3] = [__v_493, __v_494, __v_494]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_492, __v_495]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_492, __v_495]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                 let __v_496: G = __r_arr[0];
                 let __v_497: G = __r_arr[1];
                 let __v_498: G = __r_arr[2];
@@ -19921,17 +20018,17 @@ fn aiur_fn_203(
                 let __v_681: G = (__v_504 + __v_680);
                 let __v_682: G = G::from_u64(0);
                 let __v_683: G = G::from_u64(0);
-                let __r_arr: [G; OUT_194] = { let __args: [G; IN_194] = [__v_682, __v_683, __v_358, __v_534, __v_555, __v_576, __v_597]; let __cu = unconstrained; if let Some(result) = record.function_queries[194].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_194(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_194] = unsafe { *(result.output.as_ptr() as *const [G; OUT_194]) }; __ret } } else { aiur_fn_194(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_195] = { let __args: [G; IN_195] = [__v_682, __v_683, __v_358, __v_534, __v_555, __v_576, __v_597]; let __cu = unconstrained; if let Some(result) = record.function_queries[195].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_195(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_195] = unsafe { *(result.output.as_ptr() as *const [G; OUT_195]) }; __ret } } else { aiur_fn_195(__args, record, io_buffer, __cu)? } };
                 let __v_684: G = __r_arr[0];
                 let __v_685: G = __r_arr[1];
                 let __v_686: G = G::from_u64(0);
-                let __r_arr: [G; OUT_192] = { let __args: [G; IN_192] = [__v_361, __v_362, __v_34, __v_30, __v_66, __v_68, __v_63, __v_64, __v_61, __v_686, __v_684, __v_685, __v_534, __v_555, __v_576, __v_597, __v_618, __v_639, __v_660, __v_681]; let __cu = unconstrained; if let Some(result) = record.function_queries[192].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_192(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_192] = unsafe { *(result.output.as_ptr() as *const [G; OUT_192]) }; __ret } } else { aiur_fn_192(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_193] = { let __args: [G; IN_193] = [__v_361, __v_362, __v_34, __v_30, __v_66, __v_68, __v_63, __v_64, __v_61, __v_686, __v_684, __v_685, __v_534, __v_555, __v_576, __v_597, __v_618, __v_639, __v_660, __v_681]; let __cu = unconstrained; if let Some(result) = record.function_queries[193].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_193(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_193] = unsafe { *(result.output.as_ptr() as *const [G; OUT_193]) }; __ret } } else { aiur_fn_193(__args, record, io_buffer, __cu)? } };
                 let __v_687: G = __r_arr[0];
-                let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_361]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+                let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_361]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
                 let __v_688: G = __r_arr[0];
                 match __v_38.as_canonical_u64() {
                   _ => {
-                    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
                     let __v_689: G = __r_arr[0];
                     let __v_690: G = G::from_u64(1);
                     let __v_691: G = G::from_u64(1);
@@ -19941,7 +20038,7 @@ fn aiur_fn_203(
     break '__mc_3 [__v_692];
   },
   1u64 => {
-    let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_64, __v_692]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_64, __v_692]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
     let __v_693: G = __r_arr[0];
     break '__mc_3 [__v_693];
   },
@@ -19951,18 +20048,18 @@ fn aiur_fn_203(
 }
  };
                     let __v_693: G = __mc_out___mc_3[0];
-                    let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_61, __v_693]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_61, __v_693]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
                     let __v_694: G = __r_arr[0];
-                    let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_68, __v_694]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_68, __v_694]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
                     let __v_695: G = __r_arr[0];
-                    let __r_arr: [G; OUT_122] = { let __args: [G; IN_122] = [__v_66, __v_695]; let __cu = unconstrained; if let Some(result) = record.function_queries[122].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_122(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_122] = unsafe { *(result.output.as_ptr() as *const [G; OUT_122]) }; __ret } } else { aiur_fn_122(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_123] = { let __args: [G; IN_123] = [__v_66, __v_695]; let __cu = unconstrained; if let Some(result) = record.function_queries[123].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_123(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_123] = unsafe { *(result.output.as_ptr() as *const [G; OUT_123]) }; __ret } } else { aiur_fn_123(__args, record, io_buffer, __cu)? } };
                     let __v_696: G = __r_arr[0];
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_512, __v_696]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_512, __v_696]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_697: G = __r_arr[0];
                     let __v_698: G = G::from_u64(1);
                     let __v_699: G = G::from_u64(1);
                     let __v_700: G = { let __values: [G; 3] = [__v_698, __v_699, __v_699]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_164] = { let __args: [G; IN_164] = [__v_697, __v_700]; let __cu = unconstrained; if let Some(result) = record.function_queries[164].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_164(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_164] = unsafe { *(result.output.as_ptr() as *const [G; OUT_164]) }; __ret } } else { aiur_fn_164(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_165] = { let __args: [G; IN_165] = [__v_697, __v_700]; let __cu = unconstrained; if let Some(result) = record.function_queries[165].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_165(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_165] = unsafe { *(result.output.as_ptr() as *const [G; OUT_165]) }; __ret } } else { aiur_fn_165(__args, record, io_buffer, __cu)? } };
                     let __v_701: G = __r_arr[0];
                     let __v_702: G = __r_arr[1];
                     let __v_703: G = __r_arr[2];
@@ -20023,28 +20120,28 @@ fn aiur_fn_203(
                     let __v_758: G = (__v_743 + __v_757);
                     let __v_759: G = (__v_741 + __v_758);
                     let __v_760: G = (__v_709 + __v_759);
-                    let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_717, __v_38, __v_40, __v_209]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_127] = { let __args: [G; IN_127] = [__v_717, __v_38, __v_40, __v_209]; let __cu = unconstrained; if let Some(result) = record.function_queries[127].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_127(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_127] = unsafe { *(result.output.as_ptr() as *const [G; OUT_127]) }; __ret } } else { aiur_fn_127(__args, record, io_buffer, __cu)? } };
                     let __v_761: G = __r_arr[0];
                     let __v_762: G = __r_arr[1];
                     let __v_763: G = G::from_u64(1);
                     let __v_764: G = G::from_u64(1);
                     let __v_765: G = { let __values: [G; 3] = [__v_763, __v_764, __v_764]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-                    let __r_arr: [G; OUT_120] = { let __args: [G; IN_120] = [__v_50, __v_765]; let __cu = unconstrained; if let Some(result) = record.function_queries[120].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_120(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_120] = unsafe { *(result.output.as_ptr() as *const [G; OUT_120]) }; __ret } } else { aiur_fn_120(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_121] = { let __args: [G; IN_121] = [__v_50, __v_765]; let __cu = unconstrained; if let Some(result) = record.function_queries[121].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_121(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_121] = unsafe { *(result.output.as_ptr() as *const [G; OUT_121]) }; __ret } } else { aiur_fn_121(__args, record, io_buffer, __cu)? } };
                     let __v_766: G = __r_arr[0];
-                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_762, __v_766]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_762, __v_766]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
                     let __v_767: G = __r_arr[0];
-                    let __r_arr: [G; OUT_124] = { let __args: [G; IN_124] = [__v_767, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[124].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_124(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_124] = unsafe { *(result.output.as_ptr() as *const [G; OUT_124]) }; __ret } } else { aiur_fn_124(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_767, __v_38]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
                     let __v_768: G = __r_arr[0];
-                    let __r_arr: [G; OUT_125] = { let __args: [G; IN_125] = [__v_768, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_219]; let __cu = unconstrained; if let Some(result) = record.function_queries[125].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_125(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_125] = unsafe { *(result.output.as_ptr() as *const [G; OUT_125]) }; __ret } } else { aiur_fn_125(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_126] = { let __args: [G; IN_126] = [__v_768, __v_52, __v_53, __v_54, __v_55, __v_56, __v_57, __v_58, __v_59, __v_219]; let __cu = unconstrained; if let Some(result) = record.function_queries[126].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_126(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_126] = unsafe { *(result.output.as_ptr() as *const [G; OUT_126]) }; __ret } } else { aiur_fn_126(__args, record, io_buffer, __cu)? } };
                     let __v_769: G = __r_arr[0];
                     let __v_770: G = __r_arr[1];
                     let __v_771: G = (__v_689 + __v_159);
-                    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_769, __v_770, __v_199, __v_771]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_148] = { let __args: [G; IN_148] = [__v_769, __v_770, __v_199, __v_771]; let __cu = unconstrained; if let Some(result) = record.function_queries[148].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_148(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_148] = unsafe { *(result.output.as_ptr() as *const [G; OUT_148]) }; __ret } } else { aiur_fn_148(__args, record, io_buffer, __cu)? } };
                     let __v_772: G = __r_arr[0];
                     let __v_773: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_150] = { let __args: [G; IN_150] = [__v_44, __v_48, __v_773, __v_199]; let __cu = unconstrained; if let Some(result) = record.function_queries[150].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_150(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_150] = unsafe { *(result.output.as_ptr() as *const [G; OUT_150]) }; __ret } } else { aiur_fn_150(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_44, __v_48, __v_773, __v_199]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
                     let __v_774: G = __r_arr[0];
-                    let __r_arr: [G; OUT_146] = { let __args: [G; IN_146] = [__v_769, __v_770, __v_774, __v_739, __v_760, __v_66, __v_68, __v_61, __v_63, __v_64, __v_24, __v_26, __v_28, __v_363, __v_362, __v_34, __v_660, __v_681, __v_688, __v_159, __v_771, __v_761, __v_38, __v_50, __v_689]; let __cu = unconstrained; if let Some(result) = record.function_queries[146].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_146(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_146] = unsafe { *(result.output.as_ptr() as *const [G; OUT_146]) }; __ret } } else { aiur_fn_146(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_147] = { let __args: [G; IN_147] = [__v_769, __v_770, __v_774, __v_739, __v_760, __v_66, __v_68, __v_61, __v_63, __v_64, __v_24, __v_26, __v_28, __v_363, __v_362, __v_34, __v_660, __v_681, __v_688, __v_159, __v_771, __v_761, __v_38, __v_50, __v_689]; let __cu = unconstrained; if let Some(result) = record.function_queries[147].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_147(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_147] = unsafe { *(result.output.as_ptr() as *const [G; OUT_147]) }; __ret } } else { aiur_fn_147(__args, record, io_buffer, __cu)? } };
                     let __v_775: G = __r_arr[0];
                     let __v_776: G = G::from_u64(0);
                     if (__v_169 != __v_776) {
@@ -20058,15 +20155,15 @@ fn aiur_fn_203(
                     if (__v_189 != __v_778) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_189.as_canonical_u64(), rhs: __v_778.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_196] = { let __args: [G; IN_196] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[196].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_196(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_196] = unsafe { *(result.output.as_ptr() as *const [G; OUT_196]) }; __ret } } else { aiur_fn_196(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_197] = { let __args: [G; IN_197] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[197].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_197(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_197] = unsafe { *(result.output.as_ptr() as *const [G; OUT_197]) }; __ret } } else { aiur_fn_197(__args, record, io_buffer, __cu)? } };
                     let __v_779: G = __r_arr[0];
                     let __v_780: G = G::from_u64(1);
                     if (__v_779 != __v_780) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_779.as_canonical_u64(), rhs: __v_780.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_22]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
                     let __v_781: G = __r_arr[0];
-                    let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_256]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_256]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
                     let __v_782: G = __r_arr[0];
                     let __v_783: G = (__v_781 - __v_782);
                     let __v_784: G = G::from_bool((__v_783 == G::ZERO));
@@ -20074,9 +20171,9 @@ fn aiur_fn_203(
                     if (__v_784 != __v_785) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_784.as_canonical_u64(), rhs: __v_785.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_361]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_361]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
                     let __v_786: G = __r_arr[0];
-                    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_30]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                     let __v_787: G = __r_arr[0];
                     let __v_788: G = (__v_786 - __v_787);
                     let __v_789: G = G::from_bool((__v_788 == G::ZERO));
@@ -20084,7 +20181,7 @@ fn aiur_fn_203(
                     if (__v_789 != __v_790) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_789.as_canonical_u64(), rhs: __v_790.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_40]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_211(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
                     let __v_791: G = __r_arr[0];
                     let __v_792: G = (__v_791 - __v_689);
                     let __v_793: G = G::from_bool((__v_792 == G::ZERO));
@@ -20092,16 +20189,16 @@ fn aiur_fn_203(
                     if (__v_793 != __v_794) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_793.as_canonical_u64(), rhs: __v_794.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_44]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                     let __v_795: G = __r_arr[0];
                     let __v_796: G = G::from_u64(3);
-                    let __r_arr: [G; OUT_131] = { let __args: [G; IN_131] = [__v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[131].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_131(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_131] = unsafe { *(result.output.as_ptr() as *const [G; OUT_131]) }; __ret } } else { aiur_fn_131(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_132] = { let __args: [G; IN_132] = [__v_63, __v_64]; let __cu = unconstrained; if let Some(result) = record.function_queries[132].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_132(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_132] = unsafe { *(result.output.as_ptr() as *const [G; OUT_132]) }; __ret } } else { aiur_fn_132(__args, record, io_buffer, __cu)? } };
                     let __v_797: G = __r_arr[0];
                     let __v_798: G = (__v_796 + __v_797);
                     if (__v_795 != __v_798) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_795.as_canonical_u64(), rhs: __v_798.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_48]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
                     let __v_799: G = __r_arr[0];
                     let __v_800: G = (__v_799 - __v_689);
                     let __v_801: G = G::from_bool((__v_800 == G::ZERO));
@@ -20109,7 +20206,7 @@ fn aiur_fn_203(
                     if (__v_801 != __v_802) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_801.as_canonical_u64(), rhs: __v_802.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_50]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
                     let __v_803: G = __r_arr[0];
                     let __v_804: G = G::from_u64(1);
                     if (__v_803 != __v_804) {
@@ -20121,14 +20218,14 @@ fn aiur_fn_203(
                     if (__v_806 != __v_807) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_806.as_canonical_u64(), rhs: __v_807.as_canonical_u64(), msg: None });
                     }
-                    let __r_arr: [G; OUT_151] = { let __args: [G; IN_151] = [__v_44, __v_772, __v_24, __v_26, __v_28, __v_363, __v_63, __v_64, __v_362, __v_34, __v_688, __v_159, __v_771]; let __cu = unconstrained; if let Some(result) = record.function_queries[151].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_151(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_151] = unsafe { *(result.output.as_ptr() as *const [G; OUT_151]) }; __ret } } else { aiur_fn_151(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_152] = { let __args: [G; IN_152] = [__v_44, __v_772, __v_24, __v_26, __v_28, __v_363, __v_63, __v_64, __v_362, __v_34, __v_688, __v_159, __v_771]; let __cu = unconstrained; if let Some(result) = record.function_queries[152].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_152(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_152] = unsafe { *(result.output.as_ptr() as *const [G; OUT_152]) }; __ret } } else { aiur_fn_152(__args, record, io_buffer, __cu)? } };
                     let __v_808: G = __r_arr[0];
                     let __v_809: G = G::from_u64(1);
                     if (__v_808 != __v_809) {
                       return Err(ExecError::AssertEqMismatch { lhs: __v_808.as_canonical_u64(), rhs: __v_809.as_canonical_u64(), msg: None });
                     }
                     let __v_810: G = G::from_u64(0);
-                    let __r_arr: [G; OUT_154] = { let __args: [G; IN_154] = [__v_48, __v_38, __v_775, __v_772, __v_810, __v_771]; let __cu = unconstrained; if let Some(result) = record.function_queries[154].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_154(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_154] = unsafe { *(result.output.as_ptr() as *const [G; OUT_154]) }; __ret } } else { aiur_fn_154(__args, record, io_buffer, __cu)? } };
+                    let __r_arr: [G; OUT_155] = { let __args: [G; IN_155] = [__v_48, __v_38, __v_775, __v_772, __v_810, __v_771]; let __cu = unconstrained; if let Some(result) = record.function_queries[155].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_155(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_155] = unsafe { *(result.output.as_ptr() as *const [G; OUT_155]) }; __ret } } else { aiur_fn_155(__args, record, io_buffer, __cu)? } };
                     let __v_811: G = __r_arr[0];
                     break '__mc_1 [__v_811];
                   },
@@ -20377,45 +20474,14 @@ fn aiur_fn_203(
     if (__v_361 != __v_518) {
       return Err(ExecError::AssertEqMismatch { lhs: __v_361.as_canonical_u64(), rhs: __v_518.as_canonical_u64(), msg: None });
     }
-    let __ret: [G; OUT_203] = [];
-    if let Some(result) = record.function_queries[203].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[203].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+    let __ret: [G; OUT_204] = [];
+    if let Some(result) = record.function_queries[204].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
     return Ok(__ret);
   })
 }
 
-const INPUT_SIZE_204: usize = 2;
-const IN_204: usize = 2;
-const OUT_204: usize = 1;
-fn aiur_fn_204(
-  inp: [G; IN_204],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_204], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
-    let __v_2: G = __r_arr[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_3: G = __loaded[0];
-    let __v_4: G = __loaded[1];
-    let __v_5: G = __loaded[2];
-    match __v_3.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_204] = [__v_4];
-        if let Some(result) = record.function_queries[204].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[204].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_205: usize = 1;
-const IN_205: usize = 1;
+const INPUT_SIZE_205: usize = 2;
+const IN_205: usize = 2;
 const OUT_205: usize = 1;
 fn aiur_fn_205(
   inp: [G; IN_205],
@@ -20425,28 +20491,21 @@ fn aiur_fn_205(
 ) -> Result<[G; OUT_205], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    match __v_1.as_canonical_u64() {
-      1u64 => {
-        let __v_4: G = G::from_u64(0);
+    let __v_1: G = inp[1];
+    let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+    let __v_2: G = __r_arr[0];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_3: G = __loaded[0];
+    let __v_4: G = __loaded[1];
+    let __v_5: G = __loaded[2];
+    match __v_3.as_canonical_u64() {
+      0u64 => {
         let __ret: [G; OUT_205] = [__v_4];
         if let Some(result) = record.function_queries[205].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
-      0u64 => {
-        let __r_arr: [G; OUT_205] = { let __args: [G; IN_205] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[205].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_205(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_205] = unsafe { *(result.output.as_ptr() as *const [G; OUT_205]) }; __ret } } else { aiur_fn_205(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __v_5: G = G::from_u64(1);
-        let __v_6: G = (__v_4 + __v_5);
-        let __ret: [G; OUT_205] = [__v_6];
-        if let Some(result) = record.function_queries[205].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[205].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_3.as_canonical_u64()));
       },
     }
   })
@@ -20463,24 +20522,23 @@ fn aiur_fn_206(
 ) -> Result<[G; OUT_206], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
     let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __ret: [G; OUT_206] = [__v_5];
+        let __v_4: G = G::from_u64(0);
+        let __ret: [G; OUT_206] = [__v_4];
         if let Some(result) = record.function_queries[206].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
-        let __v_5: G = __r_arr[0];
-        let __v_6: G = G::from_u64(1);
-        let __v_7: G = (__v_5 + __v_6);
-        let __ret: [G; OUT_206] = [__v_7];
+        let __r_arr: [G; OUT_206] = { let __args: [G; IN_206] = [__v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[206].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_206(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_206] = unsafe { *(result.output.as_ptr() as *const [G; OUT_206]) }; __ret } } else { aiur_fn_206(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
+        let __v_5: G = G::from_u64(1);
+        let __v_6: G = (__v_4 + __v_5);
+        let __ret: [G; OUT_206] = [__v_6];
         if let Some(result) = record.function_queries[206].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[206].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -20491,8 +20549,8 @@ fn aiur_fn_206(
   })
 }
 
-const INPUT_SIZE_207: usize = 2;
-const IN_207: usize = 2;
+const INPUT_SIZE_207: usize = 1;
+const IN_207: usize = 1;
 const OUT_207: usize = 1;
 fn aiur_fn_207(
   inp: [G; IN_207],
@@ -20502,35 +20560,36 @@ fn aiur_fn_207(
 ) -> Result<[G; OUT_207], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
-    let __v_2: G = __loaded[0];
-    let __v_3: G = __loaded[1];
-    let __v_4: G = __loaded[2];
-    match __v_2.as_canonical_u64() {
+    let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    match __v_1.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_207] = [__v_1];
+        let __v_5: G = G::from_u64(0);
+        let __ret: [G; OUT_207] = [__v_5];
         if let Some(result) = record.function_queries[207].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __v_5: G = G::from_u64(0);
-        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
-        let __v_6: G = __r_arr[0];
-        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __r_arr: [G; OUT_207] = { let __args: [G; IN_207] = [__v_4]; let __cu = unconstrained; if let Some(result) = record.function_queries[207].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_207(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_207] = unsafe { *(result.output.as_ptr() as *const [G; OUT_207]) }; __ret } } else { aiur_fn_207(__args, record, io_buffer, __cu)? } };
+        let __v_5: G = __r_arr[0];
+        let __v_6: G = G::from_u64(1);
+        let __v_7: G = (__v_5 + __v_6);
         let __ret: [G; OUT_207] = [__v_7];
         if let Some(result) = record.function_queries[207].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[207].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
 }
 
-const INPUT_SIZE_208: usize = 1;
-const IN_208: usize = 1;
+const INPUT_SIZE_208: usize = 2;
+const IN_208: usize = 2;
 const OUT_208: usize = 1;
 fn aiur_fn_208(
   inp: [G; IN_208],
@@ -20540,31 +20599,28 @@ fn aiur_fn_208(
 ) -> Result<[G; OUT_208], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
-    let __v_1: G = __loaded[0];
-    let __v_2: G = __loaded[1];
-    let __v_3: G = __loaded[2];
-    let __v_4: G = __loaded[3];
-    let __v_5: G = __loaded[4];
-    let __v_6: G = __loaded[5];
-    match __v_1.as_canonical_u64() {
+    let __v_1: G = inp[1];
+    let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
+    let __v_2: G = __loaded[0];
+    let __v_3: G = __loaded[1];
+    let __v_4: G = __loaded[2];
+    match __v_2.as_canonical_u64() {
       1u64 => {
-        let __v_7: G = G::from_u64(0);
-        let __ret: [G; OUT_208] = [__v_7];
+        let __ret: [G; OUT_208] = [__v_1];
         if let Some(result) = record.function_queries[208].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
-        let __v_7: G = __r_arr[0];
-        let __v_8: G = G::from_u64(1);
-        let __v_9: G = (__v_7 + __v_8);
-        let __ret: [G; OUT_208] = [__v_9];
+        let __v_5: G = G::from_u64(0);
+        let __r_arr: [G; OUT_208] = { let __args: [G; IN_208] = [__v_4, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[208].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_208(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_208] = unsafe { *(result.output.as_ptr() as *const [G; OUT_208]) }; __ret } } else { aiur_fn_208(__args, record, io_buffer, __cu)? } };
+        let __v_6: G = __r_arr[0];
+        let __v_7: G = { let __values: [G; 3] = [__v_5, __v_3, __v_6]; let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
+        let __ret: [G; OUT_208] = [__v_7];
         if let Some(result) = record.function_queries[208].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[208].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+        return Err(ExecError::MatchNoCase(__v_2.as_canonical_u64()));
       },
     }
   })
@@ -20581,27 +20637,26 @@ fn aiur_fn_209(
 ) -> Result<[G; OUT_209], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
-    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
     let __v_3: G = __loaded[2];
     let __v_4: G = __loaded[3];
     let __v_5: G = __loaded[4];
     let __v_6: G = __loaded[5];
-    let __v_7: G = __loaded[6];
     match __v_1.as_canonical_u64() {
       1u64 => {
-        let __v_8: G = G::from_u64(0);
-        let __ret: [G; OUT_209] = [__v_8];
+        let __v_7: G = G::from_u64(0);
+        let __ret: [G; OUT_209] = [__v_7];
         if let Some(result) = record.function_queries[209].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_209(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
-        let __v_8: G = __r_arr[0];
-        let __v_9: G = G::from_u64(1);
-        let __v_10: G = (__v_8 + __v_9);
-        let __ret: [G; OUT_209] = [__v_10];
+        let __r_arr: [G; OUT_209] = { let __args: [G; IN_209] = [__v_6]; let __cu = unconstrained; if let Some(result) = record.function_queries[209].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_209(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_209] = unsafe { *(result.output.as_ptr() as *const [G; OUT_209]) }; __ret } } else { aiur_fn_209(__args, record, io_buffer, __cu)? } };
+        let __v_7: G = __r_arr[0];
+        let __v_8: G = G::from_u64(1);
+        let __v_9: G = (__v_7 + __v_8);
+        let __ret: [G; OUT_209] = [__v_9];
         if let Some(result) = record.function_queries[209].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[209].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
@@ -20623,6 +20678,48 @@ fn aiur_fn_210(
 ) -> Result<[G; OUT_210], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
+    let __loaded: [G; 7] = { let __mq = record.memory_queries.get_mut(&7).ok_or(ExecError::InvalidMemorySize(7))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 7 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 7] = __args[..7].try_into().unwrap(); __arr };
+    let __v_1: G = __loaded[0];
+    let __v_2: G = __loaded[1];
+    let __v_3: G = __loaded[2];
+    let __v_4: G = __loaded[3];
+    let __v_5: G = __loaded[4];
+    let __v_6: G = __loaded[5];
+    let __v_7: G = __loaded[6];
+    match __v_1.as_canonical_u64() {
+      1u64 => {
+        let __v_8: G = G::from_u64(0);
+        let __ret: [G; OUT_210] = [__v_8];
+        if let Some(result) = record.function_queries[210].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      0u64 => {
+        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_7]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __v_8: G = __r_arr[0];
+        let __v_9: G = G::from_u64(1);
+        let __v_10: G = (__v_8 + __v_9);
+        let __ret: [G; OUT_210] = [__v_10];
+        if let Some(result) = record.function_queries[210].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_211: usize = 1;
+const IN_211: usize = 1;
+const OUT_211: usize = 1;
+fn aiur_fn_211(
+  inp: [G; IN_211],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_211], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
     let __loaded: [G; 10] = { let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 10 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 10] = __args[..10].try_into().unwrap(); __arr };
     let __v_1: G = __loaded[0];
     let __v_2: G = __loaded[1];
@@ -20637,17 +20734,17 @@ fn aiur_fn_210(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_11: G = G::from_u64(0);
-        let __ret: [G; OUT_210] = [__v_11];
-        if let Some(result) = record.function_queries[210].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_211] = [__v_11];
+        if let Some(result) = record.function_queries[211].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_210] = { let __args: [G; IN_210] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[210].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_210(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_210] = unsafe { *(result.output.as_ptr() as *const [G; OUT_210]) }; __ret } } else { aiur_fn_210(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_211] = { let __args: [G; IN_211] = [__v_10]; let __cu = unconstrained; if let Some(result) = record.function_queries[211].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_211(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_211] = unsafe { *(result.output.as_ptr() as *const [G; OUT_211]) }; __ret } } else { aiur_fn_211(__args, record, io_buffer, __cu)? } };
         let __v_11: G = __r_arr[0];
         let __v_12: G = G::from_u64(1);
         let __v_13: G = (__v_11 + __v_12);
-        let __ret: [G; OUT_210] = [__v_13];
-        if let Some(result) = record.function_queries[210].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[210].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_211] = [__v_13];
+        if let Some(result) = record.function_queries[211].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -20657,19 +20754,19 @@ fn aiur_fn_210(
   })
 }
 
-const INPUT_SIZE_211: usize = 2;
-const IN_211: usize = 2;
-const OUT_211: usize = 4;
-fn aiur_fn_211(
-  inp: [G; IN_211],
+const INPUT_SIZE_212: usize = 2;
+const IN_212: usize = 2;
+const OUT_212: usize = 4;
+fn aiur_fn_212(
+  inp: [G; IN_212],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_211], ExecError> {
+) -> Result<[G; OUT_212], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_219(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_220] = { let __args: [G; IN_220] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[220].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_220(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_220] = unsafe { *(result.output.as_ptr() as *const [G; OUT_220]) }; __ret } } else { aiur_fn_220(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -20680,8 +20777,8 @@ fn aiur_fn_211(
     let __v_8: G = __loaded[5];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_211] = [__v_4, __v_5, __v_6, __v_7];
-        if let Some(result) = record.function_queries[211].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[211].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_212] = [__v_4, __v_5, __v_6, __v_7];
+        if let Some(result) = record.function_queries[212].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -20691,15 +20788,15 @@ fn aiur_fn_211(
   })
 }
 
-const INPUT_SIZE_212: usize = 1;
-const IN_212: usize = 1;
-const OUT_212: usize = 1;
-fn aiur_fn_212(
-  inp: [G; IN_212],
+const INPUT_SIZE_213: usize = 1;
+const IN_213: usize = 1;
+const OUT_213: usize = 1;
+fn aiur_fn_213(
+  inp: [G; IN_213],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_212], ExecError> {
+) -> Result<[G; OUT_213], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
@@ -20709,14 +20806,14 @@ fn aiur_fn_212(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_4: G = G::from_u64(1);
-        let __ret: [G; OUT_212] = [__v_4];
-        if let Some(result) = record.function_queries[212].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_213] = [__v_4];
+        if let Some(result) = record.function_queries[213].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         let __v_4: G = G::from_u64(0);
-        let __ret: [G; OUT_212] = [__v_4];
-        if let Some(result) = record.function_queries[212].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[212].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_213] = [__v_4];
+        if let Some(result) = record.function_queries[213].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -20726,19 +20823,19 @@ fn aiur_fn_212(
   })
 }
 
-const INPUT_SIZE_213: usize = 2;
-const IN_213: usize = 2;
-const OUT_213: usize = 2;
-fn aiur_fn_213(
-  inp: [G; IN_213],
+const INPUT_SIZE_214: usize = 2;
+const IN_214: usize = 2;
+const OUT_214: usize = 2;
+fn aiur_fn_214(
+  inp: [G; IN_214],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_213], ExecError> {
+) -> Result<[G; OUT_214], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
-    let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
+    let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_0, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_219(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
     let __v_2: G = __r_arr[0];
     let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_2.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
     let __v_3: G = __loaded[0];
@@ -20747,8 +20844,8 @@ fn aiur_fn_213(
     let __v_6: G = __loaded[3];
     match __v_3.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_213] = [__v_4, __v_5];
-        if let Some(result) = record.function_queries[213].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[213].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_214] = [__v_4, __v_5];
+        if let Some(result) = record.function_queries[214].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -20758,15 +20855,15 @@ fn aiur_fn_213(
   })
 }
 
-const INPUT_SIZE_214: usize = 2;
-const IN_214: usize = 2;
-const OUT_214: usize = 1;
-fn aiur_fn_214(
-  inp: [G; IN_214],
+const INPUT_SIZE_215: usize = 2;
+const IN_215: usize = 2;
+const OUT_215: usize = 1;
+fn aiur_fn_215(
+  inp: [G; IN_215],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_214], ExecError> {
+) -> Result<[G; OUT_215], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
@@ -20783,17 +20880,17 @@ fn aiur_fn_214(
     let __v_11: G = __loaded[9];
     match __v_2.as_canonical_u64() {
       1u64 => {
-        let __ret: [G; OUT_214] = [__v_1];
-        if let Some(result) = record.function_queries[214].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_215] = [__v_1];
+        if let Some(result) = record.function_queries[215].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
         let __v_12: G = G::from_u64(0);
-        let __r_arr: [G; OUT_214] = { let __args: [G; IN_214] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[214].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_214(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_214] = unsafe { *(result.output.as_ptr() as *const [G; OUT_214]) }; __ret } } else { aiur_fn_214(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_11, __v_1]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
         let __v_13: G = __r_arr[0];
         let __v_14: G = { let __values: [G; 10] = [__v_12, __v_3, __v_4, __v_5, __v_6, __v_7, __v_8, __v_9, __v_10, __v_13]; let __mq = record.memory_queries.get_mut(&10).ok_or(ExecError::InvalidMemorySize(10))?; if let Some(result) = __mq.get_mut(&__values[..]) { if !unconstrained { *result.multiplicity += G::ONE; } result.output[0] } else { let __ptr = G::from_usize(__mq.len()); __mq.insert(&__values[..], &[__ptr], G::from_bool(!unconstrained)); __ptr } };
-        let __ret: [G; OUT_214] = [__v_14];
-        if let Some(result) = record.function_queries[214].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[214].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_215] = [__v_14];
+        if let Some(result) = record.function_queries[215].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -20803,15 +20900,15 @@ fn aiur_fn_214(
   })
 }
 
-const INPUT_SIZE_215: usize = 1;
-const IN_215: usize = 1;
-const OUT_215: usize = 1;
-fn aiur_fn_215(
-  inp: [G; IN_215],
+const INPUT_SIZE_216: usize = 1;
+const IN_216: usize = 1;
+const OUT_216: usize = 1;
+fn aiur_fn_216(
+  inp: [G; IN_216],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_215], ExecError> {
+) -> Result<[G; OUT_216], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 5] = { let __mq = record.memory_queries.get_mut(&5).ok_or(ExecError::InvalidMemorySize(5))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 5 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 5] = __args[..5].try_into().unwrap(); __arr };
@@ -20823,17 +20920,17 @@ fn aiur_fn_215(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_6: G = G::from_u64(0);
-        let __ret: [G; OUT_215] = [__v_6];
-        if let Some(result) = record.function_queries[215].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_216] = [__v_6];
+        if let Some(result) = record.function_queries[216].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[216].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_215] = { let __args: [G; IN_215] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[215].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_215(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_215] = unsafe { *(result.output.as_ptr() as *const [G; OUT_215]) }; __ret } } else { aiur_fn_215(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_5]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
         let __v_6: G = __r_arr[0];
         let __v_7: G = G::from_u64(1);
         let __v_8: G = (__v_6 + __v_7);
-        let __ret: [G; OUT_215] = [__v_8];
-        if let Some(result) = record.function_queries[215].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[215].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_216] = [__v_8];
+        if let Some(result) = record.function_queries[216].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[216].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
@@ -20843,28 +20940,28 @@ fn aiur_fn_215(
   })
 }
 
-const INPUT_SIZE_216: usize = 2;
-const IN_216: usize = 2;
-const OUT_216: usize = 1;
-fn aiur_fn_216(
-  inp: [G; IN_216],
+const INPUT_SIZE_217: usize = 2;
+const IN_217: usize = 2;
+const OUT_217: usize = 1;
+fn aiur_fn_217(
+  inp: [G; IN_217],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_216], ExecError> {
+) -> Result<[G; OUT_217], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __v_1: G = inp[1];
     match __v_1.as_canonical_u64() {
       0u64 => {
-        let __ret: [G; OUT_216] = [__v_0];
-        if let Some(result) = record.function_queries[216].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[216].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_217] = [__v_0];
+        if let Some(result) = record.function_queries[217].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[217].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
         let __v_2: G = G::from_u64(1);
         let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_216] = { let __args: [G; IN_216] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[216].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_216(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_216] = unsafe { *(result.output.as_ptr() as *const [G; OUT_216]) }; __ret } } else { aiur_fn_216(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
         let __loaded: [G; 3] = { let __mq = record.memory_queries.get_mut(&3).ok_or(ExecError::InvalidMemorySize(3))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 3 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 3] = __args[..3].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
@@ -20872,8 +20969,8 @@ fn aiur_fn_216(
         let __v_7: G = __loaded[2];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_216] = [__v_7];
-            if let Some(result) = record.function_queries[216].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[216].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_217] = [__v_7];
+            if let Some(result) = record.function_queries[217].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[217].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -20885,15 +20982,15 @@ fn aiur_fn_216(
   })
 }
 
-const INPUT_SIZE_217: usize = 1;
-const IN_217: usize = 1;
-const OUT_217: usize = 1;
-fn aiur_fn_217(
-  inp: [G; IN_217],
+const INPUT_SIZE_218: usize = 1;
+const IN_218: usize = 1;
+const OUT_218: usize = 1;
+fn aiur_fn_218(
+  inp: [G; IN_218],
   record: &mut QueryRecord,
   io_buffer: &mut IOBuffer,
   unconstrained: bool,
-) -> Result<[G; OUT_217], ExecError> {
+) -> Result<[G; OUT_218], ExecError> {
   stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
     let __v_0: G = inp[0];
     let __loaded: [G; 8] = { let __mq = record.memory_queries.get_mut(&8).ok_or(ExecError::InvalidMemorySize(8))?; let __ptr_u64 = __v_0.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 8 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 8] = __args[..8].try_into().unwrap(); __arr };
@@ -20908,64 +21005,21 @@ fn aiur_fn_217(
     match __v_1.as_canonical_u64() {
       1u64 => {
         let __v_9: G = G::from_u64(0);
-        let __ret: [G; OUT_217] = [__v_9];
-        if let Some(result) = record.function_queries[217].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[217].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        let __ret: [G; OUT_218] = [__v_9];
+        if let Some(result) = record.function_queries[218].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[218].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       0u64 => {
-        let __r_arr: [G; OUT_217] = { let __args: [G; IN_217] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[217].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_217(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_217] = unsafe { *(result.output.as_ptr() as *const [G; OUT_217]) }; __ret } } else { aiur_fn_217(__args, record, io_buffer, __cu)? } };
+        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_8]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
         let __v_9: G = __r_arr[0];
         let __v_10: G = G::from_u64(1);
         let __v_11: G = (__v_9 + __v_10);
-        let __ret: [G; OUT_217] = [__v_11];
-        if let Some(result) = record.function_queries[217].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[217].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-        return Ok(__ret);
-      },
-      _ => {
-        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
-      },
-    }
-  })
-}
-
-const INPUT_SIZE_218: usize = 2;
-const IN_218: usize = 2;
-const OUT_218: usize = 1;
-fn aiur_fn_218(
-  inp: [G; IN_218],
-  record: &mut QueryRecord,
-  io_buffer: &mut IOBuffer,
-  unconstrained: bool,
-) -> Result<[G; OUT_218], ExecError> {
-  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
-    let __v_0: G = inp[0];
-    let __v_1: G = inp[1];
-    match __v_1.as_canonical_u64() {
-      0u64 => {
-        let __ret: [G; OUT_218] = [__v_0];
+        let __ret: [G; OUT_218] = [__v_11];
         if let Some(result) = record.function_queries[218].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[218].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
         return Ok(__ret);
       },
       _ => {
-        let __v_2: G = G::from_u64(1);
-        let __v_3: G = (__v_1 - __v_2);
-        let __r_arr: [G; OUT_218] = { let __args: [G; IN_218] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[218].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_218(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_218] = unsafe { *(result.output.as_ptr() as *const [G; OUT_218]) }; __ret } } else { aiur_fn_218(__args, record, io_buffer, __cu)? } };
-        let __v_4: G = __r_arr[0];
-        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
-        let __v_5: G = __loaded[0];
-        let __v_6: G = __loaded[1];
-        let __v_7: G = __loaded[2];
-        let __v_8: G = __loaded[3];
-        match __v_5.as_canonical_u64() {
-          0u64 => {
-            let __ret: [G; OUT_218] = [__v_8];
-            if let Some(result) = record.function_queries[218].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[218].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
-            return Ok(__ret);
-          },
-          _ => {
-            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
-          },
-        }
+        return Err(ExecError::MatchNoCase(__v_1.as_canonical_u64()));
       },
     }
   })
@@ -20994,6 +21048,49 @@ fn aiur_fn_219(
         let __v_3: G = (__v_1 - __v_2);
         let __r_arr: [G; OUT_219] = { let __args: [G; IN_219] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[219].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_219(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_219] = unsafe { *(result.output.as_ptr() as *const [G; OUT_219]) }; __ret } } else { aiur_fn_219(__args, record, io_buffer, __cu)? } };
         let __v_4: G = __r_arr[0];
+        let __loaded: [G; 4] = { let __mq = record.memory_queries.get_mut(&4).ok_or(ExecError::InvalidMemorySize(4))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 4 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 4] = __args[..4].try_into().unwrap(); __arr };
+        let __v_5: G = __loaded[0];
+        let __v_6: G = __loaded[1];
+        let __v_7: G = __loaded[2];
+        let __v_8: G = __loaded[3];
+        match __v_5.as_canonical_u64() {
+          0u64 => {
+            let __ret: [G; OUT_219] = [__v_8];
+            if let Some(result) = record.function_queries[219].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[219].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            return Ok(__ret);
+          },
+          _ => {
+            return Err(ExecError::MatchNoCase(__v_5.as_canonical_u64()));
+          },
+        }
+      },
+    }
+  })
+}
+
+const INPUT_SIZE_220: usize = 2;
+const IN_220: usize = 2;
+const OUT_220: usize = 1;
+fn aiur_fn_220(
+  inp: [G; IN_220],
+  record: &mut QueryRecord,
+  io_buffer: &mut IOBuffer,
+  unconstrained: bool,
+) -> Result<[G; OUT_220], ExecError> {
+  stacker::maybe_grow(64 * 1024, 4 * 1024 * 1024, || {
+    let __v_0: G = inp[0];
+    let __v_1: G = inp[1];
+    match __v_1.as_canonical_u64() {
+      0u64 => {
+        let __ret: [G; OUT_220] = [__v_0];
+        if let Some(result) = record.function_queries[220].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[220].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+        return Ok(__ret);
+      },
+      _ => {
+        let __v_2: G = G::from_u64(1);
+        let __v_3: G = (__v_1 - __v_2);
+        let __r_arr: [G; OUT_220] = { let __args: [G; IN_220] = [__v_0, __v_3]; let __cu = unconstrained; if let Some(result) = record.function_queries[220].get_mut(&__args[..]) { if !__cu && *result.multiplicity == G::ZERO { aiur_fn_220(__args, record, io_buffer, false)? } else { if !unconstrained { *result.multiplicity += G::ONE; } let __ret: [G; OUT_220] = unsafe { *(result.output.as_ptr() as *const [G; OUT_220]) }; __ret } } else { aiur_fn_220(__args, record, io_buffer, __cu)? } };
+        let __v_4: G = __r_arr[0];
         let __loaded: [G; 6] = { let __mq = record.memory_queries.get_mut(&6).ok_or(ExecError::InvalidMemorySize(6))?; let __ptr_u64 = __v_4.as_canonical_u64(); let __ptr_usize = usize::try_from(__ptr_u64).ok().ok_or(ExecError::PointerTooLarge(__ptr_u64))?; let (__args, __mult) = __mq.get_index_mut(__ptr_usize).ok_or(ExecError::UnboundPointer { ptr: __ptr_u64, size: 6 })?; if !unconstrained { *__mult += G::ONE; } let __arr: [G; 6] = __args[..6].try_into().unwrap(); __arr };
         let __v_5: G = __loaded[0];
         let __v_6: G = __loaded[1];
@@ -21003,8 +21100,8 @@ fn aiur_fn_219(
         let __v_10: G = __loaded[5];
         match __v_5.as_canonical_u64() {
           0u64 => {
-            let __ret: [G; OUT_219] = [__v_10];
-            if let Some(result) = record.function_queries[219].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[219].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
+            let __ret: [G; OUT_220] = [__v_10];
+            if let Some(result) = record.function_queries[220].get_mut(&inp[..]) { debug_assert_eq!(result.output, &__ret[..]); if !unconstrained { *result.multiplicity += G::ONE; } } else { record.function_queries[220].insert(&inp[..], &__ret[..], G::from_bool(!unconstrained)); };
             return Ok(__ret);
           },
           _ => {
@@ -22121,6 +22218,11 @@ pub(crate) fn execute_generated(
     219u64 => {
       let __inp: [G; IN_219] = args.try_into().expect("input size mismatch");
       let __out = aiur_fn_219(__inp, record, io_buffer, false)?;
+      return Ok(__out.to_vec());
+    },
+    220u64 => {
+      let __inp: [G; IN_220] = args.try_into().expect("input size mismatch");
+      let __out = aiur_fn_220(__inp, record, io_buffer, false)?;
       return Ok(__out.to_vec());
     },
     _ => {


### PR DESCRIPTION
The in-circuit pruned-multiproof walk (mmcs_verify_multi / frontier_level) collapses queries that share a parent to a single lead node and hashes only the lead's rows via inject_maybe(ar, ...). Non-lead members' opened rows for the shorter (injected) matrices were still consumed in their own per-query FRI arithmetic (batch_views_at) but never authenticated against any commitment — the leaf hash covers only the tallest matrices, and shorter ones are bound solely through injection. A prover could therefore forge a non-lead member's shorter-matrix opening. Plonky3's reference verify_batch_pruned guards exactly this with InconsistentGroupOpening (and InconsistentDuplicateOpenings for equal-index queries); the port had neither. The prior per-query walk did not have the gap, so it was introduced with the direct multiproof consumption.

- frontier_level: on a group merge, assert the lead and member agree on every not-yet-injected matrix (height <= next_lh) via select_rows_le + pointer equality. Transitive across pairwise merges, so the whole group is pinned; matches InconsistentGroupOpening.
- frontier_merge: duplicate transcript indices must open the SAME full rows, not merely the same tallest-matrix leaf digest; matches InconsistentDuplicateOpenings.

Pointer equality is admissible inside assert_eq! (equal pointers imply equal content; a spurious mismatch costs only completeness — see IxVM.Core). select_rows_le selects rows of matrices at height <= target, mirroring select_rows.

Validated: the group-merge branch is genuinely reached by the factorial recursion proof (an always-false variant of the new assert fails the honest test), the honest proof still verifies with the real assert (completeness preserved), the existing tamper tests still reject, and the full lake test suite is green (2717 checks). aiur_multi_stark.rs regenerated; kernel executor unchanged.